### PR TITLE
update build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **The Quokka methods paper is now available: https://arxiv.org/abs/2110.01792**
 
-**NOTE: Documentation is still a work in progress. Please see the sections "Quickstart" and "Running on GPUs" below. You can start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support, or open an [Issue](https://github.com/BenWibking/quokka/issues) for any bug reports.**
+**Please see the sections "Quickstart" and "Running on GPUs" below. You can start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support, or open an [Issue](https://github.com/BenWibking/quokka/issues) for any bug reports.**
 
 Quokka is a two-moment radiation hydrodynamics code that uses the piecewise-parabolic method, with AMR and subcycling in time. Runs on CPUs (MPI+vectorized) or NVIDIA GPUs (MPI+CUDA) with a single-source codebase. Written in C++17. (100% Fortran-free.)
 
@@ -85,7 +85,10 @@ Alternatively, you can work around this problem by disabling Python support. Pyt
 to the CMake command-line options (or change the `QUOKKA_PYTHON` option to `OFF` in CMakeLists.txt).
 
 ## Running on GPUs
-By default, Quokka compiles itself to run only on CPUs. If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.7 is required. Quokka is only supported on Volta V100 GPUs or newer models.*)
+By default, Quokka compiles itself to run only on CPUs. Quokka can run on either NVIDIA, AMD, or Intel GPUs. Consult the sub-sections below for the build instructions for a given GPU vendor.
+
+### NVIDIA GPUs
+If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.7 is required. Quokka is only supported on Volta V100 GPUs or newer models.*)
 ```
 cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMREX_GPUS_PER_NODE=N -G Ninja
 ninja -j6
@@ -107,9 +110,11 @@ which should end with output similar to the following:
 Total Test time (real) = 353.77 sec
 ```
 
-**AMD GPUs:** Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Quokka has been tested on MI100 and MI250X GPUs.
+### AMD GPUs
+Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Quokka has been tested on MI100 and MI250X GPUs.
 
-**Intel GPUs:** Not tested.
+### Intel GPUs
+Not tested. Please start a Discussion if you encounter issues on Intel GPUs.
 
 ## Building a specific test problem
 By default, all available test problems will be compiled. If you only want to build a specific problem, you can list all of the available CMake targets:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Quokka also features advanced Adaptive Quokka Refinement:tm: technology:
 
 ![Image of Quokka with Baby in Pouch](extern/quokka2.png)
 
+## Dependencies
+* C++ compiler (with C++17 support)
+* CMake 3.16+
+* MPI library (OpenMPI, MPICH, or Cray MPI)
+* HDF5 1.10+ (serial version)
+* CUDA 11.7+ (optional, for NVIDIA GPUs)
+* ROCm 5.2.0+ (optional, for AMD GPUs)
+* Ninja (optional, for faster builds)
+* Python 3.7+ (optional)
+
 ## Quickstart
 
 To run Quokka, download this repository to your local machine:
@@ -63,6 +73,13 @@ to compile Quokka for 3D problems.
 **By default, Quokka compiles itself *only* for CPUs. If you want to run Quokka on GPUs, see the section "Running on GPUs" below.**
 
 Have fun!
+
+## Building with CMake+`make`
+If you do not want to use Ninja to build, you can instead CMake with `make` as follows:
+```
+cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
+make -j6
+```
 
 ## CMake
 Quokka uses CMake for its build system. If you don't have CMake installed already, you can simply run `python3 -m pip install cmake ninja --user` or use another [installation method](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html). If you are unfamiliar with CMake, [this tutorial](https://hsf-training.github.io/hsf-training-cmake-webpage/) may be useful.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **The Quokka methods paper is now available: https://arxiv.org/abs/2110.01792**
 
