### PR TITLE
use internal energy for AMR interpolation

### DIFF
--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -64,6 +64,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	using AMRSimulation<problem_t>::tNew_;
 	using AMRSimulation<problem_t>::boxArray;
 	using AMRSimulation<problem_t>::DistributionMap;
+	using AMRSimulation<problem_t>::InterpHookNone;
 
 	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &boundaryConditions)
       : AMRSimulation<problem_t>(boundaryConditions) {
@@ -270,7 +271,7 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 
 	// update ghost zones [w/ old timestep]
 	// (N.B. the input and output multifabs are allowed to be the same, as done here)
-	fillBoundaryConditions(state_old_[lev], state_old_[lev], lev, time);
+	fillBoundaryConditions(state_old_[lev], state_old_[lev], lev, time, InterpHookNone, InterpHookNone);
 
 	amrex::Real fluxScaleFactor = NAN;
 	if constexpr (integratorOrder_ == 2) {
@@ -311,7 +312,8 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 
 	if constexpr (integratorOrder_ == 2) {
 		// update ghost zones [w/ intermediate stage stored in state_new_]
-		fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_lev);
+		fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_lev,
+				InterpHookNone, InterpHookNone);
 
 		// advance all grids on local processor (Stage 2 of integrator)
 		for (amrex::MFIter iter(state_new_[lev]); iter.isValid(); ++iter) {

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -591,9 +591,9 @@ void RadhydroSimulation<problem_t>::PreInterpState(amrex::FArrayBox &fab, amrex:
 		const auto Etot = cons(i, j, k, HydroSystem<problem_t>::energy_index);
 		const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
 
-		// replace hydro total energy with internal energy
-		const auto Eint = Etot - kinetic_energy;
-		cons(i, j, k, HydroSystem<problem_t>::energy_index) = Eint;
+		// replace hydro total energy with specific internal energy (SIE)
+		const auto e = (Etot - kinetic_energy) / rho;
+		cons(i, j, k, HydroSystem<problem_t>::energy_index) = e;
 	});
 }
 
@@ -609,10 +609,11 @@ void RadhydroSimulation<problem_t>::PostInterpState(amrex::FArrayBox &fab, amrex
 		const auto px = cons(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
 		const auto py = cons(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
 		const auto pz = cons(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-		const auto Eint = cons(i, j, k, HydroSystem<problem_t>::energy_index);
+		const auto e = cons(i, j, k, HydroSystem<problem_t>::energy_index);
+		const auto Eint = rho * e;
 		const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
 
-		// recompute hydro total energy
+		// recompute hydro total energy from Eint + KE
 		const auto Etot = Eint + kinetic_energy;
 		cons(i, j, k, HydroSystem<problem_t>::energy_index) = Etot;
 	});

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -1153,7 +1153,8 @@ void RadhydroSimulation<problem_t>::advanceRadiationSubstepAtLevel(
 	// and another to store the intermediate stage (which is reused for the final stage).
 
 	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_[lev], state_old_[lev], lev, time);
+	fillBoundaryConditions(state_old_[lev], state_old_[lev], lev, time,
+			PreInterpState, PostInterpState);
 
 	// advance all grids on local processor (Stage 1 of integrator)
 	for (amrex::MFIter iter(state_new_[lev]); iter.isValid(); ++iter) {
@@ -1184,7 +1185,8 @@ void RadhydroSimulation<problem_t>::advanceRadiationSubstepAtLevel(
 	}
 
 	// update ghost zones [intermediate stage stored in state_new_]
-	fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_radiation);
+	fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_radiation,
+			PreInterpState, PostInterpState);
 
 	// advance all grids on local processor (Stage 2 of integrator)
 	for (amrex::MFIter iter(state_new_[lev]); iter.isValid(); ++iter) {

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -78,6 +78,8 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::cellUpdates_;
 	using AMRSimulation<problem_t>::CountCells;
 	using AMRSimulation<problem_t>::WriteCheckpointFile;
+	using AMRSimulation<problem_t>::GetData;
+	using AMRSimulation<problem_t>::FillPatchWithData;
 
 	std::vector<double> t_vec_;
 	std::vector<double> Trad_vec_;
@@ -142,7 +144,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
 	void preCalculateInitialConditions() override;
-  void setInitialConditionsOnGrid(std::vector<quokka::grid> &grid_vec) override;
+  	void setInitialConditionsOnGrid(std::vector<quokka::grid> &grid_vec) override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
 									  int ncycle) override;
 	void computeAfterTimestep() override;
@@ -158,6 +160,13 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 	// fix-up states
 	void FixupState(int level) override;
+
+	// implement FillPatch function
+	void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp) override;
+
+	// functions to operate on state vector before/after interpolating between levels
+	static void PreInterpState(amrex::FArrayBox &fab, amrex::Box const &box, int scomp, int ncomp);
+	static void PostInterpState(amrex::FArrayBox &fab, amrex::Box const &box, int scomp, int ncomp);
 
 	// tag cells for refinement
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
@@ -538,6 +547,77 @@ void RadhydroSimulation<problem_t>::FixupState(int lev)
 	}
 }
 
+// Compute a new multifab 'mf' by copying in state from valid region and filling
+// ghost cells
+// NOTE: This has to be implemented here because PreInterpState and PostInterpState
+// are implemented in this class (and must be *static* functions).
+template <typename problem_t>
+void RadhydroSimulation<problem_t>::FillPatch(int lev, amrex::Real time,
+                                         amrex::MultiFab &mf, int icomp,
+                                         int ncomp) {
+  BL_PROFILE("AMRSimulation::FillPatch()");
+
+  amrex::Vector<amrex::MultiFab *> cmf;
+  amrex::Vector<amrex::MultiFab *> fmf;
+  amrex::Vector<amrex::Real> ctime;
+  amrex::Vector<amrex::Real> ftime;
+
+  if (lev == 0) {
+    // in this case, should return either state_new_[lev] or state_old_[lev]
+    GetData(lev, time, fmf, ftime);
+  } else {
+    // in this case, should return either state_new_[lev] or state_old_[lev]
+    GetData(lev, time, fmf, ftime);
+    // returns old state, new state, or both depending on 'time'
+    GetData(lev - 1, time, cmf, ctime);
+  }
+
+  FillPatchWithData(lev, time, mf, cmf, ctime, fmf, ftime, icomp, ncomp,
+		PreInterpState, PostInterpState);
+}
+
+template <typename problem_t>
+void RadhydroSimulation<problem_t>::PreInterpState(amrex::FArrayBox &fab, amrex::Box const &box,
+	int scomp, int ncomp)
+{
+	BL_PROFILE("RadhydroSimulation::PreInterpState()");
+
+	auto const &cons = fab.array();
+	amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const auto rho = cons(i, j, k, HydroSystem<problem_t>::density_index);
+		const auto px = cons(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+		const auto py = cons(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+		const auto pz = cons(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+		const auto Etot = cons(i, j, k, HydroSystem<problem_t>::energy_index);
+		const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
+
+		// replace hydro total energy with internal energy
+		const auto Eint = Etot - kinetic_energy;
+		cons(i, j, k, HydroSystem<problem_t>::energy_index) = Eint;
+	});
+}
+
+template <typename problem_t>
+void RadhydroSimulation<problem_t>::PostInterpState(amrex::FArrayBox &fab, amrex::Box const &box,
+	int scomp, int ncomp)
+{
+	BL_PROFILE("RadhydroSimulation::PostInterpState()");
+
+	auto const &cons = fab.array();
+	amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const auto rho = cons(i, j, k, HydroSystem<problem_t>::density_index);
+		const auto px = cons(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+		const auto py = cons(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+		const auto pz = cons(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+		const auto Eint = cons(i, j, k, HydroSystem<problem_t>::energy_index);
+		const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
+
+		// recompute hydro total energy
+		const auto Etot = Eint + kinetic_energy;
+		cons(i, j, k, HydroSystem<problem_t>::energy_index) = Etot;
+	});
+}
+
 template <typename problem_t>
 void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real time,
 							amrex::Real dt_lev,
@@ -563,7 +643,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	addStrangSplitSources(state_old_tmp, lev, time, 0.5*dt_lev);
 
 	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_tmp, state_old_tmp, lev, time);
+	fillBoundaryConditions(state_old_tmp, state_old_tmp, lev, time, PreInterpState, PostInterpState);
 
 	// check state validity
 	AMREX_ASSERT(!state_old_tmp.contains_nan(0, state_old_tmp.nComp()));
@@ -645,7 +725,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 	if (integratorOrder_ == 2) {
 		// update ghost zones [intermediate stage stored in state_new_]
-		fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_lev);
+		fillBoundaryConditions(state_new_[lev], state_new_[lev], lev, time + dt_lev,
+			PreInterpState, PostInterpState);
 
 		// check intermediate state validity
 		AMREX_ASSERT(!state_new_[lev].contains_nan(0, state_new_[lev].nComp()));

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -153,16 +153,24 @@ public:
                                const amrex::DistributionMapping &dm) override;
 
   // AMR utility functions
+  template <typename PreInterpHook, typename PostInterpHook>
   void fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state,
