### PR TITLE
Add performance hints

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,8 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 # this is necessary to prevent the host compiler from complaining about nv_pragmas
-add_compile_options(-Wno-unknown-pragmas)
+# only works for gcc
+#add_compile_options(-Wno-unknown-pragmas)
 
 add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>)
 

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -283,7 +283,7 @@ void HydroSystem<problem_t>::EnforcePressureFloor(
           state(i, j, k, density_index) = rho_new;
         }
 
-        if constexpr (!is_eos_isothermal()) {
+        if (!is_eos_isothermal()) {
           // recompute gas energy (to prevent P < 0)
           amrex::Real const Eint_star = Etot - 0.5 * rho_new * vsq;
           amrex::Real const P_star = Eint_star * (gamma_ - 1.);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,48 +15,50 @@
 
 #include "main.hpp"
 
-auto main(int argc, char **argv) -> int
-{
-	// Initialization (copied from ExaWind)
+auto main(int argc, char **argv) -> int {
+  // Initialization (copied from ExaWind)
 
-	amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, []() {
-		amrex::ParmParse pp("amrex");
-		// Set the defaults so that we throw an exception instead of attempting
-		// to generate backtrace files. However, if the user has explicitly set
-		// these options in their input files respect those settings.
-		if (!pp.contains("throw_exception")) {
-			pp.add("throw_exception", 1);
-		}
-		if (!pp.contains("signal_handling")) {
-			pp.add("signal_handling", 0);
-		}
-	});
+  amrex::Initialize(argc, argv, true, MPI_COMM_WORLD, []() {
+    amrex::ParmParse pp("amrex");
+    // Set the defaults so that we throw an exception instead of attempting
+    // to generate backtrace files. However, if the user has explicitly set
+    // these options in their input files respect those settings.
+    if (!pp.contains("throw_exception")) {
+      pp.add("throw_exception", 1);
+    }
+    if (!pp.contains("signal_handling")) {
+      pp.add("signal_handling", 0);
+    }
 
-	amrex::Real start_time = amrex::ParallelDescriptor::second();
+    // Set GPU memory handling defaults:
+    // since performance is terrible if we have to swap pages between device and
+    // host memory due to exceeding the size of device memory, we crash the code
+    // if this happens, allowing the user to restart with more nodes.
+    if (!pp.contains("abort_on_out_of_gpu_memory")) {
+      pp.add("abort_on_out_of_gpu_memory", 1);
+    }
+  });
 
-	int result = 0;
-	{ // objects must be destroyed before amrex::finalize, so enter new
-	  // scope here to do that automatically
+  amrex::Real start_time = amrex::ParallelDescriptor::second();
 
-		result = problem_main();
+  int result = 0;
+  { // objects must be destroyed before amrex::finalize, so enter new
+    // scope here to do that automatically
 
-	} // destructors must be called before amrex::Finalize()
+    result = problem_main();
 
-	// compute elapsed time
-	amrex::Real elapsed_sec = amrex::ParallelDescriptor::second() - start_time;
-	const int IOProc = amrex::ParallelDescriptor::IOProcessorNumber();
-	amrex::ParallelDescriptor::ReduceRealMax(elapsed_sec, IOProc);
+  } // destructors must be called before amrex::Finalize()
 
-	if (amrex::ParallelDescriptor::IOProcessor()) {
-		//const double zone_cycles = cycleCount_ * (nx_[0] * nx_[1] * nx_[2]);
-		//const double microseconds_per_update = 1.0e6 * elapsed_sec / zone_cycles;
-		//const double megaupdates_per_second = 1.0 / microseconds_per_update;
-		//amrex::Print() << "Performance figure-of-merit: " << microseconds_per_update
-		//	       << " μs/zone-update [" << megaupdates_per_second << " Mupdates/s]\n";
-		amrex::Print() << "elapsed time: " << elapsed_sec << " seconds.\n";
-	}
+  // compute elapsed time
+  amrex::Real elapsed_sec = amrex::ParallelDescriptor::second() - start_time;
+  const int IOProc = amrex::ParallelDescriptor::IOProcessorNumber();
+  amrex::ParallelDescriptor::ReduceRealMax(elapsed_sec, IOProc);
 
-	amrex::Finalize();
+  if (amrex::ParallelDescriptor::IOProcessor()) {
+    amrex::Print() << "elapsed time: " << elapsed_sec << " seconds.\n";
+  }
 
-	return result;
+  amrex::Finalize();
+
+  return result;
 }

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -852,6 +852,13 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar,
     const double x3GasMom0 = consPrev(i, j, k, x3GasMomentum_index);
     const double Egastot0 = consPrev(i, j, k, gasEnergy_index);
 
+    // load radiation energy
+    const double Erad0 = consPrev(i, j, k, radEnergy_index);
+
+    // load radiation energy source term
+    // plus advection source term (for well-balanced/SDC integrators)
+    const double Src = dt * ((chat * radEnergySource(i, j, k)) + advectionFluxes(i, j, k));
+
     double Egas0 = NAN;
     double Ekin0 = NAN;
     double Egas_guess = NAN;
@@ -862,14 +869,6 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar,
       Egas0 =
           ComputeEintFromEgas(rho, x1GasMom0, x2GasMom0, x3GasMom0, Egastot0);
       Ekin0 = Egastot0 - Egas0;
-
-      // load radiation energy
-      const double Erad0 = consPrev(i, j, k, radEnergy_index);
-
-      // load radiation energy source term
-      // plus advection source term (for well-balanced/SDC integrators)
-      const double Src =
-          dt * ((chat * radEnergySource(i, j, k)) + advectionFluxes(i, j, k));
 
       AMREX_ASSERT(Src >= 0.0);
       AMREX_ASSERT(Egas0 > 0.0);


### PR DESCRIPTION
Add runtime warnings when blocking_factor and max_grid_size are too small. Enable amrex.abort_on_out_of_gpu_memory by default.