### PR TITLE
disable additional subcycling code

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -818,6 +818,7 @@ auto AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
   /// "additional AMR subcycling" code borrowed from Chombo:
   stepsLeft--;
 
+#if 0
   // If this wasn't just done by the next coarser level, check to see if
   // it is necessary to do additional subcycling in time.
   if ((!coarseTimeBoundary) && (constantDt_ <= 0)) {
@@ -873,6 +874,7 @@ auto AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time,
       }
     }
   }
+#endif
 
   if (Verbose()) {
     amrex::Print() << "[Level " << lev << " step " << istep[lev] + 1 << "] ";


### PR DESCRIPTION
Disables the additional subcycling code borrowed from Chombo.

It is complicated, and does not work correctly for some subcycling patterns. The capability has been partially replaced by the hydro timestep retries functionality. In the near future, we will also add the ability to retry coarse timesteps, superceding this capability.