### PR TITLE
[WIP] use HyperbolicSystem RK2 functions in hydro advance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,8 @@ option(ENABLE_ASAN "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
   enable_language(CUDA)
   
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.2)
-    message(FATAL_ERROR "For best performance, you must use CUDA 11.2 or higher to compile Quokka. It is strongly recommended to use a newer version of CUDA.")
-  endif()
-  if(CMAKE_CUDA_COMPILER_VERSION MATCHES 11.6)
-    message(FATAL_ERROR "You must use a CUDA version 11.2-11.5 to compile Quokka. CUDA 11.6 has compiler bugs that cause Quokka to crash.")
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.7)
+    message(FATAL_ERROR "You must use CUDA 11.7 or higher to compile Quokka. All previous versions have compiler bugs that cause compilation to fail or runtime crashes.")
   endif()
 
   set(CMAKE_CUDA_ARCHITECTURES 70 80 CACHE STRING "")

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -500,6 +500,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		    {AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
 				  fluxArrays[2].const_array())},
 		    dt_lev, geom[lev].CellSizeArray(), indexRange, ncompHydro_,
+			HydroSystem<problem_t>::isStateValid,
 			redoFlag.array());
 
 		// first-order flux correction (FOFC)
@@ -526,6 +527,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 					{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
 						fluxArrays[2].const_array())},
 					dt_lev, geom[lev].CellSizeArray(), indexRange, ncompHydro_,
+					HydroSystem<problem_t>::isStateValid,
 					redoFlag.array());
 
 				if(redoFlag.max<amrex::RunOn::Device>() == quokka::redoFlag::none) {
@@ -576,6 +578,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 				{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
 					fluxArrays[2].const_array())},
 				dt_lev, geom[lev].CellSizeArray(), indexRange, ncompHydro_,
+				HydroSystem<problem_t>::isStateValid,
 				redoFlag.array());
 
 			// first-order flux correction (FOFC)
@@ -602,6 +605,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 						{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
 							fluxArrays[2].const_array())},
 						dt_lev, geom[lev].CellSizeArray(), indexRange, ncompHydro_,
+						HydroSystem<problem_t>::isStateValid,
 						redoFlag.array());
 
 					if(redoFlag.max<amrex::RunOn::Device>() == quokka::redoFlag::none) {

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -82,20 +82,6 @@ public:
   isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j,
                int k) -> bool;
 
