### PR TITLE
retry hydro step on post-hoc CFL violation

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -749,7 +749,8 @@ auto RadhydroSimulation<problem_t>::isCflViolated(int lev, amrex::Real time,
 	const amrex::Real dt_cfl = cflNumber_ * (dx_min / max_signal);
 
 	// check whether dt_actual > dt_cfl (CFL violation)
-	if ((dt_actual > dt_cfl) && Verbose()) {
+	const amrex::Real max_factor = 1.1;
+	if ((dt_actual > (max_factor * dt_cfl)) && Verbose()) {
 		amrex::Print() << "\t>> CFL violation detected on level " << lev
 					   << " with dt_lev = " << dt_actual
 					   << " and dt_cfl = " << dt_cfl << "\n"

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -750,13 +750,14 @@ auto RadhydroSimulation<problem_t>::isCflViolated(int lev, amrex::Real time,
 
 	// check whether dt_actual > dt_cfl (CFL violation)
 	const amrex::Real max_factor = 1.1;
-	if ((dt_actual > (max_factor * dt_cfl)) && Verbose()) {
+	const bool cflViolation = dt_actual > (max_factor * dt_cfl);
+	if (cflViolation && Verbose()) {
 		amrex::Print() << "\t>> CFL violation detected on level " << lev
 					   << " with dt_lev = " << dt_actual
 					   << " and dt_cfl = " << dt_cfl << "\n"
 					   << "\t   max_signal = " << max_signal << "\n";
 	}
-	return (dt_actual > dt_cfl);
+	return cflViolation;
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -62,6 +62,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::areInitialConditionsDefined_;
 	using AMRSimulation<problem_t>::BCs_cc_;
 	using AMRSimulation<problem_t>::componentNames_cc_;
+	using AMRSimulation<problem_t>::cflNumber_;
 	using AMRSimulation<problem_t>::fillBoundaryConditions;
 	using AMRSimulation<problem_t>::geom;
 	using AMRSimulation<problem_t>::grids;
@@ -187,12 +188,15 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 				 amrex::YAFluxRegister *fr_as_crse,
 				 amrex::YAFluxRegister *fr_as_fine);
 
-	auto advanceHydroAtLevel(int lev, amrex::Real time, amrex::Real dt_lev,
+	auto advanceHydroAtLevel(amrex::MultiFab &state_old_tmp, 
+				 int lev, amrex::Real time, amrex::Real dt_lev,
 				 amrex::YAFluxRegister *fr_as_crse,
 				 amrex::YAFluxRegister *fr_as_fine) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time,
 				 amrex::Real dt_lev);
+
+	auto isCflViolated(int lev, amrex::Real time, amrex::Real dt_actual) -> bool;			 
 
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew);
@@ -683,22 +687,38 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 	// timestep retries
 	const int max_retries = 4;
 	bool success = false;
+	amrex::Real cur_time;
 
 	for (int retry_count = 0; retry_count < max_retries; ++retry_count) {
 		// reduce timestep by a factor of 2^retry_count
 		const int nsubsteps = std::pow(2, retry_count);
 		const amrex::Real dt_step = dt_lev / nsubsteps;
+		cur_time = time;
+
 		if (retry_count > 0 && Verbose()) {
 			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev
-						   << " with timestep reduced by factor " << nsubsteps << "\n";
+						   << " with reduced timestep (nsubsteps = " << nsubsteps
+						   << ", dt_new = " << dt_step << ")\n";
 		}
+
+		// create temporary multifab for old state
+		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], ncomp_cc_, nghost_);
+		amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, ncomp_cc_, nghost_);
 
 		// subcycle advanceHydroAtLevel, checking return value
 		for (int substep = 0; substep < nsubsteps; ++substep) {
-			success = advanceHydroAtLevel(lev, time, dt_step, fr_as_crse, fr_as_fine);
+			if (substep > 0) {
+				// since we are starting a new substep, we need to copy hydro state from
+				//  the new state vector to old state vector
+				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_);
+			}
+
+			success = advanceHydroAtLevel(state_old_cc_tmp, lev, time, dt_step, fr_as_crse, fr_as_fine);
+			cur_time += dt_step;
+
 			if (!success) {
 				if (Verbose()) {
-					amrex::Print() << "Warning: Hydro advance failed on level " << lev << "\n";
+					amrex::Print() << "\t>> WARNING: Hydro advance failed on level " << lev << "\n";
 				}
 				break;
 			}
@@ -709,11 +729,37 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 			break;
 		}
 	}
