### PR TITLE
add CFL-respecting AMR subcycling

### DIFF
--- a/src/Advection2D/CMakeLists.txt
+++ b/src/Advection2D/CMakeLists.txt
@@ -3,4 +3,6 @@ if (AMReX_SPACEDIM GREATER_EQUAL 2)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_advection2d)
     endif()
+    
+    add_test(NAME Advection2D COMMAND test_advection2d advection2d_amr.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -144,8 +144,8 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.cflNumber_ = CFL_number;
 	sim.maxTimesteps_ = max_timesteps;
-	sim.plotfileInterval_ = 10;   // for debugging
-	sim.checkpointInterval_ = 10; // for debugging
+	sim.plotfileInterval_ = 100;   // for debugging
+	sim.checkpointInterval_ = 1000; // for debugging
 
 	sim.advectionVx_ = advection_velocity;
 	sim.advectionVy_ = advection_velocity;

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -26,136 +26,147 @@
 #include "AdvectionSimulation.hpp"
 #include "test_advection2d.hpp"
 
-struct SquareProblem {
-};
+using amrex::Real;
+
+struct SquareProblem {};
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto
-exactSolutionAtIndex(int i, int j, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-		     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
-		     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx) -> amrex::Real
-{
-	amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
-	amrex::Real const y = prob_lo[1] + (j + amrex::Real(0.5)) * dx[1];
-	amrex::Real const x0 = prob_lo[0] + amrex::Real(0.5) * (prob_hi[0] - prob_lo[0]);
-	amrex::Real const y0 = prob_lo[1] + amrex::Real(0.5) * (prob_hi[1] - prob_lo[1]);
-	amrex::Real rho = 0.;
+exactSolutionAtIndex(int i, int j,
+                     amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo,
+                     amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
+                     amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx) -> Real {
+  Real const x = prob_lo[0] + (i + Real(0.5)) * dx[0];
+  Real const y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+  Real const x0 = prob_lo[0] + Real(0.5) * (prob_hi[0] - prob_lo[0]);
+  Real const y0 = prob_lo[1] + Real(0.5) * (prob_hi[1] - prob_lo[1]);
 
-	if ((std::abs(x - x0) < 0.1) && (std::abs(y - y0) < 0.1)) {
-		rho = 1.;
-	}
-	return rho;
-}
-
-template <> void AdvectionSimulation<SquareProblem>::setInitialConditionsAtLevel(int level)
-{
-	auto prob_lo = geom[level].ProbLoArray();
-	auto prob_hi = geom[level].ProbHiArray();
-	auto dx = geom[level].CellSizeArray();
-
-	for (amrex::MFIter iter(state_old_[level]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox(); // excludes ghost zones
-		auto const &state = state_new_[level].array(iter);
-
-		amrex::ParallelFor(
-		    indexRange, ncomp_, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
-			    state(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx);
-		    });
-	}
-
-	// set flag
-	areInitialConditionsDefined_ = true;
-}
-
-void ComputeExactSolution(amrex::Array4<amrex::Real> const &exact_arr, amrex::Box const &indexRange,
-			  const int nvars,
-			  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const prob_lo,
-			  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const prob_hi,
-			  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
-{
-	amrex::ParallelFor(indexRange, nvars, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
-		exact_arr(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx);
-	});
+  Real rho = 0.;
+  if ((std::abs(x - x0) < 0.1) && (std::abs(y - y0) < 0.1)) {
+    rho = 1.;
+  }
+  return rho;
 }
 
 template <>
-void AdvectionSimulation<SquareProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags,
-						  amrex::Real /*time*/, int /*ngrow*/)
-{
-	// tag cells for refinement
+void AdvectionSimulation<SquareProblem>::setInitialConditionsAtLevel(
+    int level) {
+  auto prob_lo = geom[level].ProbLoArray();
+  auto prob_hi = geom[level].ProbHiArray();
+  auto dx = geom[level].CellSizeArray();
 
-	const amrex::Real eta_threshold = 0.5; // gradient refinement threshold
-	const amrex::Real rho_min = 0.1;       // minimum rho for refinement
+  for (amrex::MFIter iter(state_old_[level]); iter.isValid(); ++iter) {
+    const amrex::Box &indexRange = iter.validbox(); // excludes ghost zones
+    auto const &state = state_new_[level].array(iter);
 
-	for (amrex::MFIter mfi(state_new_[lev]); mfi.isValid(); ++mfi) {
-		const amrex::Box &box = mfi.validbox();
-		const auto state = state_new_[lev].const_array(mfi);
-		const auto tag = tags.array(mfi);
+    amrex::ParallelFor(
+        indexRange, ncomp_, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
+          state(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx);
+        });
+  }
 
-		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			int const n = 0;
-			amrex::Real const rho = state(i, j, k, n);
-
-			amrex::Real const del_x = std::max(std::abs(state(i + 1, j, k, n) - rho),
-							   std::abs(rho - state(i - 1, j, k, n)));
-			amrex::Real const del_y = std::max(std::abs(state(i, j + 1, k, n) - rho),
-							   std::abs(rho - state(i, j - 1, k, n)));
-			amrex::Real const gradient_indicator =
-			    std::max(del_x, del_y) / std::max(rho, rho_min);
-
-			if (gradient_indicator > eta_threshold) {
-				tag(i, j, k) = amrex::TagBox::SET;
-			}
-		});
-	}
+  // set flag
+  areInitialConditionsDefined_ = true;
 }
 
