### PR TITLE
avoid filling old_state when regridding

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -538,17 +538,13 @@ void RadhydroSimulation<problem_t>::FixupState(int lev)
 	BL_PROFILE("RadhydroSimulation::FixupState()");
 
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.fabbox(); // include ghost zones!
+		const amrex::Box &indexRange = iter.validbox();
 		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto const &stateOld = state_old_cc_[lev].array(iter);
-
+		
 		// fix hydro state
-		//HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
-		//HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateOld);
-
+		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
 		// sync internal energy and total energy
 		HydroSystem<problem_t>::SyncDualEnergy(stateNew, indexRange);
-		HydroSystem<problem_t>::SyncDualEnergy(stateOld, indexRange);
 	}
 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -922,7 +922,6 @@ void AMRSimulation<problem_t>::RemakeLevel(
   amrex::MultiFab max_signal_speed(ba, dm, 1, nghost);
 
   FillPatch(level, time, new_state, 0, ncomp);
-  FillPatch(level, time, old_state, 0, ncomp); // also necessary
 
   std::swap(new_state, state_new_cc_[level]);
   std::swap(old_state, state_old_cc_[level]);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -902,7 +902,6 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(
   }
 
   FillCoarsePatch(level, time, state_new_cc_[level], 0, ncomp);
-  FillCoarsePatch(level, time, state_old_cc_[level], 0, ncomp); // also necessary
 }
 
 // Remake an existing level using provided BoxArray and DistributionMapping and


### PR DESCRIPTION
Avoid filling old_state_ multifabs when regridding. It should not be necessary, and avoiding this will reduce communication.