### PR TITLE
use custom AMR interpolation method

### DIFF
--- a/src/Advection/CMakeLists.txt
+++ b/src/Advection/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection test_advection.cpp ../main.cpp ../fextract.cpp)
+add_executable(test_advection test_advection.cpp ../main.cpp ../MFInterpolater.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection)

--- a/src/Advection2D/CMakeLists.txt
+++ b/src/Advection2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_advection2d ../main.cpp test_advection2d.cpp)
+    add_executable(test_advection2d ../main.cpp ../MFInterpolater.cpp test_advection2d.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_advection2d)
     endif()

--- a/src/AdvectionSemiellipse/CMakeLists.txt
+++ b/src/AdvectionSemiellipse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection_se test_advection_semiellipse.cpp ../main.cpp ../fextract.cpp)
+add_executable(test_advection_se test_advection_semiellipse.cpp ../main.cpp ../MFInterpolater.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection_se)

--- a/src/Cooling/CMakeLists.txt
+++ b/src/Cooling/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_cooling ../main.cpp test_cooling.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+    add_executable(test_cooling ../main.cpp ../MFInterpolater.cpp test_cooling.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_cooling)

--- a/src/HydroBlast2D/CMakeLists.txt
+++ b/src/HydroBlast2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_blast ../main.cpp test_hydro2d_blast.cpp)
+    add_executable(test_hydro2d_blast ../main.cpp ../MFInterpolater.cpp test_hydro2d_blast.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_blast)
     endif()

--- a/src/HydroBlast3D/CMakeLists.txt
+++ b/src/HydroBlast3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_hydro3d_blast ../main.cpp test_hydro3d_blast.cpp)
+    add_executable(test_hydro3d_blast ../main.cpp ../MFInterpolater.cpp test_hydro3d_blast.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro3d_blast)
     endif()

--- a/src/HydroContact/CMakeLists.txt
+++ b/src/HydroContact/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_contact test_hydro_contact.cpp ../main.cpp ../fextract.cpp)
+add_executable(test_hydro_contact test_hydro_contact.cpp ../main.cpp ../MFInterpolater.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_contact)

--- a/src/HydroHighMach/CMakeLists.txt
+++ b/src/HydroHighMach/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_highmach test_hydro_highmach.cpp ../main.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_highmach test_hydro_highmach.cpp ../main.cpp ../MFInterpolater.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_highmach)

--- a/src/HydroKelvinHelmholz/CMakeLists.txt
+++ b/src/HydroKelvinHelmholz/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_kh ../main.cpp test_hydro2d_kh.cpp)
+    add_executable(test_hydro2d_kh ../main.cpp ../MFInterpolater.cpp test_hydro2d_kh.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_kh)
     endif()

--- a/src/HydroLeblanc/CMakeLists.txt
+++ b/src/HydroLeblanc/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_leblanc ../main.cpp test_hydro_leblanc.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_leblanc ../main.cpp ../MFInterpolater.cpp test_hydro_leblanc.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_leblanc)

--- a/src/HydroQuirk/CMakeLists.txt
+++ b/src/HydroQuirk/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_quirk ../main.cpp test_quirk.cpp)
+    add_executable(test_quirk ../main.cpp ../MFInterpolater.cpp test_quirk.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_quirk)
     endif()

--- a/src/HydroRichtmeyerMeshkov/CMakeLists.txt
+++ b/src/HydroRichtmeyerMeshkov/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_rm ../main.cpp test_hydro2d_rm.cpp)
+    add_executable(test_hydro2d_rm ../main.cpp ../MFInterpolater.cpp test_hydro2d_rm.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_rm)
     endif()

--- a/src/HydroSMS/CMakeLists.txt
+++ b/src/HydroSMS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_sms ../main.cpp test_hydro_sms.cpp ../fextract.cpp)
+add_executable(test_hydro_sms ../main.cpp ../MFInterpolater.cpp test_hydro_sms.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_sms)

--- a/src/HydroShocktube/CMakeLists.txt
+++ b/src/HydroShocktube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shocktube ../main.cpp test_hydro_shocktube.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_shocktube ../main.cpp ../MFInterpolater.cpp test_hydro_shocktube.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shocktube)

--- a/src/HydroShuOsher/CMakeLists.txt
+++ b/src/HydroShuOsher/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shuosher ../main.cpp test_hydro_shuosher.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_shuosher ../main.cpp ../MFInterpolater.cpp test_hydro_shuosher.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shuosher)

--- a/src/HydroVacuum/CMakeLists.txt
+++ b/src/HydroVacuum/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_vacuum ../main.cpp test_hydro_vacuum.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_vacuum ../main.cpp ../MFInterpolater.cpp test_hydro_vacuum.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_vacuum)

