### PR TITLE
update .clang-format

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -117,7 +117,7 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: LS_Cpp17
+Standard: c++17
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION


### PR DESCRIPTION
The .clang-format file stopped working with the current version of `clang-format`. This updates it so it works again.