### PR TITLE
add stop_time, plotfile_interval, and checkpoint_interval parameters

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -377,6 +377,15 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters() {
   // Default CFL number == 0.3, set to whatever is in the file
   pp.query("cfl", cflNumber_);
 
+  // Default stopping time
+  pp.query("stop_time", stopTime_);
+
+  // Default output interval
+  pp.query("plotfile_interval", plotfileInterval_);
+
+  // Default checkpoint interval
+  pp.query("checkpoint_interval", checkpointInterval_);
+
   // Default do_reflux = 1
   pp.query("do_reflux", do_reflux);
 


### PR DESCRIPTION
Read stop_time, plotfile_interval, and checkpoint_interval from ParmParse file (*.in file).