### PR TITLE
add automated test for carbuncle instability

### DIFF
--- a/src/HydroQuirk/CMakeLists.txt
+++ b/src/HydroQuirk/CMakeLists.txt
@@ -3,4 +3,6 @@ if (AMReX_SPACEDIM GREATER_EQUAL 2)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_quirk)
     endif()
+
+    add_test(NAME HydroQuirk COMMAND test_quirk quirk.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -7,11 +7,14 @@
 /// \brief Defines a test problem for the odd-even decoupling instability.
 ///
 
+#include "AMReX.H"
 #include "AMReX_Array.H"
 #include "AMReX_BCRec.H"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_Config.H"
+#include "AMReX_IntVect.H"
+#include "AMReX_MultiFab.H"
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
@@ -20,98 +23,157 @@
 
 #include "RadhydroSimulation.hpp"
 #include "hydro_system.hpp"
+#include "radiation_system.hpp"
 #include "test_quirk.hpp"
+#include <algorithm>
+#include <vector>
 
 using Real = amrex::Real;
 
-struct QuirkProblem {
-};
+struct QuirkProblem {};
 
 template <> struct EOS_Traits<QuirkProblem> {
-	static constexpr double gamma = 5. / 3.;
-	static constexpr bool reconstruct_eint = false;
+  static constexpr double gamma = 5. / 3.;
+  static constexpr bool reconstruct_eint = false;
 };
 
-constexpr Real dl =  3.692;
+constexpr Real dl = 3.692;
 constexpr Real ul = -0.625;
-constexpr Real pl =  26.85;
-constexpr Real dr =  1.0;
+constexpr Real pl = 26.85;
+constexpr Real dr = 1.0;
 constexpr Real ur = -5.0;
-constexpr Real pr =  0.6;
+constexpr Real pr = 0.6;
+AMREX_GPU_MANAGED int ishock = 0;
 
-template <> void RadhydroSimulation<QuirkProblem>::setInitialConditionsAtLevel(int lev)
-{
-	// Initial conditions from:
-	// T. Hanawa et al. / Journal of Computational Physics 227 (2008) 7952–7976
-	// and based on Athena++'s quirk.cpp.
+template <>
+void RadhydroSimulation<QuirkProblem>::setInitialConditionsAtLevel(int lev) {
+  // Initial conditions from:
+  // T. Hanawa et al. / Journal of Computational Physics 227 (2008) 7952–7976
+  // and based on Athena++'s quirk.cpp.
 
-	amrex::GpuArray<Real, AMREX_SPACEDIM> dx = geom[lev].CellSizeArray();
-	amrex::GpuArray<Real, AMREX_SPACEDIM> prob_lo = geom[lev].ProbLoArray();
+  amrex::GpuArray<Real, AMREX_SPACEDIM> dx = geom[lev].CellSizeArray();
+  amrex::GpuArray<Real, AMREX_SPACEDIM> prob_lo = geom[lev].ProbLoArray();
 
-	Real xshock = 0.4;
-	int ishock = 0;
-	for (ishock = 0; (prob_lo[0] + dx[0]*(ishock + Real(0.5))) < xshock; ++ishock) {}
-	ishock--;
-	amrex::Print() << "ishock = " << ishock << "\n";
+  Real xshock = 0.4;
+  for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + Real(0.5))) < xshock;
+       ++ishock) {
+  }
+  ishock--;
+  amrex::Print() << "ishock = " << ishock << "\n";
 
+  Real dd = dl - 0.135;
+  Real ud = ul + 0.219;
+  Real pd = pl - 1.31;
 
