### PR TITLE
use MultiFab ParallelFor for hydro

### DIFF
--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -301,7 +301,7 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 		if (do_reflux) {
 #ifdef USE_YAFLUXREGISTER
 			// increment flux registers
-			//incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 #else
 			for (int i = 0; i < AMREX_SPACEDIM; i++) {
 				fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);
@@ -330,7 +330,7 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 			if (do_reflux) {
 #ifdef USE_YAFLUXREGISTER
 				// increment flux registers
-				//incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+				incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 #else
 				for (int i = 0; i < AMREX_SPACEDIM; i++) {
 					fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);

--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -99,14 +99,14 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	// tag cells for refinement
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
-	auto computeFluxes(amrex::Array4<const amrex::Real> const &consVar,
-			   const amrex::Box &indexRange, int nvars)
-	    -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>;
+	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev)
+		 -> std::array<amrex::MultiFab, AMREX_SPACEDIM>;
 
 	template <FluxDir DIR>
-	void fluxFunction(amrex::Array4<const amrex::Real> const &consState,
-			  amrex::Array4<amrex::Real> const &x1Flux, const amrex::Box &indexRange,
-			  int nvars);
+	void fluxFunction(amrex::MultiFab const &consState,
+						  amrex::MultiFab &primVar, amrex::MultiFab &x1Flux,
+						  amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState,
+						  const int ng_reconstruct, const int nvars);
 
 	double advectionVx_ = 1.0; // default
 	double advectionVy_ = 0.0; // default
@@ -289,27 +289,19 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 	}
 
 	// advance all grids on local processor (Stage 1 of integrator)
-	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateOld = state_old_cc_[lev].const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto fluxArrays = computeFluxes(stateOld, indexRange, ncomp_cc_);
-
-		amrex::IArrayBox redoFlag(indexRange, 1, amrex::The_Async_Arena());
+	{
+		auto const &stateOld = state_old_cc_[lev];
+		auto &stateNew = state_new_cc_[lev];
+		auto fluxArrays = computeFluxes(stateOld, ncomp_cc_, lev);
 
 		// Stage 1 of RK2-SSP
-		LinearAdvectionSystem<problem_t>::PredictStep(
-		    stateOld, stateNew,
-		    {AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
-				  fluxArrays[2].const_array())},
-		    dt_lev, geomLevel.CellSizeArray(), indexRange, ncomp_cc_,
-			redoFlag.array());
+		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays,
+		    dt_lev, geomLevel.CellSizeArray(), ncomp_cc_);
 
 		if (do_reflux) {
 #ifdef USE_YAFLUXREGISTER
 			// increment flux registers
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays, lev,
-					       fluxScaleFactor * dt_lev);
+			//incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 #else
 			for (int i = 0; i < AMREX_SPACEDIM; i++) {
 				fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);
@@ -324,28 +316,21 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 				InterpHookNone, InterpHookNone);
 
 		// advance all grids on local processor (Stage 2 of integrator)
-		for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
-			const amrex::Box &indexRange = iter.validbox();
-			auto const &stateInOld = state_old_cc_[lev].const_array(iter);
-			auto const &stateInStar = state_new_cc_[lev].const_array(iter);
-			auto const &stateOut = state_new_cc_[lev].array(iter);
-			auto fluxArrays = computeFluxes(stateInStar, indexRange, ncomp_cc_);
-
-			amrex::IArrayBox redoFlag(indexRange, 1, amrex::The_Async_Arena());
+		{
+			auto const &stateInOld = state_old_cc_[lev];
+			auto const &stateInStar = state_new_cc_[lev];
+			auto &stateOut = state_new_cc_[lev];
+			auto fluxArrays = computeFluxes(stateInStar, ncomp_cc_, lev);
 
 			// Stage 2 of RK2-SSP
 			LinearAdvectionSystem<problem_t>::AddFluxesRK2(
-			    stateOut, stateInOld, stateInStar,
-			    {AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
-					  fluxArrays[2].const_array())},
-			    dt_lev, geomLevel.CellSizeArray(), indexRange, ncomp_cc_,
-				redoFlag.array());
+			    stateOut, stateInOld, stateInStar, fluxArrays,
+			    dt_lev, geomLevel.CellSizeArray(), ncomp_cc_);
 
 			if (do_reflux) {
 #ifdef USE_YAFLUXREGISTER
 				// increment flux registers
-				incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays,
-						       lev, fluxScaleFactor * dt_lev);
+				//incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 #else
 				for (int i = 0; i < AMREX_SPACEDIM; i++) {
 					fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);
@@ -383,83 +368,62 @@ void AdvectionSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex
 }
 
 template <typename problem_t>
-auto AdvectionSimulation<problem_t>::computeFluxes(amrex::Array4<const amrex::Real> const &consVar,
-						   const amrex::Box &indexRange, const int nvars)
-    -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>
+auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
+    -> std::array<amrex::MultiFab, AMREX_SPACEDIM>
 {
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, 0);
-	amrex::FArrayBox x1Flux(x1FluxRange, nvars,
-				amrex::The_Async_Arena()); // node-centered in x
-#if (AMREX_SPACEDIM >= 2)
-	amrex::Box const &x2FluxRange = amrex::surroundingNodes(indexRange, 1);
-	amrex::FArrayBox x2Flux(x2FluxRange, nvars,
-				amrex::The_Async_Arena()); // node-centered in y
-#endif
-#if (AMREX_SPACEDIM == 3)
-	amrex::Box const &x3FluxRange = amrex::surroundingNodes(indexRange, 2);
-	amrex::FArrayBox x3Flux(x3FluxRange, nvars,
-				amrex::The_Async_Arena()); // node-centered in z
-#endif
+	auto ba = grids[lev];
+	auto dm = dmap[lev];
+	const int reconstructRange = 1;
 
-	AMREX_D_TERM(fluxFunction<FluxDir::X1>(consVar, x1Flux.array(), indexRange, nvars);
-		     , fluxFunction<FluxDir::X2>(consVar, x2Flux.array(), indexRange, nvars);
-		     , fluxFunction<FluxDir::X3>(consVar, x3Flux.array(), indexRange, nvars);)
+	// allocate temporary MultiFabs
+	amrex::MultiFab primVar(ba, dm, nvars, nghost_);
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
 
-	return {AMREX_D_DECL(std::move(x1Flux), std::move(x2Flux), std::move(x3Flux))};
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
+		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
+	}
+
+	AMREX_D_TERM(fluxFunction<FluxDir::X1>(consVar, primVar, flux[0], leftState[0], rightState[0], reconstructRange, nvars);
+		       , fluxFunction<FluxDir::X2>(consVar, primVar, flux[1], leftState[1], rightState[1], reconstructRange, nvars);
+		       , fluxFunction<FluxDir::X3>(consVar, primVar, flux[2], leftState[2], rightState[2], reconstructRange, nvars);)
+
+	// synchronization point to prevent MultiFabs from going out of scope
+	amrex::Gpu::streamSynchronizeAll();
+	return flux;
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void AdvectionSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> const &consState,
-						  amrex::Array4<amrex::Real> const &x1Flux,
-						  const amrex::Box &indexRange, const int nvars)
+void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consState,
+						  amrex::MultiFab &primVar, amrex::MultiFab &x1Flux,
+						  amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState,
+						  const int ng_reconstruct, const int nvars)
 {
 	amrex::Real advectionVel = NAN;
-	int dim = 0;
 	if constexpr (DIR == FluxDir::X1) {
 		advectionVel = advectionVx_;
-		// [0 == x1 direction]
-		dim = 0;
 	} else if constexpr (DIR == FluxDir::X2) {
 		advectionVel = advectionVy_;
-		// [1 == x2 direction]
-		dim = 1;
 	} else if constexpr (DIR == FluxDir::X3) {
 		advectionVel = advectionVz_;
-		// [2 == x3 direction]
-		dim = 2;
 	}
 
-	// extend box to include ghost zones
-	amrex::Box const &ghostRange = amrex::grow(indexRange, nghost_);
-	amrex::Box const &reconstructRange = amrex::grow(indexRange, 1);
-	amrex::Box const &x1ReconstructRange = amrex::surroundingNodes(reconstructRange, dim);
-	amrex::FArrayBox primVar(ghostRange, nvars,
-				 amrex::The_Async_Arena()); // cell-centered
-	amrex::FArrayBox x1LeftState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x1RightState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
+	//amrex::Box const &reconstructRange = amrex::grow(indexRange, 1);
+	//amrex::Box const &x1ReconstructRange = amrex::surroundingNodes(reconstructRange, dim);
 
-	// cell-centered kernel
-	LinearAdvectionSystem<problem_t>::ConservedToPrimitive(consState, primVar.array(),
-							       ghostRange, nvars);
+	LinearAdvectionSystem<problem_t>::ConservedToPrimitive(consState, primVar,
+		nghost_, nvars);
 
-	if constexpr (reconstructOrder_ == 3) {
-		// mixed interface/cell-centered kernel
-		LinearAdvectionSystem<problem_t>::template ReconstructStatesPPM<DIR>(
-		    primVar.array(), x1LeftState.array(), x1RightState.array(), reconstructRange,
-		    x1ReconstructRange, nvars);
-	} else if constexpr (reconstructOrder_ == 1) {
-		// interface-centered kernel
-		LinearAdvectionSystem<problem_t>::template ReconstructStatesConstant<DIR>(
-		    primVar.array(), x1LeftState.array(), x1RightState.array(), x1ReconstructRange,
-		    nvars);
-	}
-
-	// interface-centered kernel
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, dim);
+	LinearAdvectionSystem<problem_t>::template ReconstructStatesPPM<DIR>(
+		primVar, x1LeftState, x1RightState, ng_reconstruct, nvars);
 
 	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(
-	    x1Flux, x1LeftState.array(), x1RightState.array(), advectionVel, x1FluxRange, nvars);
+	    x1Flux, x1LeftState, x1RightState, advectionVel, nvars);
 }
 
 #endif // ADVECTION_SIMULATION_HPP_

--- a/src/ArrayView_2d.hpp
+++ b/src/ArrayView_2d.hpp
@@ -36,7 +36,7 @@ template <class T, FluxDir N, class Enable = void> struct Array4View {
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = N;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 };
 
 // X1-flux
@@ -46,7 +46,7 @@ template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_c
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X1;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T &
@@ -66,7 +66,7 @@ template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_co
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X1;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T
@@ -88,7 +88,7 @@ template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_c
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X2;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T &
@@ -108,7 +108,7 @@ template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_co
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X2;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T

--- a/src/ArrayView_3d.hpp
+++ b/src/ArrayView_3d.hpp
@@ -43,7 +43,7 @@ template <class T, FluxDir N, class Enable = void> struct Array4View {
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = N;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 };
 
 // X1-flux
