### PR TITLE
fix clang-tidy-review GitHub action

### DIFF
--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -1,9 +1,9 @@
-name: Post clang-tidy review comments
+name: Post clang-tidy-review comments
 
 on:
   workflow_run:
     # The name field of the lint action
-    workflows: ["clang-tidy-review"]
+    workflows: [clang-tidy-review]
     types:
       - completed
 

--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -36,4 +36,4 @@ jobs:
       - name: 'Unzip artifact'
         run: unzip clang-tidy-review.zip
 
-      - uses: ZedThree/clang-tidy-review/post@v0.10.0
+      - uses: ZedThree/clang-tidy-review/post@v0.10.1

--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -1,0 +1,39 @@
+name: Post clang-tidy review comments
+
+on:
+  workflow_run:
+    # The name field of the lint action
+    workflows: ["clang-tidy-review"]
+    types:
+      - completed
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Downloads the artifact uploaded by the lint action
+      - name: 'Download artifact'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-review"
+            })[0];
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            const fs = require('fs');
+            fs.writeFileSync('${{github.workspace}}/clang-tidy-review.zip', Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip clang-tidy-review.zip
+
+      - uses: ZedThree/clang-tidy-review/post@v0.10.0

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -13,13 +13,13 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: ZedThree/clang-tidy-review@v0.10.0
+    - uses: ZedThree/clang-tidy-review@v0.10.1
       id: review
       with:
         config_file: src/.clang-tidy
         build_dir: build
-        apt_packages: gcc-11,g++-11,python3-dev,,python3-numpy,python3-matplotlib,python3-pip,libopenmpi-dev,libhdf5-mpi-dev
-        cmake_command: cmake . -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        apt_packages: libopenmpi-dev,libhdf5-mpi-dev
+        cmake_command: cmake . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DQUOKKA_PYTHON=OFF
         split_workflow: true
 
     - uses: actions/upload-artifact@v3
@@ -28,4 +28,3 @@ jobs:
         path: |
           clang-tidy-review-output.json
           clang-tidy-review-metadata.json
-  

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -35,6 +35,7 @@ jobs:
       id: review
       with:
         config_file: 'src/.clang-tidy'
+        build_dir: 'build'
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0
       run: exit 1

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,30 +13,19 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - name: Create Build Environment
-      # Some projects don't allow in-source building, so create a separate build directory
-      # We'll use this as our working directory for all subsequent commands
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: Install dependencies
-      run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip lcov libopenmpi-dev libhdf5-mpi-dev ccache libboost-dev
-
-    - name: Configure CMake
-      # Use a bash shell so we can use the same syntax for environment variable
-      # access regardless of the host operating system
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-
     - uses: ZedThree/clang-tidy-review@v0.10.0
       id: review
       with:
-        config_file: 'src/.clang-tidy'
-        build_dir: 'build'
-    # If there are any comments, fail the check
-    - if: steps.review.outputs.total_comments > 0
-      run: exit 1
+        config_file: src/.clang-tidy
+        build_dir: build
+        apt_packages: gcc-11,g++-11,python3-dev,,python3-numpy,python3-matplotlib,python3-pip,libopenmpi-dev,libhdf5-mpi-dev
+        cmake_command: cmake . -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+        split_workflow: true
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: clang-tidy-review
+        path: |
+          clang-tidy-review-output.json
+          clang-tidy-review-metadata.json
   


### PR DESCRIPTION
This fixes the clang-tidy-review GitHub action so that it actually uses the `compile_commands.json` file generated by CMake. Then it uploads the output of `clang-tidy` as an artifact and uses a separate action to post comments on the pull request.