### PR TITLE
fix carbuncle correction in 2D

### DIFF
--- a/src/ArrayView.hpp
+++ b/src/ArrayView.hpp
@@ -8,169 +8,18 @@
 /// \file ArrayView.hpp
 /// \brief A container for an array of Reals with template magic to permute indices
 
-// library headers
-#include <AMReX_Utility.H>
+#include <AMReX.H>
 
-// These functions are defined such that, e.g., Array4View<X2>::operator(LOOP_ORDER_X2(i,j,k)) ==
-// arr_(i,j,k). Therefore, they do NOT have the same index ordering as that inside the corresponding
-// Array4View<>::operator()!
+#if AMREX_SPACEDIM == 1
+#include "ArrayView_3d.hpp" // same as 3D
+#endif
 
-enum class FluxDir { X1 = 0, X2 = 1, X3 = 2 };
+#if AMREX_SPACEDIM == 2
+#include "ArrayView_2d.hpp"
+#endif
 
-namespace quokka
-{
-template <FluxDir N> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex(int, int, int);
-
-template <>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X1>(int i, int j, int k)
-{
-	return std::make_tuple(i, j, k);
-}
-
-template <>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X2>(int i, int j, int k)
-{
-	return std::make_tuple(j, k, i);
-}
-
-template <>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X3>(int i, int j, int k)
-{
-	return std::make_tuple(k, i, j);
-}
-
-template <class T, FluxDir N, class Enable = void> struct Array4View {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = N;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-};
-
-// X1-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T &
-	{
-		return arr_(i, j, k, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T &
-	{
-		return arr_(i, j, k);
-	}
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T
-	{
-		return arr_(i, j, k, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T
-	{
-		return arr_(i, j, k);
-	}
-};
-
-// X2-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T &
-	{
-		return arr_(k, i, j, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T &
-	{
-		return arr_(k, i, j);
-	}
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T
-	{
-		return arr_(k, i, j, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T
-	{
-		return arr_(k, i, j);
-	}
-};
-
-// X3-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X3;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T &
-	{
-		return arr_(j, k, i, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T &
-	{
-		return arr_(j, k, i);
-	}
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X3;
-
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
-								 int n) const noexcept -> T
-	{
-		return arr_(j, k, i, n);
-	}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
-	    -> T
-	{
-		return arr_(j, k, i);
-	}
-};
-} // namespace quokka
+#if AMREX_SPACEDIM == 3
+#include "ArrayView_3d.hpp"
+#endif
 
 #endif // ARRAYVIEW_HPP_

--- a/src/ArrayView_2d.hpp
+++ b/src/ArrayView_2d.hpp
@@ -1,0 +1,128 @@
+#ifndef ARRAYVIEW_2D_HPP_
+#define ARRAYVIEW_2D_HPP_
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file ArrayView_2d.hpp
+/// \brief A container for an array of Reals with template magic to permute indices
+
+// library headers
+#include <AMReX_Utility.H>
+
+// These functions are defined such that, e.g., Array4View<X2>::operator(LOOP_ORDER_X2(i,j,k)) ==
+// arr_(i,j,k).
+
+enum class FluxDir { X1 = 0, X2 = 1, X3 = 2 };
+
+namespace quokka
+{
+template <FluxDir N> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex(int, int, int);
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X1>(int i, int j, int k)
+{
+	return std::make_tuple(i, j, k);
+}
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X2>(int i, int j, int k)
+{
+	return std::make_tuple(j, i, k);
+}
+
+template <class T, FluxDir N, class Enable = void> struct Array4View {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = N;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+};
+
+// X1-flux
+
+// if T is non-const
+template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X1;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T &
+	{
+		return arr_(i, j, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T &
+	{
+		return arr_(i, j, k);
+	}
+};
+
+// if T is const
+template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X1;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T
+	{
+		return arr_(i, j, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T
+	{
+		return arr_(i, j, k);
+	}
+};
+
+// X2-flux
+
+// if T is non-const
+template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X2;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T &
+	{
+		return arr_(j, i, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T &
+	{
+		return arr_(j, i, k);
+	}
+};
+
+// if T is const
+template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X2;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T
+	{
+		return arr_(j, i, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T
+	{
+		return arr_(j, i, k);
+	}
+};
+
+} // namespace quokka
+
+#endif // ARRAYVIEW__2D_HPP_

--- a/src/ArrayView_3d.hpp
+++ b/src/ArrayView_3d.hpp
@@ -1,0 +1,176 @@
+#ifndef ARRAYVIEW_3D_HPP_
+#define ARRAYVIEW_3D_HPP_
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file ArrayView.hpp
+/// \brief A container for an array of Reals with template magic to permute indices
+
+// library headers
+#include <AMReX_Utility.H>
+
+// These functions are defined such that, e.g., Array4View<X2>::operator(LOOP_ORDER_X2(i,j,k)) ==
+// arr_(i,j,k). Therefore, they do NOT have the same index ordering as that inside the corresponding
+// Array4View<>::operator()!
+
+enum class FluxDir { X1 = 0, X2 = 1, X3 = 2 };
+
+namespace quokka
+{
+template <FluxDir N> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex(int, int, int);
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X1>(int i, int j, int k)
+{
+	return std::make_tuple(i, j, k);
+}
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X2>(int i, int j, int k)
+{
+	return std::make_tuple(j, k, i);
+}
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X3>(int i, int j, int k)
+{
+	return std::make_tuple(k, i, j);
+}
+
+template <class T, FluxDir N, class Enable = void> struct Array4View {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = N;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+};
+
+// X1-flux
+
+// if T is non-const
+template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X1;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T &
+	{
+		return arr_(i, j, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T &
+	{
+		return arr_(i, j, k);
+	}
+};
+
+// if T is const
+template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X1;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T
+	{
+		return arr_(i, j, k, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T
+	{
+		return arr_(i, j, k);
+	}
+};
+
+// X2-flux
+
+// if T is non-const
+template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X2;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T &
+	{
+		return arr_(k, i, j, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T &
+	{
+		return arr_(k, i, j);
+	}
+};
+
+// if T is const
+template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X2;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T
+	{
+		return arr_(k, i, j, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T
+	{
+		return arr_(k, i, j);
+	}
+};
+
+// X3-flux
+
+// if T is non-const
+template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<!std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X3;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T &
+	{
+		return arr_(j, k, i, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T &
+	{
+		return arr_(j, k, i);
+	}
+};
+
+// if T is const
+template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<std::is_const_v<T>>> {
+	amrex::Array4<T> arr_;
+	constexpr static FluxDir indexOrder = FluxDir::X3;
+
+	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
+								 int n) const noexcept -> T
+	{
+		return arr_(j, k, i, n);
+	}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept
+	    -> T
+	{
+		return arr_(j, k, i);
+	}
+};
+} // namespace quokka
+
+#endif // ARRAYVIEW_3D_HPP_

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -150,7 +150,7 @@ template <> void RadhydroSimulation<QuirkProblem>::computeAfterTimestep() {
       amrex::GpuArray<int, 3> box_lo = bx.loVect3d();
       jlo = box_lo[1];
       klo = box_lo[2];
-      amrex::IntVect cell{ilo, jlo, klo};
+      amrex::IntVect cell{AMREX_D_DECL(ilo, jlo, klo)};
       if (bx.contains(cell)) {
         box_no = mfi.index();
         break;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -679,9 +679,15 @@ void HydroSystem<problem_t>::ComputeFluxes(
     } else if constexpr (DIR == FluxDir::X2) {
       u_L = vy_L;
       u_R = vy_R;
-      velN_index = x2Velocity_index;
-      velV_index = x3Velocity_index;
-      velW_index = x1Velocity_index;
+      if constexpr (AMREX_SPACEDIM == 2) {
+        velN_index = x2Velocity_index;
+        velV_index = x1Velocity_index;
+        velW_index = x3Velocity_index; // unchanged in 2D
+      } else if constexpr (AMREX_SPACEDIM == 3) {
+        velN_index = x2Velocity_index;
+        velV_index = x3Velocity_index;
+        velW_index = x1Velocity_index;
+      }
     } else if constexpr (DIR == FluxDir::X3) {
       u_L = vz_L;
       u_R = vz_R;
@@ -728,9 +734,11 @@ void HydroSystem<problem_t>::ComputeFluxes(
     double dw = std::min(dvl, dvr);
 #endif
 #if AMREX_SPACEDIM == 3
-    amrex::Real dwl = std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index),
+    amrex::Real dwl =
+        std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index),
                  q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
-    amrex::Real dwr = std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index),
+    amrex::Real dwr =
+        std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index),
                  q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
     dw = std::min(std::min(dwl, dwr), dw);
 #endif


### PR DESCRIPTION
Fixes an index permutation bug in the carbuncle correction when `AMREX_SPACEDIM` is 2. This does not affect 3D simulations.