-**NOTE: The code documentation is still a work in progress. Please see the Installation Notes below. You can start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support, or open an [Issue](https://github.com/BenWibking/quokka/issues) for any bug reports.**
+**NOTE: Documentation is still a work in progress. Please see the sections "Quickstart" and "Running on GPUs" below. You can start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support, or open an [Issue](https://github.com/BenWibking/quokka/issues) for any bug reports.**
 
 Quokka is a two-moment radiation hydrodynamics code that uses the piecewise-parabolic method, with AMR and subcycling in time. Runs on CPUs (MPI+vectorized) or NVIDIA GPUs (MPI+CUDA) with a single-source codebase. Written in C++17. (100% Fortran-free.)
 
@@ -26,7 +26,7 @@ Quokka also features advanced Adaptive Quokka Refinement:tm: technology:
 
 ![Image of Quokka with Baby in Pouch](extern/quokka2.png)
 
-## Installation Notes
+## Quickstart
 
 To run Quokka, download this repository to your local machine:
 ```
@@ -59,6 +59,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -G Ninja
 ninja -j6
 ```
 to compile Quokka for 3D problems.
+
+**By default, Quokka compiles itself *only* for CPUs. If you want to run Quokka on GPUs, see the section "Running on GPUs" below.**
 
 Have fun!
 

--- a/README.md
+++ b/README.md
@@ -74,15 +74,12 @@ to compile Quokka for 3D problems.
 
 Have fun!
 
-## Building with CMake+`make`
-If you do not want to use Ninja to build, you can instead CMake with `make` as follows:
+## Building with CMake + `make`
+If you are unable to install Ninja, you can instead use CMake with the Makefile generator, which should produce identical results but is slower:
 ```
 cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
 make -j6
 ```
-
-## CMake
-Quokka uses CMake for its build system. If you don't have CMake installed already, you can simply run `python3 -m pip install cmake ninja --user` or use another [installation method](https://cliutils.gitlab.io/modern-cmake/chapters/intro/installing.html). If you are unfamiliar with CMake, [this tutorial](https://hsf-training.github.io/hsf-training-cmake-webpage/) may be useful.
 
 ## Could NOT find Python error
 If CMake prints an error saying that Python could not be found, e.g.:

--- a/README.md
+++ b/README.md
@@ -109,12 +109,11 @@ which should end with output similar to the following:
 
 Total Test time (real) = 353.77 sec
 ```
-
 ### AMD GPUs
 Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Quokka has been tested on MI100 and MI250X GPUs.
 
 ### Intel GPUs
-Not tested. Please start a Discussion if you encounter issues on Intel GPUs.
+Not tested. You can attempt this by compiling with `-DAMReX_GPU_BACKEND=SYCL`. Please start a Discussion if you encounter issues on Intel GPUs.
 
 ## Building a specific test problem
 By default, all available test problems will be compiled. If you only want to build a specific problem, you can list all of the available CMake targets:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Quokka uses CMake (and optionally, Ninja) as its build system. If you don't have
 ```
 python3 -m pip install cmake ninja --user
 ```
-Now that CMake is installed, create a build/ subdirectory and compile Quokka, as shown below.
+Now that CMake is installed, create a `build/` subdirectory and compile Quokka, as shown below.
 ```
 cd quokka
 mkdir build; cd build
@@ -83,18 +83,16 @@ Alternatively, you can work around this problem by disabling Python support. Pyt
 to the CMake command-line options (or change the `QUOKKA_PYTHON` option to `OFF` in CMakeLists.txt).
 
 ## Running on GPUs
-By default, Quokka compiles itself to run only on CPUs. If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (CUDA >= 11.7 is required.)
+By default, Quokka compiles itself to run only on CPUs. If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.7 is required. Quokka is only supported on Volta V100 GPUs or newer models.*)
 ```
 cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMREX_GPUS_PER_NODE=N -G Ninja
 ninja -j6
 ```
 where $N$ is the number of GPUs available per compute node.
 
-It is necessary to use `-DAMREX_GPUS_PER_NODE` to specify the number of GPUs per compute node. Without this, performance will be very poor. All GPUs on a node must be visible from each MPI rank on the node for efficient GPU-aware MPI communication to take place via CUDA IPC. (When using the SLURM job scheduler, this means that `--gpu-bind` should be set to `none`.)
+**It is necessary to use `-DAMREX_GPUS_PER_NODE` to specify the number of GPUs per compute node. Without this, performance will be very poor. All GPUs on a node must be visible from each MPI rank on the node for efficient GPU-aware MPI communication to take place via CUDA IPC.** When using the SLURM job scheduler, this means that `--gpu-bind` should be set to `none`.
 
 The compiled test problems are in the test problem subdirectories in `build/src/`. Example scripts for running Quokka on compute clusters are in the `scripts/` subdirectory.
-
-Quokka is only supported on Volta-class (V100) GPUs or newer.
 
 Note that 1D problems can run very slowly on GPUs due to a lack of sufficient parallelism. To run the test suite in a reasonable amount of time, you may wish to exclude the matter-energy exchange tests, e.g.:
 ```
@@ -109,7 +107,7 @@ Total Test time (real) = 353.77 sec
 
 **AMD GPUs:** Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Quokka has been tested on MI100 and MI250X GPUs.
 
-**Intel GPUs:** (not tested).
+**Intel GPUs:** Not tested.
 
 ## Building a specific test problem
 By default, all available test problems will be compiled. If you only want to build a specific problem, you list all of the available CMake targets:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you are unable to install Ninja, you can instead use CMake with the Makefile 
 ```
 cmake .. -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles"
 make -j6
+make test
 ```
 
 ## Could NOT find Python error

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Total Test time (real) = 353.77 sec
 **Intel GPUs:** Not tested.
 
 ## Building a specific test problem
-By default, all available test problems will be compiled. If you only want to build a specific problem, you list all of the available CMake targets:
+By default, all available test problems will be compiled. If you only want to build a specific problem, you can list all of the available CMake targets:
 ```
 cmake --build . --target help
 ```


### PR DESCRIPTION
Updates build instructions in README.md.

- Using `ninja` to build instead of `make` is recommended.
- Added subsection listing dependencies (including optional dependencies)
- Removed old note about Intel classic compilers being broken.
- Removed old note about CUDA 11.6 being broken.
- Added notes on building for AMD GPUs.
- Added notes on building for Intel GPUs.
- Added notes on building a specific test problem.