### PR TITLE
refactor hydro riemann solver

### DIFF
--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -71,7 +71,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars> cons
 	double S_R = sR.u + q_R * sR.cs;
 
 	// carbuncle correction [Eq. 10 of Minoshima & Miyoshi (2021)]
-	
+
 	const double cs_max = std::max(sL.cs, sR.cs);
 	const double tp = std::min(1., (cs_max - std::min(du, 0.)) / (cs_max - std::min(dw, 0.)));
 	const double theta = tp * tp * tp * tp;
@@ -157,4 +157,4 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars> cons
 }
 } // namespace quokka::Riemann
 
-#endif // HYDROSTATE_HPP_
+#endif // HLLC_HPP_

--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -1,0 +1,182 @@
+#ifndef HLLC_HPP_ // NOLINT
+#define HLLC_HPP_
+
+#include "AMReX_Extension.H"
+#include "AMReX_GpuQualifiers.H"
+#include <AMReX.H>
+#include <AMReX_REAL.H>
+
+#include "ArrayView.hpp"
+#include "HydroState.hpp"
+#include "valarray.hpp"
+
+namespace quokka::Riemann
+{
+// HLLC solver following Toro (1998) and Balsara (2017).
+// [Carbuncle correction:
+//  Minoshima & Miyoshi, "A low-dissipation HLLD approximate Riemann solver
+//  	for a very wide range of Mach numbers," JCP (2021).]
+//
+template <FluxDir DIR, int N_scalars, int fluxdim>
+AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars> const &sL, quokka::HydroState<N_scalars> const &sR, const double gamma,
+					      quokka::Array4View<const amrex::Real, DIR> const &q, amrex::Dim3 const &cell_idx,
+					      AMREX_D_DECL(const int velN_index, const int velV_index, const int velW_index))
+    -> quokka::valarray<double, fluxdim>
+{
+	// compute PVRS states (Toro 10.5.2)
+
+	const double rho_bar = 0.5 * (sL.rho + sR.rho);
+	const double cs_bar = 0.5 * (sL.cs + sR.cs);
+	const double P_PVRS = 0.5 * (sL.P + sR.P) - 0.5 * (sR.u - sL.u) * (rho_bar * cs_bar);
+
+	// choose P_star adaptively (Fig. 9.4 of Toro)
+
+	const double P_min = std::min(sL.P, sR.P);
+	const double P_max = std::max(sL.P, sR.P);
+	const double Q = P_max / P_min;
+	constexpr double Q_crit = 2.;
+	double P_star = NAN;
+
+	if (gamma == 1.0) {
+		P_star = std::max(P_PVRS, 0.0); // only estimate compatible with gamma = 1
+	} else {				// gamma > 1
+		if ((Q < Q_crit) && (P_min < P_PVRS) && (P_PVRS < P_max)) {
+			// use PVRS estimate
+			P_star = P_PVRS;
+		} else if (P_PVRS < P_min) {
+			// compute two-rarefaction TRRS states (Toro 10.5.2, eq. 10.63)
+			const double z = (gamma - 1.) / (2. * gamma);
+			const double P_TRRS =
+			    std::pow((sL.cs + sR.cs - 0.5 * (gamma - 1.) * (sR.u - sL.u)) / (sL.cs / std::pow(sL.P, z) + sR.cs / std::pow(sR.P, z)), (1. / z));
+			P_star = P_TRRS;
+		} else {
+			// compute two-shock TSRS states (Toro 10.5.2, eq. 10.65)
+			const double A_L = 2. / ((gamma + 1.) * sL.rho);
+			const double A_R = 2. / ((gamma + 1.) * sR.rho);
+			const double B_L = ((gamma - 1.) / (gamma + 1.)) * sL.P;
+			const double B_R = ((gamma - 1.) / (gamma + 1.)) * sR.P;
+			const double P_0 = std::max(P_PVRS, 0.0);
+			const double G_L = std::sqrt(A_L / (P_0 + B_L));
+			const double G_R = std::sqrt(A_R / (P_0 + B_R));
+			const double delta_u = sR.u - sL.u;
+			const double P_TSRS = (G_L * sL.P + G_R * sR.P - delta_u) / (G_L + G_R);
+			P_star = P_TSRS;
+		}
+	}
+
+	// compute wave speeds
+
+	const double q_L = (P_star <= sL.P) ? 1.0 : std::sqrt(1.0 + ((gamma + 1.0) / (2.0 * gamma)) * ((P_star / sL.P) - 1.0));
+	const double q_R = (P_star <= sR.P) ? 1.0 : std::sqrt(1.0 + ((gamma + 1.0) / (2.0 * gamma)) * ((P_star / sR.P) - 1.0));
+
+	double S_L = sL.u - q_L * sL.cs;
+	double S_R = sR.u + q_R * sR.cs;
+
+	// carbuncle correction [Eq. 10 of Minoshima & Miyoshi (2021)]
+	auto [i, j, k] = cell_idx;
+
+	// difference in normal velocity along normal axis
+	const double du = q(i, j, k, velN_index) - q(i - 1, j, k, velN_index);
+
+	// difference in transverse velocity
+#if AMREX_SPACEDIM == 1
+	const double dw = 0.;
+#else
+	amrex::Real dvl = std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index), q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
+	amrex::Real dvr = std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index), q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
+	double dw = std::min(dvl, dvr);
+#endif
+#if AMREX_SPACEDIM == 3
+	amrex::Real dwl = std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index), q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
+	amrex::Real dwr = std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index), q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
+	dw = std::min(std::min(dwl, dwr), dw);
+#endif
+
+	const double cs_max = std::max(sL.cs, sR.cs);
+	const double tp = std::min(1., (cs_max - std::min(du, 0.)) / (cs_max - std::min(dw, 0.)));
+	const double theta = tp * tp * tp * tp;
+
+	// compute speed of the 'star' state
+
+	const double S_star =
+	    (theta * (sR.P - sL.P) + (sL.rho * sL.u * (S_L - sL.u) - sR.rho * sR.u * (S_R - sR.u))) / (sL.rho * (S_L - sL.u) - sR.rho * (S_R - sR.u));
+
+	// Low-dissipation pressure correction 'phi' [Eq. 23 of Minoshima & Miyoshi]
+
+	const double vmag_L = std::sqrt(sL.vx * sL.vx + sL.vy * sL.vy + sL.vz * sL.vz);
+	const double vmag_R = std::sqrt(sR.vx * sR.vx + sR.vy * sR.vy + sR.vz * sR.vz);
+	const double chi = std::min(1., std::max(vmag_L, vmag_R) / cs_max);
+	const double phi = chi * (2. - chi);
+
+	const double P_LR = 0.5 * (sL.P + sR.P) + 0.5 * phi * (sL.rho * (S_L - sL.u) * (S_star - sL.u) + sR.rho * (S_R - sR.u) * (S_star - sR.u));
+
+	/// compute fluxes
+
+	quokka::valarray<double, fluxdim> D_L{};
+	quokka::valarray<double, fluxdim> D_R{};
+	quokka::valarray<double, fluxdim> D_star{};
+
+	// N.B.: quokka::valarray is written to allow assigning <= fluxdim
+	// components, so this works even if there are more components than
+	// enumerated in the initializer list. The remaining components are
+	// assigned a default value of zero.
+	if constexpr (DIR == FluxDir::X1) {
+		D_L = {0., 1., 0., 0., sL.u, 0.};
+		D_R = {0., 1., 0., 0., sR.u, 0.};
+		D_star = {0., 1., 0., 0., S_star, 0.};
+	} else if constexpr (DIR == FluxDir::X2) {
+		D_L = {0., 0., 1., 0., sL.u, 0.};
+		D_R = {0., 0., 1., 0., sR.u, 0.};
+		D_star = {0., 0., 1., 0., S_star, 0.};
+	} else if constexpr (DIR == FluxDir::X3) {
+		D_L = {0., 0., 0., 1., sL.u, 0.};
+		D_R = {0., 0., 0., 1., sR.u, 0.};
+		D_star = {0., 0., 0., 1., S_star, 0.};
+	}
+
+	const std::initializer_list<double> state_L = {sL.rho, sL.rho * sL.vx, sL.rho * sL.vy, sL.rho * sL.vz, sL.E, sL.Eint};
+	const std::initializer_list<double> state_R = {sR.rho, sR.rho * sR.vx, sR.rho * sR.vy, sR.rho * sR.vz, sR.E, sR.Eint};
+
+	AMREX_ASSERT(state_L.size() == state_R.size());
+
+	// N.B.: quokka::valarray is written to allow assigning <= fluxdim
+	// components, so this works even if there are more components than
+	// enumerated in the initializer list. The remaining components are
+	// assigned a default value of zero.
+	quokka::valarray<double, fluxdim> U_L = state_L;
+	quokka::valarray<double, fluxdim> U_R = state_R;
+
+	// The remaining components are passive scalars, so just copy them from
+	// x1LeftState and x1RightState into the (left, right) state vectors U_L and
+	// U_R
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = static_cast<int>(state_L.size());
+		U_L[nstart + n] = sL.scalar[n];
+		U_R[nstart + n] = sR.scalar[n];
+	}
+
+	const quokka::valarray<double, fluxdim> F_L = sL.u * U_L + sL.P * D_L;
+	const quokka::valarray<double, fluxdim> F_R = sR.u * U_R + sR.P * D_R;
+
+	const quokka::valarray<double, fluxdim> F_starL = (S_star * (S_L * U_L - F_L) + S_L * P_LR * D_star) / (S_L - S_star);
+	const quokka::valarray<double, fluxdim> F_starR = (S_star * (S_R * U_R - F_R) + S_R * P_LR * D_star) / (S_R - S_star);
+
+	// open the Riemann fan
+	quokka::valarray<double, fluxdim> F{};
+
+	// HLLC flux
+	if (S_L > 0.0) {
+		F = F_L;
+	} else if ((S_star > 0.0) && (S_L <= 0.0)) {
+		F = F_starL;
+	} else if ((S_star <= 0.0) && (S_R >= 0.0)) {
+		F = F_starR;
+	} else { // S_R < 0.0
+		F = F_R;
+	}
+
+	return F;
+}
+} // namespace quokka::Riemann
+
+#endif // HYDROSTATE_HPP_

--- a/src/HydroState.hpp
+++ b/src/HydroState.hpp
@@ -1,0 +1,22 @@
+#ifndef HYDROSTATE_HPP_ // NOLINT
+#define HYDROSTATE_HPP_
+
+#include <array>
+namespace quokka
+{
+template <int N> struct HydroState {
+	double rho;		      // density
+	double vx;		      // x-vel
+	double vy;		      // y-vel
+	double vz;		      // z-vel
+	double P;		      // pressure
+	double u;		      // normal velocity component
+	double cs;		      // adiabatic sound speed
+	double E;		      // total energy density
+	double Eint;		      // internal energy density
+	std::array<double, N> scalar; // passive scalars
+};
+
+} // namespace quokka
+
+#endif // HYDROSTATE_HPP_

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -22,6 +22,7 @@
 
 // internal headers
 #include "ArrayView.hpp"
+#include "HLLC.hpp"
 #include "hyperbolic_system.hpp"
 #include "radiation_system.hpp"
 #include "valarray.hpp"
