### PR TITLE
specify max_timesteps at runtime for HydroBlast3d

### DIFF
--- a/scripts/gpu_wrapper_sedov_256_gpuaware.sh
+++ b/scripts/gpu_wrapper_sedov_256_gpuaware.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export CUDA_VISIBLE_DEVICES=$(($OMPI_COMM_WORLD_LOCAL_RANK % 4))
+./build/src/HydroBlast3D/test_hydro3d_blast tests/blast_unigrid_256.in amrex.use_gpu_aware_mpi=1
+
+

--- a/tests/blast_unigrid_256.in
+++ b/tests/blast_unigrid_256.in
@@ -22,3 +22,5 @@ amr.grid_eff        = 0.7   # default
 
 do_reflux = 0
 do_subcycle = 0
+
+max_timesteps = 1000


### PR DESCRIPTION
Allow specifying `max_timesteps` in the input params file for the HydroBlast3D problem.