### PR TITLE
run CI on pull requests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,6 @@
 name: CMake
 
-on: [push]
+on: [push, pull_request]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -13,7 +13,6 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     runs-on: ubuntu-20.04
-    #runs-on: self-hosted
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This fixes a configuration error in the GitHub CMake build workflow. It should now build on pull requests from other users.

GitHub will still build both on push and on a pull request event, so there is some duplication. It is a known issue in GitHub actions: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662