### PR TITLE
avoid allocating radiation variables for hydro-only problems

### DIFF
--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -355,7 +355,7 @@ auto problem_main() -> int {
 #endif
   }
 
-  RadhydroSimulation<CoolingTest> sim(boundaryConditions);
+  RadhydroSimulation<CoolingTest> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
 

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -169,7 +169,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BlastProblem> sim(boundaryConditions, true);
+	RadhydroSimulation<BlastProblem> sim(boundaryConditions, false);
 	sim.is_hydro_enabled_ = true;
 	sim.is_radiation_enabled_ = false;
 	sim.stopTime_ = 0.1; //1.5;

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -169,7 +169,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BlastProblem> sim(boundaryConditions);
+	RadhydroSimulation<BlastProblem> sim(boundaryConditions, true);
 	sim.is_hydro_enabled_ = true;
 	sim.is_radiation_enabled_ = false;
 	sim.stopTime_ = 0.1; //1.5;

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -272,7 +272,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<SedovProblem> sim(boundaryConditions, true);
+  RadhydroSimulation<SedovProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -178,26 +178,15 @@ void RadhydroSimulation<SedovProblem>::ErrorEst(int lev,
 template <>
 void RadhydroSimulation<SedovProblem>::computeAfterEvolve(
     amrex::Vector<amrex::Real> &initSumCons) {
-  // check conservation of total energy
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 =
       geom[0].CellSizeArray();
   amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 
+  // check conservation of total energy
   amrex::Real const Egas0 =
       initSumCons[RadSystem<SedovProblem>::gasEnergy_index];
-  amrex::Real const Erad0 =
-      initSumCons[RadSystem<SedovProblem>::radEnergy_index];
-  amrex::Real const Etot0 = Egas0 + (RadSystem<SedovProblem>::c_light_ /
-                                     RadSystem<SedovProblem>::c_hat_) *
-                                        Erad0;
-
   amrex::Real const Egas =
       state_new_[0].sum(RadSystem<SedovProblem>::gasEnergy_index) * vol;
-  amrex::Real const Erad =
-      state_new_[0].sum(RadSystem<SedovProblem>::radEnergy_index) * vol;
-  amrex::Real const Etot = Egas + (RadSystem<SedovProblem>::c_light_ /
-                                   RadSystem<SedovProblem>::c_hat_) *
-                                      Erad;
 
   // compute kinetic energy
   amrex::MultiFab Ekin_mf(boxArray(0), DistributionMap(0), 1, 0);
@@ -220,13 +209,13 @@ void RadhydroSimulation<SedovProblem>::computeAfterEvolve(
   amrex::Real const frac_Ekin = Ekin / Egas;
   amrex::Real const frac_Ekin_exact = 0.218729;
 
-  amrex::Real const abs_err = (Etot - Etot0);
-  amrex::Real const rel_err = abs_err / Etot0;
+  amrex::Real const abs_err = (Egas - Egas0);
+  amrex::Real const rel_err = abs_err / Egas0;
 
   amrex::Real const rel_err_Ekin = frac_Ekin - frac_Ekin_exact;
 
-  amrex::Print() << "\nInitial gas+radiation energy = " << Etot0 << std::endl;
-  amrex::Print() << "Final gas+radiation energy = " << Etot << std::endl;
+  amrex::Print() << "\nInitial energy = " << Egas0 << std::endl;
+  amrex::Print() << "Final energy = " << Egas << std::endl;
   amrex::Print() << "\tabsolute conservation error = " << abs_err << std::endl;
   amrex::Print() << "\trelative conservation error = " << rel_err << std::endl;
   amrex::Print() << "\tkinetic energy = " << Ekin << std::endl;

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -283,7 +283,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<SedovProblem> sim(boundaryConditions);
+  RadhydroSimulation<SedovProblem> sim(boundaryConditions, true);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -200,7 +200,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<ContactProblem> sim(boundaryConditions);
+  RadhydroSimulation<ContactProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.stopTime_ = 2.0;

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -246,7 +246,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<HighMachProblem> sim(boundaryConditions);
+  RadhydroSimulation<HighMachProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.computeReferenceSolution_ = true;

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -134,7 +134,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<KelvinHelmholzProblem> sim(boundaryConditions, true);
+  RadhydroSimulation<KelvinHelmholzProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.stopTime_ = 1.5;

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -134,7 +134,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<KelvinHelmholzProblem> sim(boundaryConditions);
+  RadhydroSimulation<KelvinHelmholzProblem> sim(boundaryConditions, true);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.stopTime_ = 1.5;

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -359,7 +359,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions);
+  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.cflNumber_ = CFL_number;

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -275,7 +275,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<QuirkProblem> sim(boundaryConditions, true);
+  RadhydroSimulation<QuirkProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.reconstructionOrder_ = 2; // PLM

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -275,7 +275,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<QuirkProblem> sim(boundaryConditions);
+  RadhydroSimulation<QuirkProblem> sim(boundaryConditions, true);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.reconstructionOrder_ = 2; // PLM

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -191,7 +191,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<RichtmeyerMeshkovProblem> sim(boundaryConditions, true);
+	RadhydroSimulation<RichtmeyerMeshkovProblem> sim(boundaryConditions, false);
 	sim.is_hydro_enabled_ = true;
 	sim.is_radiation_enabled_ = false;
 	sim.stopTime_ = 2.5;

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -191,7 +191,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<RichtmeyerMeshkovProblem> sim(boundaryConditions);
+	RadhydroSimulation<RichtmeyerMeshkovProblem> sim(boundaryConditions, true);
 	sim.is_hydro_enabled_ = true;
 	sim.is_radiation_enabled_ = false;
 	sim.stopTime_ = 2.5;

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -266,7 +266,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions);
+  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.cflNumber_ = CFL_number;

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -368,7 +368,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions);
+  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   // sim.cflNumber_ = CFL_number;

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -128,11 +128,6 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(
       P / (gamma - 1.) + 0.5 * rho * (vx * vx);
   consVar(i, j, k, RadSystem<ShocktubeProblem>::gasInternalEnergy_index) =
       P / (gamma - 1.);
-  // must also set radiation variables to zero, otherwise we get NaN asserts
-  consVar(i, j, k, RadSystem<ShocktubeProblem>::radEnergy_index) = 0;
-  consVar(i, j, k, RadSystem<ShocktubeProblem>::x1RadFlux_index) = 0;
-  consVar(i, j, k, RadSystem<ShocktubeProblem>::x2RadFlux_index) = 0;
-  consVar(i, j, k, RadSystem<ShocktubeProblem>::x3RadFlux_index) = 0;
 }
 
 template <>