@@ -53,7 +53,7 @@ template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_c
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X1;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T &
@@ -73,7 +73,7 @@ template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_co
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X1;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T
@@ -95,7 +95,7 @@ template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_c
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X2;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T &
@@ -115,7 +115,7 @@ template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_co
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X2;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T
@@ -137,7 +137,7 @@ template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<!std::is_c
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X3;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T &
@@ -157,7 +157,7 @@ template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<std::is_co
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = FluxDir::X3;
 
-	explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k,
 								 int n) const noexcept -> T

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -714,6 +714,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
+	amrex::Gpu::streamSynchronizeAll();
 
 	// Stage 2 of RK2-SSP
 	{
@@ -749,6 +750,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
+	amrex::Gpu::streamSynchronizeAll();
 
 	// do Strang split source terms (second half-step)
 	addStrangSplitSources(state_new_cc_[lev], lev, time + dt_lev, 0.5*dt_lev);

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -888,16 +888,7 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 	const int ng_reconstruct,
 	const int nvars)
 {
-	int dir = 0;
-	if constexpr (DIR == FluxDir::X1) {
-		dir = 0;
-	} else if constexpr (DIR == FluxDir::X2) {
-		dir = 1;
-	} else if constexpr (DIR == FluxDir::X3) {
-		dir = 2;
-	}
-
-	// interface-centered kernel
+	// cell-centered kernel
 	HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 
 #if 0

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -247,7 +247,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 	void replaceFluxes(
 			std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes,
-			std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,	amrex::MultiFab &redoFlag,
+			std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,	amrex::iMultiFab &redoFlag,
 			const int ncomp);
 };
 
@@ -712,7 +712,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		auto [fluxArrays, faceVel] = computeHydroFluxes(stateOld, ncompHydro_, lev);
 
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
-		amrex::MultiFab redoFlag(grids[lev], dmap[lev], 1, 0);
+		amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 0);
 		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
 		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, faceVel);
 		HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs, dt_lev, ncompHydro_, redoFlag);
@@ -775,7 +775,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		auto [fluxArrays, faceVel] = computeHydroFluxes(stateInter, ncompHydro_, lev);
 
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
-		amrex::MultiFab redoFlag(grids[lev], dmap[lev], 1, 0);
+		amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 0);
 		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
 		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateInter, dx, faceVel);
 		HydroSystem<problem_t>::AddFluxesRK2(stateFinal, stateOld, stateInter, rhs, dt_lev, ncompHydro_, redoFlag);
@@ -829,7 +829,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 template <typename problem_t>
 void RadhydroSimulation<problem_t>::replaceFluxes(
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes,
-    std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,	amrex::MultiFab &redoFlag,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,	amrex::iMultiFab &redoFlag,
 	const int ncomp)
 {
 	BL_PROFILE("RadhydroSimulation::replaceFluxes()");

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -177,6 +177,9 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	// tag cells for refinement
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
+	auto expandFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, int nstartNew,
+			      int ncompNew) -> std::array<amrex::MultiFab, AMREX_SPACEDIM>;
+
 	auto expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, int nstartNew,
 			      int ncompNew) -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>;
 
@@ -711,8 +714,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 		if (do_reflux) {
 			// increment flux registers
-			//auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-			//incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+			auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
@@ -747,8 +750,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 		if (do_reflux) {
 			// increment flux registers
-			// auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-			//incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+			auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
@@ -794,6 +797,28 @@ void RadhydroSimulation<problem_t>::replaceFluxes(
 		});
 	}
 }
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::expandFluxArrays(
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, const int nstartNew, const int ncompNew)
+    -> std::array<amrex::MultiFab, AMREX_SPACEDIM>
+{
+	BL_PROFILE("RadhydroSimulation::expandFluxArrays()");
+
+	// This is needed because reflux arrays must have the same number of components as
+	// state_new_cc_[lev]
+
+	auto copyFlux = [nstartNew, ncompNew](amrex::MultiFab const &oldFlux) {
+		amrex::MultiFab newFlux(oldFlux.boxArray(), oldFlux.DistributionMap(), ncompNew, 0);
+		newFlux.setVal(0.);
+		// copy oldFlux (starting at 0) to newFlux (starting at nstart)
+		AMREX_ASSERT(ncompNew >= oldFlux.nComp());
+		newFlux.ParallelCopy(oldFlux, 0, 0, oldFlux.nComp());
+		return newFlux;
+	};
+	return {AMREX_D_DECL(copyFlux(fluxes[0]), copyFlux(fluxes[1]), copyFlux(fluxes[2]))};
+}
+
 
 template <typename problem_t>
 auto RadhydroSimulation<problem_t>::expandFluxArrays(

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -844,7 +844,7 @@ void RadhydroSimulation<problem_t>::replaceFluxes(
 		// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
 		// the interface on the right of zone i.
 
-		amrex::IntVect ng{0,0,0};
+		amrex::IntVect ng{AMREX_D_DECL(0,0,0)};
 
 		amrex::ParallelFor(fluxes[idim], ng, ncomp,
 			[=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -222,13 +222,14 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 	template <FluxDir DIR>
 	void hydroFluxFunction(amrex::MultiFab const &primVar,
-			  amrex::MultiFab const &consVar,
+			  amrex::MultiFab &leftState,
+			  amrex::MultiFab &rightState,
 			  amrex::MultiFab &x1Flux,
 			  amrex::MultiFab &x1FaceVel,
 			  amrex::MultiFab const &x1Flat,
 			  amrex::MultiFab const &x2Flat,
 			  amrex::MultiFab const &x3Flat,
-    		  int nvars);
+			  int ng_reconstruct, int nvars);
 
 	void replaceFluxes(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes,
 			  std::array<amrex::FArrayBox, AMREX_SPACEDIM> &FOfluxes,
@@ -711,7 +712,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		if (do_reflux) {
 			// increment flux registers
 			//auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+			//incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
@@ -747,7 +748,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 		if (do_reflux) {
 			// increment flux registers
 			// auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
+			//incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
@@ -840,7 +841,7 @@ auto RadhydroSimulation<problem_t>::computeHydroFluxes(
 	}
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir));
+		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
@@ -859,29 +860,32 @@ auto RadhydroSimulation<problem_t>::computeHydroFluxes(
 			primVar, flatCoefs[2], flatteningGhost); )
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, consVar, flux[0], facevel[0],
-					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars);
-		     , hydroFluxFunction<FluxDir::X2>(primVar, consVar, flux[1], facevel[1],
-					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars);
-		     , hydroFluxFunction<FluxDir::X3>(primVar, consVar, flux[2], facevel[2],
-					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars); )
+	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructRange, nvars);
+		     , hydroFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructRange, nvars);
+		     , hydroFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructRange, nvars); )
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
 
 	// return flux and face-centered velocities
-	return std::make_pair(flux, facevel);
+	return std::make_pair(std::move(flux), std::move(facevel));
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
 void RadhydroSimulation<problem_t>::hydroFluxFunction(
     amrex::MultiFab const &primVar,
+	amrex::MultiFab &leftState,
+	amrex::MultiFab &rightState,
 	amrex::MultiFab &flux,
 	amrex::MultiFab &faceVel,
 	amrex::MultiFab const &x1Flat,
 	amrex::MultiFab const &x2Flat,
 	amrex::MultiFab const &x3Flat,
+	const int ng_reconstruct,
 	const int nvars)
 {
 	int dir = 0;
@@ -894,22 +898,22 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 	}
 
 	// interface-centered kernel
+	HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
+
+#if 0
 	if (reconstructionOrder_ == 3) {
-		HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState,
-									   reconstructRange, x1ReconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 2) {
-		HydroSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar, leftState, rightState,
-									   reconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 1) {
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState,
-										reconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
 	}
+#endif
 
 	// cell-centered kernel
-	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState,
-							    reconstructRange, nvars);
+	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
 	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar);

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -913,10 +913,6 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 	const int ng_reconstruct,
 	const int nvars)
 {
-	// cell-centered kernel
-	HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
-
-#if 0
 	if (reconstructionOrder_ == 3) {
 		HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 2) {
@@ -926,7 +922,6 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
 	}
-#endif
 
 	// cell-centered kernel
 	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -210,16 +210,10 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	    -> std::tuple<std::array<amrex::FArrayBox, AMREX_SPACEDIM>,
 			  std::array<amrex::FArrayBox, AMREX_SPACEDIM>>;
 
-	auto computeHydroFluxes(amrex::Array4<const amrex::Real> const &consVar,
-				const amrex::Box &indexRange, int nvars)
-	    -> std::pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>,
-					 std::array<amrex::FArrayBox, AMREX_SPACEDIM>>;
+	auto computeHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
+	    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+					 std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
-	auto computeFOHydroFluxes(amrex::Array4<const amrex::Real> const &consVar,
-				const amrex::Box &indexRange, int nvars)
-    	-> std::pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>,
-					 std::array<amrex::FArrayBox, AMREX_SPACEDIM>>;
-	
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState,
 			  amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
@@ -227,22 +221,15 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 			  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::Array4<const amrex::Real> const &primVar,
-			  amrex::Array4<const amrex::Real> const &consVar,
-			  amrex::FArrayBox &x1Flux,
-			  amrex::FArrayBox &x1FaceVel,
-			  amrex::Array4<const amrex::Real> const &x1Flat,
-			  amrex::Array4<const amrex::Real> const &x2Flat,
-			  amrex::Array4<const amrex::Real> const &x3Flat,
-    		  const amrex::Box &indexRange, int nvars);
+	void hydroFluxFunction(amrex::MultiFab const &primVar,
+			  amrex::MultiFab const &consVar,
+			  amrex::MultiFab &x1Flux,
+			  amrex::MultiFab &x1FaceVel,
+			  amrex::MultiFab const &x1Flat,
+			  amrex::MultiFab const &x2Flat,
+			  amrex::MultiFab const &x3Flat,
+    		  int nvars);
 
-	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::Array4<const amrex::Real> const &primVar,
-				amrex::Array4<const amrex::Real> const &consVar,
-				amrex::FArrayBox &x1Flux,
-				amrex::FArrayBox &x1FaceVel,
-				const amrex::Box &indexRange, int nvars);
-	
 	void replaceFluxes(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes,
 			  std::array<amrex::FArrayBox, AMREX_SPACEDIM> &FOfluxes,
 			  amrex::IArrayBox &redoFlag, amrex::Box const &validBox, int ncomp);
@@ -546,15 +533,10 @@ void RadhydroSimulation<problem_t>::FixupState(int lev)
 {
 	BL_PROFILE("RadhydroSimulation::FixupState()");
 
-	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		
-		// fix hydro state
-		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
-		// sync internal energy and total energy
-		HydroSystem<problem_t>::SyncDualEnergy(stateNew, indexRange);
-	}
+	// fix hydro state
+	HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, state_new_cc_[lev]);
+	// sync internal energy and total energy
+	HydroSystem<problem_t>::SyncDualEnergy(state_new_cc_[lev]);
 }
 
 // Compute a new multifab 'mf' by copying in state from valid region and filling
