### PR TITLE
have clang-tidy read compile_commands.json

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -35,6 +35,7 @@ jobs:
       id: review
       with:
         config_file: 'src/.clang-tidy'
+        build_dir: 'build'
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0
       run: exit 1


### PR DESCRIPTION
`clang-tidy` needs to know the build directory to find `compile_commands.json`. Otherwise it can't find AMReX header files.