-	Real dd = dl - 0.135;
-	Real ud = ul + 0.219;
-	Real pd = pl - 1.31;
+  for (amrex::MFIter iter(state_old_[lev]); iter.isValid(); ++iter) {
+    const amrex::Box &indexRange = iter.validbox(); // excludes ghost zones
+    auto const &state = state_new_[lev].array(iter);
 
-	for (amrex::MFIter iter(state_old_[lev]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox(); // excludes ghost zones
-		auto const &state = state_new_[lev].array(iter);
+    amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+      double vx = NAN;
+      double vy = 0.;
+      double vz = 0.;
+      double rho = NAN;
+      double P = NAN;
 
-		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-			double vx = NAN;
-			double vy = 0.;
-			double vz = 0.;
-			double rho = NAN;
-			double P = NAN;
+      if (i <= ishock) {
+        rho = dl;
+        vx = ul;
+        P = pl;
+      } else {
+        rho = dr;
+        vx = ur;
+        P = pr;
+      }
 
-			if (i <= ishock) {
-				rho = dl;
-				vx = ul;
-				P = pl;
-			} else {
-				rho = dr;
-				vx = ur;
-				P = pr;
-			}
+      if ((i == ishock) && (j % 2 == 0)) {
+        rho = dd;
+        vx = ud;
+        P = pd;
+      }
 
-			if ((i == ishock) && (j % 2 == 0)) {
-				rho = dd;
-				vx = ud;
-				P = pd;
-			}
+      AMREX_ASSERT(!std::isnan(vx));
+      AMREX_ASSERT(!std::isnan(vy));
+      AMREX_ASSERT(!std::isnan(vz));
+      AMREX_ASSERT(!std::isnan(rho));
+      AMREX_ASSERT(!std::isnan(P));
 
-			AMREX_ASSERT(!std::isnan(vx));
-			AMREX_ASSERT(!std::isnan(vy));
-			AMREX_ASSERT(!std::isnan(vz));
-			AMREX_ASSERT(!std::isnan(rho));
-			AMREX_ASSERT(!std::isnan(P));
+      const auto v_sq = vx * vx + vy * vy + vz * vz;
+      const auto gamma = HydroSystem<QuirkProblem>::gamma_;
 
-			const auto v_sq = vx * vx + vy * vy + vz * vz;
-			const auto gamma = HydroSystem<QuirkProblem>::gamma_;
+      state(i, j, k, HydroSystem<QuirkProblem>::density_index) = rho;
+      state(i, j, k, HydroSystem<QuirkProblem>::x1Momentum_index) = rho * vx;
+      state(i, j, k, HydroSystem<QuirkProblem>::x2Momentum_index) = rho * vy;
+      state(i, j, k, HydroSystem<QuirkProblem>::x3Momentum_index) = rho * vz;
+      state(i, j, k, HydroSystem<QuirkProblem>::energy_index) =
+          P / (gamma - 1.) + 0.5 * rho * v_sq;
 
-			state(i, j, k, HydroSystem<QuirkProblem>::density_index) = rho;
-			state(i, j, k, HydroSystem<QuirkProblem>::x1Momentum_index) = rho * vx;
-			state(i, j, k, HydroSystem<QuirkProblem>::x2Momentum_index) = rho * vy;
-			state(i, j, k, HydroSystem<QuirkProblem>::x3Momentum_index) = rho * vz;
-			state(i, j, k, HydroSystem<QuirkProblem>::energy_index) =
-			    P / (gamma - 1.) + 0.5 * rho * v_sq;
+      // initialize radiation variables to zero
+      state(i, j, k, RadSystem<QuirkProblem>::radEnergy_index) = 0;
+      state(i, j, k, RadSystem<QuirkProblem>::x1RadFlux_index) = 0;
+      state(i, j, k, RadSystem<QuirkProblem>::x2RadFlux_index) = 0;
+      state(i, j, k, RadSystem<QuirkProblem>::x3RadFlux_index) = 0;
+    });
+  }
 