--- a/src/HydroWave/CMakeLists.txt
+++ b/src/HydroWave/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_wave ../main.cpp test_hydro_wave.cpp ../fextract.cpp)
+add_executable(test_hydro_wave ../main.cpp ../MFInterpolater.cpp test_hydro_wave.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_wave)

--- a/src/MFInterp_1D_C.H
+++ b/src/MFInterp_1D_C.H
@@ -1,0 +1,41 @@
+#ifndef MF_INTERP_1D_C_H_
+#define MF_INTERP_1D_C_H_
+
+namespace amrex {
+
+// limits the slopes of all components in a given cell the same way
+//  *and* prevents new minima or maxima from appearing in the fine grid
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_quokka_interp_llslope (int i, int, int, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dc = mf_compute_slopes_x(i, 0, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,0,0,nu) - u(i  ,0,0,nu));
+        Real db = Real(2.0) * (u(i  ,0,0,nu) - u(i-1,0,0,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        slope(i,0,0,ns) = dc;
+
+        // additional limiting is unnecessary in 1D
+
+        if (dc != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dc);
+        }
+    }
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,0,0,ns) *= sfx;
+    }
+}
+
+}
+
+#endif

--- a/src/MFInterp_2D_C.H
+++ b/src/MFInterp_2D_C.H
@@ -1,0 +1,78 @@
+#ifndef MF_INTERP_2D_C_H_
+#define MF_INTERP_2D_C_H_
+
+#include <AMReX_Geometry.H>
+
+namespace amrex {
+
+// limits the slopes of all components in a given cell the same way
+//  *and* prevents new minima or maxima from appearing in the fine grid
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_quokka_interp_llslope (int i, int j, int, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+    Real sfy = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dcx = mf_compute_slopes_x(i, j, 0, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,0,nu) - u(i  ,j,0,nu));
+        Real db = Real(2.0) * (u(i  ,j,0,nu) - u(i-1,j,0,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        slope(i,j,0,ns        ) = dcx;
+
+        // y-direction
+        Real dcy = mf_compute_slopes_y(i, j, 0, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j+1,0,nu) - u(i,j  ,0,nu));
+        db = Real(2.0) * (u(i,j  ,0,nu) - u(i,j-1,0,nu));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        slope(i,j,0,ns+  ncomp) = dcy;
+
+        // adjust limited slopes to prevent new min/max for this component
+        Real alpha = Real(1.0);
+        if (sx != Real(0.0) || sy != Real(0.0)) {
+            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1]);
+            Real umax = u(i,j,0,nu);
+            Real umin = u(i,j,0,nu);
+            for (int joff = -1; joff <= 1; ++joff) {
+            for (int ioff = -1; ioff <= 1; ++ioff) {
+                umin = amrex::min(umin, u(i+ioff,j+joff,0,nu));
+                umax = amrex::max(umax, u(i+ioff,j+joff,0,nu));
+            }}
+            if (dumax * alpha > (umax - u(i,j,0,nu))) {
+                alpha = (umax - u(i,j,0,nu)) / dumax;
+            }
+            if (dumax * alpha > (u(i,j,0,nu) - umin)) {
+                alpha = (u(i,j,0,nu) - umin) / dumax;
+            }
+        }
+        sx *= alpha;
+        sy *= alpha;
+
+        // for each direction, compute minimum of the ratio of limited to unlimited slopes
+        if (dcx != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dcx);
+        }
+        if (dcy != Real(0.0)) {
+            sfy = amrex::min(sfy, sy / dcy);
+        }
+    }
+
+    // multiply unlimited slopes by the minimum of the ratio of limited to unlimited slopes
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,j,0,ns        ) *= sfx;
+        slope(i,j,0,ns+  ncomp) *= sfy;
+    }
+}
+
+} // namespace amrex
+
+#endif

