### PR TITLE
fix memory errors in setInitialConditionsOnGrid

### DIFF
--- a/src/grid.hpp
+++ b/src/grid.hpp
@@ -12,14 +12,15 @@ namespace quokka {
   enum class direction { na=-1, x, y, z };
 
   struct grid {
-    const amrex::Array4<double>& array;
-    const amrex::Box& indexRange;
+    amrex::Array4<double> array;
+    amrex::Box indexRange;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi;
     enum centering cen;
     enum direction dir;
-    grid(const amrex::Array4<double>& array, const amrex::Box& indexRange,
+    
+    grid(amrex::Array4<double> const& array, amrex::Box const& indexRange,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo,
         amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi,

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -324,14 +324,12 @@ void AMRSimulation<problem_t>::initialize(
 
 template <typename problem_t>
 void AMRSimulation<problem_t>::setInitialConditionsAtLevel(int level) {
-  // initialise grid-struct, which the user will opperate on
-  std::vector<quokka::grid> grid_vec;
-
   // perform precalculation step defined by the user
   preCalculateInitialConditions();
 
-  // itterate over the domain
+  // iterate over the domain
   for (amrex::MFIter iter(state_new_cc_[level]); iter.isValid(); ++iter) {
+    std::vector<quokka::grid> grid_vec;
     // cell-centred states
     grid_vec.emplace_back(state_new_cc_[level].array(iter), iter.validbox(),
                           geom[level].CellSizeArray(), geom[level].ProbLoArray(),


### PR DESCRIPTION
This fixes use-after-scope errors in `setInitialConditionsOnGrid`.

To manually check correctness, build with `-DENABLE_ASAN=ON` and run `ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=../tests/leak_suppress.txt ctest`