### PR TITLE
Fix P -> Pgas in Hydro_System assert

### DIFF
--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -178,7 +178,7 @@ void HydroSystem<problem_t>::ConservedToPrimitive(
 
     AMREX_ASSERT(rho > 0.);
     if constexpr (!is_eos_isothermal()) {
-      AMREX_ASSERT(P > 0.);
+      AMREX_ASSERT(Pgas > 0.);
     }
 
     primVar(i, j, k, primDensity_index) = rho;


### PR DESCRIPTION
The `P` variable was renamed to `Pgas`, but not when it was used inside an `AMREX_ASSERT`, so it was not caught by the release-mode CI build.