--- a/src/MFInterp_3D_C.H
+++ b/src/MFInterp_3D_C.H
@@ -7,7 +7,7 @@ namespace amrex {
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_quokka_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,
-                                      Box const& domain, BCRec const* bc) noexcept
+                                      Box const& domain, IntVect const& ratio, BCRec const* bc) noexcept
 {
     Real sfx = Real(1.0);
     Real sfy = Real(1.0);
@@ -17,105 +17,73 @@ void mf_quokka_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
         int nu = ns + scomp;
 
         // x-direction
-        Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+        Real dcx = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
         Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
         Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
         Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
-        if (dc != Real(0.0)) {
-            sfx = amrex::min(sfx, sx / dc);
-        }
-        slope(i,j,k,ns        ) = dc;
+        sx = amrex::Math::copysign(Real(1.),dcx)*amrex::min(sx,amrex::Math::abs(dcx));
+        slope(i,j,k,ns        ) = dcx;  // unlimited slope
 
         // y-direction
-        dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+        Real dcy = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
         db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
         Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
-        if (dc != Real(0.0)) {
-            sfy = amrex::min(sfy, sy / dc);
-        }
-        slope(i,j,k,ns+  ncomp) = dc;
+        sy = amrex::Math::copysign(Real(1.),dcy)*amrex::min(sy,amrex::Math::abs(dcy));
+        slope(i,j,k,ns+  ncomp) = dcy;  // unlimited slope
 
         // z-direction
-        dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+        Real dcz = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
         df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
         db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
         Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-        sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
-        if (dc != Real(0.0)) {
-            sfz = amrex::min(sfz, sz / dc);
+        sz = amrex::Math::copysign(Real(1.),dcz)*amrex::min(sz,amrex::Math::abs(dcz));
+        slope(i,j,k,ns+2*ncomp) = dcz;  // unlimited slope
+
+        // adjust limited slopes to prevent new min/max for this component
+        Real alpha = 1.0;
+        if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
+            Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+                +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
+                +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+            Real umax = u(i,j,k,nu);
+            Real umin = u(i,j,k,nu);
+            for (int koff = -1; koff <= 1; ++koff) {
+            for (int joff = -1; joff <= 1; ++joff) {
+            for (int ioff = -1; ioff <= 1; ++ioff) {
+                umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
+                umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
+            }}}
+            if (dumax * alpha > (umax - u(i,j,k,nu))) {
+                alpha = (umax - u(i,j,k,nu)) / dumax;
+            }
+            if (dumax * alpha > (u(i,j,k,nu) - umin)) {
+                alpha = (u(i,j,k,nu) - umin) / dumax;
+            }
         }
-        slope(i,j,k,ns+2*ncomp) = dc;
+        sx *= alpha;
+        sy *= alpha;
+        sz *= alpha;
+
+        // for each direction, compute minimum of the ratio of limited to unlimited slopes
+        if (dcx != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dcx);
+        }
+        if (dcy != Real(0.0)) {
+            sfy = amrex::min(sfy, sy / dcy);
+        }
+        if (dcz != Real(0.0)) {
+            sfz = amrex::min(sfz, sz / dcz);
+        }
     }
 
+    // multiply unlimited slopes by the minimum of the ratio of limited to unlimited slopes
     for (int ns = 0; ns < ncomp; ++ns) {
         slope(i,j,k,ns        ) *= sfx;
         slope(i,j,k,ns+  ncomp) *= sfy;
         slope(i,j,k,ns+2*ncomp) *= sfz;
     }
 }
-
-#if 0
-// this operates independently for each component,
-//   but it ensures that no new minima or maxima are created by the interpolation
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void mf_quokka_interp_mcslope (int i, int j, int k, int ns, Array4<Real> const& slope,
-                                      Array4<Real const> const& u, int scomp, int ncomp,
-                                      Box const& domain, IntVect const& ratio,
-                                      BCRec const* bc) noexcept
-{
-    int nu = ns + scomp;
-
-    // x-direction
-    Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
-    Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
-    Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
-    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
-
-    // y-direction
-    dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
-    db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
-    Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
-
-    // z-direction
-    dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
-    df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
-    db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
-    Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
-    sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
-
-    Real alpha = 1.0;
-    if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
-        Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
-            +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
-            +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
-        Real umax = u(i,j,k,nu);
-        Real umin = u(i,j,k,nu);
-        for (int koff = -1; koff <= 1; ++koff) {
-        for (int joff = -1; joff <= 1; ++joff) {
-        for (int ioff = -1; ioff <= 1; ++ioff) {
-            umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
-            umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
-        }}}
-        if (dumax * alpha > (umax - u(i,j,k,nu))) {
-            alpha = (umax - u(i,j,k,nu)) / dumax;
-        }
-        if (dumax * alpha > (u(i,j,k,nu) - umin)) {
-            alpha = (u(i,j,k,nu) - umin) / dumax;
-        }
-    }
-
-    slope(i,j,k,ns        ) = sx * alpha;
-    slope(i,j,k,ns+  ncomp) = sy * alpha;
-    slope(i,j,k,ns+2*ncomp) = sz * alpha;
-}
-#endif
 
 } // namespace amrex
 

