### PR TITLE
remove dt assert in ODEIntegrate

### DIFF
--- a/src/ODEIntegrate.hpp
+++ b/src/ODEIntegrate.hpp
@@ -175,9 +175,6 @@ rk_adaptive_integrate(F &&rhs, Real t0, quokka::valarray<Real, N> &y0, Real t1,
 
     bool step_success = false;
     for (int k = 0; k < maxRetries; ++k) {
-      // check that timestep is not infinitesimal
-      AMREX_ALWAYS_ASSERT(dt > (hmin * (t1 - t0)));
-
       // compute single step of chosen RK method
       int ierr = rk12_single_step(rhs, time, y, dt, ynew, yerr, user_data);
 


### PR DESCRIPTION
The assert in ODEIntegrate on the timestep is not necessary, since there is a limit on the maximum number of substeps. It sometimes prevents problems from integrating successfully, even though they do not require an unreasonable number of substeps.