### PR TITLE
use fast scaled interpolation of cooling tables

### DIFF
--- a/src/CloudyCooling.hpp
+++ b/src/CloudyCooling.hpp
@@ -18,6 +18,7 @@
 #include "Interpolate2D.hpp"
 #include "radiation_system.hpp"
 #include "root_finding.hpp"
+#include "FastMath.hpp"
 #include <limits>
 
 // From Grackle source code (initialize_chemistry_data.c, line 114):
@@ -87,9 +88,9 @@ cloudy_cooling_function(Real const rho, Real const T,
                                             tables.log_Tgas, tables.metalHeat);
 
   const double netLambda_prim =
-      std::pow(10., logPrimHeat) - std::pow(10., logPrimCool);
+      FastMath::pow10(logPrimHeat) - FastMath::pow10(logPrimCool);
   const double netLambda_metals =
-      std::pow(10., logMetalHeat) - std::pow(10., logMetalCool);
+      FastMath::pow10(logMetalHeat) - FastMath::pow10(logMetalCool);
   const double netLambda = netLambda_prim + netLambda_metals;
 
   // multiply by the square of H mass density (**NOT number density**)

--- a/src/FastMath.hpp
+++ b/src/FastMath.hpp
@@ -18,16 +18,18 @@
 // https://github.com/lanl/singularity-eos
 
 #include "AMReX_Extension.H"