--- a/src/MFInterp_3D_C.H
+++ b/src/MFInterp_3D_C.H
@@ -1,0 +1,122 @@
+#ifndef MF_INTERP_3D_C_H_
+#define MF_INTERP_3D_C_H_
+
+namespace amrex {
+
+// limits the slopes of all components in a given cell the same way
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_quokka_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, BCRec const* bc) noexcept
+{
+    Real sfx = Real(1.0);
+    Real sfy = Real(1.0);
+    Real sfz = Real(1.0);
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        int nu = ns + scomp;
+
+        // x-direction
+        Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+        Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+        Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+        Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+        if (dc != Real(0.0)) {
+            sfx = amrex::min(sfx, sx / dc);
+        }
+        slope(i,j,k,ns        ) = dc;
+
+        // y-direction
+        dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+        db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+        Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+        if (dc != Real(0.0)) {
+            sfy = amrex::min(sfy, sy / dc);
+        }
+        slope(i,j,k,ns+  ncomp) = dc;
+
+        // z-direction
+        dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+        df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+        db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+        Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+        sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+        if (dc != Real(0.0)) {
+            sfz = amrex::min(sfz, sz / dc);
+        }
+        slope(i,j,k,ns+2*ncomp) = dc;
+    }
+
+    for (int ns = 0; ns < ncomp; ++ns) {
+        slope(i,j,k,ns        ) *= sfx;
+        slope(i,j,k,ns+  ncomp) *= sfy;
+        slope(i,j,k,ns+2*ncomp) *= sfz;
+    }
+}
+
+#if 0
+// this operates independently for each component,
+//   but it ensures that no new minima or maxima are created by the interpolation
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void mf_quokka_interp_mcslope (int i, int j, int k, int ns, Array4<Real> const& slope,
+                                      Array4<Real const> const& u, int scomp, int ncomp,
+                                      Box const& domain, IntVect const& ratio,
+                                      BCRec const* bc) noexcept
+{
+    int nu = ns + scomp;
+
+    // x-direction
+    Real dc = mf_compute_slopes_x(i, j, k, u, nu, domain, bc[ns]);
+    Real df = Real(2.0) * (u(i+1,j,k,nu) - u(i  ,j,k,nu));
+    Real db = Real(2.0) * (u(i  ,j,k,nu) - u(i-1,j,k,nu));
+    Real sx = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+    sx = amrex::Math::copysign(Real(1.),dc)*amrex::min(sx,amrex::Math::abs(dc));
+
+    // y-direction
+    dc = mf_compute_slopes_y(i, j, k, u, nu, domain, bc[ns]);
+    df = Real(2.0) * (u(i,j+1,k,nu) - u(i,j  ,k,nu));
+    db = Real(2.0) * (u(i,j  ,k,nu) - u(i,j-1,k,nu));
+    Real sy = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+    sy = amrex::Math::copysign(Real(1.),dc)*amrex::min(sy,amrex::Math::abs(dc));
+
+    // z-direction
+    dc = mf_compute_slopes_z(i, j, k, u, nu, domain, bc[ns]);
+    df = Real(2.0) * (u(i,j,k+1,nu) - u(i,j,k  ,nu));
+    db = Real(2.0) * (u(i,j,k  ,nu) - u(i,j,k-1,nu));
+    Real sz = (df*db >= Real(0.0)) ? amrex::min(amrex::Math::abs(df),amrex::Math::abs(db)) : Real(0.);
+    sz = amrex::Math::copysign(Real(1.),dc)*amrex::min(sz,amrex::Math::abs(dc));
+
+    Real alpha = 1.0;
+    if (sx != Real(0.0) || sy != Real(0.0) || sz != Real(0.0)) {
+        Real dumax = amrex::Math::abs(sx) * Real(ratio[0]-1)/Real(2*ratio[0])
+            +        amrex::Math::abs(sy) * Real(ratio[1]-1)/Real(2*ratio[1])
+            +        amrex::Math::abs(sz) * Real(ratio[2]-1)/Real(2*ratio[2]);
+        Real umax = u(i,j,k,nu);
+        Real umin = u(i,j,k,nu);
+        for (int koff = -1; koff <= 1; ++koff) {
+        for (int joff = -1; joff <= 1; ++joff) {
+        for (int ioff = -1; ioff <= 1; ++ioff) {
+            umin = amrex::min(umin, u(i+ioff,j+joff,k+koff,nu));
+            umax = amrex::max(umax, u(i+ioff,j+joff,k+koff,nu));
+        }}}
+        if (dumax * alpha > (umax - u(i,j,k,nu))) {
+            alpha = (umax - u(i,j,k,nu)) / dumax;
+        }
+        if (dumax * alpha > (u(i,j,k,nu) - umin)) {
+            alpha = (u(i,j,k,nu) - umin) / dumax;
+        }
+    }
+
+    slope(i,j,k,ns        ) = sx * alpha;
+    slope(i,j,k,ns+  ncomp) = sy * alpha;
+    slope(i,j,k,ns+2*ncomp) = sz * alpha;
+}
+#endif
+
+} // namespace amrex
+
+#endif

