### PR TITLE
add ability to retry hydro advance with smaller dt

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -183,9 +183,13 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	auto expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, int nstartNew,
 			      int ncompNew) -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>;
 
-	void advanceHydroAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
+	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev,
 				 amrex::YAFluxRegister *fr_as_crse,
 				 amrex::YAFluxRegister *fr_as_fine);
+
+	auto advanceHydroAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
+				 amrex::YAFluxRegister *fr_as_crse,
+				 amrex::YAFluxRegister *fr_as_fine) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time,
 				 amrex::Real dt_lev);
@@ -513,7 +517,7 @@ void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex:
 
 	// advance hydro
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
-		advanceHydroAtLevel(lev, time, dt_lev, fr_as_crse, fr_as_fine);
+		advanceHydroAtLevelWithRetries(lev, time, dt_lev, fr_as_crse, fr_as_fine);
 	} else {
 		// copy hydro vars from state_old_cc_ to state_new_cc_
 		// (otherwise radiation update will be wrong!)
@@ -674,10 +678,48 @@ auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F 
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real time,
+void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time,
 							amrex::Real dt_lev,
 							amrex::YAFluxRegister *fr_as_crse,
 							amrex::YAFluxRegister *fr_as_fine)
+{
+	// timestep retries
+	const int max_retries = 4;
+	bool success = false;
+
+	for (int retry_count = 0; retry_count < max_retries; ++retry_count) {
+		// reduce timestep by a factor of 2^retry_count
+		const int nsubsteps = std::pow(2, retry_count);
+		const amrex::Real dt_step = dt_lev / nsubsteps;
+		if (retry_count > 0 && Verbose()) {
+			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev
+						   << " with timestep reduced by factor " << nsubsteps << "\n";
+		}
+
+		// subcycle advanceHydroAtLevel, checking return value
+		for (int substep = 0; substep < nsubsteps; ++substep) {
+			success = advanceHydroAtLevel(lev, time, dt_step, fr_as_crse, fr_as_fine);
+			if (!success) {
+				if (Verbose()) {
+					amrex::Print() << "Warning: Hydro advance failed on level " << lev << "\n";
+				}
+				break;
+			}
+		}
+
+		if (success) {
+			// we are done, do not attempt more retries
+			break;
+		}
+	}
+	AMREX_ALWAYS_ASSERT(success); // crash if we exceeded max_retries
+}
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real time,
+							amrex::Real dt_lev,
+							amrex::YAFluxRegister *fr_as_crse,
+							amrex::YAFluxRegister *fr_as_fine) -> bool
 {
 	BL_PROFILE("RadhydroSimulation::advanceHydroAtLevel()");
 
@@ -697,6 +739,9 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	// do Strang split source terms (first half-step)
 	addStrangSplitSources(state_old_cc_tmp, lev, time, 0.5*dt_lev);
 
+	// create temporary multifab for intermediate state
+	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], ncomp_cc_, nghost_);
+
 	// Stage 1 of RK2-SSP
 	{
 		// update ghost zones [old timestep]
@@ -708,7 +753,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 		// advance all grids on local processor (Stage 1 of integrator)
 		auto const &stateOld = state_old_cc_tmp;
-		auto &stateNew = state_new_cc_[lev];
+		auto &stateNew = state_inter_cc_;
 		auto [fluxArrays, faceVel] = computeHydroFluxes(stateOld, ncompHydro_, lev);
 
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
@@ -739,7 +784,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			amrex::Gpu::streamSynchronizeAll(); // just in case
 			if (redoFlag.max(0) == quokka::redoFlag::redo) {
 				// FOFC failed
-				amrex::Abort("First-order flux correction failed! Enable timestep retries or run with a lower CFL.");
+				return false;
+				//amrex::Abort("First-order flux correction failed! Enable timestep retries or run with a lower CFL.");
 			}
 		}
 
@@ -761,16 +807,16 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 	// Stage 2 of RK2-SSP
 	{
-		// update ghost zones [intermediate stage stored in state_new_cc_]
-		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, time + dt_lev, PreInterpState,
-				       PostInterpState);
+		// update ghost zones [intermediate stage stored in state_inter_cc_]
+		fillBoundaryConditions(state_inter_cc_, state_inter_cc_, lev, time + dt_lev, PreInterpState,
+					PostInterpState);
 
 		// check intermediate state validity
-		AMREX_ASSERT(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()));
-		AMREX_ASSERT(!state_new_cc_[lev].contains_nan()); // check ghost zones
+		AMREX_ASSERT(!state_inter_cc_.contains_nan(0, state_inter_cc_.nComp()));
+		AMREX_ASSERT(!state_inter_cc_.contains_nan()); // check ghost zones
 
 		auto const &stateOld = state_old_cc_tmp;
-		auto const &stateInter = state_new_cc_[lev];
+		auto const &stateInter = state_inter_cc_;
 		auto &stateFinal = state_new_cc_[lev];
 		auto [fluxArrays, faceVel] = computeHydroFluxes(stateInter, ncompHydro_, lev);
 
@@ -789,7 +835,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			}
 
 			// replace fluxes around troubled cells with Godunov fluxes
-			auto [FOfluxArrays, FOfaceVel] = computeFOHydroFluxes(stateOld, ncompHydro_, lev);
+			auto [FOfluxArrays, FOfaceVel] = computeFOHydroFluxes(stateInter, ncompHydro_, lev);
 			replaceFluxes(fluxArrays, FOfluxArrays, redoFlag, ncompHydro_);
 			replaceFluxes(faceVel, FOfaceVel, redoFlag, ncompHydro_); // needed for dual energy
 			redoFlag.setVal(quokka::redoFlag::none); // reset redoFlag
@@ -802,7 +848,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 			amrex::Gpu::streamSynchronizeAll(); // just in case
 			if (redoFlag.max(0) == quokka::redoFlag::redo) {
 				// FOFC failed
-				amrex::Abort("First-order flux correction failed! Enable timestep retries or run with a lower CFL.");
+				return false;
+				//amrex::Abort("First-order flux correction failed! Enable timestep retries or run with a lower CFL.");
 			}
 		}
 
@@ -824,6 +871,9 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 	// do Strang split source terms (second half-step)
 	addStrangSplitSources(state_new_cc_[lev], lev, time + dt_lev, 0.5*dt_lev);
+
+	// we have successfully advanced by dt_lev
+	return true;
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -543,7 +543,6 @@ void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex:
 
 	// check state validity
 	AMREX_ASSERT(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()));
-	AMREX_ASSERT(!state_new_cc_[lev].contains_nan()); // check ghost zones
 }
 
 // fix-up any unphysical states created by AMR operations
@@ -741,6 +740,7 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 
 	// create temporary multifab for intermediate state
 	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], ncomp_cc_, nghost_);
+	state_inter_cc_.setVal(0); // prevent assert in fillBoundaryConditions when radiation is enabled
 
 	// Stage 1 of RK2-SSP
 	{


### PR DESCRIPTION
Adds the capability to re-try the hydro advance on a given level with a timestep reduced by a factor of 2. This will subcycle the hydro advance until it reaches the time it was supposed to reach.

This is needed for difficult problems when first-order flux correction can still fail to produce a positive density or pressure. It should work because (in 1D) HLLC is positivity-preserving with Godunov fluxes for a sufficiently small timestep (unless vacuum is physically created) [1][2].

[1] https://ui.adsabs.harvard.edu/abs/1991JCoPh..92..273E/abstract
[2] https://ui.adsabs.harvard.edu/abs/1997SJSC...18.1553B/abstract