-auto problem_main() -> int
-{
-	// check that we are in strict IEEE 754 mode
-	// (If we are, then the results should be symmetric [about the diagonal of the grid] not
-	// only to machine epsilon but to every last digit! BUT not necessarily true when refinement
-	// is enabled.)
-	static_assert(std::numeric_limits<double>::is_iec559);
+template <>
+void AdvectionSimulation<SquareProblem>::computeReferenceSolution(
+    amrex::MultiFab &ref,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi) {
+  // compute exact solution
 
-	// Problem parameters
-	const int nx = 100;
-	const double Lx = 1.0;
-	const double advection_velocity = 1.0; // same for x- and y- directions
-	const double CFL_number = 0.4;
-	const double max_time = 1.0;
-	const int max_timesteps = 1e4;
-	const int nvars = 1; // only density
+  for (amrex::MFIter iter(state_old_[0]); iter.isValid(); ++iter) {
+    const amrex::Box &indexRange = iter.validbox();
+    auto const &state = ref.array(iter);
 
-	amrex::IntVect gridDims{AMREX_D_DECL(nx, nx, 4)};
+    amrex::ParallelFor(
+        indexRange, ncomp_, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
+          state(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx);
+        });
+  }
+}
 
-	amrex::RealBox boxSize{{AMREX_D_DECL(amrex::Real(0.0), amrex::Real(0.0), amrex::Real(0.0))},
-			       {AMREX_D_DECL(amrex::Real(Lx), amrex::Real(Lx), amrex::Real(1.0))}};
+template <>
+void AdvectionSimulation<SquareProblem>::ErrorEst(int lev,
+                                                  amrex::TagBoxArray &tags,
+                                                  Real /*time*/,
+                                                  int /*ngrow*/) {
+  // tag cells for refinement
 
-	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			boundaryConditions[n].setLo(i, amrex::BCType::int_dir); // periodic
-			boundaryConditions[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+  const Real eta_threshold = 0.5; // gradient refinement threshold
+  const Real rho_min = 0.1;       // minimum rho for refinement
+  auto const &dx = geom[lev].CellSizeArray();
 
-	// Problem initialization
-	AdvectionSimulation<SquareProblem> sim(gridDims, boxSize, boundaryConditions);
-	sim.stopTime_ = max_time;
-	sim.cflNumber_ = CFL_number;
-	sim.maxTimesteps_ = max_timesteps;
-	sim.plotfileInterval_ = 100;   // for debugging
-	sim.checkpointInterval_ = 1000; // for debugging
+  for (amrex::MFIter mfi(state_new_[lev]); mfi.isValid(); ++mfi) {
+    const amrex::Box &box = mfi.validbox();
+    const auto state = state_new_[lev].const_array(mfi);
+    const auto tag = tags.array(mfi);
 
-	sim.advectionVx_ = advection_velocity;
-	sim.advectionVy_ = advection_velocity;
+    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+      int const n = 0;
+      Real const rho = state(i, j, k, n);
 
-	// set initial conditions
-	sim.setInitialConditions();
+      Real const del_x =
+          (state(i + 1, j, k, n) - state(i - 1, j, k, n)) / (2.0 * dx[0]);
+      Real const del_y =
+          (state(i, j + 1, k, n) - state(i, j - 1, k, n)) / (2.0 * dx[1]);
+      Real const gradient_indicator =
+          std::sqrt(del_x * del_x + del_y * del_y) / rho;
 
-	// run simulation
-	sim.evolve();
+      if (gradient_indicator > eta_threshold && rho >= rho_min) {
+        tag(i, j, k) = amrex::TagBox::SET;
+      }
+    });
+  }
+}
 