@@ -699,178 +681,72 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	// do Strang split source terms (first half-step)
 	addStrangSplitSources(state_old_cc_tmp, lev, time, 0.5*dt_lev);
 
-	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, PreInterpState, PostInterpState);
+	// Stage 1 of RK2-SSP
+	{
+		// update ghost zones [old timestep]
+		fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, PreInterpState, PostInterpState);
 
-	// check state validity
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
+		// check state validity
+		AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
+		AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
 
-	// advance all grids on local processor (Stage 1 of integrator)
-	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
+		// advance all grids on local processor (Stage 1 of integrator)
+		auto const &stateOld = state_old_cc_tmp;
+		auto &stateNew = state_new_cc_[lev];
+		auto [fluxArrays, faceVel] = computeHydroFluxes(stateOld, ncompHydro_, lev);
 
-		const amrex::Box &indexRange = iter.validbox(); // 'validbox' == exclude ghost zones
-		auto const &stateOld = state_old_cc_tmp.const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto [fluxArrays, faceVel] = computeHydroFluxes(stateOld, indexRange, ncompHydro_);
-
-		// temporary FABs for RK stage
-		amrex::IArrayBox redoFlag(indexRange, 1, amrex::The_Async_Arena());
-		redoFlag.setVal<amrex::RunOn::Device>(quokka::redoFlag::none);
-		amrex::FArrayBox rhs(indexRange, ncompHydro_, amrex::The_Async_Arena());
-		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs.array(),
-			{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(), fluxArrays[2].const_array())}, dx, indexRange, ncompHydro_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs.array(), stateOld,
-			indexRange, dx, redoFlag.const_array(),
-			{AMREX_D_DECL(faceVel[0].const_array(), faceVel[1].const_array(), faceVel[2].const_array())});
-
-		// Stage 1 of RK2-SSP
-		HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs.const_array(),
-		    dt_lev, indexRange, ncompHydro_, redoFlag.array());
-
-		// first-order flux correction (FOFC)
-		if (redoFlag.max<amrex::RunOn::Device>() != quokka::redoFlag::none) {
-			// compute first-order fluxes (on the whole FAB)
-			auto [FOFluxArrays, FOFaceVel] = computeFOHydroFluxes(stateOld, indexRange, ncompHydro_);
-
-			for(int i = 0; i < fofcMaxIterations_; ++i) {
-				if (Verbose()) {
-					std::cout << "[FOFC-1] iter = "
-							  << i
-							  << ", ncells = "
-							  << redoFlag.sum<amrex::RunOn::Device>(0)
-							  << "\n";
-				}
-
-				// replace fluxes in fluxArrays with first-order fluxes at faces of flagged cells
-				replaceFluxes(fluxArrays, FOFluxArrays, redoFlag, indexRange, ncompHydro_);
-				// replace velocities, recompute P dV source
-				//replaceFluxes(faceVel, FOFaceVel, redoFlag, indexRange, 1);
-				HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs.array(),
-					{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
-					fluxArrays[2].const_array())}, dx, indexRange, ncompHydro_);
-				HydroSystem<problem_t>::AddInternalEnergyPdV(rhs.array(), stateOld,
-					indexRange, dx, redoFlag.const_array(),
-					{AMREX_D_DECL(faceVel[0].const_array(), faceVel[1].const_array(), faceVel[2].const_array())});
-
-				// re-do RK stage update for *all* cells
-				// (since neighbors of problem cells will have modified states as well)
-				HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs.const_array(),
-					dt_lev, indexRange, ncompHydro_, redoFlag.array());
-
-				if(redoFlag.max<amrex::RunOn::Device>() == quokka::redoFlag::none) {
-					break;
-				}
-			}
-		}
+		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, nghost_);
+		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, faceVel);
+		HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs, dt_lev, ncompHydro_);
 
 		// prevent vacuum
-		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateNew);
+		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, stateNew);
 
 		if (useDualEnergy_ == 1) {
 			// sync internal energy (requires positive density)
-			HydroSystem<problem_t>::SyncDualEnergy(stateNew, indexRange);
+			HydroSystem<problem_t>::SyncDualEnergy(stateNew);
 		}
 
 		if (do_reflux) {
 			// increment flux registers
-			auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev,
-					       fluxScaleFactor * dt_lev);
+			//auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 
-	if (integratorOrder_ == 2) {
+	// Stage 2 of RK2-SSP
+	{
 		// update ghost zones [intermediate stage stored in state_new_cc_]
-		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, time + dt_lev,
-			PreInterpState, PostInterpState);
+		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, time + dt_lev, PreInterpState,
+				       PostInterpState);
 
 		// check intermediate state validity
 		AMREX_ASSERT(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()));
 		AMREX_ASSERT(!state_new_cc_[lev].contains_nan()); // check ghost zones
 
-		// advance all grids on local processor (Stage 2 of integrator)
-		for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
+		auto const &stateOld = state_old_cc_tmp;
+		auto const &stateInter = state_new_cc_[lev];
+		auto &stateFinal = state_new_cc_[lev];
+		auto [fluxArrays, faceVel] = computeHydroFluxes(stateInter, ncompHydro_, lev);
 
-			const amrex::Box &indexRange = iter.validbox(); // 'validbox' == exclude ghost zones
-			auto const &stateOld = state_old_cc_tmp.const_array(iter);
-			auto const &stateInter = state_new_cc_[lev].const_array(iter);
-			auto [fluxArrays, faceVel] = computeHydroFluxes(stateInter, indexRange, ncompHydro_);
+		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, nghost_);
+		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateInter, dx, faceVel);
+		HydroSystem<problem_t>::AddFluxesRK2(stateFinal, stateOld, stateInter, rhs, dt_lev, ncompHydro_);
 
-			amrex::FArrayBox stateFinalFAB = amrex::FArrayBox(indexRange, ncompHydro_,
-															amrex::The_Async_Arena());
-			auto const &stateFinal = stateFinalFAB.array();
+		// prevent vacuum
+		HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, stateFinal);
 
-			// temporary FABs for RK stage
-			amrex::IArrayBox redoFlag(indexRange, 1, amrex::The_Async_Arena());
-			redoFlag.setVal<amrex::RunOn::Device>(quokka::redoFlag::none);
-			amrex::FArrayBox rhs(indexRange, ncompHydro_, amrex::The_Async_Arena());
-			HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs.array(),
-				{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
-					fluxArrays[2].const_array())}, dx, indexRange, ncompHydro_);
-			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs.array(), stateInter,
-				indexRange, dx, redoFlag.const_array(),
-				{AMREX_D_DECL(faceVel[0].const_array(), faceVel[1].const_array(), faceVel[2].const_array())});
+		if (useDualEnergy_ == 1) {
+			// sync internal energy (requires positive density)
+			HydroSystem<problem_t>::SyncDualEnergy(stateFinal);
+		}
 
-			// Stage 2 of RK2-SSP
-			HydroSystem<problem_t>::AddFluxesRK2(stateFinal, stateOld, stateInter, rhs.const_array(),
-				dt_lev, indexRange, ncompHydro_,	redoFlag.array());
-
-			// first-order flux correction (FOFC)
-			if (redoFlag.max<amrex::RunOn::Device>() != quokka::redoFlag::none) {
-				// compute first-order fluxes (on the whole FAB)
-				auto [FOFluxArrays, FOFaceVel] = computeFOHydroFluxes(stateInter, indexRange, ncompHydro_);
-
-				for(int i = 0; i < fofcMaxIterations_; ++i) {
-					if (Verbose()) {
-						std::cout << "[FOFC-2] iter = "
-								<< i
-								<< ", ncells = "
-								<< redoFlag.sum<amrex::RunOn::Device>(0)
-								<< "\n";
-					}
-					
-					// replace fluxes in fluxArrays with first-order fluxes at faces of flagged cells
-					replaceFluxes(fluxArrays, FOFluxArrays, redoFlag, indexRange, ncompHydro_);
-					// replace velocities, recompute P dV source
-					//replaceFluxes(faceVel, FOFaceVel, redoFlag, indexRange, 1);
-					HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs.array(),
-						{AMREX_D_DECL(fluxArrays[0].const_array(), fluxArrays[1].const_array(),
-						fluxArrays[2].const_array())}, dx, indexRange, ncompHydro_);
-					HydroSystem<problem_t>::AddInternalEnergyPdV(rhs.array(), stateInter,
-						indexRange, dx, redoFlag.const_array(),
-						{AMREX_D_DECL(faceVel[0].const_array(), faceVel[1].const_array(), faceVel[2].const_array())});
-
-					// re-do RK stage update for *all* cells
-					// (since neighbors of problem cells will have modified states as well)
-					HydroSystem<problem_t>::AddFluxesRK2(stateFinal, stateOld, stateInter, rhs.const_array(),
-						dt_lev, indexRange, ncompHydro_, redoFlag.array());
-
-					if(redoFlag.max<amrex::RunOn::Device>() == quokka::redoFlag::none) {
-						break;
-					}
-				}
-			}
-
-			// prevent vacuum
-			HydroSystem<problem_t>::EnforceDensityFloor(densityFloor_, indexRange, stateFinal);
-
-			if (useDualEnergy_ == 1) {
-				// sync internal energy (requires positive density)
-				HydroSystem<problem_t>::SyncDualEnergy(stateFinal, indexRange);
-			}
-
-			// copy stateNew to state_new_cc_[lev]
-			auto const &stateNew = state_new_cc_[lev].array(iter);
-			amrex::FArrayBox stateNewFAB = amrex::FArrayBox(stateNew);
-			stateNewFAB.copy<amrex::RunOn::Device>(stateFinalFAB, 0, 0, ncompHydro_);
-			
-			if (do_reflux) {
-				// increment flux registers
-				auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
-				incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev,
-							fluxScaleFactor * dt_lev);
-			}
+		if (do_reflux) {
+			// increment flux registers
+			// auto expandedFluxes = expandFluxArrays(fluxArrays, 0, state_new_cc_[lev].nComp());
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
 		}
 	}
 
@@ -939,66 +815,72 @@ auto RadhydroSimulation<problem_t>::expandFluxArrays(
 
 template <typename problem_t>
 auto RadhydroSimulation<problem_t>::computeHydroFluxes(
-    amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, const int nvars)
-    -> std::pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>
+    amrex::MultiFab const &consVar, const int nvars, const int lev)
+    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
 	BL_PROFILE("RadhydroSimulation::computeHydroFluxes()");
 
-	// convert conserved to primitive variables
-	amrex::Box const &ghostRange = amrex::grow(indexRange, nghost_);
-	amrex::FArrayBox primVar(ghostRange, nvars, amrex::The_Async_Arena());
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar.array(), ghostRange);
+	auto ba = grids[lev];
+	auto dm = dmap[lev];
+	const int flatteningGhost = 2;
+	const int reconstructRange = 1;
+
+	// allocate temporary MultiFabs
+	amrex::MultiFab primVar(ba, dm, nvars, nghost_);
+	std::array<amrex::MultiFab, 3> flatCoefs;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+
+	for (int idim = 0; idim < 3; ++idim) {
+		flatCoefs[idim] = amrex::MultiFab(ba, dm, 1, flatteningGhost);
+	}
+
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir));
+		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
+		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, 0);
+	}
+
+	// conserved to primitive variables
+	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar, nghost_);
 
 	// compute flattening coefficients
-	amrex::Box const &flatteningRange = amrex::grow(indexRange, 2); // +1 greater
-	amrex::FArrayBox x1Flat(flatteningRange, 1, amrex::The_Async_Arena());
-	amrex::FArrayBox x2Flat(flatteningRange, 1, amrex::The_Async_Arena());
-	amrex::FArrayBox x3Flat(flatteningRange, 1, amrex::The_Async_Arena());
 	AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(
-			primVar.array(), x1Flat.array(), flatteningRange);
+			primVar, flatCoefs[0], flatteningGhost);
 		, HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X2>(
-			primVar.array(), x2Flat.array(), flatteningRange);
+			primVar, flatCoefs[1], flatteningGhost);
 		, HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(
-			primVar.array(), x3Flat.array(), flatteningRange); )
-
-	// allocate flux arrays
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, 0); // x-faces
-	amrex::FArrayBox x1Flux(x1FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x1FaceVel(x1FluxRange, 1, amrex::The_Async_Arena());
-#if (AMREX_SPACEDIM >= 2)
-	amrex::Box const &x2FluxRange = amrex::surroundingNodes(indexRange, 1); // y-faces
-	amrex::FArrayBox x2Flux(x2FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x2FaceVel(x2FluxRange, 1, amrex::The_Async_Arena());
-#endif
-#if (AMREX_SPACEDIM == 3)
-	amrex::Box const &x3FluxRange = amrex::surroundingNodes(indexRange, 2); // z-faces
-	amrex::FArrayBox x3Flux(x3FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x3FaceVel(x3FluxRange, 1, amrex::The_Async_Arena());
-#endif
+			primVar, flatCoefs[2], flatteningGhost); )
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar.const_array(), consVar, x1Flux, x1FaceVel,
-					x1Flat.array(), x2Flat.array(), x3Flat.array(), indexRange, nvars);
-		     , hydroFluxFunction<FluxDir::X2>(primVar.const_array(), consVar, x2Flux, x2FaceVel,
-					x1Flat.array(), x2Flat.array(), x3Flat.array(), indexRange, nvars);
-		     , hydroFluxFunction<FluxDir::X3>(primVar.const_array(), consVar, x3Flux, x3FaceVel,
-					x1Flat.array(), x2Flat.array(), x3Flat.array(), indexRange, nvars); )
+	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, consVar, flux[0], facevel[0],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars);
+		     , hydroFluxFunction<FluxDir::X2>(primVar, consVar, flux[1], facevel[1],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars);
+		     , hydroFluxFunction<FluxDir::X3>(primVar, consVar, flux[2], facevel[2],
+					flatCoefs[0], flatCoefs[1], flatCoefs[2], nvars); )
 
-	return std::make_pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>({AMREX_D_DECL(std::move(x1Flux), std::move(x2Flux), std::move(x3Flux))},
-			{AMREX_D_DECL(std::move(x1FaceVel), std::move(x2FaceVel), std::move(x3FaceVel))});
+	// synchronization point to prevent MultiFabs from going out of scope
+	amrex::Gpu::streamSynchronizeAll();
+
+	// return flux and face-centered velocities
+	return std::make_pair(flux, facevel);
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
 void RadhydroSimulation<problem_t>::hydroFluxFunction(
-    amrex::Array4<const amrex::Real> const &primVar,
-	amrex::Array4<const amrex::Real> const &consVar,
-	amrex::FArrayBox &x1Flux,
-	amrex::FArrayBox &x1FaceVel,
-	amrex::Array4<const amrex::Real> const &x1Flat,
-	amrex::Array4<const amrex::Real> const &x2Flat,
-	amrex::Array4<const amrex::Real> const &x3Flat,
-    const amrex::Box &indexRange, const int nvars)
+    amrex::MultiFab const &primVar,
+	amrex::MultiFab &flux,
+	amrex::MultiFab &faceVel,
+	amrex::MultiFab const &x1Flat,
+	amrex::MultiFab const &x2Flat,
+	amrex::MultiFab const &x3Flat,
+	const int nvars)
 {
 	int dir = 0;
 	if constexpr (DIR == FluxDir::X1) {
@@ -1009,115 +891,26 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(
 		dir = 2;
 	}
 
-	// N.B.: A one-zone layer around the cells must be fully reconstructed for PPM.
-	amrex::Box const &reconstructRange = amrex::grow(indexRange, 1);
-	amrex::Box const &x1ReconstructRange = amrex::surroundingNodes(reconstructRange, dir);
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, dir);
-
-	amrex::FArrayBox x1LeftState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x1RightState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
-
+	// interface-centered kernel
 	if (reconstructionOrder_ == 3) {
-		// mixed interface/cell-centered kernel
-		HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(
-			primVar, x1LeftState.array(), x1RightState.array(), reconstructRange,
-			x1ReconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState,
+									   reconstructRange, x1ReconstructRange, nvars);
 	} else if (reconstructionOrder_ == 2) {
-		// interface-centered kernel
-		HydroSystem<problem_t>::template ReconstructStatesPLM<DIR>(
-			primVar, x1LeftState.array(), x1RightState.array(),
-			x1ReconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar, leftState, rightState,
+									   reconstructRange, nvars);
 	} else if (reconstructionOrder_ == 1) {
-		// interface-centered kernel
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(
-			primVar, x1LeftState.array(), x1RightState.array(),
-			x1ReconstructRange, nvars);
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState,
+										reconstructRange, nvars);
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
 	}
 
 	// cell-centered kernel
-	HydroSystem<problem_t>::template FlattenShocks<DIR>(
-	    primVar, x1Flat, x2Flat, x3Flat, x1LeftState.array(), x1RightState.array(),
-	    reconstructRange, nvars);
+	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState,
+							    reconstructRange, nvars);
 
 	// interface-centered kernel
-	HydroSystem<problem_t>::template ComputeFluxes<DIR>(
-	    x1Flux.array(), x1FaceVel.array(), x1LeftState.array(), x1RightState.array(),
-		primVar, x1FluxRange);
-}
-
-template <typename problem_t>
-auto RadhydroSimulation<problem_t>::computeFOHydroFluxes(
-    amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, const int nvars)
-    -> std::pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>
-{
-	BL_PROFILE("RadhydroSimulation::computeFOHydroFluxes()");
-
-	// convert conserved to primitive variables
-	amrex::Box const &ghostRange = amrex::grow(indexRange, nghost_);
-	amrex::FArrayBox primVar(ghostRange, nvars, amrex::The_Async_Arena());
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar.array(), ghostRange);
-
-	// allocate flux arrays
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, 0); // x-faces
-	amrex::FArrayBox x1Flux(x1FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x1FaceVel(x1FluxRange, 1, amrex::The_Async_Arena());
-#if (AMREX_SPACEDIM >= 2)
-	amrex::Box const &x2FluxRange = amrex::surroundingNodes(indexRange, 1); // y-faces
-	amrex::FArrayBox x2Flux(x2FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x2FaceVel(x2FluxRange, 1, amrex::The_Async_Arena());
-#endif
-#if (AMREX_SPACEDIM == 3)
-	amrex::Box const &x3FluxRange = amrex::surroundingNodes(indexRange, 2); // z-faces
-	amrex::FArrayBox x3Flux(x3FluxRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x3FaceVel(x3FluxRange, 1, amrex::The_Async_Arena());
-#endif
-
-	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar.const_array(), consVar, x1Flux, x1FaceVel, indexRange, nvars);
-		       , hydroFOFluxFunction<FluxDir::X2>(primVar.const_array(), consVar, x2Flux, x2FaceVel, indexRange, nvars);
-		       , hydroFOFluxFunction<FluxDir::X3>(primVar.const_array(), consVar, x3Flux, x3FaceVel, indexRange, nvars); )
-
-	return std::make_pair<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>({AMREX_D_DECL(std::move(x1Flux), std::move(x2Flux), std::move(x3Flux))},
-			{AMREX_D_DECL(std::move(x1FaceVel), std::move(x2FaceVel), std::move(x3FaceVel))});
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
-void RadhydroSimulation<problem_t>::hydroFOFluxFunction(
-    amrex::Array4<const amrex::Real> const &primVar,
-    amrex::Array4<const amrex::Real> const &consVar,
-	amrex::FArrayBox &x1Flux,
-	amrex::FArrayBox &x1FaceVel,
-    const amrex::Box &indexRange, const int nvars)
-{
-	int dir = 0;
-	if constexpr (DIR == FluxDir::X1) {
-		dir = 0;
-	} else if constexpr (DIR == FluxDir::X2) {
-		dir = 1;
-	} else if constexpr (DIR == FluxDir::X3) {
-		dir = 2;
-	}
-
-	amrex::Box const &reconstructRange = amrex::grow(indexRange, 1);
-	amrex::Box const &x1ReconstructRange = amrex::surroundingNodes(reconstructRange, dir);
-	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, dir);
-
-	amrex::FArrayBox x1LeftState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
-	amrex::FArrayBox x1RightState(x1ReconstructRange, nvars, amrex::The_Async_Arena());
-
-	// interface-centered kernel
-	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(
-			primVar, x1LeftState.array(), x1RightState.array(),
-			x1ReconstructRange, nvars);
-
-	// interface-centered kernel
-	HydroSystem<problem_t>::template ComputeFluxes<DIR>(
-	    x1Flux.array(), x1FaceVel.array(),
-		x1LeftState.array(), x1RightState.array(),
-		primVar, x1FluxRange);
+	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar);
 }
 
 template <typename problem_t>

--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -12,14 +12,14 @@ namespace quokka {
   enum class direction { na=-1, x, y, z };
 
   struct grid {
-    const amrex::Array4<double>& array;
-    const amrex::Box& indexRange;
+    amrex::Array4<double> array;
+    amrex::Box indexRange;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi;
     enum centering cen;
     enum direction dir;
-    grid(const amrex::Array4<double>& array, const amrex::Box& indexRange,
+    grid(amrex::Array4<double> const &array, amrex::Box const& indexRange,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi,

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -74,9 +74,7 @@ public:
   static auto CheckStatesValid(amrex::Box const &indexRange,
                                amrex::Array4<const amrex::Real> const &cons)
       -> bool;
-  static void EnforceDensityFloor(amrex::Real densityFloor,
-                                   amrex::Box const &indexRange,
-                                   amrex::Array4<amrex::Real> const &state);
+  static void EnforceDensityFloor(amrex::Real const densityFloor, amrex::MultiFab &state_mf);
 
   AMREX_GPU_DEVICE static auto
   ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j,
@@ -98,31 +96,21 @@ public:
   isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j,
                int k) -> bool;
 
-  static void ComputeRhsFromFluxes(amrex::Array4<amrex::Real> const &rhs,
-                          std::array<arrayconst_t, AMREX_SPACEDIM> const &fluxArray,
-                          amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-                          amrex::Box const &indexRange, int nvars);
+  static void ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf,
+				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
+				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars);
 
-  static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, arrayconst_t &rhs,
-                          double dt, amrex::Box const &indexRange, int nvars,
-                          amrex::Array4<int> const &redoFlag);
+  static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs,
+			  const double dt, const int nvars);
 