--- a/src/MFInterp_3D_C.H
+++ b/src/MFInterp_3D_C.H
@@ -4,6 +4,8 @@
 namespace amrex {
 
 // limits the slopes of all components in a given cell the same way
+//  *and* prevents new minima or maxima from appearing in the fine grid
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void mf_quokka_interp_llslope (int i, int j, int k, Array4<Real> const& slope,
                                       Array4<Real const> const& u, int scomp, int ncomp,

--- a/src/MFInterpolater.H
+++ b/src/MFInterpolater.H
@@ -1,9 +1,17 @@
 #ifndef MF_INTERPOLATER_H_
 #define MF_INTERPOLATER_H_
 #include <AMReX_Config.H>
-
 #include <AMReX_Extension.H>
 #include <AMReX_InterpBase.H>
+#include <AMReX_MFInterp_C.H>
+
+#if (AMREX_SPACEDIM == 1)
+#include "MFInterp_1D_C.H"
+#elif (AMREX_SPACEDIM == 2)
+#include "MFInterp_2D_C.H"
+#else
+#include "MFInterp_3D_C.H"
+#endif
 
 namespace amrex {
 

--- a/src/MFInterpolater.H
+++ b/src/MFInterpolater.H
@@ -1,0 +1,44 @@
+#ifndef MF_INTERPOLATER_H_
+#define MF_INTERPOLATER_H_
+#include <AMReX_Config.H>
+
+#include <AMReX_Extension.H>
+#include <AMReX_InterpBase.H>
+
+namespace amrex {
+
+class MultiFab;
+class Geometry;
+
+/**
+* \brief Linear conservative interpolation on cell centered data
+*
+* Linear conservative interpolation on cell centered data, i.e, conservative
+* interpolation with a limiting scheme that preserves the value of any
+* linear combination of the fab components. If sum_ivar
+* a(ic,jc,ivar)*fab(ic,jc,ivar) = 0, then sum_ivar
+* a(ic,jc,ivar)*fab(if,jf,ivar) = 0 is satisfied in all fine cells if,jf
+* covering coarse cell ic,jc.
+*/
+class MFQuokkaInterp
+    : public MFInterpolater
+{
+public:
+    explicit MFQuokkaInterp () {}
+
+    virtual ~MFQuokkaInterp () = default;
+
+    virtual Box CoarseBox (Box const& fine, int ratio) override;
+    virtual Box CoarseBox (Box const& fine, IntVect const& ratio) override;
+
+    virtual void interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int ncomp,
+                         IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
+                         Box const& dest_domain, IntVect const& ratio,
+                         Vector<BCRec> const& bcs, int bcscomp) override;
+};
+
+extern AMREX_EXPORT MFQuokkaInterp mf_linear_slope_minmax_interp;
+
+}
+
+#endif

--- a/src/MFInterpolater.cpp
+++ b/src/MFInterpolater.cpp
@@ -1,0 +1,110 @@
+#include <AMReX_Interp_C.H>
+#include <AMReX_MFInterp_C.H>
+#include <AMReX_MFInterpolater.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_MultiFab.H>
+
+#include "MFInterpolater.H"
+#include "MFInterp_3D_C.H"
+
+namespace amrex {
+
+// Cell centered
+MFQuokkaInterp mf_linear_slope_minmax_interp;
+
+Box
+MFQuokkaInterp::CoarseBox (const Box& fine, const IntVect& ratio)
+{
+    Box crse = amrex::coarsen(fine,ratio);
+    crse.grow(1);
+    return crse;
+}
+
+Box
+MFQuokkaInterp::CoarseBox (const Box& fine, int ratio)
+{
+    Box crse = amrex::coarsen(fine,ratio);
+    crse.grow(1);
+    return crse;
+}
+
+void
+MFQuokkaInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int fcomp, int nc,
+                             IntVect const& ng, Geometry const& cgeom, Geometry const& fgeom,
+                             Box const& dest_domain, IntVect const& ratio,
+                             Vector<BCRec> const& bcs, int bcomp)
+{
+    AMREX_ASSERT(crsemf.nGrowVect() == 0);
+    amrex::ignore_unused(fgeom);
+
+    Box const& cdomain = cgeom.Domain();
+
+#ifdef AMREX_USE_GPU
+    if (Gpu::inLaunchRegion()) {
+        MultiFab crse_tmp(crsemf.boxArray(), crsemf.DistributionMap(), AMREX_SPACEDIM*nc, 0);
+        auto const& crse = crsemf.const_arrays();
+        auto const& tmp = crse_tmp.arrays();
+        auto const& ctmp = crse_tmp.const_arrays();
+        auto const& fine = finemf.arrays();
+
+        Gpu::DeviceVector<BCRec> d_bc(nc);
+        BCRec const* pbc = d_bc.data();
+        Gpu::copyAsync(Gpu::hostToDevice, bcs.begin()+bcomp, bcs.begin()+bcomp+nc, d_bc.begin());
+
+        ParallelFor(crsemf, IntVect(-1),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+        {
+            mf_quokka_interp_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
+                                            cdomain, pbc);
+        });
+
+        ParallelFor(finemf, ng, nc,
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k, int n) noexcept
+        {
+            if (dest_domain.contains(i,j,k)) {
+                mf_cell_cons_lin_interp(i,j,k,n, fine[box_no], fcomp, ctmp[box_no],
+                                        crse[box_no], ccomp, nc, ratio);
+            }
+        });
+
+        Gpu::streamSynchronize();
+    } else
+#endif
+    {
+        BCRec const* pbc = bcs.data() + bcomp;
+
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+        {
+            FArrayBox tmpfab;
+            for (MFIter mfi(finemf); mfi.isValid(); ++mfi) {
+                auto const& fine = finemf.array(mfi);
+                auto const& crse = crsemf.const_array(mfi);
+
+                Box const& cbox = amrex::grow(crsemf[mfi].box(), -1);
+                tmpfab.resize(cbox, AMREX_SPACEDIM*nc);
+                auto const& tmp = tmpfab.array();
+                auto const& ctmp = tmpfab.const_array();
+
+                Box const& fbox = amrex::grow(mfi.validbox(), ng) & dest_domain;
+
+                amrex::LoopConcurrentOnCpu(cbox,
+                [&] (int i, int j, int k) noexcept
+                {
+                    mf_quokka_interp_llslope(i,j,k, tmp, crse, ccomp, nc,
+                                                    cdomain, pbc);
+                });
+
+                amrex::LoopConcurrentOnCpu(fbox, nc,
+                [&] (int i, int j, int k, int n) noexcept
+                {
+                    mf_cell_cons_lin_interp(i,j,k,n, fine, fcomp, ctmp,
+                                            crse, ccomp, nc, ratio);
+                });
+            }
+        }
+    }
+}
+
+} // namespace amrex

