### PR TITLE
add passive scalars

### DIFF
--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -35,7 +35,7 @@ struct CoolingTest {
 constexpr double m_H = hydrogen_mass_cgs_;
 constexpr double seconds_in_year = 3.154e7;
 
-template <> struct EOS_Traits<CoolingTest> {
+template <> struct HydroSystem_Traits<CoolingTest> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -39,6 +39,7 @@ template <> struct HydroSystem_Traits<CoolingTest> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 constexpr double Tgas0 = 6000.;       // K

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -25,7 +25,7 @@
 struct BlastProblem {
 };
 
-template <> struct EOS_Traits<BlastProblem> {
+template <> struct HydroSystem_Traits<BlastProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -133,10 +133,7 @@ void RadhydroSimulation<BlastProblem>::ErrorEst(int lev, amrex::TagBoxArray &tag
 auto problem_main() -> int
 {
 	// Problem parameters
-	amrex::IntVect gridDims{AMREX_D_DECL(400, 600, 4)};
-	amrex::RealBox boxSize{
-	    {AMREX_D_DECL(amrex::Real(0.0), amrex::Real(0.0), amrex::Real(0.0))},
-	    {AMREX_D_DECL(amrex::Real(1.0), amrex::Real(1.5), amrex::Real(1.0))}};
+	constexpr bool reflecting_boundary = true;
 
 	auto isNormalComp = [=](int n, int dim) {
 		if ((n == HydroSystem<BlastProblem>::x1Momentum_index) && (dim == 0)) {
@@ -150,8 +147,6 @@ auto problem_main() -> int
 		}
 		return false;
 	};
-
-	constexpr bool reflecting_boundary = true;
 
 	const int nvars = RadhydroSimulation<BlastProblem>::nvarTotal_;
 	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
@@ -174,7 +169,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BlastProblem> sim(gridDims, boxSize, boundaryConditions);
+	RadhydroSimulation<BlastProblem> sim(boundaryConditions);
 	sim.is_hydro_enabled_ = true;
 	sim.is_radiation_enabled_ = false;
 	sim.stopTime_ = 0.1; //1.5;

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -28,6 +28,7 @@ struct BlastProblem {
 template <> struct HydroSystem_Traits<BlastProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr bool reconstruct_eint = false;
+  	static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <> void RadhydroSimulation<BlastProblem>::setInitialConditionsAtLevel(int lev)

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -32,6 +32,7 @@ constexpr bool simulate_full_box = false;
 template <> struct HydroSystem_Traits<SedovProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = false;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -29,7 +29,7 @@ struct SedovProblem {};
 // if false, use octant symmetry instead
 constexpr bool simulate_full_box = false;
 
-template <> struct EOS_Traits<SedovProblem> {
+template <> struct HydroSystem_Traits<SedovProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -23,7 +23,7 @@ struct ContactProblem {};
 template <> struct HydroSystem_Traits<ContactProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
-  static constexpr int nscalars = 0;       // number of passive scalars
+  static constexpr int nscalars = 2;       // number of passive scalars
 };
 constexpr double v_contact = 0.0; // contact wave velocity
 

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -20,7 +20,7 @@
 
 struct ContactProblem {};
 
-template <> struct EOS_Traits<ContactProblem> {
+template <> struct HydroSystem_Traits<ContactProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -23,6 +23,7 @@ struct ContactProblem {};
 template <> struct HydroSystem_Traits<ContactProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 constexpr double v_contact = 0.0; // contact wave velocity
 

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -28,6 +28,7 @@ struct HighMachProblem {};
 template <> struct HydroSystem_Traits<HighMachProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = false;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -25,7 +25,7 @@ using amrex::Real;
 
 struct HighMachProblem {};
 
-template <> struct EOS_Traits<HighMachProblem> {
+template <> struct HydroSystem_Traits<HighMachProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -24,6 +24,7 @@ struct KelvinHelmholzProblem {};
 template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = false;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -21,7 +21,7 @@
 
 struct KelvinHelmholzProblem {};
 
-template <> struct EOS_Traits<KelvinHelmholzProblem> {
+template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -27,7 +27,7 @@
 
 struct ShocktubeProblem {};
 
-template <> struct EOS_Traits<ShocktubeProblem> {
+template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = (5. / 3.);
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -30,6 +30,7 @@ struct ShocktubeProblem {};
 template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = (5. / 3.);
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -40,7 +40,7 @@ using Real = amrex::Real;
 
 struct QuirkProblem {};
 
-template <> struct EOS_Traits<QuirkProblem> {
+template <> struct HydroSystem_Traits<QuirkProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -43,6 +43,7 @@ struct QuirkProblem {};
 template <> struct HydroSystem_Traits<QuirkProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = false;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 constexpr Real dl = 3.692;

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -24,6 +24,7 @@ struct RichtmeyerMeshkovProblem {
 template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
+	static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 //#define DEBUG_SYMMETRY

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -21,7 +21,7 @@
 struct RichtmeyerMeshkovProblem {
 };
 
-template <> struct EOS_Traits<RichtmeyerMeshkovProblem> {
+template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.hpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.hpp
@@ -18,7 +18,6 @@
 
 // internal headers
 
-#include "hydro_system.hpp"
 extern "C" {
     #include "interpolate.h"
 }

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -23,6 +23,7 @@ struct ShocktubeProblem {};
 template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -20,7 +20,7 @@
 
 struct ShocktubeProblem {};
 
-template <> struct EOS_Traits<ShocktubeProblem> {
+template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -25,7 +25,7 @@
 
 struct ShocktubeProblem {};
 
-template <> struct EOS_Traits<ShocktubeProblem> {
+template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -28,6 +28,7 @@ struct ShocktubeProblem {};
 template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 // left- and right- side shock states

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -25,6 +25,7 @@ struct ShocktubeProblem {};
 template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -22,7 +22,7 @@
 
 struct ShocktubeProblem {};
 
-template <> struct EOS_Traits<ShocktubeProblem> {
+template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -24,7 +24,7 @@
 
 struct ShocktubeProblem {};
 
-template <> struct EOS_Traits<ShocktubeProblem> {
+template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -27,6 +27,7 @@ struct ShocktubeProblem {};
 template <> struct HydroSystem_Traits<ShocktubeProblem> {
   static constexpr double gamma = 1.4;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -23,6 +23,7 @@ struct WaveProblem {};
 template <> struct HydroSystem_Traits<WaveProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 constexpr double rho0 = 1.0; // background density

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -20,7 +20,7 @@
 
 struct WaveProblem {};
 
-template <> struct EOS_Traits<WaveProblem> {
+template <> struct HydroSystem_Traits<WaveProblem> {
   static constexpr double gamma = 5. / 3.;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -55,7 +55,7 @@ template <> struct RadSystem_Traits<TubeProblem> {
   static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct EOS_Traits<TubeProblem> {
+template <> struct HydroSystem_Traits<TubeProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr double cs_isothermal = a0; // only used when gamma = 1
   static constexpr bool reconstruct_eint = false; // unused if isothermal

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -59,6 +59,7 @@ template <> struct HydroSystem_Traits<TubeProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr double cs_isothermal = a0; // only used when gamma = 1
   static constexpr bool reconstruct_eint = false; // unused if isothermal
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -56,7 +56,7 @@ template <> struct RadSystem_Traits<ShellProblem> {
   static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct EOS_Traits<ShellProblem> {
+template <> struct HydroSystem_Traits<ShellProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr bool reconstruct_eint = false;
 };

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -59,6 +59,7 @@ template <> struct RadSystem_Traits<ShellProblem> {
 template <> struct HydroSystem_Traits<ShellProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr bool reconstruct_eint = false;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 constexpr amrex::Real Msun = 2.0e33;           // g

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<ShockProblem> {
 template <> struct HydroSystem_Traits<ShockProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr bool reconstruct_eint = true;
-  static constexpr int nscalars = 0;       // number of passive scalars
+  static constexpr int nscalars = 1;       // number of passive scalars
 };
 
 template <>

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -65,7 +65,7 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct EOS_Traits<ShockProblem> {
+template <> struct HydroSystem_Traits<ShockProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr bool reconstruct_eint = true;
 };

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -68,6 +68,7 @@ template <> struct RadSystem_Traits<ShockProblem> {
 template <> struct HydroSystem_Traits<ShockProblem> {
   static constexpr double gamma = gamma_gas;
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct EOS_Traits<ShockProblem> {
+template <> struct HydroSystem_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 	static constexpr bool reconstruct_eint = true;
 };

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -71,6 +71,7 @@ template <> struct RadSystem_Traits<ShockProblem> {
 template <> struct HydroSystem_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 	static constexpr bool reconstruct_eint = true;
+  	static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 template <>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -109,21 +109,17 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	    : AMRSimulation<problem_t>(boundaryConditions,
 				       RadSystem<problem_t>::nvar_, ncompHyperbolic_)
 	{
-		componentNames_ = {"gasDensity",    "x-GasMomentum", "y-GasMomentum",
-				   "z-GasMomentum", "gasEnergy",     "gasInternalEnergy",	"radEnergy",
-				   "x-RadFlux",	    "y-RadFlux",     "z-RadFlux"};
+		std::vector<std::string> hydroNames = {"gasDensity", "x-GasMomentum", "y-GasMomentum",
+				   							   "z-GasMomentum", "gasEnergy", "gasInternalEnergy"};
+		std::vector<std::string> radNames = {"radEnergy", "x-RadFlux", "y-RadFlux", "z-RadFlux"};
+		std::vector<std::string> scalarNames = getScalarVariableNames();
+
+		componentNames_.insert(componentNames_.end(), hydroNames.begin(), hydroNames.end());
+		componentNames_.insert(componentNames_.end(), scalarNames.begin(), scalarNames.end());
+		componentNames_.insert(componentNames_.end(), radNames.begin(), radNames.end());
 	}
 
-	RadhydroSimulation(amrex::IntVect & /*gridDims*/, amrex::RealBox & /*boxSize*/,
-			   amrex::Vector<amrex::BCRec> &boundaryConditions)
-	    : AMRSimulation<problem_t>(boundaryConditions,
-				       RadSystem<problem_t>::nvar_, ncompHyperbolic_)
-	{
-		componentNames_ = {"gasDensity",    "x-GasMomentum", "y-GasMomentum",
-				   "z-GasMomentum", "gasEnergy",     "gasInternalEnergy",	"radEnergy",
-				   "x-RadFlux",	    "y-RadFlux",     "z-RadFlux"};
-	}
-
+	auto getScalarVariableNames() const -> std::vector<std::string>;
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
 	void setInitialConditionsAtLevel(int level) override;
@@ -214,6 +210,21 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 			  std::array<amrex::FArrayBox, AMREX_SPACEDIM> &FOfluxes,
 			  amrex::IArrayBox &redoFlag, amrex::Box const &validBox, int ncomp);
 };
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::getScalarVariableNames() const -> std::vector<std::string> {
+	// return vector of names for the passive scalars
+	// this can be specialized by the user to provide more descriptive names
+	// (these names are used to label the variables in the plotfiles)
+
+	std::vector<std::string> names;
+	int nscalars = HydroSystem<problem_t>::nscalars_;
+	for(int n = 0; n < nscalars; ++n) {
+		// write string 'scalar_1', etc.
+		names.push_back(fmt::format("scalar_{}", n));
+	}
+	return names;
+}
 
 template <typename problem_t>
 auto RadhydroSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -119,7 +119,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 		componentNames_.insert(componentNames_.end(), radNames.begin(), radNames.end());
 	}
 
-	auto getScalarVariableNames() const -> std::vector<std::string>;
+	[[nodiscard]] auto getScalarVariableNames() const -> std::vector<std::string>;
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
 	void setInitialConditionsAtLevel(int level) override;
@@ -219,6 +219,7 @@ auto RadhydroSimulation<problem_t>::getScalarVariableNames() const -> std::vecto
 
 	std::vector<std::string> names;
 	int nscalars = HydroSystem<problem_t>::nscalars_;
+	names.reserve(nscalars);
 	for(int n = 0; n < nscalars; ++n) {
 		// write string 'scalar_1', etc.
 		names.push_back(fmt::format("scalar_{}", n));

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -39,7 +39,7 @@ struct ShockCloud {
 constexpr double m_H = hydrogen_mass_cgs_;
 constexpr double seconds_in_year = 3.154e7;
 
-template <> struct EOS_Traits<ShockCloud> {
+template <> struct HydroSystem_Traits<ShockCloud> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -43,6 +43,7 @@ template <> struct HydroSystem_Traits<ShockCloud> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 constexpr Real Tgas0 = 1.0e7;            // K

--- a/src/ShockCloud/test_cloudy.cpp
+++ b/src/ShockCloud/test_cloudy.cpp
@@ -29,6 +29,7 @@ template <> struct HydroSystem_Traits<ShockCloud> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;
+  static constexpr int nscalars = 0;       // number of passive scalars
 };
 
 struct ODEUserData {

--- a/src/ShockCloud/test_cloudy.cpp
+++ b/src/ShockCloud/test_cloudy.cpp
@@ -25,7 +25,7 @@ using amrex::Real;
 struct ShockCloud {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct EOS_Traits<ShockCloud> {
+template <> struct HydroSystem_Traits<ShockCloud> {
   static constexpr double gamma = 5. / 3.; // default value
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -30,6 +30,7 @@
 template <typename problem_t> struct HydroSystem_Traits {
   static constexpr double gamma = 5. / 3.;     // default value
   static constexpr double cs_isothermal = NAN; // only used when gamma = 1
+  static constexpr int nscalars = 0;           // number of passive scalars
   // if true, reconstruct e_int instead of pressure
   static constexpr bool reconstruct_eint = true;
 };
@@ -45,7 +46,8 @@ public:
     x2Momentum_index = 2,
     x3Momentum_index = 3,
     energy_index = 4,
-    internalEnergy_index = 5 // auxiliary internal energy (rho * e)
+    internalEnergy_index = 5, // auxiliary internal energy (rho * e)
+    scalar0_index = 6 // first passive scalar (only present if nscalars > 0!)
   };
   enum primVarIndex {
     primDensity_index = 0,
@@ -53,10 +55,13 @@ public:
     x2Velocity_index = 2,
     x3Velocity_index = 3,
     pressure_index = 4,
-    primEint_index = 5 // auxiliary internal energy (rho * e)
+    primEint_index = 5, // auxiliary internal energy (rho * e)
+    primScalar0_index =
+        6 // first passive scalar (only present if nscalars > 0!)
   };
 
-  static constexpr int nvar_ = 6;
+  static constexpr int nscalars_ = HydroSystem_Traits<problem_t>::nscalars;
+  static constexpr int nvar_ = 6 + nscalars_;
 
   static void ConservedToPrimitive(amrex::Array4<const amrex::Real> const &cons,
                                    array_t &primVar,
@@ -133,7 +138,8 @@ public:
   // C++ does not allow constexpr to be uninitialized, even in a templated
   // class!
   static constexpr double gamma_ = HydroSystem_Traits<problem_t>::gamma;
-  static constexpr double cs_iso_ = HydroSystem_Traits<problem_t>::cs_isothermal;
+  static constexpr double cs_iso_ =
+      HydroSystem_Traits<problem_t>::cs_isothermal;
   static constexpr bool reconstruct_eint =
       HydroSystem_Traits<problem_t>::reconstruct_eint;
 
@@ -187,6 +193,12 @@ void HydroSystem<problem_t>::ConservedToPrimitive(
     }
     // save auxiliary internal energy (rho * e)
     primVar(i, j, k, primEint_index) = Eint_aux;
+
+    // copy any passive scalars
+    for (int nc = 0; nc < nscalars_; ++nc) {
+      primVar(i, j, k, primScalar0_index + nc) =
+          cons(i, j, k, scalar0_index + nc);
+    }
   });
 }
 

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -27,7 +27,7 @@
 
 // this struct is specialized by the user application code
 //
-template <typename problem_t> struct EOS_Traits {
+template <typename problem_t> struct HydroSystem_Traits {
   static constexpr double gamma = 5. / 3.;     // default value
   static constexpr double cs_isothermal = NAN; // only used when gamma = 1
   // if true, reconstruct e_int instead of pressure
@@ -132,10 +132,10 @@ public:
 
   // C++ does not allow constexpr to be uninitialized, even in a templated
   // class!
-  static constexpr double gamma_ = EOS_Traits<problem_t>::gamma;
-  static constexpr double cs_iso_ = EOS_Traits<problem_t>::cs_isothermal;
+  static constexpr double gamma_ = HydroSystem_Traits<problem_t>::gamma;
+  static constexpr double cs_iso_ = HydroSystem_Traits<problem_t>::cs_isothermal;
   static constexpr bool reconstruct_eint =
-      EOS_Traits<problem_t>::reconstruct_eint;
+      HydroSystem_Traits<problem_t>::reconstruct_eint;
 
   static constexpr auto is_eos_isothermal() -> bool { return (gamma_ == 1.0); }
 };

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -53,22 +53,26 @@ template <typename problem_t> struct RadSystem_Traits {
 template <typename problem_t>
 class RadSystem : public HyperbolicSystem<problem_t> {
 public:
-  enum consVarIndex {
+  static constexpr int nstartHyperbolic_ = HydroSystem<problem_t>::nvar_;
+
+  enum gasVarIndex {
     gasDensity_index = 0,
     x1GasMomentum_index = 1,
     x2GasMomentum_index = 2,
     x3GasMomentum_index = 3,
     gasEnergy_index = 4,
-    gasInternalEnergy_index = 5,
-    radEnergy_index = 6,
-    x1RadFlux_index = 7,
-    x2RadFlux_index = 8,
-    x3RadFlux_index = 9
+    gasInternalEnergy_index = 5
   };
 
-  static constexpr int nvar_ = 10;
-  static constexpr int nvarHyperbolic_ = 4;
-  static constexpr int nstartHyperbolic_ = radEnergy_index;
+  enum radVarIndex {
+    radEnergy_index = nstartHyperbolic_,
+    x1RadFlux_index,
+    x2RadFlux_index,
+    x3RadFlux_index
+  };
+
+  static constexpr int nvarHyperbolic_ = 4; // number of radiation variables
+  static constexpr int nvar_ = nstartHyperbolic_ + nvarHyperbolic_;
 
   enum primVarIndex {
     primRadEnergy_index = 0,
@@ -349,7 +353,7 @@ void RadSystem<problem_t>::AddFluxesRK2(
 #endif
       // save results in cons_new
       cons_new[n] = (0.5 * U_0 + 0.5 * U_1) +
-                       (AMREX_D_TERM(0.5 * FxU_1, +0.5 * FyU_1, +0.5 * FzU_1));
+                    (AMREX_D_TERM(0.5 * FxU_1, +0.5 * FyU_1, +0.5 * FzU_1));
     }
 
     if (!isStateValid(cons_new)) {
@@ -368,9 +372,8 @@ void RadSystem<problem_t>::AddFluxesRK2(
                                           x3FluxDiffusive(i, j, k + 1, n));
 #endif
         // save results in cons_new
-        cons_new[n] =
-            (0.5 * U_0 + 0.5 * U_1) +
-            (AMREX_D_TERM(0.5 * FxU_1, +0.5 * FyU_1, +0.5 * FzU_1));
+        cons_new[n] = (0.5 * U_0 + 0.5 * U_1) +
+                      (AMREX_D_TERM(0.5 * FxU_1, +0.5 * FyU_1, +0.5 * FzU_1));
       }
     }
 
@@ -381,8 +384,8 @@ void RadSystem<problem_t>::AddFluxesRK2(
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEddingtonFactor(double f_in)
-    -> double {
+AMREX_GPU_HOST_DEVICE auto
+RadSystem<problem_t>::ComputeEddingtonFactor(double f_in) -> double {
   // f is the reduced flux == |F|/cE.
   // compute Levermore (1984) closure [Eq. 25]
   // the is the M1 closure that is derived from Lorentz invariance
@@ -436,9 +439,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(
 
   if constexpr (gamma_ != 1.0) {
     Eint_L = RadSystem<problem_t>::ComputeEintFromEgas(
-      rho_L, x1GasMom_L, x2GasMom_L, x3GasMom_L, Egas_L);
+        rho_L, x1GasMom_L, x2GasMom_L, x3GasMom_L, Egas_L);
     Eint_R = RadSystem<problem_t>::ComputeEintFromEgas(
-      rho_R, x1GasMom_R, x2GasMom_R, x3GasMom_R, Egas_R);
+        rho_R, x1GasMom_R, x2GasMom_R, x3GasMom_R, Egas_R);
     Tgas_L = RadSystem<problem_t>::ComputeTgasFromEgas(rho_L, Eint_L);
     Tgas_R = RadSystem<problem_t>::ComputeTgasFromEgas(rho_R, Eint_R);
   }
@@ -858,7 +861,8 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar,
 
     // load radiation energy source term
     // plus advection source term (for well-balanced/SDC integrators)
-    const double Src = dt * ((chat * radEnergySource(i, j, k)) + advectionFluxes(i, j, k));
+    const double Src =
+        dt * ((chat * radEnergySource(i, j, k)) + advectionFluxes(i, j, k));
 
     double Egas0 = NAN;
     double Ekin0 = NAN;
@@ -871,13 +875,13 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar,
           ComputeEintFromEgas(rho, x1GasMom0, x2GasMom0, x3GasMom0, Egastot0);
       Ekin0 = Egastot0 - Egas0;
 
-    AMREX_ASSERT(Src >= 0.0);
-    AMREX_ASSERT(Egas0 > 0.0);
-    AMREX_ASSERT(Erad0 > 0.0);
+      AMREX_ASSERT(Src >= 0.0);
+      AMREX_ASSERT(Egas0 > 0.0);
+      AMREX_ASSERT(Erad0 > 0.0);
 
-    const double Etot0 = Egas0 + (c / chat) * (Erad0 + Src);
+      const double Etot0 = Egas0 + (c / chat) * (Erad0 + Src);
 
-    // BEGIN NEWTON-RAPHSON LOOP
+      // BEGIN NEWTON-RAPHSON LOOP
       Egas_guess = Egas0;
       Erad_guess = Erad0;
 
@@ -1037,11 +1041,12 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar,
       // 4b. Store new radiation energy, gas energy
       consNew(i, j, k, radEnergy_index) = Erad_guess + dErad_work;
       consNew(i, j, k, gasEnergy_index) = Egastot1;
-      consNew(i, j, k, gasInternalEnergy_index) += dEint; // must compute difference
+      consNew(i, j, k, gasInternalEnergy_index) +=
+          dEint; // must compute difference
     } else {
       amrex::ignore_unused(Erad_guess);
       amrex::ignore_unused(Egas_guess);
-    }  // endif gamma != 1.0
+    } // endif gamma != 1.0
   });
 }
 


### PR DESCRIPTION
This adds passive scalar support to Quokka.

The number of passive scalars is set at compile time with `HydroSystem_Traits<>::nscalars`. This updates the component indicies used in both HydroSystem and RadSystem, as well as the total number of variables in RadhydroSimulation. A new function is added to set the names of the passive scalars as used in the plotfiles.