-  static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, arrayconst_t &rhs,
-                          double dt, amrex::Box const &indexRange, int nvars,
-                          amrex::Array4<int> const &redoFlag);
+  static void AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf,
+			   amrex::MultiFab const &rhs_mf, const double dt, const int nvars);
 
-  static void AddInternalEnergyPdV(amrex::Array4<amrex::Real> const &rhs,
-                          amrex::Array4<amrex::Real const> const &consVar,
-                          amrex::Box const &indexRange,
-                          amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
-                          amrex::Array4<const int> const &redoFlag,
-                          std::array<arrayconst_t, AMREX_SPACEDIM> const &faceVelArray);
+  static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
+				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray);
 
-  static void SyncDualEnergy(amrex::Array4<amrex::Real> const &consVar,
-                           amrex::Box const &indexRange);
-
-  static void OverrideInternalEnergy(amrex::Array4<amrex::Real> const &consVar,
-                           amrex::Box const &indexRange);
+  static void SyncDualEnergy(amrex::MultiFab &consVar_mf);
 
   template <FluxDir DIR>
   static void
@@ -301,16 +289,17 @@ auto HydroSystem<problem_t>::CheckStatesValid(
 
 template <typename problem_t>
 void HydroSystem<problem_t>::EnforceDensityFloor(amrex::Real const densityFloor, 
-    amrex::Box const &indexRange, amrex::Array4<amrex::Real> const &state) {
+    amrex::MultiFab &state_mf) {
   // prevent negative densities
+  auto state = state_mf.arrays();
 
   amrex::ParallelFor(
-      indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        amrex::Real rho = state(i, j, k, density_index);
+      state_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+        amrex::Real rho = state[bx](i, j, k, density_index);
 
         // reset density if less than densityFloor
         if (rho < densityFloor) {
-          state(i, j, k, density_index) = densityFloor;
+          state[bx](i, j, k, density_index) = densityFloor;
         }
       });
 }