+	AMREX_ALWAYS_ASSERT(amrex::almostEqual(cur_time, time + dt_lev, 5));
 	AMREX_ALWAYS_ASSERT(success); // crash if we exceeded max_retries
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real time,
+auto RadhydroSimulation<problem_t>::isCflViolated(int lev, amrex::Real time,
+							amrex::Real dt_actual) -> bool
+{
+	// check wheter dt_actual would violate CFL condition using the post-update hydro state
+
+	// compute max signal speed
+	amrex::Real max_signal = HydroSystem<problem_t>::maxSignalSpeedLocal(state_new_cc_[lev]);
+	amrex::ParallelDescriptor::ReduceRealMax(max_signal);
+
+	// compute dt_cfl
+	auto dx = geom[lev].CellSizeArray();
+	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+	const amrex::Real dt_cfl = cflNumber_ * (dx_min / max_signal);
+
+	// check whether dt_actual > dt_cfl (CFL violation)
+	if ((dt_actual > dt_cfl) && Verbose()) {
+		amrex::Print() << "\t>> CFL violation detected on level " << lev
+					   << " with dt_lev = " << dt_actual
+					   << " and dt_cfl = " << dt_cfl << "\n";
+	}
+	return (dt_actual > dt_cfl);
+}
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp,
+							int lev, amrex::Real time,
 							amrex::Real dt_lev,
 							amrex::YAFluxRegister *fr_as_crse,
 							amrex::YAFluxRegister *fr_as_fine) -> bool
@@ -728,10 +774,6 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	}
 
 	auto dx = geom[lev].CellSizeArray();
-
-	// create temporary multifab for Strang-split sources, copy old state
-	amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], ncomp_cc_, nghost_);
-	amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, ncomp_cc_, nghost_);
 
 	// do Strang split source terms (first half-step)
 	addStrangSplitSources(state_old_cc_tmp, lev, time, 0.5*dt_lev);
@@ -870,8 +912,8 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(int lev, amrex::Real tim
 	// do Strang split source terms (second half-step)
 	addStrangSplitSources(state_new_cc_[lev], lev, time + dt_lev, 0.5*dt_lev);
 
-	// we have successfully advanced by dt_lev
-	return true;
+	// return success if we have not violated the CFL timestep
+	return (!isCflViolated(lev, time, dt_lev));
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -752,7 +752,8 @@ auto RadhydroSimulation<problem_t>::isCflViolated(int lev, amrex::Real time,
 	if ((dt_actual > dt_cfl) && Verbose()) {
 		amrex::Print() << "\t>> CFL violation detected on level " << lev
 					   << " with dt_lev = " << dt_actual
-					   << " and dt_cfl = " << dt_cfl << "\n";
+					   << " and dt_cfl = " << dt_cfl << "\n"
+					   << "\t   max_signal = " << max_signal << "\n";
 	}
 	return (dt_actual > dt_cfl);
 }

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -207,7 +207,7 @@ auto HydroSystem<problem_t>::maxSignalSpeedLocal(amrex::MultiFab const &cons_mf)
   // return maximum signal speed on local grids
   
   auto const &cons = cons_mf.const_arrays();
-  return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMin>{}, amrex::TypeList<amrex::Real>{},
+  return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMax>{}, amrex::TypeList<amrex::Real>{},
                           cons_mf, amrex::IntVect(0), // no ghost cells
       [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k)
           noexcept -> amrex::GpuTuple<amrex::Real>

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -65,6 +65,8 @@ public:
 
   static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost);
 
+  static auto maxSignalSpeedLocal(amrex::MultiFab const &cons) -> amrex::Real;
+
   static void
   ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons,
                         array_t &maxSignal, amrex::Box const &indexRange);
@@ -198,6 +200,36 @@ void HydroSystem<problem_t>::ConservedToPrimitive(
       primVar[bx](i, j, k, primScalar0_index + nc) = cons[bx](i, j, k, scalar0_index + nc);
     }
   });
+}
+
+template <typename problem_t>
+auto HydroSystem<problem_t>::maxSignalSpeedLocal(amrex::MultiFab const &cons_mf) -> amrex::Real {
+  // return maximum signal speed on local grids
+  
+  auto const &cons = cons_mf.const_arrays();
+  return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMin>{}, amrex::TypeList<amrex::Real>{},
+                          cons_mf, amrex::IntVect(0), // no ghost cells
+      [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k)
+          noexcept -> amrex::GpuTuple<amrex::Real>
+      {
+        const auto rho = cons[bx](i, j, k, HydroSystem<problem_t>::density_index);
+        const auto px  = cons[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+        const auto py  = cons[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+        const auto pz  = cons[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+        const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
+        const double abs_vel = std::sqrt(2.0 * kinetic_energy / rho);
+        double cs = NAN;
+
+        if constexpr (is_eos_isothermal()) {
+          cs = cs_iso_;
+        } else {
+          const auto Etot = cons[bx](i, j, k, HydroSystem<problem_t>::energy_index);
+          const auto Eint = Etot - kinetic_energy;
+          const auto P = Eint * (HydroSystem<problem_t>::gamma_ - 1.0);
+          cs = std::sqrt(HydroSystem<problem_t>::gamma_ * P / rho);
+        }
+        return { cs + abs_vel };
+      });
 }
 
 template <typename problem_t>


### PR DESCRIPTION
If the actual timestep taken by a hydro advance is greater than the CFL timestep as computed from the post-advance state, then re-do the hydro advance with a halved timestep.

Closes https://github.com/BenWibking/quokka/issues/101.