### PR TITLE
allow limiting timesteps based on extra physics

### DIFF
--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -78,6 +78,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	    : AMRSimulation<problem_t>(boundaryConditions) { }
 
 	void computeMaxSignalLocal(int level) override;
+	auto computeExtraPhysicsTimestep(int level) -> amrex::Real override;
 	void preCalculateInitialConditions() override;
   void setInitialConditionsOnGrid(std::vector<quokka::grid> &grid_vec) override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
@@ -129,6 +130,13 @@ void AdvectionSimulation<problem_t>::computeMaxSignalLocal(int const level)
 		LinearAdvectionSystem<problem_t>::ComputeMaxSignalSpeed(
 		    stateOld, maxSignal, advectionVx_, advectionVy_, advectionVz_, indexRange);
 	}
+}
+
+template <typename problem_t>
+auto AdvectionSimulation<problem_t>::computeExtraPhysicsTimestep(int const level) -> amrex::Real
+{
+	// user can override this
+	return std::numeric_limits<amrex::Real>::max();
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -144,6 +144,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
+	auto computeExtraPhysicsTimestep(int lev) -> amrex::Real override;
 	void preCalculateInitialConditions() override;
   	void setInitialConditionsOnGrid(std::vector<quokka::grid> &grid_vec) override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
@@ -328,6 +329,14 @@ void RadhydroSimulation<problem_t>::computeMaxSignalLocal(int const level)
 				     "compute a time step.");
 		}
 	}
+}
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::computeExtraPhysicsTimestep(int const level) -> amrex::Real
+{
+	BL_PROFILE("RadhydroSimulation::computeExtraPhysicsTimestep()");
+	// users can override this to enforce additional timestep constraints
+	return std::numeric_limits<amrex::Real>::max();
 }
 
 #if !defined(NDEBUG)

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -243,6 +243,9 @@ template <> auto RadhydroSimulation<ShockCloud>::computeExtraPhysicsTimestep(int
   amrex::Gpu::streamSynchronizeAll();
 
   amrex::Real min_tcool = tcool_mf.min(0);
+  if (verbose) {
+    amrex::Print() << "\tMinimum cooling time on level " << lev << ": " << min_tcool << "\n";
+  }
   return tcool_safety_fac * min_tcool;
 }
 

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -217,6 +217,35 @@ AMRSimulation<ShockCloud>::setCustomBoundaryConditions(
   }
 }
 
+template <> auto RadhydroSimulation<ShockCloud>::computeExtraPhysicsTimestep(int const lev) -> amrex::Real
+{
+	// return minimum cooling time on level 'lev'
+  amrex::Real tcool_safety_fac = 0.1;
+
+  auto const &mf = state_new_cc_[lev];
+	auto const &state = mf.const_arrays();
+  amrex::MultiFab tcool_mf(mf.boxArray(), mf.DistributionMap(), 1, 0);
+  auto const &tcool = tcool_mf.arrays();
+  auto tables = cloudyTables.const_tables();
+
+	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		const Real rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
+		const Real x1Mom = state[bx](i, j, k, HydroSystem<ShockCloud>::x1Momentum_index);
+		const Real x2Mom = state[bx](i, j, k, HydroSystem<ShockCloud>::x2Momentum_index);
+		const Real x3Mom = state[bx](i, j, k, HydroSystem<ShockCloud>::x3Momentum_index);
+		const Real Egas = state[bx](i, j, k, HydroSystem<ShockCloud>::energy_index);
+		const Real Eint = RadSystem<ShockCloud>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
+
+		Real T = ComputeTgasFromEgas(rho, Eint, HydroSystem<ShockCloud>::gamma_, tables);
+		Real Edot = cloudy_cooling_function(rho, T, tables);
+		tcool[bx](i, j, k) = std::abs(Eint / Edot);
+	});
+  amrex::Gpu::streamSynchronizeAll();
+
+  amrex::Real min_tcool = tcool_mf.min(0);
+  return tcool_safety_fac * min_tcool;
+}
+
 struct ODEUserData {
   Real rho;
   cloudyGpuConstTables tables;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -115,6 +115,7 @@ public:
   auto computeTimestepAtLevel(int lev) -> amrex::Real;
 
   virtual void computeMaxSignalLocal(int level) = 0;
+  virtual auto computeExtraPhysicsTimestep(int lev) -> amrex::Real = 0;
   virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time,
                                             amrex::Real dt_lev, int ncycle) = 0;
   virtual void preCalculateInitialConditions() = 0;
@@ -506,13 +507,19 @@ auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::Real {
   // compute CFL timestep on level 'lev'
   BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
 
+  // compute hydro timestep on level 'lev'
   computeMaxSignalLocal(lev);
-  amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
+  const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx =
       geom[lev].CellSizeArray();
-  amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+  const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+  const amrex::Real hydro_dt = cflNumber_ * (dx_min / domain_signal_max);
 
-  return cflNumber_ * (dx_min / domain_signal_max);
+  // compute timestep due to extra physics on level 'lev'
+  const amrex::Real extra_physics_dt = computeExtraPhysicsTimestep(lev);
+
+  // return minimum timestep
+  return std::min(hydro_dt, extra_physics_dt);
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {


### PR DESCRIPTION
Adds a new function `auto computeExtraPhysicsTimestep(int lev) -> amrex::Real` to AMRSimulation to allow user-specified timestep limitations calculated on each level. This can be used to, e.g., limit the timestep to some fraction of the cooling time.