### PR TITLE
apply density floor after regrid

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -538,13 +538,13 @@ void RadhydroSimulation<problem_t>::FixupState(int lev)
 	BL_PROFILE("RadhydroSimulation::FixupState()");
 
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.fabbox(); // include ghost zones!
+		const amrex::Box &indexRange = iter.validbox();
 		auto const &stateNew = state_new_cc_[lev].array(iter);
 		auto const &stateOld = state_old_cc_[lev].array(iter);
 
 		// fix hydro state
-		//HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
-		//HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateOld);
+		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
+		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateOld);
 
 		// sync internal energy and total energy
 		HydroSystem<problem_t>::SyncDualEnergy(stateNew, indexRange);


### PR DESCRIPTION
This applies a density floor after regridding (inside `RadhydroSimulation::FixUpState`). Also, the state fix-up only needs to be applied to valid cells, not ghost cells.