### PR TITLE
decide whether to subcycle based on cost

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -591,7 +591,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
   if (work_nonsubcycling <= work_subcycling) {
     // use global timestep on this coarse step
     for (int lev = 1; lev <= max_level; ++lev) {
-      nsubsteps[level] = 1;
+      nsubsteps[lev] = 1;
     }
   }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -521,25 +521,77 @@ auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::Real {
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
   BL_PROFILE("AMRSimulation::computeTimestep()");
 
+  // compute candidate timestep dt_tmp on each level
   amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
   for (int level = 0; level <= finest_level; ++level) {
     dt_tmp[level] = computeTimestepAtLevel(level);
   }
 
+  // limit change in timestep on each level
   constexpr amrex::Real change_max = 1.1;
-  amrex::Real dt_0 = dt_tmp[0];
-  int n_factor = 1;
 
   for (int level = 0; level <= finest_level; ++level) {
     dt_tmp[level] = std::min(dt_tmp[level], change_max * dt_[level]);
+  }
+
+  // set default subcycling pattern
+  if (do_subcycle == 1) {
+    for (int lev = 1; lev <= max_level; ++lev) {
+      nsubsteps[lev] = MaxRefRatio(lev - 1);
+    }
+  }
+
+  // compute root level timestep given nsubsteps
+  amrex::Real dt_0 = dt_tmp[0];
+  amrex::Long n_factor = 1;
+
+  for (int level = 0; level <= finest_level; ++level) {
     n_factor *= nsubsteps[level];
     dt_0 = std::min(dt_0, n_factor * dt_tmp[level]);
     dt_0 = std::min(dt_0, maxDt_); // limit to maxDt_
+
     if (tNew_[level] == 0.0) {     // first timestep
       dt_0 = std::min(dt_0, initDt_);
     }
     if (constantDt_ > 0.0) { // use constant timestep if set
       dt_0 = constantDt_;
+    }
+  }
+
+  // compute global timestep assuming no subcycling
+  amrex::Real dt_global = dt_tmp[0];
+
+  for (int level = 0; level <= finest_level; ++level) {
+    dt_global = std::min(dt_global, dt_tmp[level]);
+    dt_global = std::min(dt_global, maxDt_); // limit to maxDt_
+
+    if (tNew_[level] == 0.0) {  // special case: first timestep
+      dt_global = std::min(dt_global, initDt_);
+    }
+    if (constantDt_ > 0.0) {  // special case: constant timestep
+      dt_global = constantDt_;
+    }
+  }  
+
+  // compute work estimate for subcycling
+  amrex::Long n_factor_work = 1;
+  amrex::Long work_subcycling = 0;
+  for (int level = 0; level <= finest_level; ++level) {
+    n_factor_work *= nsubsteps[level];
+    work_subcycling += n_factor_work * CountCells(level);
+  }
+
+  // compute work estimate for non-subcycling
+  amrex::Long total_cells = 0;
+  for (int level = 0; level <= finest_level; ++level) {
+    total_cells += CountCells(level);
+  }
+  const amrex::Real work_nonsubcycling = static_cast<amrex::Real>(total_cells) * (dt_0 / dt_global);
+
+  if (work_nonsubcycling <= work_subcycling) {
+    // use global timestep on this coarse step
+    for (int lev = 1; lev <= max_level; ++lev) {
+      nsubsteps[level] = 1;
     }
   }
 
@@ -550,6 +602,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
     dt_0 = stopTime_ - tNew_[0];
   }
 
+  // assign timesteps on each level
   dt_[0] = dt_0;
 
   for (int level = 1; level <= finest_level; ++level) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -590,6 +590,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
 
   if (work_nonsubcycling <= work_subcycling) {
     // use global timestep on this coarse step
+    if (verbose) {
+      const amrex::Real ratio = work_nonsubcycling / work_subcycling;
+      amrex::Print() << "\t>> Using global timestep on this coarse step (estimated work ratio: " << ratio << ").\n";
+    }
     for (int lev = 1; lev <= max_level; ++lev) {
       nsubsteps[lev] = 1;
     }


### PR DESCRIPTION
We decide whether or not to subcycle each coarse step by computing an estimate of the cell update required for a given time interval with and without using subcycling factors given by `nsubsteps`.

This is especially useful when the maximum timestep is determined by reactions rather than advection terms.