### PR TITLE
inline ComputeVelocityDifferences into ComputeFluxes

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -201,7 +201,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	template <FluxDir DIR>
 	void hydroFOFluxFunction(amrex::Array4<const amrex::Real> const &primVar,
 			  amrex::FArrayBox &x1Flux, const amrex::Box &indexRange, int nvars);
-	
+
 	void replaceFluxes(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes,
 			  std::array<amrex::FArrayBox, AMREX_SPACEDIM> &FOfluxes,
 			  amrex::IArrayBox &redoFlag, amrex::Box const &validBox, int ncomp);
@@ -260,7 +260,7 @@ void RadhydroSimulation<problem_t>::computeMaxSignalLocal(int const level)
 #if !defined(NDEBUG)
 #define CHECK_HYDRO_STATES(mf) checkHydroStates(mf, __FILE__, __LINE__)
 #else
-#define CHECK_HYDRO_STATES(mf) 
+#define CHECK_HYDRO_STATES(mf)
 #endif
 
 template <typename problem_t>
@@ -416,7 +416,7 @@ void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex:
 
 	// check hydro states after hydro update
 	CHECK_HYDRO_STATES(state_new_[lev]);
-	
+
 	// subcycle radiation
 	if (is_radiation_enabled_) {
 		subcycleRadiationAtLevel(lev, time, dt_lev, fr_as_crse, fr_as_fine);
@@ -580,7 +580,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 								<< redoFlag.sum<amrex::RunOn::Device>(0)
 								<< "\n";
 					}
-					
+
 					// replace fluxes in fluxArrays with first-order fluxes at faces of flagged cells
 					replaceFluxes(fluxArrays, FOFluxArrays, redoFlag, indexRange, ncompHydro_);
 
@@ -606,7 +606,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			auto const &stateNew = state_new_[lev].array(iter);
 			amrex::FArrayBox stateNewFAB = amrex::FArrayBox(stateNew);
 			stateNewFAB.copy<amrex::RunOn::Device>(stateFinalFAB, 0, 0, ncompHydro_);
-			
+
 			if (do_reflux) {
 				// increment flux registers
 				auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_[lev].nComp());
@@ -771,13 +771,10 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 	    primVar, x1Flat, x2Flat, x3Flat, x1LeftState.array(), x1RightState.array(),
 	    reconstructRange, nvars);
 
-	amrex::FArrayBox dvn(x1FluxRange, 1, amrex::The_Async_Arena());
-	amrex::FArrayBox dvt(x1FluxRange, 1, amrex::The_Async_Arena());
-
 	// interface-centered kernel
 	HydroSystem<problem_t>::template ComputeFluxes<DIR>(
 	    x1Flux.array(), x1LeftState.array(), x1RightState.array(),
-		primVar, dvn.array(), dvt.array(), x1FluxRange);
+		primVar, x1FluxRange);
 }
 
 template <typename problem_t>
@@ -837,13 +834,10 @@ void RadhydroSimulation<problem_t>::hydroFOFluxFunction(
 			primVar, x1LeftState.array(), x1RightState.array(),
 			x1ReconstructRange, nvars);
 
-	amrex::FArrayBox dvn(x1FluxRange, 1, amrex::The_Async_Arena());
-	amrex::FArrayBox dvt(x1FluxRange, 1, amrex::The_Async_Arena());
-
 	// interface-centered kernel
 	HydroSystem<problem_t>::template ComputeFluxes<DIR>(
 	    x1Flux.array(), x1LeftState.array(), x1RightState.array(),
-		primVar, dvn.array(), dvt.array(), x1FluxRange);
+		primVar, x1FluxRange);
 }
 
 template <typename problem_t>
@@ -906,7 +900,7 @@ void RadhydroSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Rea
 			auto const &prob_lo = geom[lev].ProbLoArray();
 			auto const &prob_hi = geom[lev].ProbHiArray();
 			// update state_new_[lev] in place (updates both radiation and hydro vars)
-			operatorSplitSourceTerms(stateNew, indexRange, time_subcycle, dt_radiation, 
+			operatorSplitSourceTerms(stateNew, indexRange, time_subcycle, dt_radiation,
 									 dx, prob_lo, prob_hi);
 		}
 
