### PR TITLE
use SimulationData for problem-specific data

### DIFF
--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -188,7 +188,7 @@ auto problem_main() -> int {
 
   if (amrex::ParallelDescriptor::IOProcessor()) {
     // Solve for asymptotically-exact solution (Gonzalez et al. 2007)
-    const int nmax = sim.userData_.t_vec_.size();
+    const int nmax = static_cast<int>(sim.userData_.t_vec_.size());
     std::vector<double> t_exact(nmax);
     std::vector<double> Tgas_exact(nmax);
     const double initial_Tgas =
@@ -217,8 +217,9 @@ auto problem_main() -> int {
     // interpolate exact solution onto output timesteps
     std::vector<double> Tgas_exact_interp(sim.userData_.t_vec_.size());
     interpolate_arrays(sim.userData_.t_vec_.data(), Tgas_exact_interp.data(),
-                       sim.userData_.t_vec_.size(), t_exact.data(), Tgas_exact.data(),
-                       t_exact.size());
+                       static_cast<int>(sim.userData_.t_vec_.size()),
+                       t_exact.data(), Tgas_exact.data(),
+                       static_cast<int>(t_exact.size()));
 
     // compute L2 error norm
     double err_norm = 0.;

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -24,6 +24,12 @@ constexpr double eps_SuOlson = 1.0;
 constexpr double a_rad = 7.5646e-15; // cgs
 constexpr double alpha_SuOlson = 4.0 * a_rad / eps_SuOlson;
 
+template <> struct SimulationData<CouplingProblem> {
+  std::vector<double> t_vec_;
+	std::vector<double> Trad_vec_;
+	std::vector<double> Tgas_vec_;
+};
+
 template <> struct RadSystem_Traits<CouplingProblem> {
   static constexpr double c_light = c_light_cgs_;
   static constexpr double c_hat = c_light_cgs_;
@@ -118,7 +124,7 @@ template <> void RadhydroSimulation<CouplingProblem>::computeAfterTimestep() {
   auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5);
 
   if (amrex::ParallelDescriptor::IOProcessor()) {
-    t_vec_.push_back(tNew_[0]);
+    userData_.t_vec_.push_back(tNew_[0]);
 
     const amrex::Real Etot_i =
         values.at(RadSystem<CouplingProblem>::gasEnergy_index)[0];
@@ -136,8 +142,8 @@ template <> void RadhydroSimulation<CouplingProblem>::computeAfterTimestep() {
     const amrex::Real Erad_i =
         values.at(RadSystem<CouplingProblem>::radEnergy_index)[0];
 
-    Trad_vec_.push_back(std::pow(Erad_i / a_rad, 1. / 4.));
-    Tgas_vec_.push_back(
+    userData_.Trad_vec_.push_back(std::pow(Erad_i / a_rad, 1. / 4.));
+    userData_.Tgas_vec_.push_back(
         RadSystem<CouplingProblem>::ComputeTgasFromEgas(rho, Egas_i));
   }
 }
@@ -182,7 +188,7 @@ auto problem_main() -> int {
 
   if (amrex::ParallelDescriptor::IOProcessor()) {
     // Solve for asymptotically-exact solution (Gonzalez et al. 2007)
-    const int nmax = sim.t_vec_.size();
+    const int nmax = sim.userData_.t_vec_.size();
     std::vector<double> t_exact(nmax);
     std::vector<double> Tgas_exact(nmax);
     const double initial_Tgas =
@@ -191,7 +197,7 @@ auto problem_main() -> int {
         RadSystem<CouplingProblem>::ComputePlanckOpacity(rho0, initial_Tgas);
 
     for (int n = 0; n < nmax; ++n) {
-      const double time_t = sim.t_vec_.at(n);
+      const double time_t = sim.userData_.t_vec_.at(n);
       const double arad = RadSystem<CouplingProblem>::radiation_constant_;
       const double c = RadSystem<CouplingProblem>::c_light_;
       const double E0 = (Erad0 + Egas0) / (arad + alpha_SuOlson / 4.0);
@@ -209,16 +215,16 @@ auto problem_main() -> int {
     }
 
     // interpolate exact solution onto output timesteps
-    std::vector<double> Tgas_exact_interp(sim.t_vec_.size());
-    interpolate_arrays(sim.t_vec_.data(), Tgas_exact_interp.data(),
-                       sim.t_vec_.size(), t_exact.data(), Tgas_exact.data(),
+    std::vector<double> Tgas_exact_interp(sim.userData_.t_vec_.size());
+    interpolate_arrays(sim.userData_.t_vec_.data(), Tgas_exact_interp.data(),
+                       sim.userData_.t_vec_.size(), t_exact.data(), Tgas_exact.data(),
                        t_exact.size());
 
     // compute L2 error norm
     double err_norm = 0.;
     double sol_norm = 0.;
-    for (int i = 0; i < sim.t_vec_.size(); ++i) {
-      err_norm += std::abs(sim.Tgas_vec_[i] - Tgas_exact_interp[i]);
+    for (int i = 0; i < sim.userData_.t_vec_.size(); ++i) {
+      err_norm += std::abs(sim.userData_.Tgas_vec_[i] - Tgas_exact_interp[i]);
       sol_norm += std::abs(Tgas_exact_interp[i]);
     }
     const double rel_error = err_norm / sol_norm;
@@ -231,9 +237,9 @@ auto problem_main() -> int {
 #ifdef HAVE_PYTHON
 
     // Plot results
-    std::vector<double> &Tgas = sim.Tgas_vec_;
-    std::vector<double> &Trad = sim.Trad_vec_;
-    std::vector<double> &t = sim.t_vec_;
+    std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
+    std::vector<double> &Trad = sim.userData_.Trad_vec_;
+    std::vector<double> &t = sim.userData_.t_vec_;
 
     matplotlibcpp::clf();
     matplotlibcpp::yscale("log");

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -84,12 +84,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::GetData;
 	using AMRSimulation<problem_t>::FillPatchWithData;
 
-	std::vector<double> t_vec_;
-	std::vector<double> Trad_vec_;
-	std::vector<double> Tgas_vec_;
 	SimulationData<problem_t> userData_;
-
-	cloudy_tables cloudyTables{};
 
 	static constexpr int nvarTotal_cc_ = RadSystem<problem_t>::nvar_;
 	static constexpr int ncompHydro_ = HydroSystem<problem_t>::nvar_; // hydro

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -48,6 +48,7 @@
 #include "hydro_system.hpp"
 #include "radiation_system.hpp"
 #include "simulation.hpp"
+#include "SimulationData.hpp"
 
 // Simulation class should be initialized only once per program (i.e., is a singleton)
 template <typename problem_t> class RadhydroSimulation : public AMRSimulation<problem_t>
@@ -86,6 +87,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	std::vector<double> t_vec_;
 	std::vector<double> Trad_vec_;
 	std::vector<double> Tgas_vec_;
+	SimulationData<problem_t> userData_;
 
 	cloudy_tables cloudyTables{};
 

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -373,7 +373,7 @@ template <>
 void RadhydroSimulation<ShockCloud>::computeAfterLevelAdvance(
     int lev, Real /*time*/, Real dt_lev, int /*ncycle*/) {
   // compute operator split physics
-  computeCooling(state_new_cc_[lev], dt_lev, cloudyTables);
+  computeCooling(state_new_cc_[lev], dt_lev, userData_.cloudyTables);
 }
 
 template <>
@@ -383,7 +383,7 @@ void RadhydroSimulation<ShockCloud>::ComputeDerivedVar(
   // compute derived variables and save in 'mf'
   if (dname == "temperature") {
     const int ncomp = ncomp_cc_in;
-    auto tables = cloudyTables.const_tables();
+    auto tables = userData_.cloudyTables.const_tables();
 
     for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
       const amrex::Box &indexRange = iter.validbox();

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -20,6 +20,7 @@
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParallelContext.H"
 #include "AMReX_ParallelDescriptor.H"
+#include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 #include "AMReX_TableData.H"
 

--- a/src/SimulationData.hpp
+++ b/src/SimulationData.hpp
@@ -1,0 +1,16 @@
+#ifndef SIMULATION_DATA_HPP_ // NOLINT
+#define SIMULATION_DATA_HPP_
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file SimulationData.hpp
+/// \brief Defines a template class for user-specified simulation data
+
+template <typename problem_t> struct SimulationData
+{
+	// none
+};
+
+#endif // SIMULATION_DATA_HPP_

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -10,6 +10,7 @@
 ///
 
 // c++ headers
+#include <cmath>
 
 // library headers
 #include "AMReX_Arena.H"
@@ -24,7 +25,6 @@
 #include "hyperbolic_system.hpp"
 #include "radiation_system.hpp"
 #include "valarray.hpp"
-#include <math.h>
 
 // this struct is specialized by the user application code
 //


### PR DESCRIPTION
Adds the `SimulationData<problem_t>` struct to store problem-specific data that should last for the lifetime of the `RadhydroSimulation<problem_t>` object.

Adds a member variable `userData_` to `RadhydroSimulation` of this type, which can be used in lieu of global variables in problem generators.

This is needed to avoid double `free`s for AMReX-allocated objects that can happen with global variables, since they may be deallocated both when calling `amrex::Finalize()` and when the static destructor is called implicitly.