### PR TITLE
include ghost cells in plotfiles and ascent renders

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1193,7 +1193,7 @@ auto AMRSimulation<problem_t>::PlotFileMFAtLevel(int lev) const
     -> amrex::MultiFab {
   // Combine state_new_[lev] and derived variables in a new MF
   int comp = 0;
-  const int nGrow = 0;
+  const int nGrow = state_new_[lev].nGrow(); // workaround Ascent bug
   const int nCompState = state_new_[lev].nComp();
   const int nCompDeriv = derivedNames_.size();
   const int nCompPlotMF = nCompState + nCompDeriv;


### PR DESCRIPTION
This is to work around a bug in the AMReX / Blueprint integration that causes it to not correctly connect the AMR grids when nGrow == 0 [1].

This also fixes AMR rendering issues seen in slice plots. However, this does _not_ fix the rendering issues seen in volume renders [1].

[1] https://github.com/Alpine-DAV/ascent/issues/955