### PR TITLE
refactor hydro Riemann solver in canonical form

### DIFF
--- a/src/HydroState.hpp
+++ b/src/HydroState.hpp
@@ -2,18 +2,18 @@
 #define HYDROSTATE_HPP_
 
 #include <array>
+
 namespace quokka
 {
 template <int N> struct HydroState {
 	double rho;		      // density
-	double vx;		      // x-vel
-	double vy;		      // y-vel
-	double vz;		      // z-vel
-	double P;		      // pressure
 	double u;		      // normal velocity component
+	double v;		      // transverse velocity component
+	double w;		      // 2nd transverse velocity component
+	double P;		      // pressure
 	double cs;		      // adiabatic sound speed
 	double E;		      // total energy density
-	double Eint;		      // internal energy density
+	double Eint;		  // internal energy density
 	std::array<double, N> scalar; // passive scalars
 };
 

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -794,7 +794,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		sL.rho = rho_L;
 		sL.u = x1LeftState(i, j, k, velN_index);
 		sL.v = x1LeftState(i, j, k, velV_index);
-    	sL.w = x1LeftState(i, j, k, velW_index);
+		sL.w = x1LeftState(i, j, k, velW_index);
 		sL.P = P_L;
 		sL.cs = cs_L;
 		sL.E = E_L;
@@ -825,9 +825,9 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 #if AMREX_SPACEDIM == 1
 		const double dw = 0.;
 #else
-	  amrex::Real dvl = std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index), q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
-	  amrex::Real dvr = std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index), q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
-	  double dw = std::min(dvl, dvr);
+	  	amrex::Real dvl = std::min(q(i - 1, j + 1, k, velV_index) - q(i - 1, j, k, velV_index), q(i - 1, j, k, velV_index) - q(i - 1, j - 1, k, velV_index));
+	  	amrex::Real dvr = std::min(q(i, j + 1, k, velV_index) - q(i, j, k, velV_index), q(i, j, k, velV_index) - q(i, j - 1, k, velV_index));
+	  	double dw = std::min(dvl, dvr);
 #endif
 #if AMREX_SPACEDIM == 3
 		amrex::Real dwl =


### PR DESCRIPTION
This refactors `HydroSystem::ComputeFluxes` and `quokka::Riemann::HLLC` to be in the canonical form for Riemann solvers, i.e. where the x-momentum is always the normal direction and the y- and z- momenta are transverse to the face being considered.

This requires permuting the state components (and the flux components) inside `ComputeFluxes` but makes the actual Riemann solver itself only need to consider the case where flux is along the x-direction. This will make it easier to write and debug new Riemann solvers. 