-                              int lev, amrex::Real time);
+                              int lev, amrex::Real time,
+                              PreInterpHook const &pre_interp,
+                              PostInterpHook const&post_interp);
+
+  template <typename PreInterpHook, typename PostInterpHook>
   void FillPatchWithData(int lev, amrex::Real time, amrex::MultiFab &mf,
                          amrex::Vector<amrex::MultiFab *> &coarseData,
                          amrex::Vector<amrex::Real> &coarseTime,
                          amrex::Vector<amrex::MultiFab *> &fineData,
                          amrex::Vector<amrex::Real> &fineTime, int icomp,
-                         int ncomp);
-  void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp,
-                 int ncomp);
+                         int ncomp, PreInterpHook const &pre_interp,
+                         PostInterpHook const &post_interp);
+
+  static void InterpHookNone(amrex::FArrayBox &fab, amrex::Box const &box, int scomp, int ncomp);
+  virtual void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp,
+                 int ncomp) = 0;
   void FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf,
                        int icomp, int ncomp);
   void GetData(int lev, amrex::Real time,
@@ -941,6 +949,13 @@ void AMRSimulation<problem_t>::ClearLevel(int level) {
   flux_reg_[level].reset(nullptr);
 }
 
+template <typename problem_t>
+void AMRSimulation<problem_t>::InterpHookNone(
+    amrex::FArrayBox &fab, amrex::Box const &box, int scomp, int ncomp)
+{
+  // do nothing
+}
+
 // Make a new level from scratch using provided BoxArray and
 // DistributionMapping. Only used during initialization. Overrides the pure
 // virtual function in AmrCore
@@ -973,7 +988,8 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(
   AMREX_ALWAYS_ASSERT(!state_new_[level].contains_nan(0, ncomp));
 
   // fill ghost zones
-  fillBoundaryConditions(state_new_[level], state_new_[level], level, time);
+  fillBoundaryConditions(state_new_[level], state_new_[level], level, time,
+                         InterpHookNone, InterpHookNone);
 
   // copy to state_old_ (including ghost zones)
   state_old_[level].ParallelCopy(state_new_[level], 0, 0, ncomp, nghost,
@@ -1005,10 +1021,13 @@ AMRSimulation<problem_t>::setCustomBoundaryConditions(
 }
 
 template <typename problem_t>
+template <typename PreInterpHook, typename PostInterpHook>
 void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
                                                       amrex::MultiFab &state,
                                                       int const lev,
-                                                      amrex::Real const time) {
+                                                      amrex::Real const time,
+                                                      PreInterpHook const &pre_interp,
+                                                      PostInterpHook const &post_interp) {
   BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
 
   // On a single level, any periodic boundaries are filled first
@@ -1037,7 +1056,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
     }
 
     FillPatchWithData(lev, time, S_filled, coarseData, coarseTime, fineData,
-                      fineTime, 0, S_filled.nComp());
+                      fineTime, 0, S_filled.nComp(), pre_interp, post_interp);
   } else { // level 0
     // fill internal and periodic boundaries, ignoring corners (cross=true)
     // (there is no performance benefit for this in practice)
@@ -1069,12 +1088,14 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 // Compute a new multifab 'mf' by copying in state from given data and filling
 // ghost cells
 template <typename problem_t>
+template <typename PreInterpHook, typename PostInterpHook>
 void AMRSimulation<problem_t>::FillPatchWithData(
     int lev, amrex::Real time, amrex::MultiFab &mf,
     amrex::Vector<amrex::MultiFab *> &coarseData,
     amrex::Vector<amrex::Real> &coarseTime,
     amrex::Vector<amrex::MultiFab *> &fineData,
-    amrex::Vector<amrex::Real> &fineTime, int icomp, int ncomp) {
+    amrex::Vector<amrex::Real> &fineTime, int icomp, int ncomp,
+    PreInterpHook const &pre_interp, PostInterpHook const &post_interp) {
   BL_PROFILE("AMRSimulation::FillPatchWithData()");
 
   // create functor to fill ghost zones at domain boundaries
@@ -1105,34 +1126,9 @@ void AMRSimulation<problem_t>::FillPatchWithData(
                               fineTime, 0, icomp, ncomp, geom[lev - 1],
                               geom[lev], coarsePhysicalBoundaryFunctor, 0,
                               finePhysicalBoundaryFunctor, 0, refRatio(lev - 1),
-                              mapper, boundaryConditions_, 0);
+                              mapper, boundaryConditions_, 0,
+                              pre_interp, post_interp);
   }
-}
-
-// Compute a new multifab 'mf' by copying in state from valid region and filling
-// ghost cells
-template <typename problem_t>
-void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time,
-                                         amrex::MultiFab &mf, int icomp,
-                                         int ncomp) {
-  BL_PROFILE("AMRSimulation::FillPatch()");
-
-  amrex::Vector<amrex::MultiFab *> cmf;
-  amrex::Vector<amrex::MultiFab *> fmf;
-  amrex::Vector<amrex::Real> ctime;
-  amrex::Vector<amrex::Real> ftime;
-
-  if (lev == 0) {
-    // in this case, should return either state_new_[lev] or state_old_[lev]
-    GetData(lev, time, fmf, ftime);
-  } else {
-    // in this case, should return either state_new_[lev] or state_old_[lev]
-    GetData(lev, time, fmf, ftime);
-    // returns old state, new state, or both depending on 'time'
-    GetData(lev - 1, time, cmf, ctime);
-  }
-
-  FillPatchWithData(lev, time, mf, cmf, ctime, fmf, ftime, icomp, ncomp);
 }
 
 // Fill an entire multifab by interpolating from the coarser level


### PR DESCRIPTION
When interpolating from coarse to fine grids, interpolate the internal energy instead of the total energy.

This may reduce glitches at coarse-fine boundaries for high Mach number flows. (However, this appears to have a negligible effect on the shock-cloud problem.)

Fixes https://github.com/BenWibking/quokka/issues/102