@@ -29,363 +30,328 @@
 // this struct is specialized by the user application code
 //
 template <typename problem_t> struct HydroSystem_Traits {
-  static constexpr double gamma = 5. / 3.;     // default value
-  static constexpr double cs_isothermal = NAN; // only used when gamma = 1
-  // if true, reconstruct e_int instead of pressure
-  static constexpr bool reconstruct_eint = true;
+	static constexpr double gamma = 5. / 3.;     // default value
+	static constexpr double cs_isothermal = NAN; // only used when gamma = 1
+	// if true, reconstruct e_int instead of pressure
+	static constexpr bool reconstruct_eint = true;
 };
 
 /// Class for the Euler equations of inviscid hydrodynamics
 ///
-template <typename problem_t>
-class HydroSystem : public HyperbolicSystem<problem_t> {
-public:
-  static constexpr int nscalars_ = Physics_Traits<problem_t>::numPassiveScalars;
-  static constexpr int nvar_ = Physics_NumVars<problem_t>::numHydroVars + nscalars_;
+template <typename problem_t> class HydroSystem : public HyperbolicSystem<problem_t>
+{
+      public:
+	static constexpr int nscalars_ = Physics_Traits<problem_t>::numPassiveScalars;
+	static constexpr int nvar_ = Physics_NumVars<problem_t>::numHydroVars + nscalars_;
 
-  enum consVarIndex {
-    density_index = Physics_Indices<problem_t>::hydroFirstIndex,
-    x1Momentum_index,
-    x2Momentum_index,
-    x3Momentum_index,
-    energy_index,
-    internalEnergy_index, // auxiliary internal energy (rho * e)
-    scalar0_index // first passive scalar (only present if nscalars > 0!)
-  };
+	enum consVarIndex {
+		density_index = Physics_Indices<problem_t>::hydroFirstIndex,
+		x1Momentum_index,
+		x2Momentum_index,
+		x3Momentum_index,
+		energy_index,
+		internalEnergy_index, // auxiliary internal energy (rho * e)
+		scalar0_index	      // first passive scalar (only present if nscalars > 0!)
+	};
 
-  enum primVarIndex {
-    primDensity_index = 0,
-    x1Velocity_index,
-    x2Velocity_index,
-    x3Velocity_index,
-    pressure_index,
-    primEint_index, // auxiliary internal energy (rho * e)
-    primScalar0_index // first passive scalar (only present if nscalars > 0!)
-  };
+	enum primVarIndex {
+		primDensity_index = 0,
+		x1Velocity_index,
+		x2Velocity_index,
+		x3Velocity_index,
+		pressure_index,
+		primEint_index,	  // auxiliary internal energy (rho * e)
+		primScalar0_index // first passive scalar (only present if nscalars > 0!)
+	};
 
-  static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost);
+	static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost);
 
-  static auto maxSignalSpeedLocal(amrex::MultiFab const &cons) -> amrex::Real;
+	static auto maxSignalSpeedLocal(amrex::MultiFab const &cons) -> amrex::Real;
 
-  static void
-  ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons,
-                        array_t &maxSignal, amrex::Box const &indexRange);
+	static void ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange);
 
-  static auto CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool;
+	static auto CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool;
 
-  static void EnforceDensityFloor(amrex::Real const densityFloor, amrex::MultiFab &state_mf);
+	static void EnforceDensityFloor(amrex::Real const densityFloor, amrex::MultiFab &state_mf);
 
-  AMREX_GPU_DEVICE static auto
-  ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j,
-                  int k) -> amrex::Real;
+	AMREX_GPU_DEVICE static auto ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
-  AMREX_GPU_DEVICE static auto
-  ComputeVelocityX1(amrex::Array4<const amrex::Real> const &cons, int i, int j,
-                  int k) -> amrex::Real;
+	AMREX_GPU_DEVICE static auto ComputeVelocityX1(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
-  AMREX_GPU_DEVICE static auto
-  ComputeVelocityX2(amrex::Array4<const amrex::Real> const &cons, int i, int j,
-                  int k) -> amrex::Real;
+	AMREX_GPU_DEVICE static auto ComputeVelocityX2(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
-  AMREX_GPU_DEVICE static auto
-  ComputeVelocityX3(amrex::Array4<const amrex::Real> const &cons, int i, int j,
-                  int k) -> amrex::Real;
+	AMREX_GPU_DEVICE static auto ComputeVelocityX3(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
-  AMREX_GPU_DEVICE static auto
-  isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j,
-               int k) -> bool;
+	AMREX_GPU_DEVICE static auto isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> bool;
 
-  static void ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf,
-				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
-				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars);
+	static void ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars);
 
-  static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs,
-			  const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
+	static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs, const double dt, const int nvars,
+				amrex::iMultiFab &redoFlag_mf);
 
-  static void AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf,
-			   amrex::MultiFab const &rhs_mf, const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
+	static void AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
+				 const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
 
-  static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
-				   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
-				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray);
+	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray);
 
-  static void SyncDualEnergy(amrex::MultiFab &consVar_mf);
+	static void SyncDualEnergy(amrex::MultiFab &consVar_mf);
 
-  template <FluxDir DIR>
-  static void
-  ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-			          amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf);
+	template <FluxDir DIR>
+	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf);
 
-  template <FluxDir DIR>
-  static void
-  ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar,
-                          array_t &x1FluxDiffusive,
-                          amrex::Box const &indexRange);
+	template <FluxDir DIR>
+	static void ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar, array_t &x1FluxDiffusive, amrex::Box const &indexRange);
 
-  template <FluxDir DIR>
-  static void
-  ComputeFlatteningCoefficients(amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, const int nghost);
+	template <FluxDir DIR> static void ComputeFlatteningCoefficients(amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, const int nghost);
 
-  template <FluxDir DIR>
-  static void FlattenShocks(amrex::MultiFab const &q_mf, amrex::MultiFab const &x1Chi_mf, amrex::MultiFab const &x2Chi_mf, amrex::MultiFab const &x3Chi_mf,
-			    amrex::MultiFab &x1LeftState_mf, amrex::MultiFab &x1RightState_mf, const int nghost, const int nvars);
+	template <FluxDir DIR>
+	static void FlattenShocks(amrex::MultiFab const &q_mf, amrex::MultiFab const &x1Chi_mf, amrex::MultiFab const &x2Chi_mf,
+				  amrex::MultiFab const &x3Chi_mf, amrex::MultiFab &x1LeftState_mf, amrex::MultiFab &x1RightState_mf, const int nghost,
+				  const int nvars);
 
-  // C++ does not allow constexpr to be uninitialized, even in a templated
-  // class!
-  static constexpr double gamma_ = HydroSystem_Traits<problem_t>::gamma;
-  static constexpr double cs_iso_ = HydroSystem_Traits<problem_t>::cs_isothermal;
-  static constexpr bool reconstruct_eint =
-      HydroSystem_Traits<problem_t>::reconstruct_eint;
+	// C++ does not allow constexpr to be uninitialized, even in a templated
+	// class!
+	static constexpr double gamma_ = HydroSystem_Traits<problem_t>::gamma;
+	static constexpr double cs_iso_ = HydroSystem_Traits<problem_t>::cs_isothermal;
+	static constexpr bool reconstruct_eint = HydroSystem_Traits<problem_t>::reconstruct_eint;
 
-  static constexpr auto is_eos_isothermal() -> bool { return (gamma_ == 1.0); }
+	static constexpr auto is_eos_isothermal() -> bool { return (gamma_ == 1.0); }
 };
 
