### PR TITLE
change the way CMake finds Python headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ set(AMReX_ASSERTIONS OFF CACHE BOOL "" FORCE)
 set(AMReX_FPE OFF CACHE BOOL "" FORCE)
 set(AMReX_TINY_PROFILE ON CACHE BOOL "" FORCE)
 
+## a Python installation can be specified with Python_ROOT_DIR
+##   see: https://cmake.org/cmake/help/latest/module/FindPython.html#hints
+## NumPy and Matplotlib can be installed with `python3 -m pip install numpy matplotlib --user`
 option(QUOKKA_PYTHON "Compile with Python support (on/off)" ON)
 option(DISABLE_FMAD "Disable fused multiply-add instructions on GPU (on/off)" ON)
 option(ENABLE_ASAN "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,18 @@ Have fun!
 ## CMake
 Quokka uses CMake for its build system. If you don't have CMake installed already, you can simply `pip install cmake` or use another [installation method](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html). If you are unfamiliar with CMake, [this tutorial](https://hsf-training.github.io/hsf-training-cmake-webpage/) may be useful.
 
-## Python header file not found error
-If you get an error saying that a NumPy header file is not found, you can work around this problem by disabling Python support. Python and NumPy are only used to plot the results of some test problems, so this does not otherwise affect Quokka's functionality. Add the option
+## Could NOT find Python error
+If CMake prints an error saying that Python could not be found, e.g.:
+```
+-- Could NOT find Python (missing: Python_EXECUTABLE Python_INCLUDE_DIRS Python_LIBRARIES Python_NumPy_INCLUDE_DIRS Interpreter Development NumPy Development.Module Development.Embed)
+```
+you should be able to fix this by installing NumPy (and matplotlib) by running
+```
+python3 -m pip install numpy matplotlib --user
+```
+This should enable CMake to find the NumPy header files that are needed to successfully compile.
+
+Alternatively, you can work around this problem by disabling Python support. Python and NumPy are only used to plot the results of some test problems, so this does not otherwise affect Quokka's functionality. Add the option
 ```
 -DQUOKKA_PYTHON=OFF
 ```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,14 +1,14 @@
 if(QUOKKA_PYTHON) 
   message(STATUS "Building Quokka with Python support (to disable, add '-DQUOKKA_PYTHON=OFF' to the CMake command-line options)")
-  find_package(PythonLibs)
+  find_package(Python COMPONENTS Interpreter Development NumPy)
 else()
   message(STATUS "Building Quokka *without* Python support")
 endif()
 
 if(PythonLibs_FOUND)
     add_compile_definitions(HAVE_PYTHON)
-    include_directories(${PYTHON_INCLUDE_DIRS})
-    link_libraries(${PYTHON_LIBRARY})
+    include_directories(${Python_INCLUDE_DIRS} ${Python_NumPy_INCLUDE_DIRS})
+    link_libraries(${Python_LIBRARIES})
 endif()
 
 # HDF5


### PR DESCRIPTION
This should make it easier to compile Quokka with Python support. If CMake cannot find Python when configuring, one of the following is true:

- Python 3 is not installed
- CMake cannot find the path to the Python 3 installation directory
- NumPy headers are not installed for the Python 3 installation that CMake has found

If CMake reports it cannot find Python, it may simply not be able to find the NumPy header files. To fix this, simply run `python3 -m pip install numpy --user`.

If CMake cannot find a Python installation at all, try setting the CMake option `Python_ROOT_DIR`, e.g. by adding `-DPython_ROOT_DIR=/path/to/python_install_dir` to the CMake command-line arguments.