@@ -1001,7 +995,7 @@ void RadhydroSimulation<problem_t>::advanceRadiationSubstepAtLevel(
 
 template <typename problem_t>
 void RadhydroSimulation<problem_t>::operatorSplitSourceTerms(
-    amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, 
+    amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange,
 	const amrex::Real time, const double dt,
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -95,17 +95,11 @@ public:
 
   template <FluxDir DIR>
   static void
-  ComputeVelocityDifferences(amrex::Array4<const amrex::Real> const &primVar_in,
-                             array_t &dvn_in, array_t &dvt_in,
-                             amrex::Box const &indexRange);
-
-  template <FluxDir DIR>
-  static void
   ComputeFluxes(array_t &x1Flux_in,
                 amrex::Array4<const amrex::Real> const &x1LeftState_in,
                 amrex::Array4<const amrex::Real> const &x1RightState_in,
                 amrex::Array4<const amrex::Real> const &primVar_in,
-                array_t &dvn_in, array_t &dvt_in, amrex::Box const &indexRange);
+                amrex::Box const &indexRange);
 
   template <FluxDir DIR>
   static void
@@ -586,129 +580,16 @@ void HydroSystem<problem_t>::FlattenShocks(
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HydroSystem<problem_t>::ComputeVelocityDifferences(
-    amrex::Array4<const amrex::Real> const &primVar_in, array_t &dvn_in,
-    array_t &dvt_in, amrex::Box const &indexRange) {
-  // compute velocity differences from cell-average data for normal
-  //   and transverse directions (w/r/t DIR)
-  // (required by Minoshima+ 2021 carbuncle fix in Riemann solver)
-
-  // cell-centered kernel
-#if AMREX_SPACEDIM == 3
-  quokka::Array4View<const amrex::Real, DIR> q(primVar_in);
-  quokka::Array4View<amrex::Real, DIR> dvn(dvn_in);
-  quokka::Array4View<amrex::Real, DIR> dvt(dvt_in);
-
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i_in, int j_in,
-                                                      int k_in) {
-    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
-    int velN_index = x1Velocity_index;
-    int velV_index = x2Velocity_index;
-    int velW_index = x3Velocity_index;
-
-    if constexpr (DIR == FluxDir::X1) {
-      velN_index = x1Velocity_index;
-      velV_index = x2Velocity_index;
-      velW_index = x3Velocity_index;
-    } else if constexpr (DIR == FluxDir::X2) {
-      velN_index = x2Velocity_index;
-      velV_index = x3Velocity_index;
-      velW_index = x1Velocity_index;
-    } else if constexpr (DIR == FluxDir::X3) {
-      velN_index = x3Velocity_index;
-      velV_index = x1Velocity_index;
-      velW_index = x2Velocity_index;
-    }
-
-    // normal velocity difference
-    dvn(i, j, k) = q(i, j, k, velN_index) - q(i - 1, j, k, velN_index);
-
-    // transverse velocity difference
-    amrex::Real dvl =
-        std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index),
-                 q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
-    amrex::Real dvr =
-        std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index),
-                 q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
-
-    amrex::Real dwl =
-        std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index),
-                 q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
-    amrex::Real dwr =
-        std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index),
-                 q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
-
-    dvt(i, j, k) = std::min(std::min(dvl, dvr), std::min(dwl, dwr));
-  });
-#elif AMREX_SPACEDIM == 2
-  const auto &q = primVar_in;
-  const auto &dvn = dvn_in;
-  const auto &dvt = dvt_in;
-
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-    // normal velocity difference
-    if (DIR == FluxDir::X1) {
-      dvn(i, j, k) =
-          q(i, j, k, x1Velocity_index) - q(i - 1, j, k, x1Velocity_index);
-    } else if (DIR == FluxDir::X2) {
-      dvn(i, j, k) =
-          q(i, j, k, x2Velocity_index) - q(i, j - 1, k, x2Velocity_index);
-    }
-
-    // transverse velocity difference
-    amrex::Real dvl = NAN;
-    amrex::Real dvr = NAN;
-
-    if (DIR == FluxDir::X1) {
-      dvl = std::min(q(i - 1, j + 1, k, x2Velocity_index) -
-                         q(i - 1, j, k, x2Velocity_index),
-                     q(i - 1, j, k, x2Velocity_index) -
-                         q(i - 1, j - 1, k, x2Velocity_index));
-      dvr = std::min(
-          q(i, j + 1, k, x2Velocity_index) - q(i, j, k, x2Velocity_index),
-          q(i, j, k, x2Velocity_index) - q(i, j - 1, k, x2Velocity_index));
-    } else if (DIR == FluxDir::X2) {
-      dvl = std::min(q(i + 1, j - 1, k, x1Velocity_index) -
-                         q(i, j - 1, k, x1Velocity_index),
-                     q(i, j - 1, k, x1Velocity_index) -
-                         q(i - 1, j - 1, k, x1Velocity_index));
-      dvr = std::min(
-          q(i + 1, j, k, x1Velocity_index) - q(i, j, k, x1Velocity_index),
-          q(i, j, k, x1Velocity_index) - q(i - 1, j, k, x1Velocity_index));
-    }
-
-    dvt(i, j, k) = std::min(dvl, dvr);
-  });
-#else // AMREX_SPACEDIM == 1
-  const auto &q = primVar_in;
-  const auto &dvn = dvn_in;
-  const auto &dvt = dvt_in;
-
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-    // normal velocity difference
-    dvn(i, j, k) =
-        q(i, j, k, x1Velocity_index) - q(i - 1, j, k, x1Velocity_index);
-
-    // transverse velocity difference
-    dvt(i, j, k) = 0.;
-  });
-#endif
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(
     array_t &x1Flux_in, amrex::Array4<const amrex::Real> const &x1LeftState_in,
     amrex::Array4<const amrex::Real> const &x1RightState_in,
-    amrex::Array4<const amrex::Real> const &primVar_in, array_t &dvn_in,
-    array_t &dvt_in, amrex::Box const &indexRange) {
-  ComputeVelocityDifferences<DIR>(primVar_in, dvn_in, dvt_in, indexRange);
+    amrex::Array4<const amrex::Real> const &primVar_in,
+    amrex::Box const &indexRange) {
 
-  quokka::Array4View<const amrex::Real, DIR> dvn(dvn_in);
-  quokka::Array4View<const amrex::Real, DIR> dvt(dvt_in);
   quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in);
   quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in);
   quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in);
