### PR TITLE
Enable regridding on AMR subcycles

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -402,9 +402,6 @@ void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex:
 	// since we are starting a new timestep, need to swap old and new state vectors
 	std::swap(state_old_[lev], state_new_[lev]);
 
-	// various AMR operations can create negative pressures, etc.
-	FixupState(lev);
-
 	// check hydro states before update (this can be caused by the flux register!)
 	CHECK_HYDRO_STATES(state_old_[lev]);
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -482,12 +482,7 @@ void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
         {
             if (istep[lev] % regrid_int == 0)
             {
-				if (Verbose()) {
-					amrex::Print() << "regridding level " << lev
-								   << " and higher..." << std::endl;
-				}
-        
-		        // regrid could add newly refine levels (if finest_level < max_level)
+		        // regrid could add newly refined levels (if finest_level < max_level)
                 // so we save the previous finest level index
                 int old_finest = finest_level;
                 regrid(lev, time);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -473,7 +473,7 @@ void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
     {
         // help keep track of whether a level was already regridded
         // from a coarser level call to regrid
-        static Vector<int> last_regrid_step(max_level+1, 0);
+        static amrex::Vector<int> last_regrid_step(max_level+1, 0);
 
         // regrid changes level "lev+1" so we don't regrid on max_level
         // also make sure we don't regrid fine levels again if
@@ -484,7 +484,7 @@ void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
             {
 				if (Verbose()) {
 					amrex::Print() << "regridding level " << lev
-								   << "and above..." << std::endl;
+								   << " and higher..." << std::endl;
 				}
         
 		        // regrid could add newly refine levels (if finest_level < max_level)
@@ -500,9 +500,9 @@ void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
                 // if there are newly created levels, set the time step
                 for (int k = old_finest+1; k <= finest_level; ++k) {
 					if (do_subcycle) {
-	                    dt[k] = dt[k-1] / MaxRefRatio(k-1);
+	                    dt_[k] = dt_[k-1] / nsubsteps[k];
 					} else {
-						dt[k] = dt[k-1];
+						dt_[k] = dt_[k-1];
 					}
                 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -389,16 +389,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 	// Main time loop
 	for (int step = istep[0]; step < maxTimesteps_ && cur_time < stopTime_; ++step) {
-		amrex::ParallelDescriptor::Barrier(); // synchronize all MPI ranks
-		
 		if (suppress_output == 0) {
 			amrex::Print() << "\nCoarse STEP " << step + 1
 						   << " at t = " << cur_time << " ("
 						   << (cur_time / stopTime_) * 100. << "%) starts ..." << std::endl;
 		}
 
-		doRegridIfNeeded(step, cur_time);
-		computeTimestep(); // important to call this *after* regrid (when a global timestep is used)
+		amrex::ParallelDescriptor::Barrier(); // synchronize all MPI ranks
+		computeTimestep();
 
 		int lev = 0;
 		int iteration = 1;
@@ -464,33 +462,57 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	}
 }
 
-template <typename problem_t>
-void AMRSimulation<problem_t>::doRegridIfNeeded(int const step, amrex::Real const time)
-{
-	BL_PROFILE("AMRSimulation::doRegridIfNeeded()");
-
-	if (max_level > 0 && regrid_int > 0) // regridding is possible
-	{
-		if (step % regrid_int == 0) { // regrid on this coarse step
-			if (Verbose()) {
-				amrex::Print() << "regridding..." << std::endl;
-			}
-			regrid(0, time);
-
-			// do fix-up on all levels that have been re-gridded
-			for(int lev = 0; lev <= finest_level; ++lev) {
-				FixupState(lev);
-			}
-		}
-	}
-}
-
 // N.B.: This function actually works for subcycled or not subcycled, as long as
 // nsubsteps[lev] is set correctly.
 template <typename problem_t>
 void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
 {
 	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
+
+	if (regrid_int > 0) // regridding is possible
+    {
+        // help keep track of whether a level was already regridded
+        // from a coarser level call to regrid
+        static Vector<int> last_regrid_step(max_level+1, 0);
+
+        // regrid changes level "lev+1" so we don't regrid on max_level
+        // also make sure we don't regrid fine levels again if
+        // it was taken care of during a coarser regrid
+        if (lev < max_level && istep[lev] > last_regrid_step[lev])
+        {
+            if (istep[lev] % regrid_int == 0)
+            {
+				if (Verbose()) {
+					amrex::Print() << "regridding level " << lev
+								   << "and above..." << std::endl;
+				}
+        
+		        // regrid could add newly refine levels (if finest_level < max_level)
+                // so we save the previous finest level index
+                int old_finest = finest_level;
+                regrid(lev, time);
+
+                // mark that we have regridded this level already
+                for (int k = lev; k <= finest_level; ++k) {
+                    last_regrid_step[k] = istep[k];
+                }
+
+                // if there are newly created levels, set the time step
+                for (int k = old_finest+1; k <= finest_level; ++k) {
+					if (do_subcycle) {
+	                    dt[k] = dt[k-1] / MaxRefRatio(k-1);
+					} else {
+						dt[k] = dt[k-1];
+					}
+                }
+
+				// do fix-up on all levels that have been re-gridded
+                for (int k = lev; k <= finest_level; ++k) {
+					FixupState(k);
+				}
+            }
+        }
+    }
 
 	if (Verbose()) {
 		amrex::Print() << "[Level " << lev << " step " << istep[lev] + 1 << "] ";

--- a/tests/CoolingCloud.in
+++ b/tests/CoolingCloud.in
@@ -14,7 +14,7 @@ amr.v               = 1     # verbosity in Amr
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell          = 256 256 256
-amr.max_level       = 1     # number of levels = max_level + 1
+amr.max_level       = 2     # number of levels = max_level + 1
 amr.blocking_factor = 32    # grid size must be divisible by this
 amr.max_grid_size   = 128
 
@@ -23,4 +23,3 @@ do_subcycle = 1
 
 grackle_data_file = "../extern/grackle_data_files/input/CloudyData_UVB=HM2012.h5"
 derived_vars = temperature
-load_balance_interval = 10


### PR DESCRIPTION
Previously, re-gridding only happened on coarse timesteps. Now we should be consistent with Berger-Oliger re-gridding.