@@ -391,10 +380,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(
 
 template <typename problem_t>
 void HydroSystem<problem_t>::ComputeRhsFromFluxes(
-    amrex::Array4<amrex::Real> const &rhs,
-    std::array<arrayconst_t, AMREX_SPACEDIM> const &fluxArray,
+    amrex::MultiFab &rhs_mf,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-    amrex::Box const &indexRange, const int nvars)
+    const int nvars)
 {
   // compute the total right-hand-side for the MOL integration
 
@@ -403,65 +392,74 @@ void HydroSystem<problem_t>::ComputeRhsFromFluxes(
   // left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
   // the interface on the right of zone i.
 
-  auto const x1Flux = fluxArray[0];
-  auto const x2Flux = fluxArray[1];
-  auto const x3Flux = fluxArray[2];
+  auto const x1Flux = fluxArray[0].const_arrays();
+  auto const x2Flux = fluxArray[1].const_arrays();
+  auto const x3Flux = fluxArray[2].const_arrays();
+  auto rhs = rhs_mf.arrays();
 
-  amrex::ParallelFor(indexRange, nvars,
-    [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-      rhs(i,j,k,n) = AMREX_D_TERM( (1.0/dx[0]) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n)),
-                                 + (1.0/dx[1]) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n)),
-                                 + (1.0/dx[2]) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n)));
+  amrex::ParallelFor(rhs_mf, amrex::IntVect{0}, nvars, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
+	  rhs[bx](i, j, k, n) = AMREX_D_TERM((1.0 / dx[0]) * (x1Flux[bx](i, j, k, n) - x1Flux[bx](i + 1, j, k, n)),
+					     +(1.0 / dx[1]) * (x2Flux[bx](i, j, k, n) - x2Flux[bx](i, j + 1, k, n)),
+					     +(1.0 / dx[2]) * (x3Flux[bx](i, j, k, n) - x3Flux[bx](i, j, k + 1, n)));
   });
 }
 
 template <typename problem_t>
 void HydroSystem<problem_t>::PredictStep(
-    arrayconst_t &consVarOld, array_t &consVarNew, arrayconst_t &rhs,
-    const double dt, amrex::Box const &indexRange, const int nvars,
-    amrex::Array4<int> const &redoFlag) {
+    amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf, amrex::MultiFab const &rhs_mf,
+    const double dt, const int nvars) {
   BL_PROFILE("HydroSystem::PredictStep()");
 
-  amrex::ParallelFor(
-      indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-        for (int n = 0; n < nvars; ++n) {
-          consVarNew(i, j, k, n) = consVarOld(i, j, k, n) + dt * rhs(i, j, k, n);
-        }
+  auto const &consVarOld = consVarOld_mf.const_arrays();
+  auto const &rhs = rhs_mf.const_arrays();
+  auto consVarNew = consVarNew_mf.arrays();
 
+  amrex::ParallelFor(
+      consVarNew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+        for (int n = 0; n < nvars; ++n) {
+          consVarNew[bx](i, j, k, n) = consVarOld[bx](i, j, k, n) + dt * rhs[bx](i, j, k, n);
+        }
+#if 0
         // check if state is valid -- flag for re-do if not
         if (!isStateValid(consVarNew, i, j, k)) {
           redoFlag(i, j, k) = quokka::redoFlag::redo;
         } else {
           redoFlag(i, j, k) = quokka::redoFlag::none;
         }
+#endif
       });
 }
 
 template <typename problem_t>
 void HydroSystem<problem_t>::AddFluxesRK2(
-    array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, arrayconst_t &rhs,
-    const double dt, amrex::Box const &indexRange, const int nvars,
-    amrex::Array4<int> const &redoFlag) {
+    amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
+    const double dt, const int nvars) {
   BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
 
+  auto const &U0 = U0_mf.const_arrays();
+  auto const &U1 = U1_mf.const_arrays();
+  auto const &rhs = rhs_mf.const_arrays();
+  auto U_new = Unew_mf.arrays();
+
   amrex::ParallelFor(
-      indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+      U_new, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
         for (int n = 0; n < nvars; ++n) {
           // RK-SSP2 integrator
-          const double U_0 = U0(i, j, k, n);
-          const double U_1 = U1(i, j, k, n);
-          const double FU = dt * rhs(i, j, k, n);
+          const double U_0 = U0[bx](i, j, k, n);
+          const double U_1 = U1[bx](i, j, k, n);
+          const double FU = dt * rhs[bx](i, j, k, n);
 
           // save results in U_new
-          U_new(i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + 0.5 * FU;
+          U_new[bx](i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + 0.5 * FU;
         }
-
+#if 0
         // check if state is valid -- flag for re-do if not
         if (!isStateValid(U_new, i, j, k)) {
           redoFlag(i, j, k) = quokka::redoFlag::redo;
         } else {
           redoFlag(i, j, k) = quokka::redoFlag::none;
         }
+#endif
       });
 }
 
@@ -605,24 +603,29 @@ void HydroSystem<problem_t>::FlattenShocks(
 
 template <typename problem_t>
 void HydroSystem<problem_t>::AddInternalEnergyPdV(
-    amrex::Array4<amrex::Real> const &rhs, amrex::Array4<amrex::Real const> const &consVar,
-    amrex::Box const &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
-    amrex::Array4<const int> const &redoFlag,
-    std::array<arrayconst_t, AMREX_SPACEDIM> const &faceVelArray) {
+    amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray) {
   // compute P dV source term for the internal energy equation,
   // using the face-centered velocities in faceVelArray and the pressure
 
-  auto vel_x = faceVelArray[0];
-  auto vel_y = faceVelArray[1];
-  auto vel_z = faceVelArray[2];
+  auto vel_x = faceVelArray[0].const_arrays();
+  auto vel_y = faceVelArray[1].const_arrays();
+  auto vel_z = faceVelArray[2].const_arrays();
 
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+  auto const &consVar = consVar_mf.const_arrays();
+  auto rhs = rhs_mf.arrays();
+
+  amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
     // get cell-centered pressure
-    const amrex::Real Pgas = ComputePressure(consVar, i, j, k);
+    const amrex::Real Pgas = ComputePressure(consVar[bx], i, j, k);
 
     // compute div v from face-centered velocities
-    amrex::Real div_v = NAN;
+    amrex::Real div_v = AMREX_D_TERM(  ( vel_x[bx](i+1, j  , k  ) - vel_x[bx](i, j, k) ) / dx[0],
+                                     + ( vel_y[bx](i  , j+1, k  ) - vel_y[bx](i, j, k) ) / dx[1],
+                                     + ( vel_z[bx](i  , j  , k+1) - vel_z[bx](i, j, k) ) / dx[2]  );
 
+#if 0                    
     if (redoFlag(i,j,k) == quokka::redoFlag::none) {
       div_v = AMREX_D_TERM(  ( vel_x(i+1, j  , k  ) - vel_x(i, j, k) ) / dx[0],
                            + ( vel_y(i  , j+1, k  ) - vel_y(i, j, k) ) / dx[1],
@@ -634,27 +637,29 @@ void HydroSystem<problem_t>::AddInternalEnergyPdV(
               + ( ComputeVelocityX3(consVar, i, j, k+1) - ComputeVelocityX3(consVar, i, j, k-1) ) / dx[2]
               ) );
     }
+#endif
 
     // add P dV term to rhs array
-    rhs(i, j, k, internalEnergy_index) += -Pgas * div_v;
+    rhs[bx](i, j, k, internalEnergy_index) += -Pgas * div_v;
   });
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::SyncDualEnergy(amrex::Array4<amrex::Real> const &consVar,
-    amrex::Box const &indexRange) {
+void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf) {
   // sync internal energy and total energy
   // this step must be done as an operator-split step after *each* RK stage
 
   const amrex::Real eta = 1.0e-3; // dual energy parameter 'eta'
 
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-    amrex::Real const rho = consVar(i, j, k, density_index);
-    amrex::Real const px = consVar(i, j, k, x1Momentum_index);
-    amrex::Real const py = consVar(i, j, k, x2Momentum_index);
-    amrex::Real const pz = consVar(i, j, k, x3Momentum_index);
-    amrex::Real const Etot = consVar(i, j, k, energy_index);
-    amrex::Real const Eint_aux = consVar(i, j, k, internalEnergy_index);
+  auto consVar = consVar_mf.arrays();
+
+  amrex::ParallelFor(consVar_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+    amrex::Real const rho = consVar[bx](i, j, k, density_index);
+    amrex::Real const px = consVar[bx](i, j, k, x1Momentum_index);
+    amrex::Real const py = consVar[bx](i, j, k, x2Momentum_index);
+    amrex::Real const pz = consVar[bx](i, j, k, x3Momentum_index);
+    amrex::Real const Etot = consVar[bx](i, j, k, energy_index);
+    amrex::Real const Eint_aux = consVar[bx](i, j, k, internalEnergy_index);
 
     // abort if density is negative (can't compute kinetic energy)
     if (rho <= 0.) {
@@ -667,10 +672,10 @@ void HydroSystem<problem_t>::SyncDualEnergy(amrex::Array4<amrex::Real> const &co
     // Li et al. sync method
     // replace Eint with Eint_cons == (Etot - Ekin) if (Eint_cons / E) > eta
     if (Eint_cons > eta * Etot) {
-      consVar(i, j, k, internalEnergy_index) = Eint_cons;
+      consVar[bx](i, j, k, internalEnergy_index) = Eint_cons;
     } else { // non-conservative sync
-      consVar(i, j, k, internalEnergy_index) = Eint_aux;
-      consVar(i, j, k, energy_index) = Eint_aux + Ekin;
+      consVar[bx](i, j, k, internalEnergy_index) = Eint_aux;
+      consVar[bx](i, j, k, energy_index) = Eint_aux + Ekin;
     }
   });
 }

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -384,8 +384,12 @@ void HydroSystem<problem_t>::ComputeRhsFromFluxes(
   // the interface on the right of zone i.
 
   auto const x1Flux = fluxArray[0].const_arrays();
+#if AMREX_SPACEDIM >= 2
   auto const x2Flux = fluxArray[1].const_arrays();
+#endif
+#if AMREX_SPACEDIM == 3
   auto const x3Flux = fluxArray[2].const_arrays();
+#endif
   auto rhs = rhs_mf.arrays();
 
   amrex::ParallelFor(rhs_mf, amrex::IntVect{0}, nvars, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -99,10 +99,10 @@ public:
 				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars);
 
   static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs,
-			  const double dt, const int nvars, amrex::MultiFab &redoFlag_mf);
+			  const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
 
   static void AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf,
-			   amrex::MultiFab const &rhs_mf, const double dt, const int nvars, amrex::MultiFab &redoFlag_mf);
+			   amrex::MultiFab const &rhs_mf, const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
 
   static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
 				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
@@ -402,7 +402,7 @@ void HydroSystem<problem_t>::ComputeRhsFromFluxes(
 template <typename problem_t>
 void HydroSystem<problem_t>::PredictStep(
     amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf, amrex::MultiFab const &rhs_mf,
-    const double dt, const int nvars, amrex::MultiFab &redoFlag_mf) {
+    const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf) {
   BL_PROFILE("HydroSystem::PredictStep()");
 
   auto const &consVarOld = consVarOld_mf.const_arrays();
@@ -427,7 +427,7 @@ void HydroSystem<problem_t>::PredictStep(
 template <typename problem_t>
 void HydroSystem<problem_t>::AddFluxesRK2(
     amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
-    const double dt, const int nvars, amrex::MultiFab &redoFlag_mf) {
+    const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf) {
   BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
 
   auto const &U0 = U0_mf.const_arrays();

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -60,13 +60,12 @@ template <typename problem_t> class HyperbolicSystem
 						  int i, int j, int k, int n) -> std::pair<double, double>;
 
 	template <FluxDir DIR>
-	static void ReconstructStatesConstant(arrayconst_t &q, array_t &leftState,
-					      array_t &rightState, amrex::Box const &indexRange,
-					      int nvars);
+	static void ReconstructStatesConstant(amrex::MultiFab const &q, amrex::MultiFab &leftState,
+					      amrex::MultiFab &rightState, int nghost, int nvars);
 
 	template <FluxDir DIR>
-	static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState,
-					 amrex::Box const &indexRange, int nvars);
+	static void ReconstructStatesPLM(amrex::MultiFab const &q, amrex::MultiFab &leftState,
+						  amrex::MultiFab &rightState, int nghost, int nvars);
 
 	template <FluxDir DIR>
 	static void ReconstructStatesPPM(amrex::MultiFab const &q_in,
@@ -96,24 +95,29 @@ template <typename problem_t> class HyperbolicSystem
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HyperbolicSystem<problem_t>::ReconstructStatesConstant(arrayconst_t &q_in,
-							    array_t &leftState_in,
-							    array_t &rightState_in,
-							    amrex::Box const &indexRange,
+void HyperbolicSystem<problem_t>::ReconstructStatesConstant(amrex::MultiFab const &q_mf,
+							    amrex::MultiFab &leftState_mf,
+							    amrex::MultiFab &rightState_mf,
+							    const int nghost,
 							    const int nvars)
 {
-	// construct ArrayViews for permuted indices
-	quokka::Array4View<amrex::Real const, DIR> q(q_in);
-	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
-	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
-
 	// By convention, the interfaces are defined on the left edge of each zone, i.e. xleft_(i)
 	// is the "left"-side of the interface at the left edge of zone i, and xright_(i) is the
 	// "right"-side of the interface at the *left* edge of zone i. [Indexing note: There are (nx
 	// + 1) interfaces for nx zones.]
 
+	auto const &q_in = q_mf.const_arrays();
+	auto leftState_in = leftState_mf.arrays();
+	auto rightState_in = rightState_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
+
 	amrex::ParallelFor(
-	    indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	    q_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
+			// construct ArrayViews for permuted indices
+			quokka::Array4View<amrex::Real const, DIR> q(q_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> leftState(leftState_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> rightState(rightState_in[bx]);
+
 		    // permute array indices according to dir
 		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
@@ -126,16 +130,10 @@ void HyperbolicSystem<problem_t>::ReconstructStatesConstant(arrayconst_t &q_in,
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in,
-						       array_t &rightState_in,
-						       amrex::Box const &indexRange,
-						       const int nvars)
+void HyperbolicSystem<problem_t>::ReconstructStatesPLM(amrex::MultiFab const &q_mf,
+							   amrex::MultiFab &leftState_mf, amrex::MultiFab &rightState_mf,
+						       const int nghost, const int nvars)
 {
-	// construct ArrayViews for permuted indices
-	quokka::Array4View<amrex::Real const, DIR> q(q_in);
-	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
-	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
-
 	// Unlike PPM, PLM with the MC limiter is TVD.
 	// (There are no spurious oscillations, *except* in the slow-moving shock problem,
 	// which can produce unphysical oscillations even when using upwind Godunov fluxes.)
@@ -150,8 +148,18 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array
 
 	// Indexing note: There are (nx + 1) interfaces for nx zones.
 
+	auto const &q_in = q_mf.const_arrays();
+	auto leftState_in = leftState_mf.arrays();
+	auto rightState_in = rightState_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
+
 	amrex::ParallelFor(
-	    indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	    q_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
+			// construct ArrayViews for permuted indices
+			quokka::Array4View<amrex::Real const, DIR> q(q_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> leftState(leftState_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> rightState(rightState_in[bx]);
+
 		    // permute array indices according to dir
 		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -69,9 +69,9 @@ template <typename problem_t> class HyperbolicSystem
 					 amrex::Box const &indexRange, int nvars);
 
 	template <FluxDir DIR>
-	static void ReconstructStatesPPM(arrayconst_t &q, array_t &leftState, array_t &rightState,
-					 amrex::Box const &cellRange,
-					 amrex::Box const &interfaceRange, int nvars);
+	static void ReconstructStatesPPM(amrex::MultiFab const &q_in,
+							   amrex::MultiFab &leftState_in, amrex::MultiFab &rightState_in,
+						       const int nghost, const int nvars);
 
 	template <typename F>
 #if defined(__x86_64__)
@@ -208,29 +208,30 @@ auto HyperbolicSystem<problem_t>::GetMinmaxSurroundingCell(arrayconst_t &q,
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HyperbolicSystem<problem_t>::ReconstructStatesPPM(arrayconst_t &q_in, array_t &leftState_in,
-						       array_t &rightState_in,
-						       amrex::Box const &cellRange,
-						       amrex::Box const &interfaceRange,
-						       const int nvars)
+void HyperbolicSystem<problem_t>::ReconstructStatesPPM(amrex::MultiFab const &q_mf,
+							   amrex::MultiFab &leftState_mf, amrex::MultiFab &rightState_mf,
+						       const int nghost, const int nvars)
 {
 	BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM()");
-
-	// construct ArrayViews for permuted indices
-	quokka::Array4View<amrex::Real const, DIR> q(q_in);
-	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
-	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
 
 	// By convention, the interfaces are defined on the left edge of each
 	// zone, i.e. xleft_(i) is the "left"-side of the interface at the left
 	// edge of zone i, and xright_(i) is the "right"-side of the interface
 	// at the *left* edge of zone i.
 
-	// Indexing note: There are (nx + 1) interfaces for nx zones.
+	auto const &q_in = q_mf.const_arrays();
+	auto leftState_in = leftState_mf.arrays();
+	auto rightState_in = rightState_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
 
-	amrex::ParallelFor(
-		cellRange, nvars, // cell-centered kernel
-		[=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	// cell-centered kernel
+	amrex::ParallelFor(q_mf, ng, nvars, 
+		[=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
+			// construct ArrayViews for permuted indices
+			quokka::Array4View<amrex::Real const, DIR> q(q_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> leftState(leftState_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> rightState(rightState_in[bx]);
+
 		    // permute array indices according to dir
 		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 

--- a/src/linear_advection.hpp
+++ b/src/linear_advection.hpp
@@ -31,8 +31,9 @@ template <typename problem_t> class LinearAdvectionSystem : public HyperbolicSys
 
 	// static member functions
 
-	static void ConservedToPrimitive(arrayconst_t &cons, array_t &primVar,
-					 amrex::Box const &indexRange, int nvars);
+	static void ConservedToPrimitive(amrex::MultiFab const &cons_mf,
+						amrex::MultiFab &primVar_mf,
+						const int nghost, const int nvars);
 
 	static void ComputeMaxSignalSpeed(amrex::Array4<amrex::Real const> const & /*cons*/,
 					  amrex::Array4<amrex::Real> const &maxSignal,
@@ -43,20 +44,19 @@ template <typename problem_t> class LinearAdvectionSystem : public HyperbolicSys
 	static auto isStateValid(amrex::Array4<const amrex::Real> const &cons,
 					  int i, int j, int k) -> bool;
 	
-	static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew,
-					  std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, double dt_in,
-					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
-					  int nvars, amrex::Array4<int> const &redoFlag);
+	static void PredictStep(amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf,
+    				  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray, const double dt,
+    				  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, const int nvars);
 
-	static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1,
-    				  std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, double dt_in,
-					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
-					  int nvars, amrex::Array4<int> const &redoFlag);
+	static void AddFluxesRK2(amrex::MultiFab &U_new_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf,
+    				  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray, const double dt,
+   					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, const int nvars);
 
 	template <FluxDir DIR>
-	static void ComputeFluxes(array_t &x1Flux, arrayconst_t &x1LeftState,
-				  arrayconst_t &x1RightState, double advectionVx,
-				  amrex::Box const &indexRange, int nvars);
+	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf,
+						     amrex::MultiFab const &x1LeftState_mf,
+						     amrex::MultiFab const &x1RightState_mf,
+						     const double advectionVx, const int nvars);
 };
 
 template <typename problem_t>
@@ -75,12 +75,16 @@ void LinearAdvectionSystem<problem_t>::ComputeMaxSignalSpeed(
 }
 
 template <typename problem_t>
-void LinearAdvectionSystem<problem_t>::ConservedToPrimitive(arrayconst_t &cons, array_t &primVar,
-							    amrex::Box const &indexRange,
-							    const int nvars)
+void LinearAdvectionSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_mf,
+								amrex::MultiFab &primVar_mf,
+							    const int nghost, const int nvars)
 {
-	amrex::ParallelFor(indexRange, nvars, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) {
-		primVar(i, j, k, n) = cons(i, j, k, n);
+	auto const &cons = cons_mf.const_arrays();
+	auto primVar = primVar_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
+
+	amrex::ParallelFor(primVar_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) {
+		primVar[bx](i, j, k, n) = cons[bx](i, j, k, n);
 	});
 }
 
@@ -95,10 +99,9 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto LinearAdvectionSystem<problem_t>::isSta
 
 template <typename problem_t>
 void LinearAdvectionSystem<problem_t>::PredictStep(
-    arrayconst_t &consVarOld, array_t &consVarNew,
-    std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, const double dt_in,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
-    const int nvars_in, amrex::Array4<int> const &redoFlag)
+    amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray, const double dt,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, const int nvars)
 {
 	BL_PROFILE("LinearAdvectionSystem::PredictStep()");
 
@@ -107,45 +110,45 @@ void LinearAdvectionSystem<problem_t>::PredictStep(
 	// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
 	// the interface on the right of zone i.
 
-	int const nvars = nvars_in; // workaround nvcc bug
-	auto const dt = dt_in;
 	auto const dx = dx_in[0];
-	auto const x1Flux = fluxArray[0];
+	auto const x1Flux = fluxArray[0].const_arrays();
 #if (AMREX_SPACEDIM >= 2)
 	auto const dy = dx_in[1];
-	auto const x2Flux = fluxArray[1];
+	auto const x2Flux = fluxArray[1].const_arrays();
 #endif
 #if (AMREX_SPACEDIM == 3)
 	auto const dz = dx_in[2];
-	auto const x3Flux = fluxArray[2];
+	auto const x3Flux = fluxArray[2].const_arrays();
 #endif
+	auto const &consVarOld = consVarOld_mf.const_arrays();
+	auto consVarNew = consVarNew_mf.arrays();
 
 	amrex::ParallelFor(
-	    indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+	    consVarNew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			for (int n = 0; n < nvars; ++n) {
-				consVarNew(i, j, k, n) =
-				consVarOld(i, j, k, n) +
-				(AMREX_D_TERM( (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n)),
-							+ (dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n)),
-							+ (dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n))
+				consVarNew[bx](i, j, k, n) =
+				consVarOld[bx](i, j, k, n) +
+				(AMREX_D_TERM( (dt / dx) * (x1Flux[bx](i, j, k, n) - x1Flux[bx](i + 1, j, k, n)),
+							+ (dt / dy) * (x2Flux[bx](i, j, k, n) - x2Flux[bx](i, j + 1, k, n)),
+							+ (dt / dz) * (x3Flux[bx](i, j, k, n) - x3Flux[bx](i, j, k + 1, n))
 							));
 			}
-
+#if 0
 			// check if state is valid -- flag for re-do if not
 			if (!isStateValid(consVarNew, i, j, k)) {
 				redoFlag(i, j, k) = quokka::redoFlag::redo;
 			} else {
 				redoFlag(i, j, k) = quokka::redoFlag::none;
 			}
+#endif
 	    });
 }
 
 template <typename problem_t>
 void LinearAdvectionSystem<problem_t>::AddFluxesRK2(
-    array_t &U_new, arrayconst_t &U0, arrayconst_t &U1,
-    std::array<arrayconst_t, AMREX_SPACEDIM> fluxArray, const double dt_in,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
-    const int nvars_in, amrex::Array4<int> const &redoFlag)
+    amrex::MultiFab &U_new_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray, const double dt,
+    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, const int nvars)
 {
 	BL_PROFILE("LinearAdvectionSystem::AddFluxesRK2()");
 
@@ -154,73 +157,77 @@ void LinearAdvectionSystem<problem_t>::AddFluxesRK2(
 	// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
 	// the interface on the right of zone i.
 
-	int const nvars = nvars_in; // workaround nvcc bug
-
-	auto const dt = dt_in;
 	auto const dx = dx_in[0];
-	auto const x1Flux = fluxArray[0];
+	auto const x1Flux = fluxArray[0].const_arrays();
 #if (AMREX_SPACEDIM >= 2)
 	auto const dy = dx_in[1];
-	auto const x2Flux = fluxArray[1];
+	auto const x2Flux = fluxArray[1].const_arrays();
 #endif
 #if (AMREX_SPACEDIM == 3)
 	auto const dz = dx_in[2];
-	auto const x3Flux = fluxArray[2];
+	auto const x3Flux = fluxArray[2].const_arrays();
 #endif
+	auto const &U0 = U0_mf.const_arrays();
+	auto const &U1 = U1_mf.const_arrays();
+	auto U_new = U_new_mf.arrays();
 
 	amrex::ParallelFor(
-	    indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+	    U_new_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			for (int n = 0; n < nvars; ++n) {
 				// RK-SSP2 integrator
-				const double U_0 = U0(i, j, k, n);
-				const double U_1 = U1(i, j, k, n);
+				const double U_0 = U0[bx](i, j, k, n);
+				const double U_1 = U1[bx](i, j, k, n);
 
-				const double FxU_1 = (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n));
+				const double FxU_1 = (dt / dx) * (x1Flux[bx](i, j, k, n) - x1Flux[bx](i + 1, j, k, n));
 	#if (AMREX_SPACEDIM >= 2)
-				const double FyU_1 = (dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n));
+				const double FyU_1 = (dt / dy) * (x2Flux[bx](i, j, k, n) - x2Flux[bx](i, j + 1, k, n));
 	#endif
 	#if (AMREX_SPACEDIM == 3)
-				const double FzU_1 = (dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n));
+				const double FzU_1 = (dt / dz) * (x3Flux[bx](i, j, k, n) - x3Flux[bx](i, j, k + 1, n));
 	#endif
 
 				// save results in U_new
-				U_new(i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + (
+				U_new[bx](i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + (
 					AMREX_D_TERM( 0.5 * FxU_1 ,
 								+ 0.5 * FyU_1 ,
 								+ 0.5 * FzU_1 )
 								);
 			}
 
+#if 0
 			// check if state is valid -- flag for re-do if not
 			if (!isStateValid(U_new, i, j, k)) {
 				redoFlag(i, j, k) = quokka::redoFlag::redo;
 			} else {
 				redoFlag(i, j, k) = quokka::redoFlag::none;
 			}
+#endif
 	    });
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void LinearAdvectionSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in,
-						     arrayconst_t &x1LeftState_in,
-						     arrayconst_t &x1RightState_in,
-						     const double advectionVx,
-						     amrex::Box const &indexRange, const int nvars)
+void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
+						     amrex::MultiFab const &x1LeftState_mf,
+						     amrex::MultiFab const &x1RightState_mf,
+						     const double vx, const int nvars)
 {
-	// construct ArrayViews for permuted indices
-	quokka::Array4View<amrex::Real const, DIR> x1LeftState(x1LeftState_in);
-	quokka::Array4View<amrex::Real const, DIR> x1RightState(x1RightState_in);
-	quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in);
-
-	const auto vx = advectionVx; // avoid CUDA invalid device function error (tracked as NVIDIA
-				     // bug #3318015)
 	// By convention, the interfaces are defined on the left edge of each zone, i.e.
 	// xinterface_(i) is the solution to the Riemann problem at the left edge of zone i.
 	// [Indexing note: There are (nx + 1) interfaces for nx zones.]
 
+	auto const &x1LeftState_in = x1LeftState_mf.const_arrays();
+	auto const &x1RightState_in = x1RightState_mf.const_arrays();
+	auto x1Flux_in = x1Flux_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(0,0,0)};
+
 	amrex::ParallelFor(
-	    indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	    x1Flux_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
+			// construct ArrayViews for permuted indices
+			quokka::Array4View<amrex::Real const, DIR> x1LeftState(x1LeftState_in[bx]);
+			quokka::Array4View<amrex::Real const, DIR> x1RightState(x1RightState_in[bx]);
+			quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
+
 		    // permute array indices according to dir
 		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -53,6 +53,14 @@ template <typename problem_t> struct RadSystem_Traits {
 template <typename problem_t>
 class RadSystem : public HyperbolicSystem<problem_t> {
 public:
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+	static auto MC(double a, double b) -> double
+	{
+		return 0.5 * (sgn(a) + sgn(b)) *
+		       std::min(0.5 * std::abs(a + b),
+				std::min(2.0 * std::abs(a), 2.0 * std::abs(b)));
+	}
+  
   static constexpr int nvarHyperbolic_ = Physics_NumVars<problem_t>::numRadVars; // number of radiation variables
   static constexpr int nstartHyperbolic_ = Physics_Indices<problem_t>::radFirstIndex;
   static constexpr int nvar_ = nstartHyperbolic_ + nvarHyperbolic_;
@@ -142,6 +150,20 @@ public:
                                          array_t &src,
                                          amrex::Box const &indexRange,
                                          amrex::Real dt);
+
+	template <FluxDir DIR>
+	static void ReconstructStatesConstant(arrayconst_t &q, array_t &leftState,
+					      array_t &rightState, amrex::Box const &indexRange,
+					      int nvars);
+
+	template <FluxDir DIR>
+	static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState,
+					 amrex::Box const &indexRange, int nvars);
+
+	template <FluxDir DIR>
+	static void ReconstructStatesPPM(arrayconst_t &q, array_t &leftState, array_t &rightState,
+					 amrex::Box const &cellRange,
+					 amrex::Box const &interfaceRange, int nvars);
 
   AMREX_GPU_HOST_DEVICE static auto ComputeEddingtonFactor(double f) -> double;
   AMREX_GPU_HOST_DEVICE static auto ComputePlanckOpacity(double rho,
@@ -239,6 +261,191 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::isStateValid(
   bool isNonNegative = (E_r > 0.);
   bool isFluxCausal = (f <= 1.);
   return (isNonNegative && isFluxCausal);
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+void RadSystem<problem_t>::ReconstructStatesConstant(arrayconst_t &q_in,
+							    array_t &leftState_in,
+							    array_t &rightState_in,
+							    amrex::Box const &indexRange,
+							    const int nvars)
+{
+	// construct ArrayViews for permuted indices
+	quokka::Array4View<amrex::Real const, DIR> q(q_in);
+	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
+	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
+
+	// By convention, the interfaces are defined on the left edge of each zone, i.e. xleft_(i)
+	// is the "left"-side of the interface at the left edge of zone i, and xright_(i) is the
+	// "right"-side of the interface at the *left* edge of zone i. [Indexing note: There are (nx
+	// + 1) interfaces for nx zones.]
+
+	amrex::ParallelFor(
+	    indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+		    // permute array indices according to dir
+		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+
+		    // Use piecewise-constant reconstruction (This converges at first
+		    // order in spatial resolution.)
+		    leftState(i, j, k, n) = q(i - 1, j, k, n);
+		    rightState(i, j, k, n) = q(i, j, k, n);
+	    });
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+void RadSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in,
+						       array_t &rightState_in,
+						       amrex::Box const &indexRange,
+						       const int nvars)
+{
+	// construct ArrayViews for permuted indices
+	quokka::Array4View<amrex::Real const, DIR> q(q_in);
+	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
+	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
+
+	// Unlike PPM, PLM with the MC limiter is TVD.
+	// (There are no spurious oscillations, *except* in the slow-moving shock problem,
+	// which can produce unphysical oscillations even when using upwind Godunov fluxes.)
+	// However, most tests fail when using PLM reconstruction because
+	// the accuracy tolerances are very strict, and the L1 error is significantly
+	// worse compared to PPM for a fixed number of mesh elements.
+
+	// By convention, the interfaces are defined on the left edge of each
+	// zone, i.e. xleft_(i) is the "left"-side of the interface at
+	// the left edge of zone i, and xright_(i) is the "right"-side of the
+	// interface at the *left* edge of zone i.
+
+	// Indexing note: There are (nx + 1) interfaces for nx zones.
+
+	amrex::ParallelFor(
+	    indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+		    // permute array indices according to dir
+		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+
+		    // Use piecewise-linear reconstruction
+		    // (This converges at second order in spatial resolution.)
+		    const auto lslope = MC(q(i, j, k, n) - q(i - 1, j, k, n),
+					   q(i - 1, j, k, n) - q(i - 2, j, k, n));
+		    const auto rslope =
+			MC(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
+
+		    leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.25 * lslope; // NOLINT
+		    rightState(i, j, k, n) = q(i, j, k, n) - 0.25 * rslope;    // NOLINT
+	    });
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+void RadSystem<problem_t>::ReconstructStatesPPM(arrayconst_t &q_in, array_t &leftState_in,
+						       array_t &rightState_in,
+						       amrex::Box const &cellRange,
+						       amrex::Box const &interfaceRange,
+						       const int nvars)
+{
+	BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM()");
+
+	// construct ArrayViews for permuted indices
+	quokka::Array4View<amrex::Real const, DIR> q(q_in);
+	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
+	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
+
+	// By convention, the interfaces are defined on the left edge of each
+	// zone, i.e. xleft_(i) is the "left"-side of the interface at the left
+	// edge of zone i, and xright_(i) is the "right"-side of the interface
+	// at the *left* edge of zone i.
+
+	// Indexing note: There are (nx + 1) interfaces for nx zones.
+
+	amrex::ParallelFor(
+		cellRange, nvars, // cell-centered kernel
+		[=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+		    // permute array indices according to dir
+		    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+
+		    // (2.) Constrain interfaces to lie between surrounding cell-averaged
+		    // values (equivalent to step 2b in Athena++ [ppm_simple.cpp]).
+			// [See Eq. B8 of Mignone+ 2005.]
+
+#ifdef MULTIDIM_EXTREMA_CHECK
+			// N.B.: Checking all 27 nearest neighbors is *very* expensive on GPU
+			// (presumably due to lots of cache misses), so it is hard-coded disabled.
+			// Fortunately, almost all problems run stably without enabling this.
+			auto bounds = GetMinmaxSurroundingCell(q_in, i_in, j_in, k_in, n);
+#else
+			// compute bounds from neighboring cell-averaged values along axis
+			const std::pair<double, double> bounds =
+				std::minmax({q(i, j, k, n), q(i - 1, j, k, n), q(i + 1, j, k, n)});
+#endif
+
+		    // get interfaces
+			// PPM reconstruction following Colella & Woodward (1984), with
+			// some modifications following Mignone (2014), as implemented in
+			// Athena++.
+
+			// (1.) Estimate the interface a_{i - 1/2}. Equivalent to step 1
+			// in Athena++ [ppm_simple.cpp].
+
+			// C&W Eq. (1.9) [parabola midpoint for the case of
+			// equally-spaced zones]: a_{j+1/2} = (7/12)(a_j + a_{j+1}) -
+			// (1/12)(a_{j+2} + a_{j-1}). Terms are grouped to preserve exact
+			// symmetry in floating-point arithmetic, following Athena++.
+			const double coef_1 = (7. / 12.);
+		    const double coef_2 = (-1. / 12.);
+		    const double a_minus = (coef_1 * q(i,     j, k, n) + coef_2 * q(i + 1, j, k, n)) +
+		       					   (coef_1 * q(i - 1, j, k, n) + coef_2 * q(i - 2, j, k, n)) ;
+		    const double a_plus  = (coef_1 * q(i + 1, j, k, n) + coef_2 * q(i + 2, j, k, n)) +
+		       					   (coef_1 * q(i    , j, k, n) + coef_2 * q(i - 1, j, k, n)) ;
+
+		    // left side of zone i
+		    double new_a_minus = clamp(a_minus, bounds.first, bounds.second);
+
+		    // right side of zone i
+		    double new_a_plus = clamp(a_plus, bounds.first, bounds.second);
+
+		    // (3.) Monotonicity correction, using Eq. (1.10) in PPM paper. Equivalent
+		    // to step 4b in Athena++ [ppm_simple.cpp].
+
+		    const double a = q(i, j, k, n);	// a_i in C&W
+		    const double dq_minus = (a - new_a_minus);
+		    const double dq_plus = (new_a_plus - a);
+
+		    const double qa = dq_plus * dq_minus; // interface extrema
+
+		    if (qa <= 0.0) { // local extremum
+
+			    // Causes subtle, but very weird, oscillations in the Shu-Osher test
+			    // problem. However, it is necessary to get a reasonable solution
+			    // for the sawtooth advection problem.
+			    const double dq0 = MC(q(i + 1, j, k, n) - q(i, j, k, n),
+						  q(i, j, k, n) - q(i - 1, j, k, n));
+
+			    // use linear reconstruction, following Balsara (2017) [Living Rev
+			    // Comput Astrophys (2017) 3:2]
+			    new_a_minus = a - 0.5 * dq0;
+			    new_a_plus = a + 0.5 * dq0;
+
+			    // original C&W method for this case
+			    // new_a_minus = a;
+			    // new_a_plus = a;
+
+		    } else { // no local extrema
+
+			    // parabola overshoots near a_plus -> reset a_minus
+			    if (std::abs(dq_minus) >= 2.0 * std::abs(dq_plus)) {
+				    new_a_minus = a - 2.0 * dq_plus;
+			    }
+
+			    // parabola overshoots near a_minus -> reset a_plus
+			    if (std::abs(dq_plus) >= 2.0 * std::abs(dq_minus)) {
+				    new_a_plus = a + 2.0 * dq_minus;
+			    }
+		    }
+
+		    rightState(i, j, k, n) = new_a_minus;
+		    leftState(i + 1, j, k, n) = new_a_plus;
+	});
 }
 
 template <typename problem_t>

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -324,19 +324,16 @@ void AMRSimulation<problem_t>::initialize(
 
 template <typename problem_t>
 void AMRSimulation<problem_t>::setInitialConditionsAtLevel(int level) {
-  // initialise grid-struct, which the user will opperate on
-  std::vector<quokka::grid> grid_vec;
-
   // perform precalculation step defined by the user
   preCalculateInitialConditions();
 
-  // itterate over the domain
+  // iterate over the domain
   for (amrex::MFIter iter(state_new_cc_[level]); iter.isValid(); ++iter) {
-    // cell-centred states
+    std::vector<quokka::grid> grid_vec;
     grid_vec.emplace_back(state_new_cc_[level].array(iter), iter.validbox(),
-                          geom[level].CellSizeArray(), geom[level].ProbLoArray(),
-                          geom[level].ProbHiArray(), quokka::centering::cc,
-                          quokka::direction::na);
+                        geom[level].CellSizeArray(), geom[level].ProbLoArray(),
+                        geom[level].ProbHiArray(), quokka::centering::cc,
+                        quokka::direction::na);
 
     // set initial conditions defined by the user
     setInitialConditionsOnGrid(grid_vec);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -188,6 +188,12 @@ public:
       std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int lev,
       amrex::Real dt_lev);
 
+  void incrementFluxRegisters(
+      amrex::YAFluxRegister *fr_as_crse,
+      amrex::YAFluxRegister *fr_as_fine,
+      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int lev,
+      amrex::Real dt_lev);
+
   // boundary condition
   AMREX_GPU_DEVICE static void setCustomBoundaryConditions(
       const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest,
@@ -877,6 +883,37 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(
     fr_as_fine->FineAdd(
         mfi, {AMREX_D_DECL(&fluxArrays[0], &fluxArrays[1], &fluxArrays[2])},
         geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+  }
+}
+
+template <typename problem_t>
+void AMRSimulation<problem_t>::incrementFluxRegisters(
+    amrex::YAFluxRegister *fr_as_crse,
+    amrex::YAFluxRegister *fr_as_fine,
+    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev,
+    amrex::Real const dt_lev) {
+  BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+
+  for(amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
+    if (fr_as_crse != nullptr) {
+      AMREX_ASSERT(lev < finestLevel());
+      AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
+      fr_as_crse->CrseAdd(mfi,
+          {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi),
+                        fluxArrays[1].fabPtr(mfi),
+                        fluxArrays[2].fabPtr(mfi))},
+          geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+    }
+
+    if (fr_as_fine != nullptr) {
+      AMREX_ASSERT(lev > 0);
+      AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
+      fr_as_fine->FineAdd(mfi,
+          {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi),
+                        fluxArrays[1].fabPtr(mfi),
+                        fluxArrays[2].fabPtr(mfi))},          
+          geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+    }
   }
 }
 


### PR DESCRIPTION
This rewrites the hydro driver to use the MultiFab version of ParallelFor for each kernel. This means that only one kernel is launched for all boxes on the GPU and processes every box at once. This should reduce kernel launch overhead substantially for small boxes and/or when using AMR.

This improves performance for the ShockCloud AMR problem by ~10%.

Closes https://github.com/BenWibking/quokka/issues/45.