### PR TITLE
add Strang-split sources to hydro update

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -64,6 +64,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::componentNames_;
 	using AMRSimulation<problem_t>::fillBoundaryConditions;
 	using AMRSimulation<problem_t>::geom;
+	using AMRSimulation<problem_t>::dmap;
 	using AMRSimulation<problem_t>::flux_reg_;
 	using AMRSimulation<problem_t>::incrementFluxRegisters;
 	using AMRSimulation<problem_t>::finest_level;
@@ -165,6 +166,9 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	void advanceHydroAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
 				 amrex::YAFluxRegister *fr_as_crse,
 				 amrex::YAFluxRegister *fr_as_fine);
+
+	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time,
+				 amrex::Real dt_lev);
 
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew);
@@ -354,6 +358,14 @@ void RadhydroSimulation<problem_t>::computeAfterLevelAdvance(int lev, amrex::Rea
 }
 
 template <typename problem_t>
+void RadhydroSimulation<problem_t>::addStrangSplitSources(amrex::MultiFab &state,
+								 int lev, amrex::Real time, amrex::Real dt)
+{
+	// user should implement
+	// (when Strang splitting is enabled, dt is actually 0.5*dt_lev)
+}
+
+template <typename problem_t>
 void RadhydroSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname,
 								amrex::MultiFab &mf, const int ncomp) const
 {
@@ -529,18 +541,25 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		fluxScaleFactor = 1.0;
 	}
 
+	// create temporary multifab for Strang-split sources, copy old state
+	amrex::MultiFab state_old_tmp(geom[lev], dmap[lev], ncomp_, nghost_);
+	amrex::Copy(state_old_tmp, state_old_[lev], 0, 0, ncomp_, nghost_);
+
+	// do Strang split source terms (first half-step)
+	addStrangSplitSources(state_old_tmp, lev, time, 0.5*dt_lev);
+
 	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_[lev], state_old_[lev], lev, time);
+	fillBoundaryConditions(state_old_tmp, state_old_tmp, lev, time);
 
 	// check state validity
-	AMREX_ASSERT(!state_old_[lev].contains_nan(0, state_old_[lev].nComp()));
-	AMREX_ASSERT(!state_old_[lev].contains_nan()); // check ghost cells
+	AMREX_ASSERT(!state_old_tmp.contains_nan(0, state_old_tmp.nComp()));
+	AMREX_ASSERT(!state_old_tmp.contains_nan()); // check ghost cells
 
 	// advance all grids on local processor (Stage 1 of integrator)
 	for (amrex::MFIter iter(state_new_[lev]); iter.isValid(); ++iter) {
 
 		const amrex::Box &indexRange = iter.validbox(); // 'validbox' == exclude ghost zones
-		auto const &stateOld = state_old_[lev].const_array(iter);
+		auto const &stateOld = state_old_tmp.const_array(iter);
 		auto const &stateNew = state_new_[lev].array(iter);
 		auto fluxArrays = computeHydroFluxes(stateOld, indexRange, ncompHydro_);
 
@@ -616,7 +635,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		for (amrex::MFIter iter(state_new_[lev]); iter.isValid(); ++iter) {
 
 			const amrex::Box &indexRange = iter.validbox(); // 'validbox' == exclude ghost zones
-			auto const &stateOld = state_old_[lev].const_array(iter);
+			auto const &stateOld = state_old_tmp.const_array(iter);
 			auto const &stateInter = state_new_[lev].const_array(iter);
 			auto fluxArrays = computeHydroFluxes(stateInter, indexRange, ncompHydro_);
 
@@ -687,6 +706,9 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			}
 		}
 	}
+
+	// do Strang split source terms (second half-step)
+	addStrangSplitSources(state_new_[lev], lev, time + dt_lev, 0.5*dt_lev);
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -64,6 +64,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::componentNames_;
 	using AMRSimulation<problem_t>::fillBoundaryConditions;
 	using AMRSimulation<problem_t>::geom;
+	using AMRSimulation<problem_t>::grids;
 	using AMRSimulation<problem_t>::dmap;
 	using AMRSimulation<problem_t>::flux_reg_;
 	using AMRSimulation<problem_t>::incrementFluxRegisters;
@@ -542,7 +543,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	}
 
 	// create temporary multifab for Strang-split sources, copy old state
-	amrex::MultiFab state_old_tmp(geom[lev], dmap[lev], ncomp_, nghost_);
+	amrex::MultiFab state_old_tmp(grids[lev], dmap[lev], ncomp_, nghost_);
 	amrex::Copy(state_old_tmp, state_old_[lev], 0, 0, ncomp_, nghost_);
 
 	// do Strang split source terms (first half-step)


### PR DESCRIPTION
Adds a function `addStrangSplitSources` to `RadhydroSimulation`. This is called with `0.5*dt_lev` at the start of the hydro update, and with `0.5*dt_lev` at the end of the hydro update. Adding new Strang-split physics just requires implementing the operator split update within `addStrangSplitSources`.

Closes https://github.com/BenWibking/quokka/issues/93