--- a/src/MFInterpolater.cpp
+++ b/src/MFInterpolater.cpp
@@ -5,7 +5,6 @@
 #include <AMReX_MultiFab.H>
 
 #include "MFInterpolater.H"
-#include "MFInterp_3D_C.H"
 
 namespace amrex {
 

--- a/src/MFInterpolater.cpp
+++ b/src/MFInterpolater.cpp
@@ -55,7 +55,7 @@ MFQuokkaInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int
         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
         {
             mf_quokka_interp_llslope(i,j,k, tmp[box_no], crse[box_no], ccomp, nc,
-                                            cdomain, pbc);
+                                     cdomain, ratio, pbc);
         });
 
         ParallelFor(finemf, ng, nc,
@@ -93,7 +93,7 @@ MFQuokkaInterp::interp (MultiFab const& crsemf, int ccomp, MultiFab& finemf, int
                 [&] (int i, int j, int k) noexcept
                 {
                     mf_quokka_interp_llslope(i,j,k, tmp, crse, ccomp, nc,
-                                                    cdomain, pbc);
+                                             cdomain, ratio, pbc);
                 });
 
                 amrex::LoopConcurrentOnCpu(fbox, nc,

--- a/src/ODEIntegration/CMakeLists.txt
+++ b/src/ODEIntegration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_ode ../main.cpp test_ode.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+add_executable(test_ode ../main.cpp ../MFInterpolater.cpp test_ode.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_ode)

--- a/src/PassiveScalar/CMakeLists.txt
+++ b/src/PassiveScalar/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_scalars test_scalars.cpp ../main.cpp ../fextract.cpp)
+add_executable(test_scalars test_scalars.cpp ../main.cpp ../MFInterpolater.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_scalars)

--- a/src/RadBeam/CMakeLists.txt
+++ b/src/RadBeam/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_beam ../main.cpp test_radiation_beam.cpp)
+    add_executable(test_radiation_beam ../main.cpp ../MFInterpolater.cpp test_radiation_beam.cpp)
     
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_beam)

--- a/src/RadForce/CMakeLists.txt
+++ b/src/RadForce/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_force ../main.cpp test_radiation_force.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_force ../main.cpp ../MFInterpolater.cpp test_radiation_force.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_force)

--- a/src/RadMarshak/CMakeLists.txt
+++ b/src/RadMarshak/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak ../main.cpp test_radiation_marshak.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak ../main.cpp ../MFInterpolater.cpp test_radiation_marshak.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak)

--- a/src/RadMarshakAsymptotic/CMakeLists.txt
+++ b/src/RadMarshakAsymptotic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_asymptotic ../main.cpp test_radiation_marshak_asymptotic.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak_asymptotic ../main.cpp ../MFInterpolater.cpp test_radiation_marshak_asymptotic.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_asymptotic)

--- a/src/RadMarshakCGS/CMakeLists.txt
+++ b/src/RadMarshakCGS/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak_cgs ../main.cpp test_radiation_marshak_cgs.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak_cgs ../main.cpp ../MFInterpolater.cpp test_radiation_marshak_cgs.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_cgs)

--- a/src/RadMatterCoupling/CMakeLists.txt
+++ b/src/RadMatterCoupling/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_matter_coupling ../main.cpp test_radiation_matter_coupling.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_matter_coupling ../main.cpp ../MFInterpolater.cpp test_radiation_matter_coupling.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling)