-			// initialize radiation variables to zero
-			state(i, j, k, RadSystem<QuirkProblem>::radEnergy_index) = 0;
-			state(i, j, k, RadSystem<QuirkProblem>::x1RadFlux_index) = 0;
-			state(i, j, k, RadSystem<QuirkProblem>::x2RadFlux_index) = 0;
-			state(i, j, k, RadSystem<QuirkProblem>::x3RadFlux_index) = 0;
-		});
-	}
+  // set flag
+  areInitialConditionsDefined_ = true;
+}
 
-	// set flag
-	areInitialConditionsDefined_ = true;
+auto getDeltaEntropyVector() -> std::vector<Real> & {
+  static std::vector<Real> delta_s_vec;
+  return delta_s_vec;
+}
+
+template <> void RadhydroSimulation<QuirkProblem>::computeAfterTimestep() {
+  if (amrex::ParallelDescriptor::IOProcessor()) {
+    // it should be sufficient examine a single box on level 0
+    // (no AMR should be used for this problem, and the odd-even decoupling will
+    // manifest in every box, if it happens)
+    amrex::MultiFab &mf_state = state_new_[0];
+    const int box_no = 0;
+    auto const &state = mf_state.array(box_no);
+    amrex::GpuArray<int, 3> box_lo = mf_state.box(box_no).loVect3d();
+    const int jlo = box_lo[2];
+    const int klo = box_lo[3];
+
+    Real dodd =
+        state(ishock, jlo + 1, klo, HydroSystem<QuirkProblem>::density_index);
+    Real podd =
+        HydroSystem<QuirkProblem>::ComputePressure(state, ishock, jlo + 1, klo);
+    Real deven =
+        state(ishock, jlo, klo, HydroSystem<QuirkProblem>::density_index);
+    Real peven =
+        HydroSystem<QuirkProblem>::ComputePressure(state, ishock, jlo, klo);
+
+    // the 'entropy function' s == P / rho^gamma
+    const Real gamma = HydroSystem<QuirkProblem>::gamma_;
+    Real sodd = podd / std::pow(dodd, gamma);
+    Real seven = peven / std::pow(deven, gamma);
+    Real deltas = std::abs(sodd - seven);
+    getDeltaEntropyVector().push_back(deltas);
+  }
+}
+
+template <>
+void RadhydroSimulation<QuirkProblem>::computeAfterEvolve(
+    amrex::Vector<amrex::Real> & /*initSumCons*/) {
+  if (amrex::ParallelDescriptor::IOProcessor()) {
+    auto const &deltas_vec = getDeltaEntropyVector();
+    const Real deltas = *std::max_element(deltas_vec.begin(), deltas_vec.end());
+
+    if (deltas > 0.06) {
+      amrex::Print()
+          << "The scheme suffers from the Carbuncle phenomenon : max delta s = "
+          << deltas << "\n\n";
+      amrex::Abort("Carbuncle detected!");
+    } else {
+      amrex::Print()
+          << "The scheme looks stable against the Carbuncle phenomenon : "
+             "max delta s = "
+          << deltas << "\n\n";
+    }
+  }
 }
 
 template <>
@@ -144,7 +206,7 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(
     consVar(i, j, k, RadSystem<QuirkProblem>::gasEnergy_index) =
         pl / (gamma - 1.) + 0.5 * dl * ul * ul;
     consVar(i, j, k, RadSystem<QuirkProblem>::gasDensity_index) = dl;
-    consVar(i, j, k, RadSystem<QuirkProblem>::x1GasMomentum_index) = dl*ul;
+    consVar(i, j, k, RadSystem<QuirkProblem>::x1GasMomentum_index) = dl * ul;
     consVar(i, j, k, RadSystem<QuirkProblem>::x2GasMomentum_index) = 0.;
     consVar(i, j, k, RadSystem<QuirkProblem>::x3GasMomentum_index) = 0.;
   } else if (i >= hi[0]) {
@@ -152,45 +214,44 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(
     consVar(i, j, k, RadSystem<QuirkProblem>::gasEnergy_index) =
         pr / (gamma - 1.) + 0.5 * dr * ur * ur;
     consVar(i, j, k, RadSystem<QuirkProblem>::gasDensity_index) = dr;
-    consVar(i, j, k, RadSystem<QuirkProblem>::x1GasMomentum_index) = dr*ur;
+    consVar(i, j, k, RadSystem<QuirkProblem>::x1GasMomentum_index) = dr * ur;
     consVar(i, j, k, RadSystem<QuirkProblem>::x2GasMomentum_index) = 0.;
     consVar(i, j, k, RadSystem<QuirkProblem>::x3GasMomentum_index) = 0.;
   }
 }
 