+  quokka::Array4View<const amrex::Real, DIR> q(primVar_in);
 
   // By convention, the interfaces are defined on the left edge of each
   // zone, i.e. xinterface_(i) is the solution to the Riemann problem at
@@ -785,16 +666,28 @@ void HydroSystem<problem_t>::ComputeFluxes(
 
     double u_L = NAN;
     double u_R = NAN;
+    int velN_index = x1Velocity_index;
+    int velV_index = x2Velocity_index;
+    int velW_index = x3Velocity_index;
 
     if constexpr (DIR == FluxDir::X1) {
       u_L = vx_L;
       u_R = vx_R;
+      velN_index = x1Velocity_index;
+      velV_index = x2Velocity_index;
+      velW_index = x3Velocity_index;
     } else if constexpr (DIR == FluxDir::X2) {
       u_L = vy_L;
       u_R = vy_R;
+      velN_index = x2Velocity_index;
+      velV_index = x3Velocity_index;
+      velW_index = x1Velocity_index;
     } else if constexpr (DIR == FluxDir::X3) {
       u_L = vz_L;
       u_R = vz_R;
+      velN_index = x3Velocity_index;
+      velV_index = x1Velocity_index;
+      velW_index = x2Velocity_index;
     }
 
     // compute PVRS states (Toro 10.5.2)
@@ -822,9 +715,25 @@ void HydroSystem<problem_t>::ComputeFluxes(
 
     // carbuncle correction [Eq. 10 of Minoshima & Miyoshi (2021)]
     const double cs_max = std::max(cs_L, cs_R);
-    const double du =
-        dvn(i, j, k); // difference in normal velocity along normal axis
-    const double dw = dvt(i, j, k); // difference in transverse velocity
+    // difference in normal velocity along normal axis
+    const double du = q(i, j, k, velN_index) - q(i - 1, j, k, velN_index);
+    // difference in transverse velocity
+#if AMREX_SPACEDIM == 1
+    const double dw = 0.;
+#else
+    amrex::Real dvl = std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index),
+                 q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
+    amrex::Real dvr = std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index),
+                 q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
+    double dw = std::min(dvl, dvr);
+#endif
+#if AMREX_SPACEDIM == 3
+    amrex::Real dwl = std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index),
+                 q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
+    amrex::Real dwr = std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index),
+                 q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
+    dw = std::min(std::min(dwl, dwr), dw);
+#endif
     const double tp =
         std::min(1., (cs_max - std::min(du, 0.)) / (cs_max - std::min(dw, 0.)));
     const double theta = tp * tp * tp * tp;


### PR DESCRIPTION
The difference in normal and transverse components of velocity across an interface are used to correct for carbuncle phenomenon in the Riemann solver (https://arxiv.org/abs/2108.04991)

These values are currently stored in array that is allocated at a relatively high level, even though the velocity differences are not used anywhere else.

This PR inlines the velocity difference calculation, so that the results can be used directly without storing in an array.

Testing with the `blast_amr_maxlev2.in` (256^3, 2 AMR levels) problem gave an average performance improvement of 4.8% (zone-updates per second) on 1 V100.

`make test` passes for 1D, 2D, and 3D, however, these tests don't explicitly test for this numerical artifact. To properly test this change, the `HydroQuirk` test needs to be run and compared with a known solution.