### PR TITLE
suppress gcc warnings about ARM ABI change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   message(FATAL_ERROR "You have configured CMake to use the 'classic' Intel compilers (icc/icpc), which are the old Intel compilers. They cannot compile Quokka correctly! You must use the new LLVM-based Intel compilers (icx/icpx) instead by adding the following CMake command-line options: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx")
 endif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
 
+# this is necessary to prevent GCC from warning about ARM64 ABI changes in GCC 10.1
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  add_compile_options(-Wno-psabi)
+endif()
+
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/amrex ${QuokkaCode_BINARY_DIR}/amrex)
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/fmt ${QuokkaCode_BINARY_DIR}/fmt)
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/src ${QuokkaCode_BINARY_DIR}/src)


### PR DESCRIPTION
This adds the compiler flag `-Wno-psabi` when building with GCC. This suppresses warnings about an ABI change starting with GCC 10 in C++17 mode on ARM64 that is not relevant, since we always build with the same version of GCC (>10).