### PR TITLE
Add + turn off MHD flag (MHD is not implemented yet)

### DIFF
--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -42,11 +42,13 @@ template <> struct HydroSystem_Traits<CoolingTest> {
 };
 
 template <> struct Physics_Traits<CoolingTest> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr double Tgas0 = 6000.;       // K

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -31,11 +31,13 @@ template <> struct HydroSystem_Traits<BlastProblem> {
 };
 
 template <> struct Physics_Traits<BlastProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -37,11 +37,13 @@ template <> struct HydroSystem_Traits<SedovProblem> {
 };
 
 template <> struct Physics_Traits<SedovProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 // declare global variables

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -26,11 +26,13 @@ template <> struct HydroSystem_Traits<ContactProblem> {
 };
 
 template <> struct Physics_Traits<ContactProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 2; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr double v_contact = 0.0; // contact wave velocity

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -33,11 +33,13 @@ template <> struct HydroSystem_Traits<HighMachProblem> {
 };
 
 template <> struct Physics_Traits<HighMachProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -27,11 +27,13 @@ template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
 };
 
 template <> struct Physics_Traits<KelvinHelmholzProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -33,11 +33,13 @@ template <> struct HydroSystem_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -46,11 +46,13 @@ template <> struct HydroSystem_Traits<QuirkProblem> {
 };
 
 template <> struct Physics_Traits<QuirkProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr Real dl = 3.692;

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -27,11 +27,13 @@ template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 };
 
 template <> struct Physics_Traits<RichtmeyerMeshkovProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-	
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 //#define DEBUG_SYMMETRY

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -26,11 +26,13 @@ template <> struct HydroSystem_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -31,11 +31,13 @@ template <> struct HydroSystem_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 // left- and right- side shock states

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -28,11 +28,13 @@ template <> struct HydroSystem_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -30,11 +30,13 @@ template <> struct HydroSystem_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -26,11 +26,13 @@ template <> struct HydroSystem_Traits<WaveProblem> {
 };
 
 template <> struct Physics_Traits<WaveProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr double rho0 = 1.0; // background density

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -28,11 +28,13 @@ template <> struct HydroSystem_Traits<ScalarProblem> {
 };
 
 template <> struct Physics_Traits<ScalarProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 1; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr double v_contact = 2.0; // contact wave velocity

--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -44,11 +44,13 @@ template <> struct RadSystem_Traits<BeamProblem> {
 };
 
 template <> struct Physics_Traits<BeamProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -60,11 +60,13 @@ template <> struct HydroSystem_Traits<TubeProblem> {
 };
 
 template <> struct Physics_Traits<TubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -42,11 +42,13 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0;
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -38,11 +38,13 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0;
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -44,11 +44,13 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -36,11 +36,13 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 };
 
 template <> struct Physics_Traits<CouplingProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -38,11 +38,13 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 };
 
 template <> struct Physics_Traits<CouplingProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -39,11 +39,13 @@ template <> struct RadSystem_Traits<PulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 AMREX_GPU_HOST_DEVICE

--- a/src/RadStreaming/test_radiation_streaming.cpp
+++ b/src/RadStreaming/test_radiation_streaming.cpp
@@ -33,11 +33,13 @@ template <> struct RadSystem_Traits<StreamingProblem> {
 };
 
 template <> struct Physics_Traits<StreamingProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -52,11 +52,13 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 };
 
 template <> struct Physics_Traits<MarshakProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -49,11 +49,13 @@ template <> struct RadSystem_Traits<TophatProblem> {
 };
 
 template <> struct Physics_Traits<TophatProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadTube/test_radiation_tube.cpp
+++ b/src/RadTube/test_radiation_tube.cpp
@@ -47,11 +47,13 @@ template <> struct RadSystem_Traits<TubeProblem> {
 };
 
 template <> struct Physics_Traits<TubeProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -60,11 +60,13 @@ template <> struct HydroSystem_Traits<ShellProblem> {
 };
 
 template <> struct Physics_Traits<ShellProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr amrex::Real Msun = 2.0e33;           // g

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -72,11 +72,13 @@ template <> struct HydroSystem_Traits<ShockProblem> {
 };
 
 template <> struct Physics_Traits<ShockProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -74,11 +74,13 @@ template <> struct HydroSystem_Traits<ShockProblem> {
 };
 
 template <> struct Physics_Traits<ShockProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = true;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = true;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 template <>

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -27,11 +27,13 @@ template <> struct HydroSystem_Traits<RTProblem> {
 };
 
 template <> struct Physics_Traits<RTProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 1; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 amrex::Real constexpr g_x = 0;

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -27,11 +27,13 @@ template <> struct HydroSystem_Traits<RTProblem> {
 };
 
 template <> struct Physics_Traits<RTProblem> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 1; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 amrex::Real constexpr g_x = 0;

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -46,11 +46,13 @@ template <> struct HydroSystem_Traits<ShockCloud> {
 };
 
 template <> struct Physics_Traits<ShockCloud> {
+  // cell-centred
   static constexpr bool is_hydro_enabled = true;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-  
   static constexpr int numPassiveScalars = 0; // number of passive scalars
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 constexpr Real Tgas0 = 1.0e7;            // K

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -5,11 +5,13 @@
 
 // this struct is specialized by the user application code.
 template <typename problem_t> struct Physics_Traits {
+  // cell-centred
   static constexpr bool is_hydro_enabled = false;
-  static constexpr bool is_radiation_enabled = false;
   static constexpr bool is_chemistry_enabled = false;
-
   static constexpr int numPassiveScalars = 0;
+  static constexpr bool is_radiation_enabled = false;
+  // face-centred
+  static constexpr bool is_mhd_enabled = false;
 };
 
 // this struct stores the indices at which quantities start


### PR DESCRIPTION
This PR carries minor changes to the Physics_Traits problem instances, introducing an MHD flag, and turning it off. This is required because in another PR (https://github.com/BenWibking/quokka/pull/125) this flag is required to be defined by each problem file.