-	int status = 0;
-	return status;
+auto problem_main() -> int {
+  // check that we are in strict IEEE 754 mode
+  // (If we are, then the results should be symmetric [about the diagonal of the
+  // grid] not only to machine epsilon but to every last digit! BUT not
+  // necessarily true when refinement is enabled.)
+  static_assert(std::numeric_limits<double>::is_iec559);
+
+  // Problem parameters
+  // const int nx = 100;
+  // const double Lx = 1.0;
+  const double advection_velocity = 1.0; // same for x- and y- directions
+  const double CFL_number = 0.4;
+  const double max_time = 1.0;
+  const int max_timesteps = 1e4;
+  const int nvars = 1;
+
+  amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
+  for (int n = 0; n < nvars; ++n) {
+    for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+      boundaryConditions[n].setLo(i, amrex::BCType::int_dir); // periodic
+      boundaryConditions[n].setHi(i, amrex::BCType::int_dir);
+    }
+  }
+
+  // Problem initialization
+  AdvectionSimulation<SquareProblem> sim(boundaryConditions);
+  sim.stopTime_ = max_time;
+  sim.cflNumber_ = CFL_number;
+  sim.maxTimesteps_ = max_timesteps;
+  sim.plotfileInterval_ = 1000;
+  sim.checkpointInterval_ = -1;
+
+  sim.advectionVx_ = advection_velocity;
+  sim.advectionVy_ = advection_velocity;
+
+  // set initial conditions
+  sim.setInitialConditions();
+
+  // run simulation
+  sim.evolve();
+
+  int status;
+  if (sim.errorNorm_ < 0.15) {
+    status = 0;
+  } else {
+    status = 1;
+  }
+  return status;
 }

--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -198,7 +198,7 @@ void AdvectionSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Rea
 	const double rel_error = err_norm / sol_norm;
 	errorNorm_ = rel_error;
 
-	amrex::Print() << "Relative rms L1 error norm = " << rel_error << "\n\n";
+	amrex::Print() << "\nRelative rms L1 error norm = " << rel_error << "\n\n";
 }
 
 template <typename problem_t>

--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -81,7 +81,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void computeMaxSignalLocal(int level) override;
 	void setInitialConditionsAtLevel(int level) override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
