### PR TITLE
require CUDA 11.7+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,11 +34,8 @@ option(ENABLE_ASAN "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
   enable_language(CUDA)
   
-  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.2)
-    message(FATAL_ERROR "For best performance, you must use CUDA 11.2 or higher to compile Quokka. It is strongly recommended to use a newer version of CUDA.")
-  endif()
-  if(CMAKE_CUDA_COMPILER_VERSION MATCHES 11.6)
-    message(FATAL_ERROR "You must use a CUDA version 11.2-11.5 to compile Quokka. CUDA 11.6 has compiler bugs that cause Quokka to crash.")
+  if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.7)
+    message(FATAL_ERROR "You must use CUDA version 11.7 or newer to compile Quokka. All previous CUDA versions have compiler bugs that cause Quokka to crash.")
   endif()
 
   set(CMAKE_CUDA_ARCHITECTURES 70 80 CACHE STRING "")


### PR DESCRIPTION
Quokka requires CUDA 11.7 or newer to avoid compiler bugs that exist in all previous versions of CUDA. This prevents users from encountering these bugs by checking the CUDA version during the CMake configure step.