+#include "AMReX_GpuQualifiers.H"
 #include <cassert>
 #include <cmath>
 
 namespace FastMath {
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto as_int(double f) {
   return *reinterpret_cast<int64_t*>(&f); // NOLINT
 }
-AMREX_FORCE_INLINE
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto as_double(int64_t i) {
   return *reinterpret_cast<double*>(&i); // NOLINT
 }
@@ -35,14 +37,14 @@ auto as_double(int64_t i) {
 // Reference implementations, however the integer cast implementation
 // below is probably faster.
 /*
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double lg(const double x) {
   int n;
   assert(x > 0 && "log divergent for x <= 0");
   const double y = frexp(x, &n);
   return 2 * (y - 1) + n;
 }
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 double pow2(const double x) {
   const int flr = std::floor(x);
   const double remainder = x - flr;
@@ -52,7 +54,7 @@ double pow2(const double x) {
 }
 */
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto lg(const double x) -> double {
   // Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
   // these are floating point numbers as reinterpreted as integers.
@@ -63,7 +65,7 @@ auto lg(const double x) -> double {
   return static_cast<double>(as_int(x) - one_as_int) * scale_down;
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto pow2(const double x) -> double {
   // Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
   // these are floating point numbers as reinterpreted as integers.
@@ -74,31 +76,31 @@ auto pow2(const double x) -> double {
   return as_double(static_cast<int64_t>(x*scale_up) + one_as_int);
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto ln(const double x) -> double {
   constexpr double ILOG2E = 0.6931471805599453;
   return ILOG2E * lg(x);
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto exp(const double x) -> double {
   constexpr double LOG2E = 1.4426950408889634;
   return pow2(LOG2E * x);
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto log10(const double x) -> double {
   constexpr double LOG2OLOG10 = 0.301029995663981195;
   return LOG2OLOG10 * lg(x);
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto pow10(const double x) -> double {
   constexpr double LOG10OLOG2 = 3.321928094887362626;
   return pow2(LOG10OLOG2 * x);
 }
 
-AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 auto tanh(const double x) -> double {
   const double expx = exp(2 * x);
   return (expx - 1) / (expx + 1);

--- a/src/FastMath.hpp
+++ b/src/FastMath.hpp
@@ -1,0 +1,109 @@
+#ifndef FASTMATH_HPP_ // NOLINT
+#define FASTMATH_HPP_
+//======================================================================
+// © 2022. Triad National Security, LLC. All rights reserved.  This
+// program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S.  Department of Energy/National
+// Nuclear Security Administration. All rights in the program are
+// reserved by Triad National Security, LLC, and the U.S. Department of
+// Energy/National Nuclear Security Administration. The Government is
+// granted for itself and others acting on its behalf a nonexclusive,
+// paid-up, irrevocable worldwide license in this material to reproduce,
+// prepare derivative works, distribute copies to the public, perform
+// publicly and display publicly, and to permit others to do so.
+//======================================================================
+
+// Code taken from singularity-eos
+// https://github.com/lanl/singularity-eos
+
+#include "AMReX_Extension.H"
+#include <cassert>
+#include <cmath>
+
+namespace FastMath {
+
+AMREX_FORCE_INLINE
+auto as_int(double f) {
+  return *reinterpret_cast<int64_t*>(&f); // NOLINT
+}
+AMREX_FORCE_INLINE
+auto as_double(int64_t i) {
+  return *reinterpret_cast<double*>(&i); // NOLINT
+}
+
+// Reference implementations, however the integer cast implementation
+// below is probably faster.
+/*
+AMREX_FORCE_INLINE
+double lg(const double x) {
+  int n;
+  assert(x > 0 && "log divergent for x <= 0");
+  const double y = frexp(x, &n);
+  return 2 * (y - 1) + n;
+}
+AMREX_FORCE_INLINE
+double pow2(const double x) {
+  const int flr = std::floor(x);
+  const double remainder = x - flr;
+  const double mantissa = 0.5 * (remainder + 1);
+  const double exponent = flr + 1;
+  return ldexp(mantissa, exponent);
+}
+*/
+
+AMREX_FORCE_INLINE
+auto lg(const double x) -> double {
+  // Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
+  // these are floating point numbers as reinterpreted as integers.
+  // as_int(1.0)
+  constexpr int64_t one_as_int = 4607182418800017408;
+  // 1./static_cast<double>(as_int(2.0) - as_int(1.0))
+  constexpr double scale_down = 2.22044604925031e-16;
+  return static_cast<double>(as_int(x) - one_as_int) * scale_down;
+}
+
+AMREX_FORCE_INLINE
+auto pow2(const double x) -> double {
+  // Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
+  // these are floating point numbers as reinterpreted as integers.
+  // as_int(1.0)
+  constexpr int64_t one_as_int = 4607182418800017408;
+  // as_int(2.0) - as_int(1.0)
+  constexpr double scale_up = 4503599627370496;
+  return as_double(static_cast<int64_t>(x*scale_up) + one_as_int);
+}
+
+AMREX_FORCE_INLINE
+auto ln(const double x) -> double {
+  constexpr double ILOG2E = 0.6931471805599453;
+  return ILOG2E * lg(x);
+}
+
+AMREX_FORCE_INLINE
+auto exp(const double x) -> double {
+  constexpr double LOG2E = 1.4426950408889634;
+  return pow2(LOG2E * x);
+}
+
+AMREX_FORCE_INLINE
+auto log10(const double x) -> double {
+  constexpr double LOG2OLOG10 = 0.301029995663981195;
+  return LOG2OLOG10 * lg(x);
+}
+
+AMREX_FORCE_INLINE
+auto pow10(const double x) -> double {
+  constexpr double LOG10OLOG2 = 3.321928094887362626;
+  return pow2(LOG10OLOG2 * x);
+}
+
+AMREX_FORCE_INLINE
+auto tanh(const double x) -> double {
+  const double expx = exp(2 * x);
+  return (expx - 1) / (expx + 1);
+}
+
+} // namespace FastMath
+
+#endif // FASTMATH_HPP_


### PR DESCRIPTION
This changes the interpolation from logarithms of the cooling/heating rates to use a fast approximate log function from https://github.com/lanl/not-quite-transcendental.

(We can't change log_density and log_T to use the FastMath versions because this breaks the assumption in the current version of the 2D interpolation function that the sampling points are equally spaced.)

This leads to a ~20% speedup (in total walltime) for an AMR shock-cloud problem on a single V100 GPU.

Closes https://github.com/BenWibking/quokka/issues/57.