### PR TITLE
make functions accessed in initializer list static

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -122,8 +122,8 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 		}
 	}
 
-	[[nodiscard]] auto getScalarVariableNames() const -> std::vector<std::string>;
-	[[nodiscard]] auto getNumVars(bool allocateRadVars) const -> int;
+	[[nodiscard]] static auto getScalarVariableNames() -> std::vector<std::string>;
+	[[nodiscard]] static auto getNumVars(bool allocateRadVars) -> int;
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
@@ -217,7 +217,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 };
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::getScalarVariableNames() const -> std::vector<std::string> {
+auto RadhydroSimulation<problem_t>::getScalarVariableNames() -> std::vector<std::string> {
 	// return vector of names for the passive scalars
 	// this can be specialized by the user to provide more descriptive names
 	// (these names are used to label the variables in the plotfiles)
@@ -233,7 +233,7 @@ auto RadhydroSimulation<problem_t>::getScalarVariableNames() const -> std::vecto
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::getNumVars(bool allocateRadVars) const -> int {
+auto RadhydroSimulation<problem_t>::getNumVars(bool allocateRadVars) -> int {
 	// return the number of cell-centered variables to be allocated
 	// in the state_new_ and state_old_ multifabs
 


### PR DESCRIPTION
Fixes 'invalid vptr' error from UndefinedBehavior Sanitizer (UBSAN).

I think it is legal to call class member virtual functions within constructors (including initializer lists) [1], since the compiler _should_ devirtualize the function call. UBSAN does not like this, however.

[1] https://stackoverflow.com/questions/52831064/when-is-the-vptr-initialized-for-derived-classes