--- a/src/RadMatterCouplingRSLA/CMakeLists.txt
+++ b/src/RadMatterCouplingRSLA/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_matter_coupling_rsla ../main.cpp test_radiation_matter_coupling_rsla.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_matter_coupling_rsla ../main.cpp ../MFInterpolater.cpp test_radiation_matter_coupling_rsla.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling_rsla)

--- a/src/RadPulse/CMakeLists.txt
+++ b/src/RadPulse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_pulse ../main.cpp test_radiation_pulse.cpp ../fextract.cpp)
+add_executable(test_radiation_pulse ../main.cpp ../MFInterpolater.cpp test_radiation_pulse.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_pulse)

--- a/src/RadShadow/CMakeLists.txt
+++ b/src/RadShadow/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_shadow ../main.cpp test_radiation_shadow.cpp)
+    add_executable(test_radiation_shadow ../main.cpp ../MFInterpolater.cpp test_radiation_shadow.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_shadow)

--- a/src/RadStreaming/CMakeLists.txt
+++ b/src/RadStreaming/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_streaming ../main.cpp test_radiation_streaming.cpp ../fextract.cpp)
+add_executable(test_radiation_streaming ../main.cpp ../MFInterpolater.cpp test_radiation_streaming.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_streaming)

--- a/src/RadSuOlson/CMakeLists.txt
+++ b/src/RadSuOlson/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_SuOlson ../main.cpp test_radiation_SuOlson.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_SuOlson ../main.cpp ../MFInterpolater.cpp test_radiation_SuOlson.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_SuOlson)

--- a/src/RadTophat/CMakeLists.txt
+++ b/src/RadTophat/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_tophat ../main.cpp test_radiation_tophat.cpp)
+    add_executable(test_radiation_tophat ../main.cpp ../MFInterpolater.cpp test_radiation_tophat.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_tophat)
     endif()

--- a/src/RadTube/CMakeLists.txt
+++ b/src/RadTube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_tube ../main.cpp test_radiation_tube.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_tube ../main.cpp ../MFInterpolater.cpp test_radiation_tube.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_tube)

--- a/src/RadhydroShell/CMakeLists.txt
+++ b/src/RadhydroShell/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_radhydro3d_shell ../main.cpp test_radhydro_shell.cpp ../interpolate.cpp)
+    add_executable(test_radhydro3d_shell ../main.cpp ../MFInterpolater.cpp test_radhydro_shell.cpp ../interpolate.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radhydro3d_shell)

--- a/src/RadhydroShock/CMakeLists.txt
+++ b/src/RadhydroShock/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock ../main.cpp test_radhydro_shock.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radhydro_shock ../main.cpp ../MFInterpolater.cpp test_radhydro_shock.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock)

--- a/src/RadhydroShockCGS/CMakeLists.txt
+++ b/src/RadhydroShockCGS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock_cgs ../main.cpp test_radhydro_shock_cgs.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radhydro_shock_cgs ../main.cpp ../MFInterpolater.cpp test_radhydro_shock_cgs.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock_cgs)

--- a/src/RayleighTaylor2D/CMakeLists.txt
+++ b/src/RayleighTaylor2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_rt ../main.cpp test_hydro2d_rt.cpp)
+    add_executable(test_hydro2d_rt ../main.cpp ../MFInterpolater.cpp test_hydro2d_rt.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_rt)
     endif()

--- a/src/RayleighTaylor3D/CMakeLists.txt
+++ b/src/RayleighTaylor3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_hydro3d_rt ../main.cpp test_hydro3d_rt.cpp)
+    add_executable(test_hydro3d_rt ../main.cpp ../MFInterpolater.cpp test_hydro3d_rt.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro3d_rt)
     endif()

