### PR TITLE
update settings for Crusher (OLCF)

### DIFF
--- a/cmake/crusher.cmake
+++ b/cmake/crusher.cmake
@@ -12,4 +12,8 @@ set(CMAKE_CXX_COMPILER "CC" CACHE PATH "")
 set(AMReX_GPU_BACKEND HIP CACHE STRING "")
 set(AMReX_AMD_ARCH gfx90a CACHE STRING "") # MI250X
 set(AMREX_GPUS_PER_NODE 8 CACHE STRING "")
+set(ENV{Ascent_DIR} "/ccs/home/wibking/ascent/ascent-v0.9.0-pre/install")
+set(ENV{Kokkos_DIR} "/ccs/home/wibking/ascent/kokkos-3.6.01/install/lib64/cmake/Kokkos")
+set(AMReX_CONDUIT ON BOOL STRING "")
+set(AMReX_ASCENT ON BOOL STRING "")
 option(QUOKKA_PYTHON OFF)

--- a/scripts/crusher-1node.submit
+++ b/scripts/crusher-1node.submit
@@ -11,15 +11,19 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 1
 
+# load cray modules (must be done manually before submitting the job)
+# module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
+
 # note (5-16-22, OLCFHELP-6888)
 # this environment setting is currently needed on Crusher to work-around a
 # known issue with Libfabric
 export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
-# load cray modules
-module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
-
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
+
+# use correct NIC-to-GPU binding
+# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
+export MPICH_OFI_NIC_POLICY=NUMA
 
 srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in


### PR DESCRIPTION
Due to a configuration error, GPUs currently do not send/receive MPI messages over the correct network card. Setting `MPICH_OFI_NIC_POLICY=NUMA` ensures that the GPUs (correctly) use the NIC they are directly attached to [1].

This also updates the CMake build settings to set the path to Ascent and Kokkos.

[1] https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal