### PR TITLE
use lincc_interp AMR interpolation method by default

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -101,6 +101,7 @@ public:
   int ascentInterval_ = -1;        // -1 == no in-situ renders with Ascent
   int plotfileInterval_ = -1;      // -1 == no output
   int checkpointInterval_ = -1;    // -1 == no output
+  int amrInterpMethod_ = 1;   // 0 == piecewise constant, 1 == lincc_interp
 
   // constructor
   explicit AMRSimulation(amrex::Vector<amrex::BCRec> &boundaryConditions) {
@@ -176,6 +177,7 @@ public:
   static void InterpHookNone(amrex::MultiFab &mf, int scomp, int ncomp);
   virtual void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp,
                  int ncomp, FillPatchType fptype);
+  auto getAmrInterpolater() -> amrex::Interpolater*;
   void FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf,
                        int icomp, int ncomp);
   void GetData(int lev, amrex::Real time,
@@ -422,6 +424,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters() {
 
   // Default CFL number == 0.3, set to whatever is in the file
   pp.query("cfl", cflNumber_);
+
+  // Default AMR interpolation method == lincc_interp
+  pp.query("amr_interpolation_method", amrInterpMethod_);
 
   // Default stopping time
   pp.query("stop_time", stopTime_);
@@ -988,6 +993,22 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(
   }
 }
 
+template <typename problem_t>
+auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::Interpolater*
+{
+  amrex::Interpolater *mapper = nullptr;
+
+  if (amrInterpMethod_ == 0) {
+    mapper = &amrex::pc_interp;
+  } else if (amrInterpMethod_ == 1) {
+    mapper = &amrex::lincc_interp;
+  } else {
+    amrex::Abort("Invalid AMR interpolation method specified!");
+  }
+
+  return mapper; // global object, so this is ok
+}
+
 // Make a new level using provided BoxArray and DistributionMapping and fill
 // with interpolated coarse level data. Overrides the pure virtual function in
 // AmrCore
@@ -1065,7 +1086,6 @@ void AMRSimulation<problem_t>::InterpHookNone(amrex::MultiFab &mf, int scomp, in
 {
   // do nothing
 }
-
 
 template <typename problem_t> struct setBoundaryFunctor {
   AMREX_GPU_DEVICE void
@@ -1240,13 +1260,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(
     PreInterpHook const &pre_interp, PostInterpHook const &post_interp) {
   BL_PROFILE("AMRSimulation::FillPatchWithData()");
 
-  // use CellConservativeProtected interpolation if possible
-  amrex::Interpolater *mapper = nullptr;
-  if constexpr (AMREX_SPACEDIM == 1) {
-    mapper = &amrex::cell_cons_interp;
-  } else if constexpr (AMREX_SPACEDIM >= 2) {
-    mapper = &amrex::protected_interp; // extrema preserving, but only works in 2D/3D
-  }
+  amrex::Interpolater *mapper = getAmrInterpolater();
 
   if (fptype == FillPatchType::fillpatch_class) {
 	  if (fillpatcher_[lev] == nullptr) {
@@ -1316,13 +1330,7 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time,
       coarsePhysicalBoundaryFunctor(geom[lev - 1], BCs_cc_,
                                     boundaryFunctor);
 
-  // use CellConservativeProtected interpolation if possible
-  amrex::Interpolater *mapper = nullptr;
-  if constexpr (AMREX_SPACEDIM == 1) {
-    mapper = &amrex::cell_cons_interp;
-  } else if constexpr (AMREX_SPACEDIM >= 2) {
-    mapper = &amrex::protected_interp; // extrema preserving, but only works in 2D/3D
-  }
+  amrex::Interpolater *mapper = getAmrInterpolater();
 
   amrex::InterpFromCoarseLevel(
       mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev],

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1001,16 +1001,12 @@ auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::Interpolater*
   if (amrInterpMethod_ == 0) { // piecewise-constant interpolation
     mapper = &amrex::pc_interp;
   } else if (amrInterpMethod_ == 1) { // slope-limited linear interpolation
-    // amrex::cell_cons_interp is an alias for amrex::CellConservativeLinear(0).
+    // amrex::lincc_interp is an alias for amrex::CellConservativeLinear(1).
     //  It has the following important properties:
     // 1. should NOT produce new extrema
     // 2. should be conservative
-    //    (*except* for partial densities, which all require the same slope to be conservative,
-    //     in the sense that the partial densities should sum to the total density)
-    // 3. does NOT preserve linear combinations of variables
-    //    (amrex::lincc_interp does that instead, but violates property 1 above.)
-    //
-    mapper = &amrex::cell_cons_interp;
+    // 3. preserves linear combinations of variables in each cell
+    mapper = &amrex::lincc_interp;
   } else {
     amrex::Abort("Invalid AMR interpolation method specified!");
   }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1004,6 +1004,7 @@ auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::Interpolater*
     // amrex::lincc_interp is an alias for amrex::CellConservativeLinear(1).
     //  It has the following important properties:
     // 1. should NOT produce new extrema
+    //    (will revert to piecewise constant if any component has a local min/max)
     // 2. should be conservative
     // 3. preserves linear combinations of variables in each cell
     mapper = &amrex::lincc_interp;


### PR DESCRIPTION
This sets the AMR interpolation to use the slope-limited linear interpolation object `amrex::lincc_interp` [1] by default. (The slopes along each direction are computed with the MC limiter [2]).

Allows the user to switch to piecewise-constant interpolation (`amrex::pc_interp`) by setting the `amr_interpolation_method` runtime parameter to `0`.

```
// amrex::lincc_interp is an instance of amrex::CellConservativeLinear(1).
// It has the following important properties:
// 1. it is conservative
// 2. uses the same slope limits for each component [2]
//    (therefore it preserves linear combinations of variables in each cell)
// 3. does NOT necessarily prevent new extrema [2]
//    (does NOT limit the slope vector -- that is instead done by 
//      CellConservativeLinear(0), but it does not satisfy property 2).
```

For reference, this greatly improves the stability of the shock-cloud problem with several levels (i.e., many, many fewer timestep retries are needed, does not hit the retry limit and crash).

[1] https://amrex-codes.github.io/amrex/doxygen/classamrex_1_1CellConservativeLinear.html#details
[2] https://github.com/AMReX-Codes/amrex/blob/development/Src/AmrCore/AMReX_MFInterp_3D_C.H#L7