### PR TITLE
allow arbitrary number of scalars in riemann solver

### DIFF
--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -24,11 +24,18 @@ template <typename T, int d> class valarray
       public:
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray() = default;
 
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit valarray(T val) {
+		// initialize all components with input value 'val'
+		for(size_t i = 0; i < d; ++i) {
+			values[i] = val;
+		}
+	}
+
 	// we *want* implicit construction from initializer lists for valarrays,
 	// (although not cppcore-compliant)
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(std::initializer_list<T> list) // NOLINT
 	{
-		AMREX_ASSERT(list.size() == d);
+		AMREX_ASSERT(list.size() <= d);
 		T const *input =
 		    std::data(list); // requires nvcc to be in C++17 mode! (if it fails, the
 				     // compiler flags are wrong, probably due to a CMake issue.)


### PR DESCRIPTION
This simplifies the Riemann solver, and assumes that any components of the hydro state vector left over at the end (i.e., after the auxiliary internal energy component) are passive scalars. The total size of the hydro state vector is read from `HydroSystem::nvar_`, which is set at compile time.