### PR TITLE
Fix bug in additional subcycling

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -554,6 +554,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
   if (do_subcycle == 1) {
     for (int lev = 1; lev <= max_level; ++lev) {
       nsubsteps[lev] = MaxRefRatio(lev - 1);
+      reductionFactor_[lev] = 1; // reset additional subcycling factors
     }
   }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -686,7 +686,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve() {
 
     // sync up time (to avoid roundoff error)
     for (lev = 0; lev <= finest_level; ++lev) {
-      AMREX_ALWAYS_ASSERT(amrex::almostEqual(tNew_[lev], cur_time, 5));
+      AMREX_ALWAYS_ASSERT(std::abs((tNew_[lev] - cur_time)/cur_time) < 1e-10);
       tNew_[lev] = cur_time;
     }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -554,7 +554,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep() {
   if (do_subcycle == 1) {
     for (int lev = 1; lev <= max_level; ++lev) {
       nsubsteps[lev] = MaxRefRatio(lev - 1);
-      reductionFactor_[lev] = 1; // reset additional subcycling factors
+      reductionFactor_[lev] = 1; // reset additional subcycling
     }
   }
 
@@ -686,6 +686,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve() {
 
     // sync up time (to avoid roundoff error)
     for (lev = 0; lev <= finest_level; ++lev) {
+      AMREX_ALWAYS_ASSERT(amrex::almostEqual(tNew_[lev], cur_time, 5));
       tNew_[lev] = cur_time;
     }
 


### PR DESCRIPTION
This resets the timestep reduction factor `reductionFactor_[lev]` at the start of each coarse step.

The 'additional subcycling' code checks the CFL at the start of fine level advances to see if additional subcycles need to be done on the current level to obey the CFL limit. If so, it adjusts the timesteps on the current and finer levels and adds subcycles to the current level. However, the timestep reduction factor `reductionFactor_` was not reset at the start of the next coarse step, causing incorrect behavior on subsequent coarse steps.