-template <typename problem_t>
-void HydroSystem<problem_t>::ConservedToPrimitive(
-    amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost) {
-  // convert conserved to primitive variables
-  auto const &cons = cons_mf.const_arrays();
-  auto const &primVar = primVar_mf.arrays();
-  amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
-
-  amrex::ParallelFor(cons_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-    const auto rho = cons[bx](i, j, k, density_index);
-    const auto px = cons[bx](i, j, k, x1Momentum_index);
-    const auto py = cons[bx](i, j, k, x2Momentum_index);
-    const auto pz = cons[bx](i, j, k, x3Momentum_index);
-    const auto E = cons[bx](i, j, k, energy_index); // *total* gas energy per unit volume
-    const auto Eint_aux = cons[bx](i, j, k, internalEnergy_index);
-
-    AMREX_ASSERT(!std::isnan(rho));
-    AMREX_ASSERT(!std::isnan(px));
-    AMREX_ASSERT(!std::isnan(py));
-    AMREX_ASSERT(!std::isnan(pz));
-    AMREX_ASSERT(!std::isnan(E));
-
-    const auto vx = px / rho;
-    const auto vy = py / rho;
-    const auto vz = pz / rho;
-    const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
-    const auto Eint_cons = E - kinetic_energy;
-
-    const amrex::Real Pgas = Eint_cons * (HydroSystem<problem_t>::gamma_ - 1.0);
-    const amrex::Real eint_cons = Eint_cons / rho;
-    const amrex::Real eint_aux = Eint_aux / rho;
-
-    AMREX_ASSERT(rho > 0.);
-    if constexpr (!is_eos_isothermal()) {
-      AMREX_ASSERT(Pgas > 0.);
-    }
-
-    primVar[bx](i, j, k, primDensity_index) = rho;
-    primVar[bx](i, j, k, x1Velocity_index) = vx;
-    primVar[bx](i, j, k, x2Velocity_index) = vy;
-    primVar[bx](i, j, k, x3Velocity_index) = vz;
-
-    if constexpr (reconstruct_eint) {
-      // save specific internal energy (SIE) == (Etot - KE) / rho
-      primVar[bx](i, j, k, pressure_index) = eint_cons;
-      // save auxiliary specific internal energy (SIE) == Eint_aux / rho
-      primVar[bx](i, j, k, primEint_index) = eint_aux;
-    } else {
-      // save pressure
-      primVar[bx](i, j, k, pressure_index) = Pgas;
-      // save auxiliary internal energy (rho * e)
-      primVar[bx](i, j, k, primEint_index) = Eint_aux;
-    }
-
-    // copy any passive scalars
-    for (int nc = 0; nc < nscalars_; ++nc) {
-      primVar[bx](i, j, k, primScalar0_index + nc) = cons[bx](i, j, k, scalar0_index + nc);
-    }
-  });
-}
-
-template <typename problem_t>
-auto HydroSystem<problem_t>::maxSignalSpeedLocal(amrex::MultiFab const &cons_mf) -> amrex::Real {
-  // return maximum signal speed on local grids
-  
-  auto const &cons = cons_mf.const_arrays();
-  return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMax>{}, amrex::TypeList<amrex::Real>{},
-                          cons_mf, amrex::IntVect(0), // no ghost cells
-      [=] AMREX_GPU_DEVICE (int bx, int i, int j, int k)
-          noexcept -> amrex::GpuTuple<amrex::Real>
-      {
-        const auto rho = cons[bx](i, j, k, HydroSystem<problem_t>::density_index);
-        const auto px  = cons[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-        const auto py  = cons[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-        const auto pz  = cons[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-        const auto kinetic_energy = (px*px + py*py + pz*pz) / (2.0*rho);
-        const double abs_vel = std::sqrt(2.0 * kinetic_energy / rho);
-        double cs = NAN;
-
-        if constexpr (is_eos_isothermal()) {
-          cs = cs_iso_;
-        } else {
-          const auto Etot = cons[bx](i, j, k, HydroSystem<problem_t>::energy_index);
-          const auto Eint = Etot - kinetic_energy;
-          const auto P = Eint * (HydroSystem<problem_t>::gamma_ - 1.0);
-          cs = std::sqrt(HydroSystem<problem_t>::gamma_ * P / rho);
-        }
-        return { cs + abs_vel };
-      });
-}
-
-template <typename problem_t>
-void HydroSystem<problem_t>::ComputeMaxSignalSpeed(
-    amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal,
-    amrex::Box const &indexRange) {
-  amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-    const auto rho = cons(i, j, k, density_index);
-    const auto px = cons(i, j, k, x1Momentum_index);
-    const auto py = cons(i, j, k, x2Momentum_index);
-    const auto pz = cons(i, j, k, x3Momentum_index);
-    AMREX_ASSERT(!std::isnan(rho));
-    AMREX_ASSERT(!std::isnan(px));
-    AMREX_ASSERT(!std::isnan(py));
-    AMREX_ASSERT(!std::isnan(pz));
-
-    const auto vx = px / rho;
-    const auto vy = py / rho;
-    const auto vz = pz / rho;
-    const double vel_mag = std::sqrt(vx * vx + vy * vy + vz * vz);
-    double cs = NAN;
-
-    if constexpr (is_eos_isothermal()) {
-      cs = cs_iso_;
-    } else {
-      const auto E =
-          cons(i, j, k, energy_index); // *total* gas energy per unit volume
-      AMREX_ASSERT(!std::isnan(E));
-      const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
-      const auto thermal_energy = E - kinetic_energy;
-      const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
-      cs = std::sqrt(HydroSystem<problem_t>::gamma_ * P / rho);
-    }
-    AMREX_ASSERT(cs > 0.);
-
-    const double signal_max = cs + vel_mag;
-    maxSignal(i, j, k) = signal_max;
-  });
-}
-
-template <typename problem_t>
-auto HydroSystem<problem_t>::CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool
+template <typename problem_t> void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost)
 {
-  // check whether density or pressure are negative
-  auto const &cons = cons_mf.const_arrays();
+	// convert conserved to primitive variables
+	auto const &cons = cons_mf.const_arrays();
+	auto const &primVar = primVar_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
 
-  return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpLogicalAnd>{},
-    amrex::TypeList<bool>{}, cons_mf, amrex::IntVect(0), // no ghost cells
-			  [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept -> amrex::GpuTuple<bool> {
-				  const auto rho = cons[bx](i, j, k, density_index);
-				  const auto px = cons[bx](i, j, k, x1Momentum_index);
-				  const auto py = cons[bx](i, j, k, x2Momentum_index);
-				  const auto pz = cons[bx](i, j, k, x3Momentum_index);
-				  const auto E = cons[bx](i, j, k, energy_index);
-				  const auto vx = px / rho;
-				  const auto vy = py / rho;
-				  const auto vz = pz / rho;
-				  const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
-				  const auto thermal_energy = E - kinetic_energy;
-				  const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
+	amrex::ParallelFor(cons_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		const auto rho = cons[bx](i, j, k, density_index);
+		const auto px = cons[bx](i, j, k, x1Momentum_index);
+		const auto py = cons[bx](i, j, k, x2Momentum_index);
+		const auto pz = cons[bx](i, j, k, x3Momentum_index);
+		const auto E = cons[bx](i, j, k, energy_index); // *total* gas energy per unit volume
+		const auto Eint_aux = cons[bx](i, j, k, internalEnergy_index);
 
-				  bool negativeDensity = (rho <= 0.);
-				  bool negativePressure = (P <= 0.);
+		AMREX_ASSERT(!std::isnan(rho));
+		AMREX_ASSERT(!std::isnan(px));
+		AMREX_ASSERT(!std::isnan(py));
+		AMREX_ASSERT(!std::isnan(pz));
+		AMREX_ASSERT(!std::isnan(E));
 
-				  if constexpr (is_eos_isothermal()) {
-					  if (negativeDensity) {
-						  printf("invalid state at (%d, %d, %d): rho %g\n", i, j, k, rho);
-						  return {false};
-					  }
-				  } else {
-					  if (negativeDensity || negativePressure) {
-						  printf("invalid state at (%d, %d, %d): rho %g, Etot %g, Eint %g, P %g\n",
-							 i, j, k, rho, E, thermal_energy, P);
-						  return {false};
-					  }
-				  }
-				  return {true};
-			  });
+		const auto vx = px / rho;
+		const auto vy = py / rho;
+		const auto vz = pz / rho;
+		const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+		const auto Eint_cons = E - kinetic_energy;
+
+		const amrex::Real Pgas = Eint_cons * (HydroSystem<problem_t>::gamma_ - 1.0);
+		const amrex::Real eint_cons = Eint_cons / rho;
+		const amrex::Real eint_aux = Eint_aux / rho;
+
+		AMREX_ASSERT(rho > 0.);
+		if constexpr (!is_eos_isothermal()) {
+			AMREX_ASSERT(Pgas > 0.);
+		}
+
+		primVar[bx](i, j, k, primDensity_index) = rho;
+		primVar[bx](i, j, k, x1Velocity_index) = vx;
+		primVar[bx](i, j, k, x2Velocity_index) = vy;
+		primVar[bx](i, j, k, x3Velocity_index) = vz;
+
+		if constexpr (reconstruct_eint) {
+			// save specific internal energy (SIE) == (Etot - KE) / rho
+			primVar[bx](i, j, k, pressure_index) = eint_cons;
+			// save auxiliary specific internal energy (SIE) == Eint_aux / rho
+			primVar[bx](i, j, k, primEint_index) = eint_aux;
+		} else {
+			// save pressure
+			primVar[bx](i, j, k, pressure_index) = Pgas;
+			// save auxiliary internal energy (rho * e)
+			primVar[bx](i, j, k, primEint_index) = Eint_aux;
+		}
+
+		// copy any passive scalars
+		for (int nc = 0; nc < nscalars_; ++nc) {
+			primVar[bx](i, j, k, primScalar0_index + nc) = cons[bx](i, j, k, scalar0_index + nc);
+		}
+	});
+}
+
+template <typename problem_t> auto HydroSystem<problem_t>::maxSignalSpeedLocal(amrex::MultiFab const &cons_mf) -> amrex::Real
+{
+	// return maximum signal speed on local grids
+
+	auto const &cons = cons_mf.const_arrays();
+	return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMax>{}, amrex::TypeList<amrex::Real>{}, cons_mf, amrex::IntVect(0), // no ghost cells
+				[=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept -> amrex::GpuTuple<amrex::Real> {
+					const auto rho = cons[bx](i, j, k, HydroSystem<problem_t>::density_index);
+					const auto px = cons[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+					const auto py = cons[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+					const auto pz = cons[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+					const auto kinetic_energy = (px * px + py * py + pz * pz) / (2.0 * rho);
+					const double abs_vel = std::sqrt(2.0 * kinetic_energy / rho);
+					double cs = NAN;
+
+					if constexpr (is_eos_isothermal()) {
+						cs = cs_iso_;
+					} else {
+						const auto Etot = cons[bx](i, j, k, HydroSystem<problem_t>::energy_index);
+						const auto Eint = Etot - kinetic_energy;
+						const auto P = Eint * (HydroSystem<problem_t>::gamma_ - 1.0);
+						cs = std::sqrt(HydroSystem<problem_t>::gamma_ * P / rho);
+					}
+					return {cs + abs_vel};
+				});
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::EnforceDensityFloor(amrex::Real const densityFloor, 
-    amrex::MultiFab &state_mf) {
-  // prevent negative densities
-  auto state = state_mf.arrays();
+void HydroSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange)
+{
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const auto rho = cons(i, j, k, density_index);
+		const auto px = cons(i, j, k, x1Momentum_index);
+		const auto py = cons(i, j, k, x2Momentum_index);
+		const auto pz = cons(i, j, k, x3Momentum_index);
+		AMREX_ASSERT(!std::isnan(rho));
+		AMREX_ASSERT(!std::isnan(px));
+		AMREX_ASSERT(!std::isnan(py));
+		AMREX_ASSERT(!std::isnan(pz));
 
-  amrex::ParallelFor(
-      state_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-        amrex::Real rho = state[bx](i, j, k, density_index);
+		const auto vx = px / rho;
+		const auto vy = py / rho;
+		const auto vz = pz / rho;
+		const double vel_mag = std::sqrt(vx * vx + vy * vy + vz * vz);
+		double cs = NAN;
 
-        // reset density if less than densityFloor
-        if (rho < densityFloor) {
-          state[bx](i, j, k, density_index) = densityFloor;
-        }
-      });
+		if constexpr (is_eos_isothermal()) {
+			cs = cs_iso_;
+		} else {
+			const auto E = cons(i, j, k, energy_index); // *total* gas energy per unit volume
+			AMREX_ASSERT(!std::isnan(E));
+			const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+			const auto thermal_energy = E - kinetic_energy;
+			const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
+			cs = std::sqrt(HydroSystem<problem_t>::gamma_ * P / rho);
+		}
+		AMREX_ASSERT(cs > 0.);
+
+		const double signal_max = cs + vel_mag;
+		maxSignal(i, j, k) = signal_max;
+	});
+}
+
+template <typename problem_t> auto HydroSystem<problem_t>::CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool
+{
+	// check whether density or pressure are negative
+	auto const &cons = cons_mf.const_arrays();
+
+	return amrex::ParReduce(amrex::TypeList<amrex::ReduceOpLogicalAnd>{}, amrex::TypeList<bool>{}, cons_mf, amrex::IntVect(0), // no ghost cells
+				[=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept -> amrex::GpuTuple<bool> {
+					const auto rho = cons[bx](i, j, k, density_index);
+					const auto px = cons[bx](i, j, k, x1Momentum_index);
+					const auto py = cons[bx](i, j, k, x2Momentum_index);
+					const auto pz = cons[bx](i, j, k, x3Momentum_index);
+					const auto E = cons[bx](i, j, k, energy_index);
+					const auto vx = px / rho;
+					const auto vy = py / rho;
+					const auto vz = pz / rho;
+					const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+					const auto thermal_energy = E - kinetic_energy;
+					const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
+
+					bool negativeDensity = (rho <= 0.);
+					bool negativePressure = (P <= 0.);
+
+					if constexpr (is_eos_isothermal()) {
+						if (negativeDensity) {
+							printf("invalid state at (%d, %d, %d): rho %g\n", i, j, k, rho);
+							return {false};
+						}
+					} else {
+						if (negativeDensity || negativePressure) {
+							printf("invalid state at (%d, %d, %d): rho %g, Etot %g, Eint %g, P %g\n", i, j, k, rho, E,
+							       thermal_energy, P);
+							return {false};
+						}
+					}
+					return {true};
+				});
+}
+
+template <typename problem_t> void HydroSystem<problem_t>::EnforceDensityFloor(amrex::Real const densityFloor, amrex::MultiFab &state_mf)
+{
+	// prevent negative densities
+	auto state = state_mf.arrays();
+
+	amrex::ParallelFor(state_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		amrex::Real rho = state[bx](i, j, k, density_index);
+
+		// reset density if less than densityFloor
+		if (rho < densityFloor) {
+			state[bx](i, j, k, density_index) = densityFloor;
+		}
+	});
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto
-HydroSystem<problem_t>::ComputePressure(
-    amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
-    -> amrex::Real {
-  const auto rho = cons(i, j, k, density_index);
-  const auto px = cons(i, j, k, x1Momentum_index);
-  const auto py = cons(i, j, k, x2Momentum_index);
-  const auto pz = cons(i, j, k, x3Momentum_index);
-  const auto E =
-      cons(i, j, k, energy_index); // *total* gas energy per unit volume
-  const auto vx = px / rho;
-  const auto vy = py / rho;
-  const auto vz = pz / rho;
-  const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
-  const auto thermal_energy = E - kinetic_energy;
-  const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
-  return P;
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+    -> amrex::Real
+{
+	const auto rho = cons(i, j, k, density_index);
+	const auto px = cons(i, j, k, x1Momentum_index);
+	const auto py = cons(i, j, k, x2Momentum_index);
+	const auto pz = cons(i, j, k, x3Momentum_index);
+	const auto E = cons(i, j, k, energy_index); // *total* gas energy per unit volume
+	const auto vx = px / rho;
+	const auto vy = py / rho;
+	const auto vz = pz / rho;
+	const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+	const auto thermal_energy = E - kinetic_energy;
+	const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
+	return P;
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto
-HydroSystem<problem_t>::ComputeVelocityX1(
-    amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
-    -> amrex::Real {
-    amrex::Real const rho = cons(i, j, k, density_index);
-    amrex::Real const vel_x = cons(i, j, k, x1Momentum_index) / rho;
-    return vel_x;
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputeVelocityX1(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+    -> amrex::Real
+{
+	amrex::Real const rho = cons(i, j, k, density_index);
+	amrex::Real const vel_x = cons(i, j, k, x1Momentum_index) / rho;
+	return vel_x;
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto
-HydroSystem<problem_t>::ComputeVelocityX2(
-    amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
-    -> amrex::Real {
-    amrex::Real const rho = cons(i, j, k, density_index);
-    amrex::Real const vel_y = cons(i, j, k, x2Momentum_index) / rho;
-    return vel_y;
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputeVelocityX2(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+    -> amrex::Real
+{
+	amrex::Real const rho = cons(i, j, k, density_index);
+	amrex::Real const vel_y = cons(i, j, k, x2Momentum_index) / rho;
+	return vel_y;
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto
-HydroSystem<problem_t>::ComputeVelocityX3(
-    amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
-    -> amrex::Real {
-    amrex::Real const rho = cons(i, j, k, density_index);
-    amrex::Real const vel_z = cons(i, j, k, x3Momentum_index) / rho;
-    return vel_z;
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputeVelocityX3(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+    -> amrex::Real
+{
+	amrex::Real const rho = cons(i, j, k, density_index);
+	amrex::Real const vel_z = cons(i, j, k, x3Momentum_index) / rho;
+	return vel_z;
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(
-    amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> bool {
-  // check if cons(i, j, k) is a valid state
-  const amrex::Real rho = cons(i, j, k, density_index);
-  bool isDensityPositive = (rho > 0.);
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> bool
+{
+	// check if cons(i, j, k) is a valid state
+	const amrex::Real rho = cons(i, j, k, density_index);
+	bool isDensityPositive = (rho > 0.);
 
-  // when the dual energy method is used, we *cannot* reset on pressure
-  // failures. on the other hand, we don't need to -- the auxiliary internal
-  // energy is used instead!
+	// when the dual energy method is used, we *cannot* reset on pressure
+	// failures. on the other hand, we don't need to -- the auxiliary internal
+	// energy is used instead!
 #if 0
   bool isPressurePositive = false;
   if constexpr (!is_eos_isothermal()) {
@@ -395,269 +361,257 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(
     isPressurePositive = true;
   }
 #endif
-  // return (isDensityPositive && isPressurePositive);
+	// return (isDensityPositive && isPressurePositive);
 
-  return isDensityPositive;
+	return isDensityPositive;
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::ComputeRhsFromFluxes(
-    amrex::MultiFab &rhs_mf,
-    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-    const int nvars)
+void HydroSystem<problem_t>::ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
+						  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars)
 {
-  // compute the total right-hand-side for the MOL integration
+	// compute the total right-hand-side for the MOL integration
 
-  // By convention, the fluxes are defined on the left edge of each zone,
-  // i.e. flux_(i) is the flux *into* zone i through the interface on the
-  // left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
-  // the interface on the right of zone i.
+	// By convention, the fluxes are defined on the left edge of each zone,
+	// i.e. flux_(i) is the flux *into* zone i through the interface on the
+	// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
+	// the interface on the right of zone i.
 
-  auto const x1Flux = fluxArray[0].const_arrays();
+	auto const x1Flux = fluxArray[0].const_arrays();
 #if AMREX_SPACEDIM >= 2
-  auto const x2Flux = fluxArray[1].const_arrays();
+	auto const x2Flux = fluxArray[1].const_arrays();
 #endif
 #if AMREX_SPACEDIM == 3
-  auto const x3Flux = fluxArray[2].const_arrays();
+	auto const x3Flux = fluxArray[2].const_arrays();
 #endif
-  auto rhs = rhs_mf.arrays();
+	auto rhs = rhs_mf.arrays();
 
-  amrex::ParallelFor(rhs_mf, amrex::IntVect{0}, nvars, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
-	  rhs[bx](i, j, k, n) = AMREX_D_TERM((1.0 / dx[0]) * (x1Flux[bx](i, j, k, n) - x1Flux[bx](i + 1, j, k, n)),
-					     +(1.0 / dx[1]) * (x2Flux[bx](i, j, k, n) - x2Flux[bx](i, j + 1, k, n)),
-					     +(1.0 / dx[2]) * (x3Flux[bx](i, j, k, n) - x3Flux[bx](i, j, k + 1, n)));
-  });
+	amrex::ParallelFor(rhs_mf, amrex::IntVect{0}, nvars, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
+		rhs[bx](i, j, k, n) = AMREX_D_TERM((1.0 / dx[0]) * (x1Flux[bx](i, j, k, n) - x1Flux[bx](i + 1, j, k, n)),
+						   +(1.0 / dx[1]) * (x2Flux[bx](i, j, k, n) - x2Flux[bx](i, j + 1, k, n)),
+						   +(1.0 / dx[2]) * (x3Flux[bx](i, j, k, n) - x3Flux[bx](i, j, k + 1, n)));
+	});
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::PredictStep(
-    amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf, amrex::MultiFab const &rhs_mf,
-    const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf) {
-  BL_PROFILE("HydroSystem::PredictStep()");
+void HydroSystem<problem_t>::PredictStep(amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf, amrex::MultiFab const &rhs_mf, const double dt,
+					 const int nvars, amrex::iMultiFab &redoFlag_mf)
+{
+	BL_PROFILE("HydroSystem::PredictStep()");
 
-  auto const &consVarOld = consVarOld_mf.const_arrays();
-  auto const &rhs = rhs_mf.const_arrays();
-  auto consVarNew = consVarNew_mf.arrays();
-  auto redoFlag = redoFlag_mf.arrays();
+	auto const &consVarOld = consVarOld_mf.const_arrays();
+	auto const &rhs = rhs_mf.const_arrays();
+	auto consVarNew = consVarNew_mf.arrays();
+	auto redoFlag = redoFlag_mf.arrays();
 
-  amrex::ParallelFor(
-      consVarNew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-        for (int n = 0; n < nvars; ++n) {
-          consVarNew[bx](i, j, k, n) = consVarOld[bx](i, j, k, n) + dt * rhs[bx](i, j, k, n);
-        }
-        // check if state is valid -- flag for re-do if not
-        if (!isStateValid(consVarNew[bx], i, j, k)) {
-          redoFlag[bx](i, j, k) = quokka::redoFlag::redo;
-        } else {
-          redoFlag[bx](i, j, k) = quokka::redoFlag::none;
-        }
-      });
+	amrex::ParallelFor(consVarNew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		for (int n = 0; n < nvars; ++n) {
+			consVarNew[bx](i, j, k, n) = consVarOld[bx](i, j, k, n) + dt * rhs[bx](i, j, k, n);
+		}
+		// check if state is valid -- flag for re-do if not
+		if (!isStateValid(consVarNew[bx], i, j, k)) {
+			redoFlag[bx](i, j, k) = quokka::redoFlag::redo;
+		} else {
+			redoFlag[bx](i, j, k) = quokka::redoFlag::none;
+		}
+	});
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::AddFluxesRK2(
-    amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
-    const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf) {
-  BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
+void HydroSystem<problem_t>::AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
+					  const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf)
+{
+	BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
 
-  auto const &U0 = U0_mf.const_arrays();
-  auto const &U1 = U1_mf.const_arrays();
-  auto const &rhs = rhs_mf.const_arrays();
-  auto U_new = Unew_mf.arrays();
-  auto redoFlag = redoFlag_mf.arrays();
+	auto const &U0 = U0_mf.const_arrays();
+	auto const &U1 = U1_mf.const_arrays();
+	auto const &rhs = rhs_mf.const_arrays();
+	auto U_new = Unew_mf.arrays();
+	auto redoFlag = redoFlag_mf.arrays();
 
-  amrex::ParallelFor(
-      Unew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-        for (int n = 0; n < nvars; ++n) {
-          // RK-SSP2 integrator
-          const double U_0 = U0[bx](i, j, k, n);
-          const double U_1 = U1[bx](i, j, k, n);
-          const double FU = dt * rhs[bx](i, j, k, n);
+	amrex::ParallelFor(Unew_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		for (int n = 0; n < nvars; ++n) {
+			// RK-SSP2 integrator
+			const double U_0 = U0[bx](i, j, k, n);
+			const double U_1 = U1[bx](i, j, k, n);
+			const double FU = dt * rhs[bx](i, j, k, n);
 
-          // save results in U_new
-          U_new[bx](i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + 0.5 * FU;
-        }
+			// save results in U_new
+			U_new[bx](i, j, k, n) = (0.5 * U_0 + 0.5 * U_1) + 0.5 * FU;
+		}
 
-        // check if state is valid -- flag for re-do if not
-        if (!isStateValid(U_new[bx], i, j, k)) {
-          redoFlag[bx](i, j, k) = quokka::redoFlag::redo;
-        } else {
-          redoFlag[bx](i, j, k) = quokka::redoFlag::none;
-        }
-      });
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
-void HydroSystem<problem_t>::ComputeFlatteningCoefficients(
-    amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, const int nghost) {
-  // compute the PPM shock flattening coefficient following
-  //   Appendix B1 of Mignone+ 2005 [this description has typos].
-  // Method originally from Miller & Colella,
-  //   Journal of Computational Physics 183, 26–82 (2002) [no typos].
-
-  constexpr double beta_max = 0.85;
-  constexpr double beta_min = 0.75;
-  constexpr double Zmax = 0.75;
-  constexpr double Zmin = 0.25;
-
-  auto const &primVar_in = primVar_mf.const_arrays();
-  auto x1Chi_in = x1Chi_mf.arrays();
-  amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
-
-  // cell-centered kernel
-  amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
-	  quokka::Array4View<const amrex::Real, DIR> primVar(primVar_in[bx]);
-	  quokka::Array4View<amrex::Real, DIR> x1Chi(x1Chi_in[bx]);
-	  auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
-
-	  amrex::Real Pplus2 = primVar(i + 2, j, k, pressure_index);
-	  amrex::Real Pplus1 = primVar(i + 1, j, k, pressure_index);
-	  amrex::Real P = primVar(i, j, k, pressure_index);
-	  amrex::Real Pminus1 = primVar(i - 1, j, k, pressure_index);
-	  amrex::Real Pminus2 = primVar(i - 2, j, k, pressure_index);
-
-	  if constexpr (reconstruct_eint) {
-		  // compute (rho e) (gamma - 1)
-		  Pplus2 *= primVar(i + 2, j, k, primDensity_index) * (gamma_ - 1.0);
-		  Pplus1 *= primVar(i + 1, j, k, primDensity_index) * (gamma_ - 1.0);
-		  P *= primVar(i, j, k, primDensity_index) * (gamma_ - 1.0);
-		  Pminus1 *= primVar(i - 1, j, k, primDensity_index) * (gamma_ - 1.0);
-		  Pminus2 *= primVar(i - 2, j, k, primDensity_index) * (gamma_ - 1.0);
-	  }
-
-	  if constexpr (is_eos_isothermal()) {
-		  const amrex::Real cs_sq = cs_iso_ * cs_iso_;
-		  Pplus2 = primVar(i + 2, j, k, primDensity_index) * cs_sq;
-		  Pplus1 = primVar(i + 1, j, k, primDensity_index) * cs_sq;
-		  P = primVar(i, j, k, primDensity_index) * cs_sq;
-		  Pminus1 = primVar(i - 1, j, k, primDensity_index) * cs_sq;
-		  Pminus2 = primVar(i - 2, j, k, primDensity_index) * cs_sq;
-	  }
-
-	  // beta is a measure of shock resolution (Eq. 74 of Miller & Colella 2002)
-	  // Miller & Collela note: "If beta is 1/2, then pressure is linear across
-	  //   four computational cells. If beta is small enough, then we assume that
-	  //   any discontinuity is already sufficiently well resolved that additional
-	  //   dissipation (flattening) is not required."
-	  const double beta_denom = std::abs(Pplus2 - Pminus2);
-	  // avoid division by zero (in this case, chi = 1 anyway)
-	  const double beta = (beta_denom != 0) ? (std::abs(Pplus1 - Pminus1) / beta_denom) : 0;
-
-	  // Eq. 75 of Miller & Colella 2002
-	  const double chi_min = std::max(0., std::min(1., (beta_max - beta) / (beta_max - beta_min)));
-
-	  // Z is a measure of shock strength (Eq. 76 of Miller & Colella 2002)
-	  const double K_S = gamma_ * P; // equal to \rho c_s^2
-	  const double Z = std::abs(Pplus1 - Pminus1) / K_S;
-
-	  // check for converging flow along the normal direction DIR (Eq. 77)
-	  int velocity_index = 0;
-	  if constexpr (DIR == FluxDir::X1) {
-		  velocity_index = x1Velocity_index;
-	  } else if constexpr (DIR == FluxDir::X2) {
-		  velocity_index = x2Velocity_index;
-	  } else if constexpr (DIR == FluxDir::X3) {
-		  velocity_index = x3Velocity_index;
-	  }
-	  double chi = 1.0;
-	  if (primVar(i + 1, j, k, velocity_index) < primVar(i - 1, j, k, velocity_index)) {
-		  chi = std::max(chi_min, std::min(1., (Zmax - Z) / (Zmax - Zmin)));
-	  }
-
-	  x1Chi(i, j, k) = chi;
-  });
+		// check if state is valid -- flag for re-do if not
+		if (!isStateValid(U_new[bx], i, j, k)) {
+			redoFlag[bx](i, j, k) = quokka::redoFlag::redo;
+		} else {
+			redoFlag[bx](i, j, k) = quokka::redoFlag::none;
+		}
+	});
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HydroSystem<problem_t>::FlattenShocks(
-    amrex::MultiFab const &q_mf,
-    amrex::MultiFab const &x1Chi_mf,
-    amrex::MultiFab const &x2Chi_mf,
-    amrex::MultiFab const &x3Chi_mf, amrex::MultiFab &x1LeftState_mf,
-    amrex::MultiFab &x1RightState_mf, const int nghost, const int nvars) {
-  // Apply shock flattening based on Miller & Colella (2002)
-  // [This is necessary to get a reasonable solution to the slow-moving
-  // shock problem, and reduces post-shock oscillations in other cases.]
+void HydroSystem<problem_t>::ComputeFlatteningCoefficients(amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, const int nghost)
+{
+	// compute the PPM shock flattening coefficient following
+	//   Appendix B1 of Mignone+ 2005 [this description has typos].
+	// Method originally from Miller & Colella,
+	//   Journal of Computational Physics 183, 26–82 (2002) [no typos].
 
-  auto const &q_in = q_mf.const_arrays();
-  auto const &x1Chi_in = x1Chi_mf.const_arrays();
-  auto const &x2Chi_in = x2Chi_mf.const_arrays();
-  auto const &x3Chi_in = x3Chi_mf.const_arrays();
-  auto x1LeftState_in = x1LeftState_mf.arrays();
-  auto x1RightState_in = x1RightState_mf.arrays();
-  amrex::IntVect ng{AMREX_D_DECL(nghost,nghost,nghost)};
+	constexpr double beta_max = 0.85;
+	constexpr double beta_min = 0.75;
+	constexpr double Zmax = 0.75;
+	constexpr double Zmin = 0.25;
 
-  // cell-centered kernel
-  amrex::ParallelFor(q_mf, ng, nvars,
-      [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) {
-        quokka::Array4View<const amrex::Real, DIR> q(q_in[bx]);
-        quokka::Array4View<amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
-        quokka::Array4View<amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
+	auto const &primVar_in = primVar_mf.const_arrays();
+	auto x1Chi_in = x1Chi_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
 
-        // compute coefficient as the minimum from adjacent cells along *each
-        // axis*
-        //  (Eq. 86 of Miller & Colella 2001; Eq. 78 of Miller & Colella 2002)
-        double chi_ijk = std::min({
-          x1Chi_in[bx](i_in - 1, j_in, k_in), x1Chi_in[bx](i_in, j_in, k_in),
-              x1Chi_in[bx](i_in + 1, j_in, k_in),
+	// cell-centered kernel
+	amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
+		quokka::Array4View<const amrex::Real, DIR> primVar(primVar_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1Chi(x1Chi_in[bx]);
+		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+
+		amrex::Real Pplus2 = primVar(i + 2, j, k, pressure_index);
+		amrex::Real Pplus1 = primVar(i + 1, j, k, pressure_index);
+		amrex::Real P = primVar(i, j, k, pressure_index);
+		amrex::Real Pminus1 = primVar(i - 1, j, k, pressure_index);
+		amrex::Real Pminus2 = primVar(i - 2, j, k, pressure_index);
+
+		if constexpr (reconstruct_eint) {
+			// compute (rho e) (gamma - 1)
+			Pplus2 *= primVar(i + 2, j, k, primDensity_index) * (gamma_ - 1.0);
+			Pplus1 *= primVar(i + 1, j, k, primDensity_index) * (gamma_ - 1.0);
+			P *= primVar(i, j, k, primDensity_index) * (gamma_ - 1.0);
+			Pminus1 *= primVar(i - 1, j, k, primDensity_index) * (gamma_ - 1.0);
+			Pminus2 *= primVar(i - 2, j, k, primDensity_index) * (gamma_ - 1.0);
+		}
+
+		if constexpr (is_eos_isothermal()) {
+			const amrex::Real cs_sq = cs_iso_ * cs_iso_;
+			Pplus2 = primVar(i + 2, j, k, primDensity_index) * cs_sq;
+			Pplus1 = primVar(i + 1, j, k, primDensity_index) * cs_sq;
+			P = primVar(i, j, k, primDensity_index) * cs_sq;
+			Pminus1 = primVar(i - 1, j, k, primDensity_index) * cs_sq;
+			Pminus2 = primVar(i - 2, j, k, primDensity_index) * cs_sq;
+		}
+
+		// beta is a measure of shock resolution (Eq. 74 of Miller & Colella 2002)
+		// Miller & Collela note: "If beta is 1/2, then pressure is linear across
+		//   four computational cells. If beta is small enough, then we assume that
+		//   any discontinuity is already sufficiently well resolved that additional
+		//   dissipation (flattening) is not required."
+		const double beta_denom = std::abs(Pplus2 - Pminus2);
+		// avoid division by zero (in this case, chi = 1 anyway)
+		const double beta = (beta_denom != 0) ? (std::abs(Pplus1 - Pminus1) / beta_denom) : 0;
+
+		// Eq. 75 of Miller & Colella 2002
+		const double chi_min = std::max(0., std::min(1., (beta_max - beta) / (beta_max - beta_min)));
+
+		// Z is a measure of shock strength (Eq. 76 of Miller & Colella 2002)
+		const double K_S = gamma_ * P; // equal to \rho c_s^2
+		const double Z = std::abs(Pplus1 - Pminus1) / K_S;
+
+		// check for converging flow along the normal direction DIR (Eq. 77)
+		int velocity_index = 0;
+		if constexpr (DIR == FluxDir::X1) {
+			velocity_index = x1Velocity_index;
+		} else if constexpr (DIR == FluxDir::X2) {
+			velocity_index = x2Velocity_index;
+		} else if constexpr (DIR == FluxDir::X3) {
+			velocity_index = x3Velocity_index;
+		}
+		double chi = 1.0;
+		if (primVar(i + 1, j, k, velocity_index) < primVar(i - 1, j, k, velocity_index)) {
+			chi = std::max(chi_min, std::min(1., (Zmax - Z) / (Zmax - Zmin)));
+		}
+
+		x1Chi(i, j, k) = chi;
+	});
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::MultiFab const &x1Chi_mf, amrex::MultiFab const &x2Chi_mf,
+					   amrex::MultiFab const &x3Chi_mf, amrex::MultiFab &x1LeftState_mf, amrex::MultiFab &x1RightState_mf, const int nghost,
+					   const int nvars)
+{
+	// Apply shock flattening based on Miller & Colella (2002)
+	// [This is necessary to get a reasonable solution to the slow-moving
+	// shock problem, and reduces post-shock oscillations in other cases.]
+
+	auto const &q_in = q_mf.const_arrays();
+	auto const &x1Chi_in = x1Chi_mf.const_arrays();
+	auto const &x2Chi_in = x2Chi_mf.const_arrays();
+	auto const &x3Chi_in = x3Chi_mf.const_arrays();
+	auto x1LeftState_in = x1LeftState_mf.arrays();
+	auto x1RightState_in = x1RightState_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
+
+	// cell-centered kernel
+	amrex::ParallelFor(q_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) {
+		quokka::Array4View<const amrex::Real, DIR> q(q_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
+
+		// compute coefficient as the minimum from adjacent cells along *each
+		// axis*
+		//  (Eq. 86 of Miller & Colella 2001; Eq. 78 of Miller & Colella 2002)
+		double chi_ijk = std::min({
+			x1Chi_in[bx](i_in - 1, j_in, k_in), x1Chi_in[bx](i_in, j_in, k_in), x1Chi_in[bx](i_in + 1, j_in, k_in),
 #if (AMREX_SPACEDIM >= 2)
-              x2Chi_in[bx](i_in, j_in - 1, k_in), x2Chi_in[bx](i_in, j_in, k_in),
-              x2Chi_in[bx](i_in, j_in + 1, k_in),
+			    x2Chi_in[bx](i_in, j_in - 1, k_in), x2Chi_in[bx](i_in, j_in, k_in), x2Chi_in[bx](i_in, j_in + 1, k_in),
 #endif
 #if (AMREX_SPACEDIM == 3)
-              x3Chi_in[bx](i_in, j_in, k_in - 1), x3Chi_in[bx](i_in, j_in, k_in),
-              x3Chi_in[bx](i_in, j_in, k_in + 1),
+			    x3Chi_in[bx](i_in, j_in, k_in - 1), x3Chi_in[bx](i_in, j_in, k_in), x3Chi_in[bx](i_in, j_in, k_in + 1),
 #endif
-        });
+		});
 
-        auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
-        // get interfaces
-        const double a_minus = x1RightState(i, j, k, n);
-        const double a_plus = x1LeftState(i + 1, j, k, n);
-        const double a_mean = q(i, j, k, n);
+		// get interfaces
+		const double a_minus = x1RightState(i, j, k, n);
+		const double a_plus = x1LeftState(i + 1, j, k, n);
+		const double a_mean = q(i, j, k, n);
 
-        // left side of zone i (Eq. 70a)
-        const double new_a_minus = chi_ijk * a_minus + (1. - chi_ijk) * a_mean;
+		// left side of zone i (Eq. 70a)
+		const double new_a_minus = chi_ijk * a_minus + (1. - chi_ijk) * a_mean;
 
-        // right side of zone i (Eq. 70b)
-        const double new_a_plus = chi_ijk * a_plus + (1. - chi_ijk) * a_mean;
+		// right side of zone i (Eq. 70b)
+		const double new_a_plus = chi_ijk * a_plus + (1. - chi_ijk) * a_mean;
 
-        x1RightState(i, j, k, n) = new_a_minus;
-        x1LeftState(i + 1, j, k, n) = new_a_plus;
-      });
+		x1RightState(i, j, k, n) = new_a_minus;
+		x1LeftState(i + 1, j, k, n) = new_a_plus;
+	});
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::AddInternalEnergyPdV(
-    amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
-    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
-    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray) {
-  // compute P dV source term for the internal energy equation,
-  // using the face-centered velocities in faceVelArray and the pressure
+void HydroSystem<problem_t>::AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
+						  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+						  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray)
+{
+	// compute P dV source term for the internal energy equation,
+	// using the face-centered velocities in faceVelArray and the pressure
 
-  auto vel_x = faceVelArray[0].const_arrays();
+	auto vel_x = faceVelArray[0].const_arrays();
 #if AMREX_SPACEDIM >= 2
-  auto vel_y = faceVelArray[1].const_arrays();
+	auto vel_y = faceVelArray[1].const_arrays();
 #endif
 #if AMREX_SPACEDIM == 3
-  auto vel_z = faceVelArray[2].const_arrays();
+	auto vel_z = faceVelArray[2].const_arrays();
 #endif
 
-  auto const &consVar = consVar_mf.const_arrays();
-  auto rhs = rhs_mf.arrays();
+	auto const &consVar = consVar_mf.const_arrays();
+	auto rhs = rhs_mf.arrays();
 
-  amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-    // get cell-centered pressure
-    const amrex::Real Pgas = ComputePressure(consVar[bx], i, j, k);
+	amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		// get cell-centered pressure
+		const amrex::Real Pgas = ComputePressure(consVar[bx], i, j, k);
 
-    // compute div v from face-centered velocities
-    amrex::Real div_v = AMREX_D_TERM(  ( vel_x[bx](i+1, j  , k  ) - vel_x[bx](i, j, k) ) / dx[0],
-                                     + ( vel_y[bx](i  , j+1, k  ) - vel_y[bx](i, j, k) ) / dx[1],
-                                     + ( vel_z[bx](i  , j  , k+1) - vel_z[bx](i, j, k) ) / dx[2]  );
+		// compute div v from face-centered velocities
+		amrex::Real div_v = AMREX_D_TERM((vel_x[bx](i + 1, j, k) - vel_x[bx](i, j, k)) / dx[0], +(vel_y[bx](i, j + 1, k) - vel_y[bx](i, j, k)) / dx[1],
+						 +(vel_z[bx](i, j, k + 1) - vel_z[bx](i, j, k)) / dx[2]);
 
 #if 0                
     if (redoFlag(i,j,k) == quokka::redoFlag::none) {
@@ -673,370 +627,227 @@ void HydroSystem<problem_t>::AddInternalEnergyPdV(
     }
 #endif
 
-    // add P dV term to rhs array
-    rhs[bx](i, j, k, internalEnergy_index) += -Pgas * div_v;
-  });
+		// add P dV term to rhs array
+		rhs[bx](i, j, k, internalEnergy_index) += -Pgas * div_v;
+	});
 }
 
-template <typename problem_t>
-void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf) {
-  // sync internal energy and total energy
-  // this step must be done as an operator-split step after *each* RK stage
+template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf)
+{
+	// sync internal energy and total energy
+	// this step must be done as an operator-split step after *each* RK stage
 
-  const amrex::Real eta = 1.0e-3; // dual energy parameter 'eta'
+	const amrex::Real eta = 1.0e-3; // dual energy parameter 'eta'
 
-  auto consVar = consVar_mf.arrays();
+	auto consVar = consVar_mf.arrays();
 
-  amrex::ParallelFor(consVar_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-    amrex::Real const rho = consVar[bx](i, j, k, density_index);
-    amrex::Real const px = consVar[bx](i, j, k, x1Momentum_index);
-    amrex::Real const py = consVar[bx](i, j, k, x2Momentum_index);
-    amrex::Real const pz = consVar[bx](i, j, k, x3Momentum_index);
-    amrex::Real const Etot = consVar[bx](i, j, k, energy_index);
-    amrex::Real const Eint_aux = consVar[bx](i, j, k, internalEnergy_index);
+	amrex::ParallelFor(consVar_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		amrex::Real const rho = consVar[bx](i, j, k, density_index);
+		amrex::Real const px = consVar[bx](i, j, k, x1Momentum_index);
+		amrex::Real const py = consVar[bx](i, j, k, x2Momentum_index);
+		amrex::Real const pz = consVar[bx](i, j, k, x3Momentum_index);
+		amrex::Real const Etot = consVar[bx](i, j, k, energy_index);
+		amrex::Real const Eint_aux = consVar[bx](i, j, k, internalEnergy_index);
 
-    // abort if density is negative (can't compute kinetic energy)
-    if (rho <= 0.) {
-      amrex::Abort("density is negative in SyncDualEnergy! abort!!");
-    }
+		// abort if density is negative (can't compute kinetic energy)
+		if (rho <= 0.) {
+			amrex::Abort("density is negative in SyncDualEnergy! abort!!");
+		}
 
-    amrex::Real const Ekin = (px * px + py * py + pz * pz) / (2.0 * rho);
-    amrex::Real const Eint_cons = Etot - Ekin;
+		amrex::Real const Ekin = (px * px + py * py + pz * pz) / (2.0 * rho);
+		amrex::Real const Eint_cons = Etot - Ekin;
 
-    // Li et al. sync method
-    // replace Eint with Eint_cons == (Etot - Ekin) if (Eint_cons / E) > eta
-    if (Eint_cons > eta * Etot) {
-      consVar[bx](i, j, k, internalEnergy_index) = Eint_cons;
-    } else { // non-conservative sync
-      consVar[bx](i, j, k, internalEnergy_index) = Eint_aux;
-      consVar[bx](i, j, k, energy_index) = Eint_aux + Ekin;
-    }
-  });
+		// Li et al. sync method
+		// replace Eint with Eint_cons == (Etot - Ekin) if (Eint_cons / E) > eta
+		if (Eint_cons > eta * Etot) {
+			consVar[bx](i, j, k, internalEnergy_index) = Eint_cons;
+		} else { // non-conservative sync
+			consVar[bx](i, j, k, internalEnergy_index) = Eint_aux;
+			consVar[bx](i, j, k, energy_index) = Eint_aux + Ekin;
+		}
+	});
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf,
-    amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf,
-    amrex::MultiFab const &primVar_mf) {
+void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf)
+{
 
-  // By convention, the interfaces are defined on the left edge of each
-  // zone, i.e. xinterface_(i) is the solution to the Riemann problem at
-  // the left edge of zone i.
+	// By convention, the interfaces are defined on the left edge of each
+	// zone, i.e. xinterface_(i) is the solution to the Riemann problem at
+	// the left edge of zone i.
 
-  // Indexing note: There are (nx + 1) interfaces for nx zones.
+	// Indexing note: There are (nx + 1) interfaces for nx zones.
 
-  auto const &x1LeftState_in = x1LeftState_mf.const_arrays();
-  auto const &x1RightState_in = x1RightState_mf.const_arrays();
-  auto const &primVar_in = primVar_mf.const_arrays();
-  auto x1Flux_in = x1Flux_mf.arrays();
-  auto x1FaceVel_in = x1FaceVel_mf.arrays();
+	auto const &x1LeftState_in = x1LeftState_mf.const_arrays();
+	auto const &x1RightState_in = x1RightState_mf.const_arrays();
+	auto const &primVar_in = primVar_mf.const_arrays();
+	auto x1Flux_in = x1Flux_mf.arrays();
+	auto x1FaceVel_in = x1FaceVel_mf.arrays();
 
-  amrex::ParallelFor(x1Flux_mf, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
-    quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
-    quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
-    quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
-    quokka::Array4View<amrex::Real, DIR> x1FaceVel(x1FaceVel_in[bx]);
-    quokka::Array4View<const amrex::Real, DIR> q(primVar_in[bx]);
+	amrex::ParallelFor(x1Flux_mf, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
+		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
+		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1FaceVel(x1FaceVel_in[bx]);
+		quokka::Array4View<const amrex::Real, DIR> q(primVar_in[bx]);
 
-    auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
-    // HLLC solver following Toro (1998) and Balsara (2017).
-    // [Carbuncle correction:
-    //  Minoshima & Miyoshi, "A low-dissipation HLLD approximate Riemann solver
-    //  	for a very wide range of Mach numbers," JCP (2021).]
+		// gather left- and right- state variables
 
-    // gather left- and right- state variables
+		const double rho_L = x1LeftState(i, j, k, primDensity_index);
+		const double rho_R = x1RightState(i, j, k, primDensity_index);
 
-    const double rho_L = x1LeftState(i, j, k, primDensity_index);
-    const double rho_R = x1RightState(i, j, k, primDensity_index);
+		const double vx_L = x1LeftState(i, j, k, x1Velocity_index);
+		const double vx_R = x1RightState(i, j, k, x1Velocity_index);
 
-    const double vx_L = x1LeftState(i, j, k, x1Velocity_index);
-    const double vx_R = x1RightState(i, j, k, x1Velocity_index);
+		const double vy_L = x1LeftState(i, j, k, x2Velocity_index);
+		const double vy_R = x1RightState(i, j, k, x2Velocity_index);
 
-    const double vy_L = x1LeftState(i, j, k, x2Velocity_index);
-    const double vy_R = x1RightState(i, j, k, x2Velocity_index);
+		const double vz_L = x1LeftState(i, j, k, x3Velocity_index);
+		const double vz_R = x1RightState(i, j, k, x3Velocity_index);
 
-    const double vz_L = x1LeftState(i, j, k, x3Velocity_index);
-    const double vz_R = x1RightState(i, j, k, x3Velocity_index);
+		const double ke_L = 0.5 * rho_L * (vx_L * vx_L + vy_L * vy_L + vz_L * vz_L);
+		const double ke_R = 0.5 * rho_R * (vx_R * vx_R + vy_R * vy_R + vz_R * vz_R);
 
-    const double ke_L = 0.5 * rho_L * (vx_L * vx_L + vy_L * vy_L + vz_L * vz_L);
-    const double ke_R = 0.5 * rho_R * (vx_R * vx_R + vy_R * vy_R + vz_R * vz_R);
+		// auxiliary Eint (rho * e)
+		// this is evolved as a passive scalar by the Riemann solver
+		double Eint_L = NAN;
+		double Eint_R = NAN;
 
-    // auxiliary Eint (rho * e)
-    // this is evolved as a passive scalar by the Riemann solver
-    double Eint_L = NAN;
-    double Eint_R = NAN;
+		double P_L = NAN;
+		double P_R = NAN;
 
-    double P_L = NAN;
-    double P_R = NAN;
+		double E_L = NAN;
+		double E_R = NAN;
 
-    double E_L = NAN;
-    double E_R = NAN;
+		double cs_L = NAN;
+		double cs_R = NAN;
 
-    double cs_L = NAN;
-    double cs_R = NAN;
+		if constexpr (is_eos_isothermal()) {
+			P_L = rho_L * (cs_iso_ * cs_iso_);
+			P_R = rho_R * (cs_iso_ * cs_iso_);
 
-    if constexpr (is_eos_isothermal()) {
-      P_L = rho_L * (cs_iso_ * cs_iso_);
-      P_R = rho_R * (cs_iso_ * cs_iso_);
+			cs_L = cs_iso_;
+			cs_R = cs_iso_;
+		} else {
+			if constexpr (reconstruct_eint) {
+				// compute pressure from specific internal energy
+				// (pressure_index is actually eint)
+				const double eint_L = x1LeftState(i, j, k, pressure_index);
+				const double eint_R = x1RightState(i, j, k, pressure_index);
+				P_L = rho_L * eint_L * (gamma_ - 1.0);
+				P_R = rho_R * eint_R * (gamma_ - 1.0);
 
-      cs_L = cs_iso_;
-      cs_R = cs_iso_;
-    } else {
-      if constexpr (reconstruct_eint) {
-        // compute pressure from specific internal energy
-        // (pressure_index is actually eint)
-        const double eint_L = x1LeftState(i, j, k, pressure_index);
-        const double eint_R = x1RightState(i, j, k, pressure_index);
-        P_L = rho_L * eint_L * (gamma_ - 1.0);
-        P_R = rho_R * eint_R * (gamma_ - 1.0);
+				// auxiliary Eint is actually (auxiliary) specific internal energy
+				Eint_L = rho_L * x1LeftState(i, j, k, primEint_index);
+				Eint_R = rho_R * x1RightState(i, j, k, primEint_index);
+			} else {
+				// pressure_index is actually pressure
+				P_L = x1LeftState(i, j, k, pressure_index);
+				P_R = x1RightState(i, j, k, pressure_index);
 
-        // auxiliary Eint is actually (auxiliary) specific internal energy
-        Eint_L = rho_L * x1LeftState(i, j, k, primEint_index);
-        Eint_R = rho_R * x1RightState(i, j, k, primEint_index);
-      } else {
-        // pressure_index is actually pressure
-        P_L = x1LeftState(i, j, k, pressure_index);
-        P_R = x1RightState(i, j, k, pressure_index);
+				// primEint_index is actually (rho * e)
+				Eint_L = x1LeftState(i, j, k, primEint_index);
+				Eint_R = x1RightState(i, j, k, primEint_index);
+			}
 
-        // primEint_index is actually (rho * e)
-        Eint_L = x1LeftState(i, j, k, primEint_index);
-        Eint_R = x1RightState(i, j, k, primEint_index);
-      }
+			cs_L = std::sqrt(gamma_ * P_L / rho_L);
+			cs_R = std::sqrt(gamma_ * P_R / rho_R);
 
-      cs_L = std::sqrt(gamma_ * P_L / rho_L);
-      cs_R = std::sqrt(gamma_ * P_R / rho_R);
+			E_L = P_L / (gamma_ - 1.0) + ke_L;
+			E_R = P_R / (gamma_ - 1.0) + ke_R;
+		}
 
-      E_L = P_L / (gamma_ - 1.0) + ke_L;
-      E_R = P_R / (gamma_ - 1.0) + ke_R;
-    }
+		AMREX_ASSERT(cs_L > 0.0);
+		AMREX_ASSERT(cs_R > 0.0);
 
-    AMREX_ASSERT(cs_L > 0.0);
-    AMREX_ASSERT(cs_R > 0.0);
+		// assign normal component of velocity according to DIR
 
-    // assign normal component of velocity according to DIR
+		double u_L = NAN;
+		double u_R = NAN;
+		int velN_index = x1Velocity_index;
+		int velV_index = x2Velocity_index;
+		int velW_index = x3Velocity_index;
 
-    double u_L = NAN;
-    double u_R = NAN;
-    int velN_index = x1Velocity_index;
-    int velV_index = x2Velocity_index;
-    int velW_index = x3Velocity_index;
+		if constexpr (DIR == FluxDir::X1) {
+			u_L = vx_L;
+			u_R = vx_R;
+			velN_index = x1Velocity_index;
+			velV_index = x2Velocity_index;
+			velW_index = x3Velocity_index;
+		} else if constexpr (DIR == FluxDir::X2) {
+			u_L = vy_L;
+			u_R = vy_R;
+			if constexpr (AMREX_SPACEDIM == 2) {
+				velN_index = x2Velocity_index;
+				velV_index = x1Velocity_index;
+				velW_index = x3Velocity_index; // unchanged in 2D
+			} else if constexpr (AMREX_SPACEDIM == 3) {
+				velN_index = x2Velocity_index;
+				velV_index = x3Velocity_index;
+				velW_index = x1Velocity_index;
+			}
+		} else if constexpr (DIR == FluxDir::X3) {
+			u_L = vz_L;
+			u_R = vz_R;
+			velN_index = x3Velocity_index;
+			velV_index = x1Velocity_index;
+			velW_index = x2Velocity_index;
+		}
 
-    if constexpr (DIR == FluxDir::X1) {
-      u_L = vx_L;
-      u_R = vx_R;
-      velN_index = x1Velocity_index;
-      velV_index = x2Velocity_index;
-      velW_index = x3Velocity_index;
-    } else if constexpr (DIR == FluxDir::X2) {
-      u_L = vy_L;
-      u_R = vy_R;
-      if constexpr (AMREX_SPACEDIM == 2) {
-        velN_index = x2Velocity_index;
-        velV_index = x1Velocity_index;
-        velW_index = x3Velocity_index; // unchanged in 2D
-      } else if constexpr (AMREX_SPACEDIM == 3) {
-        velN_index = x2Velocity_index;
-        velV_index = x3Velocity_index;
-        velW_index = x1Velocity_index;
-      }
-    } else if constexpr (DIR == FluxDir::X3) {
-      u_L = vz_L;
-      u_R = vz_R;
-      velN_index = x3Velocity_index;
-      velV_index = x1Velocity_index;
-      velW_index = x2Velocity_index;
-    }
+		quokka::HydroState<nscalars_> sL{};
+		sL.rho = rho_L;
+		sL.vx = vx_L;
+		sL.vy = vy_L;
+		sL.P = P_L;
+		sL.u = u_L;
+		sL.cs = cs_L;
+		sL.E = E_L;
+		sL.Eint = Eint_L;
 
-    // compute PVRS states (Toro 10.5.2)
+		quokka::HydroState<nscalars_> sR{};
+		sR.rho = rho_R;
+		sR.vx = vx_R;
+		sR.vy = vy_L;
+		sR.vz = vz_R;
+		sR.P = P_R;
+		sR.u = u_R;
+		sR.cs = cs_R;
+		sR.E = E_R;
+		sR.Eint = Eint_R;
 
-    const double rho_bar = 0.5 * (rho_L + rho_R);
-    const double cs_bar = 0.5 * (cs_L + cs_R);
-    const double P_PVRS = 0.5 * (P_L + P_R) - 0.5 * (u_R - u_L) * (rho_bar * cs_bar);
+		// The remaining components are passive scalars, so just copy them from
+		// x1LeftState and x1RightState into the (left, right) state vectors U_L and
+		// U_R
+		for (int n = 0; n < nscalars_; ++n) {
+			sL.scalar[n] = x1LeftState(i, j, k, scalar0_index + n);
+			sR.scalar[n] = x1RightState(i, j, k, scalar0_index + n);
+		}
 
-    // choose P_star adaptively (Fig. 9.4 of Toro)
+		const amrex::Dim3 cell_idx{i, j, k};
+		constexpr int fluxdim = nvar_; // including passive scalar components
+		quokka::valarray<double, fluxdim> F =
+		    quokka::Riemann::HLLC<DIR, nscalars_, fluxdim>(sL, sR, gamma_, q, cell_idx, AMREX_D_DECL(velN_index, velV_index, velW_index));
 
-    const double P_min = std::min(P_L, P_R);
-    const double P_max = std::max(P_L, P_R);
-    const double Q = P_max / P_min;
-    constexpr double Q_crit = 2.;
-    double P_star = NAN;
+		// set energy fluxes to zero if EOS is isothermal
+		if constexpr (HydroSystem<problem_t>::is_eos_isothermal()) {
+			F[energy_index] = 0;
+			F[internalEnergy_index] = 0;
+		}
 
-    if constexpr (is_eos_isothermal()) {
-      P_star = std::max(P_PVRS, 0.0);  // only estimate compatible with gamma = 1
-      } else { // gamma > 1
-      if ((Q < Q_crit) && (P_min < P_PVRS) && (P_PVRS < P_max)) {
-        // use PVRS estimate
-        P_star = P_PVRS;
-      } else if (P_PVRS < P_min) {
-        // compute two-rarefaction TRRS states (Toro 10.5.2, eq. 10.63)
-        const double z = (gamma_ - 1.) / (2. * gamma_);
-        const double P_TRRS = std::pow( (cs_L + cs_R - 0.5 * (gamma_ - 1.) * (u_R - u_L) ) /
-                                ( cs_L / std::pow(P_L, z) + cs_R / std::pow(P_R, z) ),
-                                (1. / z));
-        P_star = P_TRRS;
-      } else {
-        // compute two-shock TSRS states (Toro 10.5.2, eq. 10.65)
-        const double A_L = 2. / ( (gamma_ + 1.) * rho_L );
-        const double A_R = 2. / ( (gamma_ + 1.) * rho_R );
-        const double B_L = ((gamma_ - 1.) / (gamma_ + 1.)) * P_L;
-        const double B_R = ((gamma_ - 1.) / (gamma_ + 1.)) * P_R;
-        const double P_0 = std::max(P_PVRS, 0.0);
-        const double G_L = std::sqrt( A_L / ( P_0 + B_L ) );
-        const double G_R = std::sqrt( A_R / ( P_0 + B_R ) );
-        const double delta_u = u_R - u_L;
-        const double P_TSRS = ( G_L * P_L + G_R * P_R - delta_u ) / ( G_L + G_R );
-        P_star = P_TSRS;
-      }
-    }
+		// compute face-centered normal velocity
+		const double v_norm = (F[density_index] >= 0.) ? (F[density_index] / rho_R) : (F[density_index] / rho_L);
+		x1FaceVel(i, j, k) = v_norm;
 
-    // compute wave speeds
-
-    const double q_L = (P_star <= P_L)
-                           ? 1.0
-                           : std::sqrt(1.0 + ((gamma_ + 1.0) / (2.0 * gamma_)) *
-                                                 ((P_star / P_L) - 1.0));
-
-    const double q_R = (P_star <= P_R)
-                           ? 1.0
-                           : std::sqrt(1.0 + ((gamma_ + 1.0) / (2.0 * gamma_)) *
-                                                 ((P_star / P_R) - 1.0));
-
-    double S_L = u_L - q_L * cs_L;
-    double S_R = u_R + q_R * cs_R;
-
-    // carbuncle correction [Eq. 10 of Minoshima & Miyoshi (2021)]
-    const double cs_max = std::max(cs_L, cs_R);
-    // difference in normal velocity along normal axis
-    const double du = q(i, j, k, velN_index) - q(i - 1, j, k, velN_index);
-    // difference in transverse velocity
-#if AMREX_SPACEDIM == 1
-    const double dw = 0.;
-#else
-    amrex::Real dvl = std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index),
-                 q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
-    amrex::Real dvr = std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index),
-                 q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
-    double dw = std::min(dvl, dvr);
-#endif
-#if AMREX_SPACEDIM == 3
-    amrex::Real dwl =
-        std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index),
-                 q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
-    amrex::Real dwr =
-        std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index),
-                 q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
-    dw = std::min(std::min(dwl, dwr), dw);
-#endif
-    const double tp =
-        std::min(1., (cs_max - std::min(du, 0.)) / (cs_max - std::min(dw, 0.)));
-    const double theta = tp * tp * tp * tp;
-
-    const double S_star = (theta * (P_R - P_L) + (rho_L * u_L * (S_L - u_L) -
-                                                  rho_R * u_R * (S_R - u_R))) /
-                          (rho_L * (S_L - u_L) - rho_R * (S_R - u_R));
-
-    // Low-dissipation pressure correction 'phi' [Eq. 23 of Minoshima & Miyoshi]
-    const double vmag_L = std::sqrt(vx_L * vx_L + vy_L * vy_L + vz_L * vz_L);
-    const double vmag_R = std::sqrt(vx_R * vx_R + vy_R * vy_R + vz_R * vz_R);
-    const double chi = std::min(1., std::max(vmag_L, vmag_R) / cs_max);
-    const double phi = chi * (2. - chi);
-
-    const double P_LR =
-        0.5 * (P_L + P_R) + 0.5 * phi *
-                                (rho_L * (S_L - u_L) * (S_star - u_L) +
-                                 rho_R * (S_R - u_R) * (S_star - u_R));
-
-    /// compute fluxes
-
-    constexpr int fluxdim = nvar_; // including passive scalar components
-
-    quokka::valarray<double, fluxdim> D_L{};
-    quokka::valarray<double, fluxdim> D_R{};
-    quokka::valarray<double, fluxdim> D_star{};
-
-    // N.B.: quokka::valarray is written to allow assigning <= fluxdim
-    // components, so this works even if there are more components than
-    // enumerated in the initializer list. The remaining components are
-    // assigned a default value of zero.
-    if constexpr (DIR == FluxDir::X1) {
-      D_L = {0., 1., 0., 0., u_L, 0.};
-      D_R = {0., 1., 0., 0., u_R, 0.};
-      D_star = {0., 1., 0., 0., S_star, 0.};
-    } else if constexpr (DIR == FluxDir::X2) {
-      D_L = {0., 0., 1., 0., u_L, 0.};
-      D_R = {0., 0., 1., 0., u_R, 0.};
-      D_star = {0., 0., 1., 0., S_star, 0.};
-    } else if constexpr (DIR == FluxDir::X3) {
-      D_L = {0., 0., 0., 1., u_L, 0.};
-      D_R = {0., 0., 0., 1., u_R, 0.};
-      D_star = {0., 0., 0., 1., S_star, 0.};
-    }
-
-    const std::initializer_list<double> state_L = {
-        rho_L, rho_L * vx_L, rho_L * vy_L, rho_L * vz_L, E_L, Eint_L};
-
-    const std::initializer_list<double> state_R = {
-        rho_R, rho_R * vx_R, rho_R * vy_R, rho_R * vz_R, E_R, Eint_R};
-
-    AMREX_ASSERT(state_L.size() == state_R.size());
-
-    // N.B.: quokka::valarray is written to allow assigning <= fluxdim
-    // components, so this works even if there are more components than
-    // enumerated in the initializer list. The remaining components are
-    // assigned a default value of zero.
-    quokka::valarray<double, fluxdim> U_L = state_L;
-    quokka::valarray<double, fluxdim> U_R = state_R;
-
-    // The remaining components are passive scalars, so just copy them from
-    // x1LeftState and x1RightState into the (left, right) state vectors U_L and
-    // U_R
-    for (int nc = static_cast<int>(state_L.size()); nc < fluxdim; ++nc) {
-      U_L[nc] = x1LeftState(i, j, k, nc);
-      U_R[nc] = x1RightState(i, j, k, nc);
-    }
-
-    const quokka::valarray<double, fluxdim> F_L = u_L * U_L + P_L * D_L;
-    const quokka::valarray<double, fluxdim> F_R = u_R * U_R + P_R * D_R;
-
-    const quokka::valarray<double, fluxdim> F_starL =
-        (S_star * (S_L * U_L - F_L) + S_L * P_LR * D_star) / (S_L - S_star);
-
-    const quokka::valarray<double, fluxdim> F_starR =
-        (S_star * (S_R * U_R - F_R) + S_R * P_LR * D_star) / (S_R - S_star);
-
-    // open the Riemann fan
-    quokka::valarray<double, fluxdim> F{};
-
-    // HLLC flux
-    if (S_L > 0.0) {
-      F = F_L;
-    } else if ((S_star > 0.0) && (S_L <= 0.0)) {
-      F = F_starL;
-    } else if ((S_star <= 0.0) && (S_R >= 0.0)) {
-      F = F_starR;
-    } else { // S_R < 0.0
-      F = F_R;
-    }
-
-    // set energy fluxes to zero if EOS is isothermal
-    if constexpr (is_eos_isothermal()) {
-      F[energy_index] = 0;
-      F[internalEnergy_index] = 0;
-    }
-
-    // compute face-centered normal velocity
-    const double v_norm = (F[density_index] >= 0.) ? (F[density_index] / rho_R)
-                                                   : (F[density_index] / rho_L);
-    x1FaceVel(i, j, k) = v_norm;
-
-    // copy all flux components to the flux array
-    for (int nc = 0; nc < fluxdim; ++nc) {
-      AMREX_ASSERT(!std::isnan(F[nc])); // check flux is valid
-      x1Flux(i, j, k, nc) = F[nc];
-    }
-  });
+		// copy all flux components to the flux array
+		for (int nc = 0; nc < fluxdim; ++nc) {
+			AMREX_ASSERT(!std::isnan(F[nc])); // check flux is valid
+			x1Flux(i, j, k, nc) = F[nc];
+		}
+	});
 }
 
 #endif // HYDRO_SYSTEM_HPP_

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -802,6 +802,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		sL.rho = rho_L;
 		sL.vx = vx_L;
 		sL.vy = vy_L;
+    sL.vz = vz_L;
 		sL.P = P_L;
 		sL.u = u_L;
 		sL.cs = cs_L;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -812,7 +812,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		quokka::HydroState<nscalars_> sR{};
 		sR.rho = rho_R;
 		sR.vx = vx_R;
-		sR.vy = vy_L;
+		sR.vy = vy_R;
 		sR.vz = vz_R;
 		sR.P = P_R;
 		sR.u = u_R;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -64,7 +64,7 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 		primScalar0_index // first passive scalar (only present if nscalars > 0!)
 	};
 
-	static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost);
+	static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, int nghost);
 
 	static auto maxSignalSpeedLocal(amrex::MultiFab const &cons) -> amrex::Real;
 
@@ -72,7 +72,7 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	static auto CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool;
 
-	static void EnforceDensityFloor(amrex::Real const densityFloor, amrex::MultiFab &state_mf);
+	static void EnforceDensityFloor(amrex::Real densityFloor, amrex::MultiFab &state_mf);
 
 	AMREX_GPU_DEVICE static auto ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
@@ -85,15 +85,15 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 	AMREX_GPU_DEVICE static auto isStateValid(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> bool;
 
 	static void ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fluxArray,
-					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, const int nvars);
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, int nvars);
 
-	static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs, const double dt, const int nvars,
+	static void PredictStep(amrex::MultiFab const &consVarOld, amrex::MultiFab &consVarNew, amrex::MultiFab const &rhs, double dt, int nvars,
 				amrex::iMultiFab &redoFlag_mf);
 
 	static void AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
-				 const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf);
+				  double dt, int nvars, amrex::iMultiFab &redoFlag_mf);
 
-	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx,
+	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray);
 
 	static void SyncDualEnergy(amrex::MultiFab &consVar_mf);
