### PR TITLE
move sonarcloud analysis to separate CI action

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,15 +28,6 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip lcov libopenmpi-dev libhdf5-mpi-dev ccache libboost-dev
 
-    - name: Install fastcov
-      run: pip3 install fastcov --user
-
-    - name: Install Sonarscan CLI
-      run: ( curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip > sonar-scanner.zip ) && unzip sonar-scanner.zip -d ${{runner.workspace}}
-      
-    - name: Install Sonarscan Build Wrapper
-      run: ( curl https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip > build-wrapper.zip ) && unzip build-wrapper.zip -d ${{runner.workspace}}
-
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
@@ -51,7 +42,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: ${{runner.workspace}}/build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config $BUILD_TYPE
 
     - name: Create test output directory
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests
@@ -69,15 +60,3 @@ jobs:
       with:
         name: test-results
         path: ${{github.workspace}}/tests
-
-    #- name: Run code coverage
-    #  working-directory: ${{runner.workspace}}/build
-    #  run: cmake --build . --config $BUILD_TYPE --target coverage
-    
-    - name: SonarCloud Scan
-      if: github.repository == 'BenWibking/quokka' # analysis fails on external PRs
-      working-directory: ${{github.workspace}}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      run: ${{runner.workspace}}/sonar-scanner-4.7.0.2747-linux/bin/sonar-scanner -Dsonar.cfamily.build-wrapper-output=${{runner.workspace}}/build/bw-output

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,56 @@
+name: Sonarcloud
+
+on: [push]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: RelWithDebInfo
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip lcov libopenmpi-dev libhdf5-mpi-dev ccache libboost-dev
+
+    - name: Install fastcov
+      run: pip3 install fastcov --user
+
+    - name: Install Sonarscan CLI
+      run: ( curl https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip > sonar-scanner.zip ) && unzip sonar-scanner.zip -d ${{runner.workspace}}
+      
+    - name: Install Sonarscan Build Wrapper
+      run: ( curl https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip > build-wrapper.zip ) && unzip build-wrapper.zip -d ${{runner.workspace}}
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DENABLE_ASAN=OFF
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ${{runner.workspace}}/build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output cmake --build . --config $BUILD_TYPE
+
+    #- name: Run code coverage
+    #  working-directory: ${{runner.workspace}}/build
+    #  run: cmake --build . --config $BUILD_TYPE --target coverage
+    
+    - name: SonarCloud Scan
+      if: github.repository == 'BenWibking/quokka' # analysis fails on external forks
+      working-directory: ${{github.workspace}}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: ${{runner.workspace}}/sonar-scanner-4.7.0.2747-linux/bin/sonar-scanner -Dsonar.cfamily.build-wrapper-output=${{runner.workspace}}/build/bw-output


### PR DESCRIPTION
Add separate GitHub action to build and run Sonarcloud static analysis. This is necessary because Sonarcloud analysis doesn't work for external PRs.