@@ -296,7 +291,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions);
+  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.cflNumber_ = CFL_number;

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -319,7 +319,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions);
+  RadhydroSimulation<ShocktubeProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.cflNumber_ = CFL_number;

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -106,7 +106,7 @@ auto problem_main() -> int {
     }
   }
 
-  RadhydroSimulation<WaveProblem> sim(boundaryConditions);
+  RadhydroSimulation<WaveProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.cflNumber_ = CFL_number;

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -219,7 +219,7 @@ auto problem_main() -> int {
   }
 
   // Problem initialization
-  RadhydroSimulation<ScalarProblem> sim(boundaryConditions);
+  RadhydroSimulation<ScalarProblem> sim(boundaryConditions, false);
   sim.is_hydro_enabled_ = true;
   sim.is_radiation_enabled_ = false;
   sim.computeReferenceSolution_ = true;

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -722,7 +722,7 @@ auto RadhydroSimulation<problem_t>::expandFluxArrays(
 		amrex::FArrayBox newFlux(fluxRange, ncompNew, amrex::The_Async_Arena());
 		newFlux.setVal<amrex::RunOn::Device>(0.);
 		// copy oldFlux (starting at 0) to newFlux (starting at nstart)
-		AMREX_ASSERT(ncompNew > oldFlux.nComp());
+		AMREX_ASSERT(ncompNew >= oldFlux.nComp());
 		newFlux.copy<amrex::RunOn::Device>(oldFlux, 0, nstartNew, oldFlux.nComp());
 		return newFlux;
 	};

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -468,9 +468,10 @@ auto problem_main() -> int {
     boundaryConditions[n].setHi(2, amrex::BCType::int_dir);
   }
 
-  RadhydroSimulation<ShockCloud> sim(boundaryConditions);
+  bool enableRadiation = false;
+  RadhydroSimulation<ShockCloud> sim(boundaryConditions, enableRadiation);
   sim.is_hydro_enabled_ = true;
-  sim.is_radiation_enabled_ = false;
+  sim.is_radiation_enabled_ = enableRadiation;
 
   // Standard PPM gives unphysically enormous temperatures when used for
   // this problem (e.g., ~1e14 K or higher), but can be fixed by

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -97,17 +97,10 @@ public:
   int plotfileInterval_ = 10;      // -1 == no output
   int checkpointInterval_ = -1;    // -1 == no output
 
-  // constructors
-
-  AMRSimulation(amrex::Vector<amrex::BCRec> &boundaryConditions,
-                const int ncomp, const int ncompPrim)
-      : ncomp_(ncomp), ncompPrimitive_(ncompPrim) {
-    initialize(boundaryConditions);
-  }
-
+  // constructor
   AMRSimulation(amrex::Vector<amrex::BCRec> &boundaryConditions,
                 const int ncomp)
-      : ncomp_(ncomp), ncompPrimitive_(ncomp) {
+      : ncomp_(ncomp) {
     initialize(boundaryConditions);
   }
 
@@ -221,7 +214,6 @@ protected:
   // Nghost = number of ghost cells for each array
   int nghost_ = 4; // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4
   int ncomp_ = 0; // = number of components (conserved variables) for each array
-  int ncompPrimitive_ = 0; // number of primitive variables
   amrex::Vector<std::string> componentNames_;
   amrex::Vector<std::string> derivedNames_;
   bool areInitialConditionsDefined_ = false;


### PR DESCRIPTION
This adds an option to the RadhydroSimulation constructor to disable allocating radiation variables, and also updates the hydro-only test problems to use it.