@@ -105,12 +105,12 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 	template <FluxDir DIR>
 	static void ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar, array_t &x1FluxDiffusive, amrex::Box const &indexRange);
 
-	template <FluxDir DIR> static void ComputeFlatteningCoefficients(amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, const int nghost);
+	template <FluxDir DIR> static void ComputeFlatteningCoefficients(amrex::MultiFab const &primVar_mf, amrex::MultiFab &x1Chi_mf, int nghost);
 
 	template <FluxDir DIR>
 	static void FlattenShocks(amrex::MultiFab const &q_mf, amrex::MultiFab const &x1Chi_mf, amrex::MultiFab const &x2Chi_mf,
-				  amrex::MultiFab const &x3Chi_mf, amrex::MultiFab &x1LeftState_mf, amrex::MultiFab &x1RightState_mf, const int nghost,
-				  const int nvars);
+				  amrex::MultiFab const &x3Chi_mf, amrex::MultiFab &x1LeftState_mf, amrex::MultiFab &x1RightState_mf, int nghost,
+				  int nvars);
 
 	// C++ does not allow constexpr to be uninitialized, even in a templated
 	// class!


### PR DESCRIPTION
This moves the implementation of the hydro HLLC Riemann solver into a standalone function `quokka::Riemann::HLLC`. `HydroSystem::ComputeFluxes` is modified to call this function with the interface states.

This will make it easier to add new Riemann solvers in the future.