### PR TITLE
add use_dual_energy parameter

### DIFF
--- a/tests/HighMach.in
+++ b/tests/HighMach.in
@@ -24,6 +24,7 @@ do_subcycle = 0
 # cfl = 0.45        # maximum stable CFL for eta = 0.001
 # cfl = 0.84        # maximum stable CFL for eta = 0.01
 cfl = 0.4
+hydro.use_dual_energy = 1
 
 stop_time = 3.0
 plotfile_interval = -1


### PR DESCRIPTION
Add a runtime parameter to enable/disable the use of an auxiliary internal energy equation for high-Mach flows.