--- a/src/ShockCloud/CMakeLists.txt
+++ b/src/ShockCloud/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 3)
-    add_executable(shock_cloud ../main.cpp cloud.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
-    add_executable(test_cloudy ../main.cpp test_cloudy.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+    add_executable(shock_cloud ../main.cpp ../MFInterpolater.cpp cloud.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+    add_executable(test_cloudy ../main.cpp ../MFInterpolater.cpp test_cloudy.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(shock_cloud)

--- a/src/ShockCloud/CMakeLists.txt
+++ b/src/ShockCloud/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 3)
-    add_executable(shock_cloud ../main.cpp cloud.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
-    add_executable(test_cloudy ../main.cpp test_cloudy.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+    add_executable(shock_cloud ../main.cpp cloud.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+    add_executable(test_cloudy ../main.cpp test_cloudy.cpp ../MFInterpolater.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(shock_cloud)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -997,23 +997,20 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(
 template <typename problem_t>
 auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::MFInterpolater*
 {
-  amrex::MFInterpolater *mapper = &amrex::mf_linear_slope_minmax_interp;
+  amrex::MFInterpolater *mapper = nullptr;
 
-#if 0
   if (amrInterpMethod_ == 0) { // piecewise-constant interpolation
     mapper = &amrex::mf_pc_interp;
   } else if (amrInterpMethod_ == 1) { // slope-limited linear interpolation
-    // amrex::lincc_interp is an alias for amrex::CellConservativeLinear(1).
     //  It has the following important properties:
     // 1. should NOT produce new extrema
     //    (will revert to piecewise constant if any component has a local min/max)
     // 2. should be conservative
     // 3. preserves linear combinations of variables in each cell
-    mapper = &amrex::mf_lincc_interp;
+    mapper = &amrex::mf_linear_slope_minmax_interp;
   } else {
     amrex::Abort("Invalid AMR interpolation method specified!");
   }
-#endif
 
   return mapper; // global object, so this is ok
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -177,7 +177,7 @@ public:
   static void InterpHookNone(amrex::MultiFab &mf, int scomp, int ncomp);
   virtual void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp,
                  int ncomp, FillPatchType fptype);
-  auto getAmrInterpolater() -> amrex::Interpolater*;
+  auto getAmrInterpolater() -> amrex::MFInterpolater*;
   void FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf,
                        int icomp, int ncomp);
   void GetData(int lev, amrex::Real time,
@@ -994,12 +994,12 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(
 }
 
 template <typename problem_t>
-auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::Interpolater*
+auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::MFInterpolater*
 {
-  amrex::Interpolater *mapper = nullptr;
+  amrex::MFInterpolater *mapper = nullptr;
 
   if (amrInterpMethod_ == 0) { // piecewise-constant interpolation
-    mapper = &amrex::pc_interp;
+    mapper = &amrex::mf_pc_interp;
   } else if (amrInterpMethod_ == 1) { // slope-limited linear interpolation
     // amrex::lincc_interp is an alias for amrex::CellConservativeLinear(1).
     //  It has the following important properties:
@@ -1007,7 +1007,7 @@ auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::Interpolater*
     //    (will revert to piecewise constant if any component has a local min/max)
     // 2. should be conservative
     // 3. preserves linear combinations of variables in each cell
-    mapper = &amrex::lincc_interp;
+    mapper = &amrex::mf_lincc_interp;
   } else {
     amrex::Abort("Invalid AMR interpolation method specified!");
   }
@@ -1266,7 +1266,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(
     PreInterpHook const &pre_interp, PostInterpHook const &post_interp) {
   BL_PROFILE("AMRSimulation::FillPatchWithData()");
 
-  amrex::Interpolater *mapper = getAmrInterpolater();
+  amrex::MFInterpolater *mapper = getAmrInterpolater();
 
   if (fptype == FillPatchType::fillpatch_class) {
 	  if (fillpatcher_[lev] == nullptr) {
@@ -1336,7 +1336,7 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time,
       coarsePhysicalBoundaryFunctor(geom[lev - 1], BCs_cc_,
                                     boundaryFunctor);
 
-  amrex::Interpolater *mapper = getAmrInterpolater();
+  amrex::MFInterpolater *mapper = getAmrInterpolater();
 
   amrex::InterpFromCoarseLevel(
       mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev],

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -67,6 +67,7 @@
 #include "CheckNaN.hpp"
 #include "math_impl.hpp"
 #include "physics_info.hpp"
+#include "MFInterpolater.H"
 
 #define USE_YAFLUXREGISTER
 
@@ -996,8 +997,9 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(
 template <typename problem_t>
 auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::MFInterpolater*
 {
-  amrex::MFInterpolater *mapper = nullptr;
+  amrex::MFInterpolater *mapper = &amrex::mf_linear_slope_minmax_interp;
 
+#if 0
   if (amrInterpMethod_ == 0) { // piecewise-constant interpolation
     mapper = &amrex::mf_pc_interp;
   } else if (amrInterpMethod_ == 1) { // slope-limited linear interpolation
@@ -1011,6 +1013,7 @@ auto AMRSimulation<problem_t>::getAmrInterpolater() -> amrex::MFInterpolater*
   } else {
     amrex::Abort("Invalid AMR interpolation method specified!");
   }
+#endif
 
   return mapper; // global object, so this is ok
 }


### PR DESCRIPTION
This uses our new linear, conservative AMR interpolator. This combines the desirable properties of `amrex::CellConservativeLinear(0)` and `amrex::CellConservativeLinear(1)`, namely:

- no new minima or maxima are created on the fine grid
- the slopes for all components in a given cell are limited consistently

The latter property implies that linear combinations of components in a given cell are preserved. This is very important to prevent inconsistent hydro states when interpolating in the conserved variables.