### PR TITLE
Disable Sonarcloud analysis on external PRs

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,8 +73,9 @@ jobs:
     #- name: Run code coverage
     #  working-directory: ${{runner.workspace}}/build
     #  run: cmake --build . --config $BUILD_TYPE --target coverage
-
+    
     - name: SonarCloud Scan
+      if: github.repository == 'BenWibking/quokka' # analysis fails on external PRs
       working-directory: ${{github.workspace}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
Since Sonarcloud analysis depends on a secret token to run, and GitHub prevents tokens from being used by external PRs, we cannot run Sonarcloud analysis on external PRs, at least until we can find a workaround.