-					  int /*iteration*/, int /*ncycle*/) override;
+					  				  int /*ncycle*/) override;
 	void computeAfterTimestep() override;
 	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
 	void computeReferenceSolution(
@@ -203,8 +203,7 @@ void AdvectionSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Rea
 
 template <typename problem_t>
 void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time,
-								  amrex::Real dt_lev,
-								  int /*iteration*/, int /*ncycle*/)
+								  amrex::Real dt_lev, int /*ncycle*/)
 {
 	// based on amrex/Tests/EB/CNS/Source/CNS_advance.cpp
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,14 +58,15 @@ endif(DISABLE_FMAD)
 # this is necessary to prevent the host compiler from complaining about nv_pragmas
 #add_compile_options(-Wno-unknown-pragmas)
 
-if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
-  add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>)
-endif()
-if(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
-  add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Xcuda-ptxas>)
-  add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-v>)
-  add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Wno-unused-command-line-argument>)
-endif()
+# emit register usage per thread from CUDA assembler
+# if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")
+#   add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:--ptxas-options=-v>)
+# endif()
+# if(CMAKE_CUDA_COMPILER_ID STREQUAL "Clang")
+#   add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Xcuda-ptxas>)
+#   add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-v>)
+#   add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Wno-unused-command-line-argument>)
+# endif()
 
 
 include_directories(${amrex_INCLUDE_DIRS_RET})

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -273,7 +273,8 @@ void computeCooling(amrex::MultiFab &mf, const Real dt_in,
 
       // do integration with RK2 (Heun's method)
       int steps_taken = 0;
-      rk_adaptive_integrate(user_rhs, 0, y, dt, &user_data, rtol, abstol, steps_taken);
+      rk_adaptive_integrate(user_rhs, 0, y, dt, &user_data, rtol, abstol,
+                            steps_taken);
 
       const Real Egas_new = RadSystem<CoolingTest>::ComputeEgasFromEint(
           rho, x1Mom, x2Mom, x3Mom, y[0]);
@@ -285,8 +286,7 @@ void computeCooling(amrex::MultiFab &mf, const Real dt_in,
 
 template <>
 void RadhydroSimulation<CoolingTest>::computeAfterLevelAdvance(
-    int lev, amrex::Real /*time*/, amrex::Real dt_lev, int /*iteration*/,
-    int /*ncycle*/) {
+    int lev, amrex::Real /*time*/, amrex::Real dt_lev, int /*ncycle*/) {
   // compute operator split physics
   computeCooling(state_new_[lev], dt_lev, cloudyTables);
 }

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -128,10 +128,10 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	void computeMaxSignalLocal(int level) override;
 	void setInitialConditionsAtLevel(int level) override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
-					  int iteration, int ncycle) override;
+									  int ncycle) override;
 	void computeAfterTimestep() override;
 	void computeAfterLevelAdvance(int lev, amrex::Real time,
-								 amrex::Real dt_lev, int /*iteration*/, int /*ncycle*/);
+								 amrex::Real dt_lev, int /*ncycle*/);
 	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
 	void computeReferenceSolution(amrex::MultiFab &ref,
 		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
@@ -294,7 +294,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterTi
 
 template <typename problem_t>
 void RadhydroSimulation<problem_t>::computeAfterLevelAdvance(int lev, amrex::Real time,
-								 amrex::Real dt_lev, int iteration, int ncycle)
+								 amrex::Real dt_lev, int ncycle)
 {
 	// user should implement if desired
 }
@@ -381,8 +381,7 @@ void RadhydroSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real
 
 template <typename problem_t>
 void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time,