-  static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew,
-                          std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray,
-                          double dt_in,
-                          amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in,
-                          amrex::Box const &indexRange, int nvars,
-                          amrex::Array4<int> const &redoFlag);
-
-  static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1,
-                           std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray,
-                           double dt_in,
-                           amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in,
-                           amrex::Box const &indexRange, int nvars,
-                           amrex::Array4<int> const &redoFlag);
-
   static void AddInternalEnergyPressureTerm(
       amrex::Array4<amrex::Real> const &consVar,
       amrex::Array4<const amrex::Real> const &primVar,
@@ -349,115 +335,6 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(
   // return (isDensityPositive && isPressurePositive);
 
   return isDensityPositive;
-}
-
-template <typename problem_t>
-void HydroSystem<problem_t>::PredictStep(
-    arrayconst_t &consVarOld, array_t &consVarNew,
-    std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, const double dt_in,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in,
-    amrex::Box const &indexRange, const int nvars_in,
-    amrex::Array4<int> const &redoFlag) {
-  BL_PROFILE("HydroSystem::PredictStep()");
-
-  // By convention, the fluxes are defined on the left edge of each zone,
-  // i.e. flux_(i) is the flux *into* zone i through the interface on the
-  // left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
-  // the interface on the right of zone i.
-
-  int const nvars = nvars_in; // workaround nvcc bug
-
-  auto const dt = dt_in;
-  auto const dx = dx_in[0];
-  auto const x1Flux = fluxArray[0];
-#if (AMREX_SPACEDIM >= 2)
-  auto const dy = dx_in[1];
-  auto const x2Flux = fluxArray[1];
-#endif
-#if (AMREX_SPACEDIM == 3)
-  auto const dz = dx_in[2];
-  auto const x3Flux = fluxArray[2];
-#endif
-
-  amrex::ParallelFor(
-      indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        for (int n = 0; n < nvars; ++n) {
-          consVarNew(i, j, k, n) =
-              consVarOld(i, j, k, n) +
-              (AMREX_D_TERM(
-                  (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n)),
-                  +(dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n)),
-                  +(dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n))));
-        }
-
-        // check if state is valid -- flag for re-do if not
-        if (!isStateValid(consVarNew, i, j, k)) {
-          redoFlag(i, j, k) = quokka::redoFlag::redo;
-        } else {
-          redoFlag(i, j, k) = quokka::redoFlag::none;
-        }
-      });
-}
-
-template <typename problem_t>
-void HydroSystem<problem_t>::AddFluxesRK2(
-    array_t &U_new, arrayconst_t &U0, arrayconst_t &U1,
-    std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, const double dt_in,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in,
-    amrex::Box const &indexRange, const int nvars_in,
-    amrex::Array4<int> const &redoFlag) {
-  BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
-
-  // By convention, the fluxes are defined on the left edge of each zone,
-  // i.e. flux_(i) is the flux *into* zone i through the interface on the
-  // left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
-  // the interface on the right of zone i.
-
-  int const nvars = nvars_in; // workaround nvcc bug
-
-  auto const dt = dt_in;
-  auto const dx = dx_in[0];
-  auto const x1Flux = fluxArray[0];
-#if (AMREX_SPACEDIM >= 2)
-  auto const dy = dx_in[1];
-  auto const x2Flux = fluxArray[1];
-#endif
-#if (AMREX_SPACEDIM == 3)
-  auto const dz = dx_in[2];
-  auto const x3Flux = fluxArray[2];
-#endif
-
-  amrex::ParallelFor(
-      indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        for (int n = 0; n < nvars; ++n) {
-          // RK-SSP2 integrator
-          const double U_0 = U0(i, j, k, n);
-          const double U_1 = U1(i, j, k, n);
-
-          const double FxU_1 =
-              (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n));
-#if (AMREX_SPACEDIM >= 2)
-          const double FyU_1 =
-              (dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n));
-#endif
-#if (AMREX_SPACEDIM == 3)
-          const double FzU_1 =
-              (dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n));
-#endif
-
-          // save results in U_new
-          U_new(i, j, k, n) =
-              (0.5 * U_0 + 0.5 * U_1) +
-              (AMREX_D_TERM(0.5 * FxU_1, +0.5 * FyU_1, +0.5 * FzU_1));
-        }
-
-        // check if state is valid -- flag for re-do if not
-        if (!isStateValid(U_new, i, j, k)) {
-          redoFlag(i, j, k) = quokka::redoFlag::redo;
-        } else {
-          redoFlag(i, j, k) = quokka::redoFlag::none;
-        }
-      });
 }
 
 template <typename problem_t>


### PR DESCRIPTION
This uses the generic HyperbolicSystem::PredictStep and HyperbolicSystem::AddFluxesRK2 functions instead of the overriden versions in HydroSystem.

**Currently does not work due to a bug in C++ template handling in extended device lambdas in all versions of CUDA:**