-auto problem_main() -> int
-{
-	// Boundary conditions
-	const int nvars = RadhydroSimulation<QuirkProblem>::nvarTotal_;
-	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		// outflow
-		boundaryConditions[0].setLo(0, amrex::BCType::ext_dir);
-		boundaryConditions[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			// periodic
-			boundaryConditions[n].setLo(i, amrex::BCType::int_dir);
-			boundaryConditions[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+auto problem_main() -> int {
+  // Boundary conditions
+  const int nvars = RadhydroSimulation<QuirkProblem>::nvarTotal_;
+  amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
+  for (int n = 0; n < nvars; ++n) {
+    // outflow
+    boundaryConditions[0].setLo(0, amrex::BCType::ext_dir);
+    boundaryConditions[0].setHi(0, amrex::BCType::ext_dir);
+    for (int i = 1; i < AMREX_SPACEDIM; ++i) {
+      // periodic
+      boundaryConditions[n].setLo(i, amrex::BCType::int_dir);
+      boundaryConditions[n].setHi(i, amrex::BCType::int_dir);
+    }
+  }
 
-	// Problem initialization
-	RadhydroSimulation<QuirkProblem> sim(boundaryConditions);
-	sim.is_hydro_enabled_ = true;
-	sim.is_radiation_enabled_ = false;
-	sim.reconstructionOrder_ = 2; // PLM
-	sim.stopTime_ = 0.4;
-	sim.cflNumber_ = 0.4;
-	sim.maxTimesteps_ = 2000;
-	sim.plotfileInterval_ = 10;
+  // Problem initialization
+  RadhydroSimulation<QuirkProblem> sim(boundaryConditions);
+  sim.is_hydro_enabled_ = true;
+  sim.is_radiation_enabled_ = false;
+  sim.reconstructionOrder_ = 2; // PLM
+  sim.stopTime_ = 0.4;
+  sim.cflNumber_ = 0.4;
+  sim.maxTimesteps_ = 2000;
+  sim.plotfileInterval_ = -1;
 
-	// initialize
-	sim.setInitialConditions();
+  // initialize
+  sim.setInitialConditions();
 
-	// evolve
-	sim.evolve();
+  // evolve
+  sim.evolve();
 
-	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
-	return 0;
+  // Cleanup and exit
+  amrex::Print() << "Finished." << std::endl;
+  return 0;
 }

--- a/tests/quirk.in
+++ b/tests/quirk.in
@@ -13,13 +13,10 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 128 16 8
+amr.n_cell          = 128 16 16
 amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 8   # grid size must be divisible by this
-amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
-
-## grid_eff = 1 forces refinement to respect symmetries of the tagged cells
-amr.grid_eff        = 0.7   # default
+amr.blocking_factor = 16    # grid size must be divisible by this
+amr.max_grid_size   = 128   # must be 128 for this problem
 
 do_reflux = 0
 do_subcycle = 0


### PR DESCRIPTION
Re-implements the [version of the test from Athena++](https://github.com/PrincetonUniversity/athena/blob/master/src/pgen/quirk.cpp) in Quokka.

The original test is from [Quirk, J.J., IJNMF, 18 (6) 555-574 (1994)](https://ui.adsabs.harvard.edu/abs/1994IJNMF..18..555Q/abstract).