### PR TITLE
use .clang-tidy file with clang-tidy-review

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -33,6 +33,8 @@ jobs:
 
     - uses: ZedThree/clang-tidy-review@v0.10.0
       id: review
+      with:
+        config_file: 'src/.clang-tidy'
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0
       run: exit 1


### PR DESCRIPTION
Use the .clang-tidy configuration file when running `clang-tidy-review` on pull requests.