```
FAILED: src/HydroBlast2D/CMakeFiles/test_hydro2d_blast.dir/test_hydro2d_blast.cpp.o 
/priv/avatar/bwibking/spack/opt/spack/linux-rocky8-cascadelake/gcc-11.2.0/cuda-11.7.0-jiqistvbod637gtrrcyiq67c7qwtir3g/bin/nvcc -forward-unknown-to-host-compiler  -I../src -I../extern/amrex/Src/Base -I../extern/amrex/Src/Base/Parser -I../extern/amrex/Src/Boundary -I../extern/amrex/Src/AmrCore -Iamrex -I../extern/fmt/include -isystem=/priv/avatar/bwibking/spack/opt/spack/linux-rocky8-cascadelake/gcc-11.2.0/openmpi-4.1.4-kk5i3mp6u7ufh4wf52vgozyzoaaxlasj/include -isystem=/priv/avatar/bwibking/spack/opt/spack/linux-rocky8-cascadelake/gcc-11.2.0/cuda-11.7.0-jiqistvbod637gtrrcyiq67c7qwtir3g/include -isystem=/priv/avatar/bwibking/spack/opt/spack/linux-rocky8-cascadelake/gcc-11.2.0/hdf5-1.8.22-e4ibsu7pdh7iqh5rjjpv2q7aur2j73o2/include -O3 -DNDEBUG --generate-code=arch=compute_70,code=[compute_70,sm_70] --generate-code=arch=compute_80,code=[compute_80,sm_80] --fmad=false --expt-relaxed-constexpr --expt-extended-lambda -Xcudafe --diag_suppress=esa_on_defaulted_function_ignored -maxrregcount=255 -Xcudafe --display_error_number --Wext-lambda-captures-this --use_fast_math --generate-line-info --source-in-ptx -Xcompiler -pthread -std=c++17 -MD -MT src/HydroBlast2D/CMakeFiles/test_hydro2d_blast.dir/test_hydro2d_blast.cpp.o -MF src/HydroBlast2D/CMakeFiles/test_hydro2d_blast.dir/test_hydro2d_blast.cpp.o.d -x cu -dc ../src/HydroBlast2D/test_hydro2d_blast.cpp -o src/HydroBlast2D/CMakeFiles/test_hydro2d_blast.dir/test_hydro2d_blast.cpp.o
nvcc_internal_extended_lambda_implementation: In instantiation of 'struct __nv_dl_wrapper_t<__nv_dl_tag<void (*)(const amrex::Array4<const double>&, const amrex::Array4<double>&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, bool (&)(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int>&), HyperbolicSystem<BlastProblem>::PredictStep<bool (&)(const amrex::Array4<const double>&, int, int, int)>, 1>, const int, const amrex::Array4<double>, const amrex::Array4<const double>, const double, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, bool(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int> >':
../src/hyperbolic_system.hpp:344:32:   required from 'static void HyperbolicSystem<problem_t>::PredictStep(arrayconst_t&, array_t&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, F&&, const amrex::Array4<int>&) [with F = bool (&)(const amrex::Array4<const double>&, int, int, int); problem_t = BlastProblem; arrayconst_t = const amrex::Array4<const double>; array_t = const amrex::Array4<double>]'
/tmp/tmpxft_0004150f_00000000-6_test_hydro2d_blast.compute_80.cudafe1.stub.c:83:610:   required from here
nvcc_internal_extended_lambda_implementation:332:44: error: data member '__nv_dl_wrapper_t<__nv_dl_tag<void (*)(const amrex::Array4<const double>&, const amrex::Array4<double>&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, bool (&)(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int>&), HyperbolicSystem<BlastProblem>::PredictStep<bool (&)(const amrex::Array4<const double>&, int, int, int)>, 1>, const int, const amrex::Array4<double>, const amrex::Array4<const double>, const double, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, bool(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int> >::f11' invalidly declared function type
nvcc_internal_extended_lambda_implementation: In instantiation of 'struct __nv_dl_wrapper_t<__nv_dl_tag<void (*)(const amrex::Array4<double>&, const amrex::Array4<const double>&, const amrex::Array4<const double>&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, bool (&)(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int>&), HyperbolicSystem<BlastProblem>::AddFluxesRK2<bool (&)(const amrex::Array4<const double>&, int, int, int)>, 1>, const int, const amrex::Array4<const double>, const amrex::Array4<const double>, const double, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const amrex::Array4<double>, bool(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int> >':
../src/hyperbolic_system.hpp:391:32:   required from 'static void HyperbolicSystem<problem_t>::AddFluxesRK2(array_t&, arrayconst_t&, arrayconst_t&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, F&&, const amrex::Array4<int>&) [with F = bool (&)(const amrex::Array4<const double>&, int, int, int); problem_t = BlastProblem; array_t = const amrex::Array4<double>; arrayconst_t = const amrex::Array4<const double>]'
/tmp/tmpxft_0004150f_00000000-6_test_hydro2d_blast.compute_80.cudafe1.stub.c:93:652:   required from here
nvcc_internal_extended_lambda_implementation:352:44: error: data member '__nv_dl_wrapper_t<__nv_dl_tag<void (*)(const amrex::Array4<double>&, const amrex::Array4<const double>&, const amrex::Array4<const double>&, std::array<const amrex::Array4<const double>, 3>, double, amrex::GpuArray<double, 3>, const amrex::Box&, int, bool (&)(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int>&), HyperbolicSystem<BlastProblem>::AddFluxesRK2<bool (&)(const amrex::Array4<const double>&, int, int, int)>, 1>, const int, const amrex::Array4<const double>, const amrex::Array4<const double>, const double, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const double, const amrex::Array4<const double>, const amrex::Array4<double>, bool(const amrex::Array4<const double>&, int, int, int), const amrex::Array4<int> >::f12' invalidly declared function type
```

Fixes https://github.com/BenWibking/quokka/issues/26 and https://github.com/AMReX-Codes/amrex/issues/2623.