-								 amrex::Real dt_lev,
-								 int iteration, int ncycle)
+								 amrex::Real dt_lev, int ncycle)
 {
 	BL_PROFILE("RadhydroSimulation::advanceSingleTimestepAtLevel()");
 
@@ -426,7 +425,7 @@ void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex:
 	CHECK_HYDRO_STATES(state_new_[lev]);
 
 	// compute any operator-split terms here (user-defined)
-	computeAfterLevelAdvance(lev, time, dt_lev, iteration, ncycle);
+	computeAfterLevelAdvance(lev, time, dt_lev, ncycle);
 
 	// check hydro states after user work
 	CHECK_HYDRO_STATES(state_new_[lev]);

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -335,7 +335,7 @@ void computeCooling(amrex::MultiFab &mf, const Real dt_in,
 
 template <>
 void RadhydroSimulation<ShockCloud>::computeAfterLevelAdvance(
-    int lev, Real /*time*/, Real dt_lev, int /*iteration*/, int /*ncycle*/) {
+    int lev, Real /*time*/, Real dt_lev, int /*ncycle*/) {
   // compute operator split physics
   computeCooling(state_new_[lev], dt_lev, cloudyTables);
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -86,8 +86,6 @@ public:
   amrex::Vector<amrex::Real> tNew_; // for state_new_
   amrex::Vector<amrex::Real> tOld_; // for state_old_
   amrex::Vector<amrex::Real> dt_;   // timestep for each level
-  // amrex::Vector<amrex::Real> dtCur_; // timestep for each level
-  // (recalculated)
   amrex::Vector<int>
       reductionFactor_;         // timestep reduction factor for each level
   amrex::Real stopTime_ = 1.0;  // default
@@ -279,7 +277,6 @@ void AMRSimulation<problem_t>::initialize(
   tNew_.resize(nlevs_max, 0.0);
   tOld_.resize(nlevs_max, -1.e100);
   dt_.resize(nlevs_max, 1.e100);
-  // dtCur_.resize(nlevs_max, 1.e100);
   reductionFactor_.resize(nlevs_max, 1);
   state_new_.resize(nlevs_max);
   state_old_.resize(nlevs_max);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -739,8 +739,8 @@ auto AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
 
         if (verbose) {
           amrex::Print() << "\t\tLevel " << i << ": factor: " << divisor << " ("
-                         << reductionFactor_[i] << "), dt: " << dt_[i]
-                         << std::endl;
+                         << reductionFactor_[i] << "), "
+                         << "dt: " << dt_[i] << std::endl;
         }
 
         reductionFactor_[i] = maxFactorSublevels;

--- a/tests/advection2d_amr.in
+++ b/tests/advection2d_amr.in
@@ -1,0 +1,22 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  1.0
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 64 64 4
+amr.max_level       = 1      # number of levels = max_level + 1
+amr.blocking_factor = 16     # grid size must be divisible by this
+amr.max_grid_size   = 64
+
+do_reflux = 1
+do_subcycle = 1

--- a/tests/advection2d_amr.in
+++ b/tests/advection2d_amr.in
@@ -8,15 +8,15 @@ geometry.is_periodic =  1    1    1
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v              = 1       # verbosity in Amr
+amr.v              = 0       # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 64 64 4
-amr.max_level       = 1      # number of levels = max_level + 1
-amr.blocking_factor = 16     # grid size must be divisible by this
-amr.max_grid_size   = 64
+amr.n_cell          = 64 64 8
+amr.max_level       = 3      # number of levels = max_level + 1
+amr.blocking_factor = 8     # grid size must be divisible by this
+amr.max_grid_size   = 16
 
 do_reflux = 1
 do_subcycle = 1

--- a/tests/shocktube.in
+++ b/tests/shocktube.in
@@ -8,14 +8,17 @@ geometry.is_periodic =  0    1    1
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v              = 0       # verbosity in Amr
+amr.v              = 1       # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 1000 4 4
-amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 4     # grid size must be divisible by this
+amr.n_cell          = 1024 16 16
+amr.max_level       = 1     # number of levels = max_level + 1
+amr.blocking_factor = 16    # grid size must be divisible by this
 
-do_reflux = 0
-do_subcycle = 0
+do_reflux = 1
+do_subcycle = 1
+
+plotfile_interval = 1000
+cfl = 0.6


### PR DESCRIPTION
Follows the Chombo implementation [1].

The first timestep of the HydroShocktube problem (with AMR enabled) is a good test of this functionality, since the wave structure is highly nonlinear. However, it needs additional testing with real problems.

_Note:_ the function signature of `RadhydroSimulation<problem_t>::computeAfterLevelAdvance` has changed.
Problems that specialize this function will need to be updated.

[1] https://github.com/applied-numerical-algorithms-group-lbnl/Chombo_3.2/blob/master/lib/src/AMRTimeDependent/AMR.cpp#L1063