### PR TITLE
fix reflux when timestep retries are used

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -711,7 +711,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 		if (do_reflux) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				auto ba_face = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
-				flux[idim] = amrex::MultiFab(ba_face, dmap[lev], ncomp_, 0);
+				flux[idim] = amrex::MultiFab(ba_face, dmap[lev], ncomp_cc_, 0);
 				flux[idim].setVal(0);
 			}
 		}

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -745,7 +745,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 					fluxScaleFactor = 1.0;
 				}
 				// increment flux registers
-				incrementFluxRegisters(fr_as_crse, fr_as_fine, flux, lev, fluxScaleFactor * dt_lev);
+				//   note: this *must* be scaled by dt_step, NOT dt_lev !
+				incrementFluxRegisters(fr_as_crse, fr_as_fine, flux, lev, fluxScaleFactor * dt_step);
 			}
 			// we are done, do not attempt more retries
 			break;

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -191,9 +191,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	auto advanceHydroAtLevel(amrex::MultiFab &state_old_tmp,
 							std::array<amrex::MultiFab, AMREX_SPACEDIM> &flux,
 							int lev, amrex::Real time,
-							amrex::Real dt_lev,
-							amrex::YAFluxRegister *fr_as_crse,
-							amrex::YAFluxRegister *fr_as_fine) -> bool;
+							amrex::Real dt_lev) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time,
 				 amrex::Real dt_lev);
@@ -725,7 +723,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_);
 			}
 
-			success = advanceHydroAtLevel(state_old_cc_tmp, lev, time, dt_step, fr_as_crse, fr_as_fine);
+			success = advanceHydroAtLevel(state_old_cc_tmp, flux, lev, time, dt_step);
 			cur_time += dt_step;
 
 			if (!success) {
@@ -786,9 +784,7 @@ template <typename problem_t>
 auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp,
 							std::array<amrex::MultiFab, AMREX_SPACEDIM> &flux,
 							int lev, amrex::Real time,
-							amrex::Real dt_lev,
-							amrex::YAFluxRegister *fr_as_crse,
-							amrex::YAFluxRegister *fr_as_fine) -> bool
+							amrex::Real dt_lev) -> bool
 {
 	BL_PROFILE("RadhydroSimulation::advanceHydroAtLevel()");
 


### PR DESCRIPTION
The previous implementation didn't remove the contribution to the flux registers when the hydro advance failed and was retried with a smaller timestep. This saves the fluxes produced by the hydro advance until it has succeeded and then adds them to the flux register.

Unfortunately, this requires an additional set of flux MultiFabs to accumulate the flux from each RK stage for each retry substep. Future enhancements to `amrex::YAFluxRegister` may allow the flux register state to be copied and restored as needed.