### PR TITLE
use MultiFab ParallelFor for RT2D/3D problems

### DIFF
--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -128,6 +128,7 @@ void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state
       state[bx](i, j, k, HydroSystem<RTProblem>::x3Momentum_index) = pz;
       state[bx](i, j, k, HydroSystem<RTProblem>::energy_index) += dKE;
   });
+  amrex::Gpu::streamSynchronize();  
 }
 
 template <>
@@ -160,6 +161,7 @@ void RadhydroSimulation<RTProblem>::ErrorEst(
         tag[bx](i, j, k) = amrex::TagBox::SET;
       }
   });
+  amrex::Gpu::streamSynchronize();
 }
 
 auto problem_main() -> int {

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -102,17 +102,15 @@ template <>
 void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf,
     const int lev, const amrex::Real time, const amrex::Real dt) {
   // add gravitational source terms
+  const auto state = state_mf.arrays();
 
-  for (amrex::MFIter mfi(state_mf); mfi.isValid(); ++mfi) {
-    const amrex::Box &box = mfi.validbox();
-    const auto state = state_mf.array(mfi);
-
-    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+  amrex::ParallelFor(state_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
       // save initial KE
-      amrex::Real const rho = state(i, j, k, HydroSystem<RTProblem>::density_index);
-      amrex::Real px = state(i, j, k, HydroSystem<RTProblem>::x1Momentum_index);
-      amrex::Real py = state(i, j, k, HydroSystem<RTProblem>::x2Momentum_index);
-      amrex::Real pz = state(i, j, k, HydroSystem<RTProblem>::x3Momentum_index);
+      amrex::Real const rho = state[bx](i, j, k, HydroSystem<RTProblem>::density_index);
+      amrex::Real px = state[bx](i, j, k, HydroSystem<RTProblem>::x1Momentum_index);
+      amrex::Real py = state[bx](i, j, k, HydroSystem<RTProblem>::x2Momentum_index);
+      amrex::Real pz = state[bx](i, j, k, HydroSystem<RTProblem>::x3Momentum_index);
+
       amrex::Real const KE_init = (px*px + py*py + pz*pz) / (2.0 * rho);
 
       // add body forces
@@ -125,12 +123,11 @@ void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state
       amrex::Real const dKE = KE_final - KE_init;
 
       // update variables
-      state(i, j, k, HydroSystem<RTProblem>::x1Momentum_index) = px;
-      state(i, j, k, HydroSystem<RTProblem>::x2Momentum_index) = py;
-      state(i, j, k, HydroSystem<RTProblem>::x3Momentum_index) = pz;
-      state(i, j, k, HydroSystem<RTProblem>::energy_index) += dKE;
-    });
-  }
+      state[bx](i, j, k, HydroSystem<RTProblem>::x1Momentum_index) = px;
+      state[bx](i, j, k, HydroSystem<RTProblem>::x2Momentum_index) = py;
+      state[bx](i, j, k, HydroSystem<RTProblem>::x3Momentum_index) = pz;
+      state[bx](i, j, k, HydroSystem<RTProblem>::energy_index) += dKE;
+  });
 }
 
 template <>
@@ -140,19 +137,18 @@ void RadhydroSimulation<RTProblem>::ErrorEst(
 
   const amrex::Real eta_threshold = 0.2; // gradient refinement threshold
   const amrex::Real rho_min = 0.1;       // minimum density for refinement
+  
+  const auto state = state_new_[lev].const_arrays();
+  const auto tag = tags.arrays();
 
-  for (amrex::MFIter mfi(state_new_[lev]); mfi.isValid(); ++mfi) {
-    const amrex::Box &box = mfi.validbox();
-    const auto state = state_new_[lev].const_array(mfi);
-    const auto tag = tags.array(mfi);
-
-    amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+  amrex::ParallelFor(state_new_[lev],
+    [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
       const int n = HydroSystem<RTProblem>::density_index;
-      amrex::Real const rho = state(i, j, k, n);
-      amrex::Real const rho_xplus = state(i + 1, j, k, n);
-      amrex::Real const rho_xminus = state(i - 1, j, k, n);
-      amrex::Real const rho_yplus = state(i, j + 1, k, n);
-      amrex::Real const rho_yminus = state(i, j - 1, k, n);
+      amrex::Real const rho = state[bx](i, j, k, n);
+      amrex::Real const rho_xplus = state[bx](i + 1, j, k, n);
+      amrex::Real const rho_xminus = state[bx](i - 1, j, k, n);
+      amrex::Real const rho_yplus = state[bx](i, j + 1, k, n);
+      amrex::Real const rho_yminus = state[bx](i, j - 1, k, n);
 
       amrex::Real const del_x = 0.5 * (rho_xplus - rho_xminus);
       amrex::Real const del_y = 0.5 * (rho_yplus - rho_yminus);
@@ -161,10 +157,9 @@ void RadhydroSimulation<RTProblem>::ErrorEst(
           std::sqrt(del_x*del_x + del_y*del_y) / rho;
 
       if ((gradient_indicator > eta_threshold) && (rho > rho_min)) {
-        tag(i, j, k) = amrex::TagBox::SET;
+        tag[bx](i, j, k) = amrex::TagBox::SET;
       }
-    });
-  }
+  });
 }
 
 auto problem_main() -> int {

--- a/src/RayleighTaylor3D/ascent_actions.yaml
+++ b/src/RayleighTaylor3D/ascent_actions.yaml
@@ -1,0 +1,32 @@
+- 
+  action: "add_pipelines"
+  pipelines: 
+    pl1: 
+      f1: 
+        type: "slice"
+        params: 
+          point: 
+            x: 0.0
+            y: 0.0
+            z: 0.0
+          normal: 
+            x: 0.0
+            y: 1.0
+            z: 0.0
+- 
+  action: "add_scenes"
+  scenes: 
+    s1: 
+      plots: 
+        p1: 
+          type: "pseudocolor"
+          field: "scalar_0"
+          pipeline: "pl1"
+      renders:
+        r1:
+          image_prefix: "scalar%05d"
+          annotations: "true"
+          camera:
+            look_at: [0, 0, 0]
+            up: [0, 0, 1]
+            position: [0, 1, 0]

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -128,6 +128,7 @@ void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state
       state[bx](i, j, k, HydroSystem<RTProblem>::x3Momentum_index) = pz;
       state[bx](i, j, k, HydroSystem<RTProblem>::energy_index) += dKE;
   });
+  amrex::Gpu::streamSynchronize();
 }
 
 template <>
@@ -163,6 +164,7 @@ void RadhydroSimulation<RTProblem>::ErrorEst(
         tag[bx](i, j, k) = amrex::TagBox::SET;
       }
   });
+  amrex::Gpu::streamSynchronize();
 }
 
 template <>


### PR DESCRIPTION
This uses the MultiFab version of `amrex::ParallelFor`.

This allows us to avoid some kernel launch overheads for the gravity source term and AMR tagging kernels. This is especially important on MI100.

Fixes https://github.com/BenWibking/quokka/issues/118.