### PR TITLE
add Hancock predictor-corrector integrator

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -750,15 +750,16 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 
 		if (success) {
 			if (do_reflux) {
-#if 0
 				amrex::Real fluxScaleFactor = NAN;
 				if (integratorOrder_ == 2) {
-					fluxScaleFactor = 0.5;
+					if (integratorType_ == "rk2") {
+						fluxScaleFactor = 0.5; // two RK2 stages
+					} else if (integratorType_ == "vl2") {
+						fluxScaleFactor = 1.0; // VL2 (single-step)
+					}
 				} else if (integratorOrder_ == 1) {
 					fluxScaleFactor = 1.0;
 				}
-#endif
-				const amrex::Real fluxScaleFactor = 1.0; // VL2
 				// increment flux registers
 				//   note: this *must* be scaled by dt_step, NOT dt_lev !
 				incrementFluxRegisters(fr_as_crse, fr_as_fine, flux, lev, fluxScaleFactor * dt_step);

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -684,7 +684,7 @@ void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf) {
   // sync internal energy and total energy
   // this step must be done as an operator-split step after *each* RK stage
 
-  const amrex::Real eta = 1.0e-3; // dual energy parameter 'eta'
+  const amrex::Real eta = 1.0e-2; // dual energy parameter 'eta'
 
   auto consVar = consVar_mf.arrays();
 

--- a/tests/HighMach.in
+++ b/tests/HighMach.in
@@ -25,6 +25,7 @@ do_subcycle = 0
 # cfl = 0.84        # maximum stable CFL for eta = 0.01
 cfl = 0.4
 hydro.use_dual_energy = 1
+hydro.reconstruction_order = 2
 
 stop_time = 3.0
 plotfile_interval = -1


### PR DESCRIPTION
This implements the Hancock predictor-corrector time integrator [1][2]. When used with PLM reconstruction (`hydro.reconstruction_order = 2`), we obtain the MUSCL-Hancock method (which itself is a simplification of the MUSCL method first presented in [3]).

This method is equivalent to the VL2 integrator implemented in Athena.

[1] [van Albada et al. (1982)](https://ui.adsabs.harvard.edu/abs/1982A%26A...108...76V/abstract)
[2] [Falle (1991)](https://ui.adsabs.harvard.edu/abs/1991MNRAS.250..581F/abstract)
[3] [van Leer (1979)](https://ui.adsabs.harvard.edu/abs/1979JCoPh..32..101V/abstract)