### PR TITLE
create EOS and EOS_Traits classes

### DIFF
--- a/src/CloudyCooling.hpp
+++ b/src/CloudyCooling.hpp
@@ -70,7 +70,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cloudy_cooling_function(Real const
 {
 	// interpolate cooling rates from Cloudy tables
 	const Real rhoH = rho * cloudy_H_mass_fraction; // mass density of H species
-	const Real nH = rhoH / hydrogen_mass_cgs_;
+	const Real nH = rhoH / quokka::hydrogen_mass_cgs;
 	const Real log_nH = std::log10(nH);
 	const Real log_T = std::log10(T);
 
@@ -94,7 +94,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cloudy_cooling_function(Real const
 
 	// compute electron density
 	// N.B. it is absolutely critical to include the metal contribution here!
-	double n_e = (rho / hydrogen_mass_cgs_) * (1.0 - mu * (X + Y / 4. + Z / mean_metals_A)) / (mu - (electron_mass_cgs / hydrogen_mass_cgs_));
+	double n_e = (rho / quokka::hydrogen_mass_cgs) * (1.0 - mu * (X + Y / 4. + Z / mean_metals_A)) / (mu - (electron_mass_cgs / quokka::hydrogen_mass_cgs));
 	// the approximation for the metals contribution to e- fails at high densities (~1e3 or higher)
 	n_e = std::max(n_e, 1.0e-4 * nH);
 
@@ -110,7 +110,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cloudy_cooling_function(Real const
 	// Compton term (CMB photons)
 	// [e.g., Hirata 2018: doi:10.1093/mnras/stx2854]
 	constexpr double Gamma_C = (8. * sigma_T * E_cmb) / (3. * electron_mass_cgs * c_light_cgs_);
-	constexpr double C_n = Gamma_C * boltzmann_constant_cgs_ / (5. / 3. - 1.0);
+	constexpr double C_n = Gamma_C * quokka::boltzmann_constant_cgs / (5. / 3. - 1.0);
 	const double compton_CMB = -C_n * (T - T_cmb) * n_e;
 	Edot += compton_CMB;
 
@@ -121,13 +121,13 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeEgasFromTgas(double rho, do
 {
 	// convert Egas (internal gas energy) to temperature
 	const Real rhoH = rho * cloudy_H_mass_fraction;
-	const Real nH = rhoH / hydrogen_mass_cgs_;
+	const Real nH = rhoH / quokka::hydrogen_mass_cgs;
 
 	// compute mu from mu(T) table
 	const Real mu = interpolate2d(std::log10(nH), std::log10(Tgas), tables.log_nH, tables.log_Tgas, tables.meanMolWeight);
 
 	// compute thermal gas energy
-	const Real Egas = (rho / (hydrogen_mass_cgs_ * mu)) * boltzmann_constant_cgs_ * Tgas / (gamma - 1.);
+	const Real Egas = (rho / (quokka::hydrogen_mass_cgs * mu)) * quokka::boltzmann_constant_cgs * Tgas / (gamma - 1.);
 	return Egas;
 }
 
@@ -149,12 +149,12 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeTgasFromEgas(double rho, do
 
 	// solve for temperature given Eint (with fixed adiabatic index gamma)
 	const Real rhoH = rho * cloudy_H_mass_fraction;
-	const Real nH = rhoH / hydrogen_mass_cgs_;
+	const Real nH = rhoH / quokka::hydrogen_mass_cgs;
 	const Real log_nH = std::log10(nH);
 
 	// mean molecular weight (in Grackle tables) is defined w/r/t
 	// hydrogen_mass_cgs_
-	const Real C = (gamma - 1.) * Egas / (boltzmann_constant_cgs_ * (rho / hydrogen_mass_cgs_));
+	const Real C = (gamma - 1.) * Egas / (quokka::boltzmann_constant_cgs * (rho / quokka::hydrogen_mass_cgs));
 
 	// solve for mu(T)*C == T.
 	// (Grackle does this with a fixed-point iteration. We use a more robust

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -32,17 +32,14 @@ using amrex::Real;
 struct CoolingTest {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-constexpr double m_H = hydrogen_mass_cgs_;
+constexpr double m_H = quokka::hydrogen_mass_cgs;
 constexpr double seconds_in_year = 3.154e7;
 
-template <> struct EOS_Traits<CoolingTest> {
+template <> struct quokka::EOS_Traits<CoolingTest> {
 	static constexpr double gamma = 5. / 3.; // default value
-	// if true, reconstruct e_int instead of pressure
 	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
 	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
-}
-;
 
 template <> struct Physics_Traits<CoolingTest> {
 	// cell-centred
@@ -137,7 +134,7 @@ template <> void RadhydroSimulation<CoolingTest>::setInitialConditionsOnGrid(quo
 		Real xmom = 0;
 		Real ymom = 0;
 		Real zmom = 0;
-		Real const P = 4.0e4 * boltzmann_constant_cgs_; // erg cm^-3
+		Real const P = 4.0e4 * quokka::boltzmann_constant_cgs; // erg cm^-3
 		Real Eint = (quokka::EOS_Traits<CoolingTest>::gamma - 1.) * P;
 
 		Real const Egas = RadSystem<CoolingTest>::ComputeEgasFromEint(rho, xmom, ymom, zmom, Eint);

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -39,7 +39,8 @@ template <typename problem_t> class EOS
 	static constexpr amrex::Real mean_molecular_weight_ = EOS_Traits<problem_t>::mean_molecular_weight;
 };
 
-template <typename problem_t> auto EOS<problem_t>::ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real
+template <typename problem_t>
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real
 {
 	// return temperature for an ideal gas
 	amrex::Real Tgas = NAN;
@@ -50,7 +51,8 @@ template <typename problem_t> auto EOS<problem_t>::ComputeTgasFromEint(amrex::Re
 	return Tgas;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real
+template <typename problem_t>
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real
 {
 	// return internal energy density for a gamma-law ideal gas
 	amrex::Real Eint = NAN;
@@ -62,7 +64,7 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::Compute
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDerivative(const amrex::Real rho, const amrex::Real /*Tgas*/) -> amrex::Real
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDerivative(const amrex::Real rho, const amrex::Real /*Tgas*/) -> amrex::Real
 {
 	// compute derivative of internal energy w/r/t temperature
 	amrex::Real dEint_dT = NAN;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -22,7 +22,7 @@ static constexpr double hydrogen_mass_cgs = 1.6726231e-24;     // cgs
 template <typename problem_t> struct EOS_Traits {
 	static constexpr double gamma = 5. / 3.;     // default value
 	static constexpr double cs_isothermal = NAN; // only used when gamma = 1
-	static constexpr double mean_molecular_weight = hydrogen_mass_cgs;
+	static constexpr double mean_molecular_weight = NAN;
 	static constexpr double boltzmann_constant = boltzmann_constant_cgs;
 };
 

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -29,9 +29,9 @@ template <typename problem_t> struct EOS_Traits {
 template <typename problem_t> class EOS
 {
       public:
-	[[nodiscard]] static auto ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real;
-	[[nodiscard]] static auto ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
-	[[nodiscard]] static auto ComputeEintTempDerivative(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
+	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real;
+	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
+	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto ComputeEintTempDerivative(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
 
       private:
 	static constexpr amrex::Real gamma_ = EOS_Traits<problem_t>::gamma;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -1,0 +1,78 @@
+#ifndef EOS_HPP_
+#define EOS_HPP_
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file EOS.hpp
+/// \brief A class for equation of state calculations.
+
+#include <cmath>
+
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_REAL.H"
+
+namespace quokka
+{
+static constexpr double boltzmann_constant_cgs = 1.380658e-16; // cgs
+static constexpr double hydrogen_mass_cgs = 1.6726231e-24;     // cgs
+
+// specify default values for ideal gamma-law EOS
+//
+template <typename problem_t> struct EOS_Traits {
+	static constexpr double gamma = 5. / 3.;     // default value
+	static constexpr double cs_isothermal = NAN; // only used when gamma = 1
+	static constexpr double mean_molecular_weight = hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = boltzmann_constant_cgs;
+};
+
+template <typename problem_t> class EOS
+{
+      public:
+	[[nodiscard]] static auto ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real;
+	[[nodiscard]] static auto ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
+	[[nodiscard]] static auto ComputeEintTempDerivative(amrex::Real rho, amrex::Real Tgas) -> amrex::Real;
+
+      private:
+	static constexpr amrex::Real gamma_ = EOS_Traits<problem_t>::gamma;
+	static constexpr amrex::Real boltzmann_constant_ = EOS_Traits<problem_t>::boltzmann_constant;
+	static constexpr amrex::Real mean_molecular_weight_ = EOS_Traits<problem_t>::mean_molecular_weight;
+};
+
+template <typename problem_t> auto EOS<problem_t>::ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint) -> amrex::Real
+{
+	// return temperature for an ideal gas
+	amrex::Real Tgas = NAN;
+	if constexpr (gamma_ != 1.0) {
+		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		Tgas = Eint / (rho * c_v);
+	}
+	return Tgas;
+}
+
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas) -> amrex::Real
+{
+	// return internal energy density for a gamma-law ideal gas
+	amrex::Real Eint = NAN;
+	if constexpr (gamma_ != 1.0) {
+		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		Eint = rho * c_v * Tgas;
+	}
+	return Eint;
+}
+
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDerivative(const amrex::Real rho, const amrex::Real /*Tgas*/) -> amrex::Real
+{
+	// compute derivative of internal energy w/r/t temperature
+	amrex::Real dEint_dT = NAN;
+	if constexpr (gamma_ != 1.0) {
+		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		dEint_dT = rho * c_v;
+	}
+	return dEint_dT;
+}
+
+} // namespace quokka
+
+#endif // EOS_HPP_

--- a/src/FCQuantities/test_fc_quantities.cpp
+++ b/src/FCQuantities/test_fc_quantities.cpp
@@ -40,10 +40,10 @@ template <> struct Physics_Traits<FCQuantities> {
 	static constexpr bool is_mhd_enabled = true;
 };
 
-constexpr double rho0 = 1.0;				       // background density
-constexpr double P0 = 1.0 / HydroSystem<FCQuantities>::gamma_; // background pressure
-constexpr double v0 = 0.;				       // background velocity
-constexpr double amp = 1.0e-6;				       // perturbation amplitude
+constexpr double rho0 = 1.0;					     // background density
+constexpr double P0 = 1.0 / quokka::EOS_Traits<FCQuantities>::gamma; // background pressure
+constexpr double v0 = 0.;					     // background velocity
+constexpr double amp = 1.0e-6;					     // perturbation amplitude
 
 AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)

--- a/src/FCQuantities/test_fc_quantities.cpp
+++ b/src/FCQuantities/test_fc_quantities.cpp
@@ -25,9 +25,10 @@
 struct FCQuantities {
 };
 
-template <> struct HydroSystem_Traits<FCQuantities> {
+template <> struct quokka::EOS_Traits<FCQuantities> {
 	static constexpr double gamma = 5. / 3.;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<FCQuantities> {
@@ -53,7 +54,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	const amrex::Real A = amp;
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
-	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (HydroSystem<FCQuantities>::gamma_ - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
+	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<FCQuantities>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
 	const quokka::valarray<double, 3> dU = (A * R / (2.0 * M_PI * dx[0])) * (std::cos(2.0 * M_PI * x_L) - std::cos(2.0 * M_PI * x_R));
 
 	double rho = U_0[0] + dU[0];

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -25,9 +25,8 @@
 struct BlastProblem {
 };
 
-template <> struct EOS_Traits<BlastProblem> {
+template <> struct quokka::EOS_Traits<BlastProblem> {
 	static constexpr double gamma = 5. / 3.;
-	static constexpr bool reconstruct_eint = false;
 };
 
 template <> struct Physics_Traits<BlastProblem> {

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -76,7 +76,7 @@ template <> void RadhydroSimulation<BlastProblem>::setInitialConditionsOnGrid(qu
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<BlastProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<BlastProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<BlastProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<BlastProblem>::x1Momentum_index) = rho * vx;

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -25,7 +25,7 @@
 struct BlastProblem {
 };
 
-template <> struct HydroSystem_Traits<BlastProblem> {
+template <> struct EOS_Traits<BlastProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -120,7 +120,7 @@ template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(qu
 		for (int n = 0; n < state_cc.nComp(); ++n) {
 			state_cc(i, j, k, n) = 0.; // zero fill all components
 		}
-		const auto gamma = HydroSystem<SedovProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<SedovProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<SedovProblem>::density_index) = rho_copy;
 		state_cc(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index) = 0;

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -32,7 +32,7 @@ constexpr bool simulate_full_box = false;
 
 bool test_passes = false; // if one of the energy checks fails, set to false
 
-template <> struct HydroSystem_Traits<SedovProblem> {
+template <> struct EOS_Traits<SedovProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -32,8 +32,11 @@ constexpr bool simulate_full_box = false;
 
 bool test_passes = false; // if one of the energy checks fails, set to false
 
-template <> struct EOS_Traits<SedovProblem> {
+template <> struct quokka::EOS_Traits<SedovProblem> {
 	static constexpr double gamma = 1.4;
+};
+
+template <> struct HydroSystem_Traits<SedovProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -21,9 +21,10 @@
 struct ContactProblem {
 };
 
-template <> struct HydroSystem_Traits<ContactProblem> {
+template <> struct quokka::EOS_Traits<ContactProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ContactProblem> {
@@ -145,7 +146,7 @@ void RadhydroSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFa
 				const auto E = val_exact.at(HydroSystem<ContactProblem>::energy_index)[i];
 				const auto vx = xmom / rho;
 				const auto Eint = E - 0.5 * rho * (vx * vx);
-				const auto P = (HydroSystem<ContactProblem>::gamma_ - 1.) * Eint;
+				const auto P = (quokka::EOS_Traits<ContactProblem>::gamma - 1.) * Eint;
 				d_exact.push_back(rho);
 				vx_exact.push_back(vx);
 				P_exact.push_back(P);
@@ -157,7 +158,7 @@ void RadhydroSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFa
 				const auto fE = values.at(HydroSystem<ContactProblem>::energy_index)[i];
 				const auto fvx = fxmom / frho;
 				const auto fEint = fE - 0.5 * frho * (fvx * fvx);
-				const auto fP = (HydroSystem<ContactProblem>::gamma_ - 1.) * fEint;
+				const auto fP = (quokka::EOS_Traits<ContactProblem>::gamma - 1.) * fEint;
 				d_final.push_back(frho);
 				vx_final.push_back(fvx);
 				P_final.push_back(fP);

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -68,7 +68,7 @@ template <> void RadhydroSimulation<ContactProblem>::setInitialConditionsOnGrid(
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		const auto gamma = HydroSystem<ContactProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<ContactProblem>::gamma;
 		for (int n = 0; n < ncomp; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
@@ -110,7 +110,7 @@ void RadhydroSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFa
 				stateExact(i, j, k, n) = 0.;
 			}
 
-			const auto gamma = HydroSystem<ContactProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ContactProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ContactProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ContactProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ContactProblem>::x2Momentum_index) = 0.;

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -64,7 +64,7 @@ template <> void RadhydroSimulation<HighMachProblem>::setInitialConditionsOnGrid
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		const auto gamma = HydroSystem<HighMachProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<HighMachProblem>::gamma;
 		for (int n = 0; n < state_cc.nComp(); ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
@@ -146,7 +146,7 @@ void RadhydroSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiF
 	amrex::Gpu::streamSynchronizeAll();
 
 	// save reference solution
-	const Real gamma = HydroSystem<HighMachProblem>::gamma_;
+	const Real gamma = quokka::EOS_Traits<HighMachProblem>::gamma;
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox(); // excludes ghost zones
 		auto const &state = ref.array(iter);

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -28,9 +28,8 @@ using amrex::Real;
 struct HighMachProblem {
 };
 
-template <> struct HydroSystem_Traits<HighMachProblem> {
+template <> struct quokka::EOS_Traits<HighMachProblem> {
 	static constexpr double gamma = 5. / 3.;
-	static constexpr bool reconstruct_eint = false;
 };
 
 template <> struct Physics_Traits<HighMachProblem> {
@@ -187,7 +186,7 @@ void RadhydroSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiF
 			const auto fE = values.at(HydroSystem<HighMachProblem>::energy_index)[i];
 			const auto fvx = fxmom / frho;
 			const auto fEint = fE - 0.5 * frho * (fvx * fvx);
-			const auto fP = (HydroSystem<HighMachProblem>::gamma_ - 1.) * fEint;
+			const auto fP = (quokka::EOS_Traits<HighMachProblem>::gamma - 1.) * fEint;
 
 			d_final.push_back(frho);
 			vx_final.push_back(fvx);

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -22,8 +22,11 @@
 struct KelvinHelmholzProblem {
 };
 
-template <> struct EOS_Traits<KelvinHelmholzProblem> {
+template <> struct quokka::EOS_Traits<KelvinHelmholzProblem> {
 	static constexpr double gamma = 1.4;
+};
+
+template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -71,7 +71,7 @@ template <> void RadhydroSimulation<KelvinHelmholzProblem>::setInitialConditions
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<KelvinHelmholzProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<KelvinHelmholzProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<KelvinHelmholzProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<KelvinHelmholzProblem>::x1Momentum_index) = rho * vx;

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -22,7 +22,7 @@
 struct KelvinHelmholzProblem {
 };
 
-template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
+template <> struct EOS_Traits<KelvinHelmholzProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -76,7 +76,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 			state_cc(i, j, k, n) = 0.;
 		}
 
-		const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;
@@ -225,7 +225,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real vx = vx_arr[i];
 			amrex::Real P = P_arr[i];
 
-			const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -28,9 +28,10 @@
 struct ShocktubeProblem {
 };
 
-template <> struct HydroSystem_Traits<ShocktubeProblem> {
+template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double gamma = (5. / 3.);
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
@@ -121,7 +122,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 		P = (2. / 3.) * 1.0e-10;
 	}
 
-	double Eint = P / (HydroSystem<ShocktubeProblem>::gamma_ - 1.);
+	double Eint = P / (quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.);
 	double E = Eint + 0.5 * rho * (vx * vx);
 
 	for (int n = 0; n < numcomp; ++n) {
@@ -167,7 +168,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 		auto density = values.at(2);
 		auto pressure = values.at(3);
 		auto velocity = values.at(4);
-		auto eint = pressure / ((HydroSystem<ShocktubeProblem>::gamma_ - 1.0) * density);
+		auto eint = pressure / ((quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.0) * density);
 
 		xs_exact.push_back(x);
 		density_exact.push_back(density);
@@ -256,7 +257,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real xvel = xmom / rho;
 			amrex::Real Eint = Egas - xmom * xmom / (2.0 * rho);
 			amrex::Real specific_Eint = Eint / rho;
-			amrex::Real pressure = (HydroSystem<ShocktubeProblem>::gamma_ - 1.) * Eint;
+			amrex::Real pressure = (quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.) * Eint;
 
 			d.at(i) = rho;
 			vx.at(i) = xvel;

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -113,7 +113,7 @@ template <> void RadhydroSimulation<QuirkProblem>::setInitialConditionsOnGrid(qu
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<QuirkProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<QuirkProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<QuirkProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<QuirkProblem>::x1Momentum_index) = rho * vx;
@@ -172,7 +172,7 @@ template <> void RadhydroSimulation<QuirkProblem>::computeAfterTimestep()
 			Real peven = HydroSystem<QuirkProblem>::ComputePressure(state, i, j, k);
 
 			// the 'entropy function' s == P / rho^gamma
-			const Real gamma = HydroSystem<QuirkProblem>::gamma_;
+			const Real gamma = quokka::EOS_Traits<QuirkProblem>::gamma;
 			Real sodd = podd / std::pow(dodd, gamma);
 			Real seven = peven / std::pow(deven, gamma);
 			s[0] = std::abs(sodd - seven);
@@ -222,7 +222,7 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
 	amrex::GpuArray<int, 3> hi = box.hiVect3d();
-	const auto gamma = HydroSystem<QuirkProblem>::gamma_;
+	const auto gamma = quokka::EOS_Traits<QuirkProblem>::gamma;
 
 	if (i < lo[0]) {
 		// x1 left side boundary

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -41,7 +41,7 @@ using Real = amrex::Real;
 struct QuirkProblem {
 };
 
-template <> struct HydroSystem_Traits<QuirkProblem> {
+template <> struct EOS_Traits<QuirkProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -41,8 +41,11 @@ using Real = amrex::Real;
 struct QuirkProblem {
 };
 
-template <> struct EOS_Traits<QuirkProblem> {
+template <> struct quokka::EOS_Traits<QuirkProblem> {
 	static constexpr double gamma = 5. / 3.;
+};
+
+template <> struct HydroSystem_Traits<QuirkProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -21,7 +21,7 @@
 struct RichtmeyerMeshkovProblem {
 };
 
-template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
+template <> struct EOS_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -21,8 +21,11 @@
 struct RichtmeyerMeshkovProblem {
 };
 
-template <> struct EOS_Traits<RichtmeyerMeshkovProblem> {
+template <> struct quokka::EOS_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr double gamma = 1.4;
+};
+
+template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -131,7 +131,7 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::setInitialConditi
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<RichtmeyerMeshkovProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<RichtmeyerMeshkovProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<RichtmeyerMeshkovProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<RichtmeyerMeshkovProblem>::x1Momentum_index) = rho * vx;

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -192,7 +192,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real vx = vx_arr[i];
 			amrex::Real P = P_arr[i];
 
-			const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -21,9 +21,10 @@
 struct ShocktubeProblem {
 };
 
-template <> struct HydroSystem_Traits<ShocktubeProblem> {
+template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
@@ -219,7 +220,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 
 			amrex::Real xvel = xmom / rho;
 			amrex::Real Eint = Egas - xmom * xmom / (2.0 * rho);
-			amrex::Real pressure = (HydroSystem<ShocktubeProblem>::gamma_ - 1.) * Eint;
+			amrex::Real pressure = (quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.) * Eint;
 
 			d.at(i) = rho;
 			vx.at(i) = xvel;

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -26,9 +26,8 @@
 struct ShocktubeProblem {
 };
 
-template <> struct HydroSystem_Traits<ShocktubeProblem> {
+template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
@@ -76,7 +75,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 		for (int n = 0; n < ncomp; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
@@ -111,7 +110,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
 	amrex::GpuArray<int, 3> hi = box.hiVect3d();
-	const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+	const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 
 	if (i < lo[0]) {
 		// x1 left side boundary -- constant
@@ -250,7 +249,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real vx = vx_arr[i];
 			amrex::Real P = P_arr[i];
 
-			const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;
@@ -278,7 +277,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real Egas = values.at(HydroSystem<ShocktubeProblem>::energy_index)[i];
 
 			amrex::Real Eint = Egas - (xmom * xmom) / (2.0 * rho);
-			amrex::Real const gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			amrex::Real const gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			d.at(i) = rho;
 			vx.at(i) = xmom / rho;
 			P.at(i) = ((gamma - 1.0) * Eint) / 10.;

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -23,9 +23,10 @@
 struct ShocktubeProblem {
 };
 
-template <> struct HydroSystem_Traits<ShocktubeProblem> {
+template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
@@ -240,7 +241,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 
 			amrex::Real xvel = xmom / rho;
 			amrex::Real Eint = Egas - xmom * xmom / (2.0 * rho);
-			amrex::Real pressure = (HydroSystem<ShocktubeProblem>::gamma_ - 1.) * Eint;
+			amrex::Real pressure = (quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.) * Eint;
 
 			d.at(i) = rho;
 			vx.at(i) = xvel;

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -72,7 +72,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 			state_cc(i, j, k, n) = 0.;
 		}
 
-		const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;
@@ -104,7 +104,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
 	amrex::GpuArray<int, 3> hi = box.hiVect3d();
-	const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+	const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 
 	double vx = NAN;
 	double rho = NAN;
@@ -212,7 +212,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real vx = vx_arr[i];
 			amrex::Real P = P_arr[i];
 
-			const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -25,9 +25,8 @@
 struct ShocktubeProblem {
 };
 
-template <> struct HydroSystem_Traits<ShocktubeProblem> {
+template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
@@ -69,7 +68,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 			state_cc(i, j, k, n) = 0.;
 		}
 
-		auto const gamma = HydroSystem<ShocktubeProblem>::gamma_;
+		auto const gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;
@@ -116,7 +115,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 		P = 0.4;
 	}
 
-	const double gamma = HydroSystem<ShocktubeProblem>::gamma_;
+	const double gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 	const double E = P / (gamma - 1.) + 0.5 * rho * (vx * vx);
 
 	// zero-fill unused components
@@ -214,7 +213,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 			amrex::Real vx = vx_arr[i];
 			amrex::Real P = P_arr[i];
 
-			const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ShocktubeProblem>::gamma;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x1Momentum_index) = rho * vx;
 			stateExact(i, j, k, HydroSystem<ShocktubeProblem>::x2Momentum_index) = 0.;

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -165,7 +165,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 		auto density = values.at(1);
 		auto velocity = values.at(2);
 		auto pressure = values.at(3);
-		auto eint = pressure / ((HydroSystem<ShocktubeProblem>::gamma_ - 1.0) * density);
+		auto eint = pressure / ((quokka::EOS_Traits<ShocktubeProblem>::gamma - 1.0) * density);
 
 		xs_exact.push_back(x);
 		density_exact.push_back(density);

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -21,9 +21,10 @@
 struct WaveProblem {
 };
 
-template <> struct HydroSystem_Traits<WaveProblem> {
+template <> struct quokka::EOS_Traits<WaveProblem> {
 	static constexpr double gamma = 5. / 3.;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<WaveProblem> {
@@ -49,7 +50,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	const amrex::Real A = amp;
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
-	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (HydroSystem<WaveProblem>::gamma_ - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
+	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<WaveProblem>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
 	const quokka::valarray<double, 3> dU = (A * R / (2.0 * M_PI * dx[0])) * (std::cos(2.0 * M_PI * x_L) - std::cos(2.0 * M_PI * x_R));
 
 	double rho = U_0[0] + dU[0];
@@ -156,7 +157,7 @@ auto problem_main() -> int
 
 			amrex::Real xvel = xmom / rho;
 			amrex::Real Eint = Egas - xmom * xmom / (2.0 * rho);
-			amrex::Real pressure = Eint * (HydroSystem<WaveProblem>::gamma_ - 1.);
+			amrex::Real pressure = Eint * (quokka::EOS_Traits<WaveProblem>::gamma - 1.);
 
 			d.at(i) = (rho - rho0) / amp;
 			vx.at(i) = (xvel - v0) / amp;
@@ -174,7 +175,7 @@ auto problem_main() -> int
 
 			amrex::Real xvel = xmom / rho;
 			amrex::Real Eint = Egas - xmom * xmom / (2.0 * rho);
-			amrex::Real pressure = Eint * (HydroSystem<WaveProblem>::gamma_ - 1.);
+			amrex::Real pressure = Eint * (quokka::EOS_Traits<WaveProblem>::gamma - 1.);
 
 			density_exact.at(i) = (rho - rho0) / amp;
 			velocity_exact.at(i) = (xvel - v0) / amp;

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -36,10 +36,10 @@ template <> struct Physics_Traits<WaveProblem> {
 	static constexpr bool is_mhd_enabled = false;
 };
 
-constexpr double rho0 = 1.0;				      // background density
-constexpr double P0 = 1.0 / HydroSystem<WaveProblem>::gamma_; // background pressure
-constexpr double v0 = 0.;				      // background velocity
-constexpr double amp = 1.0e-6;				      // perturbation amplitude
+constexpr double rho0 = 1.0;					    // background density
+constexpr double P0 = 1.0 / quokka::EOS_Traits<WaveProblem>::gamma; // background pressure
+constexpr double v0 = 0.;					    // background velocity
+constexpr double amp = 1.0e-6;					    // perturbation amplitude
 
 AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)

--- a/src/ODEIntegration/test_ode.cpp
+++ b/src/ODEIntegration/test_ode.cpp
@@ -12,8 +12,8 @@
 
 using amrex::Real;
 
-constexpr double Tgas0 = 6000.;			   // K
-constexpr double rho0 = 0.01 * hydrogen_mass_cgs_; // g cm^-3
+constexpr double Tgas0 = 6000.;				  // K
+constexpr double rho0 = 0.01 * quokka::hydrogen_mass_cgs; // g cm^-3
 
 struct ODEUserData {
 	amrex::Real rho;
@@ -24,7 +24,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cooling_function(Real const rho, R
 	// use fitting function from Koyama & Inutsuka (2002)
 	Real gamma_heat = 2.0e-26;
 	Real lambda_cool = gamma_heat * (1.0e7 * std::exp(-114800. / (T + 1000.)) + 14. * std::sqrt(T) * std::exp(-92. / T));
-	Real rho_over_mh = rho / hydrogen_mass_cgs_;
+	Real rho_over_mh = rho / quokka::hydrogen_mass_cgs;
 	Real cooling_source_term = rho_over_mh * gamma_heat - (rho_over_mh * rho_over_mh) * lambda_cool;
 	return cooling_source_term;
 }
@@ -37,7 +37,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valar
 
 	// compute temperature
 	Real Eint = y_data[0];
-	Real T = RadSystem<ODETest>::ComputeTgasFromEgas(rho, Eint);
+	Real T = quokka::EOS<ODETest>::ComputeTgasFromEint(rho, Eint);
 
 	// compute cooling function
 	y_rhs[0] = cooling_function(rho, T);
@@ -47,7 +47,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valar
 auto problem_main() -> int
 {
 	// set up initial conditions
-	const Real Eint0 = RadSystem<ODETest>::ComputeEgasFromTgas(rho0, Tgas0);
+	const Real Eint0 = quokka::EOS<ODETest>::ComputeEintFromTgas(rho0, Tgas0);
 	const Real Edot0 = cooling_function(rho0, Tgas0);
 	const Real tcool = std::abs(Eint0 / Edot0);
 	const Real max_time = 10.0 * tcool;
@@ -64,7 +64,7 @@ auto problem_main() -> int
 	int steps_taken = 0;
 	rk_adaptive_integrate(user_rhs, 0, y, max_time, &user_data, rtol, abstol, steps_taken);
 
-	const Real Tgas = RadSystem<ODETest>::ComputeTgasFromEgas(rho0, y[0]);
+	const Real Tgas = quokka::EOS<ODETest>::ComputeTgasFromEint(rho0, y[0]);
 	// for n_H = 0.01 cm^{-3} (for IK cooling function)
 	const Real Teq = 160.52611612610758;
 	const Real Terr_rel = std::abs(Tgas - Teq) / Teq;

--- a/src/ODEIntegration/test_ode.cpp
+++ b/src/ODEIntegration/test_ode.cpp
@@ -15,6 +15,12 @@ using amrex::Real;
 constexpr double Tgas0 = 6000.;				  // K
 constexpr double rho0 = 0.01 * quokka::hydrogen_mass_cgs; // g cm^-3
 
+template <> struct quokka::EOS_Traits<ODETest> {
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = 5. / 3.;
+};
+
 struct ODEUserData {
 	amrex::Real rho;
 };

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -68,7 +68,7 @@ template <> void RadhydroSimulation<ScalarProblem>::setInitialConditionsOnGrid(q
 			scalar = 0.0;
 		}
 
-		const auto gamma = HydroSystem<ScalarProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<ScalarProblem>::gamma;
 		for (int n = 0; n < state_cc.nComp(); ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
@@ -110,7 +110,7 @@ void RadhydroSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab
 				scalar = 0.0;
 			}
 
-			const auto gamma = HydroSystem<ScalarProblem>::gamma_;
+			const auto gamma = quokka::EOS_Traits<ScalarProblem>::gamma;
 			for (int n = 0; n < ncomp; ++n) {
 				stateExact(i, j, k, n) = 0.;
 			}

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -23,9 +23,10 @@ using amrex::Real;
 struct ScalarProblem {
 };
 
-template <> struct HydroSystem_Traits<ScalarProblem> {
+template <> struct quokka::EOS_Traits<ScalarProblem> {
 	static constexpr double gamma = 1.4;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ScalarProblem> {
@@ -164,7 +165,7 @@ void RadhydroSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab
 				const auto s = val_exact.at(HydroSystem<ScalarProblem>::scalar0_index)[i];
 				const auto vx = xmom / rho;
 				const auto Eint = E - 0.5 * rho * (vx * vx);
-				const auto P = (HydroSystem<ScalarProblem>::gamma_ - 1.) * Eint;
+				const auto P = (quokka::EOS_Traits<ScalarProblem>::gamma - 1.) * Eint;
 				d_exact.push_back(rho);
 				vx_exact.push_back(vx);
 				P_exact.push_back(P);
@@ -178,7 +179,7 @@ void RadhydroSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab
 				const auto fs = values.at(HydroSystem<ScalarProblem>::scalar0_index)[i];
 				const auto fvx = fxmom / frho;
 				const auto fEint = fE - 0.5 * frho * (fvx * fvx);
-				const auto fP = (HydroSystem<ScalarProblem>::gamma_ - 1.) * fEint;
+				const auto fP = (quokka::EOS_Traits<ScalarProblem>::gamma - 1.) * fEint;
 				d_final.push_back(frho);
 				vx_final.push_back(fvx);
 				P_final.push_back(fP);

--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -215,7 +215,7 @@ template <> void RadhydroSimulation<BeamProblem>::setInitialConditionsOnGrid(quo
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const double Erad = a_rad * std::pow(T_initial, 4);
 		const double rho = rho0;
-		const double Egas = RadSystem<BeamProblem>::ComputeEgasFromTgas(rho, T_initial);
+		const double Egas = quokka::EOS<BeamProblem>::ComputeEintFromTgas(rho, T_initial);
 
 		state_cc(i, j, k, RadSystem<BeamProblem>::radEnergy_index) = Erad;
 		state_cc(i, j, k, RadSystem<BeamProblem>::x1RadFlux_index) = 0;

--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -32,13 +32,16 @@ constexpr double T_initial = 300.;   // K
 constexpr double a_rad = 7.5646e-15; // erg cm^-3 K^-4
 constexpr double c = 2.99792458e10;  // cm s^-1
 
+template <> struct quokka::EOS_Traits<BeamProblem> {
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<BeamProblem> {
 	static constexpr double c_light = c_light_cgs_;
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
-	static constexpr double mean_molecular_mass = hydrogen_mass_cgs_;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -58,11 +58,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct HydroSystem_Traits<TubeProblem> {
-	static constexpr double gamma = gamma_gas;
-	static constexpr bool reconstruct_eint = false; // unused if isothermal
-};
-
 template <> struct Physics_Traits<TubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -28,11 +28,11 @@
 struct TubeProblem {
 };
 
-constexpr double kappa0 = 5.0;			 // cm^2 g^-1
-constexpr double mu = 2.33 * hydrogen_mass_cgs_; // g
-constexpr double gamma_gas = 1.0;		 // isothermal gas EOS
-constexpr double a0 = 0.2e5;			 // cm s^-1
-constexpr double tau = 1.0e-6;			 // optical depth (dimensionless)
+constexpr double kappa0 = 5.0;				// cm^2 g^-1
+constexpr double mu = 2.33 * quokka::hydrogen_mass_cgs; // g
+constexpr double gamma_gas = 1.0;			// isothermal gas EOS
+constexpr double a0 = 0.2e5;				// cm s^-1
+constexpr double tau = 1.0e-6;				// optical depth (dimensionless)
 
 constexpr double rho0 = 1.0e5 * mu; // g cm^-3
 constexpr double Mach0 = 1.1;	    // Mach number at wind base
@@ -43,20 +43,23 @@ constexpr double Frad0 = rho0 * a0 * c_light_cgs_ / tau; // erg cm^-2 s^-1
 constexpr double g0 = kappa0 * Frad0 / c_light_cgs_;	 // cm s^{-2}
 constexpr double Lx = (a0 * a0) / g0;			 // cm
 
+template <> struct quokka::EOS_Traits<TubeProblem> {
+	static constexpr double mean_molecular_mass = mu;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = gamma_gas;
+	static constexpr double cs_isothermal = a0; // only used when gamma = 1
+};
+
 template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr double c_light = c_light_cgs_;
 	static constexpr double c_hat = 10. * (Mach1 * a0);
 	static constexpr double radiation_constant = radiation_constant_cgs_;
-	static constexpr double mean_molecular_mass = mu;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = gamma_gas;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
 template <> struct HydroSystem_Traits<TubeProblem> {
 	static constexpr double gamma = gamma_gas;
-	static constexpr double cs_isothermal = a0;	// only used when gamma = 1
 	static constexpr bool reconstruct_eint = false; // unused if isothermal
 };
 

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -32,13 +32,16 @@ template <> struct SimulationData<CouplingProblem> {
 	std::vector<double> Tgas_vec_;
 };
 
+template <> struct quokka::EOS_Traits<CouplingProblem> {
+	static constexpr double mean_molecular_mass = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr double c_light = c_light_cgs_;
 	static constexpr double c_hat = c_rsla;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
-	static constexpr double mean_molecular_mass = hydrogen_mass_cgs_;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
@@ -60,17 +63,17 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeRossel
 	return 1.0;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeTgasFromEgas(const double /*rho*/, const double Egas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeEgasFromTgas(const double /*rho*/, const double Tgas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas) -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeEgasTempDerivative(const double /*rho*/, const double Tgas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas) -> double
 {
 	// This is also known as the heat capacity, i.e.
 	// 		\del E_g / \del T = \rho c_v,
@@ -124,7 +127,7 @@ template <> void RadhydroSimulation<CouplingProblem>::computeAfterTimestep()
 		const amrex::Real Erad_i = values.at(RadSystem<CouplingProblem>::radEnergy_index)[0];
 
 		userData_.Trad_vec_.push_back(std::pow(Erad_i / a_rad, 1. / 4.));
-		userData_.Tgas_vec_.push_back(RadSystem<CouplingProblem>::ComputeTgasFromEgas(rho, Egas_i));
+		userData_.Tgas_vec_.push_back(quokka::EOS<CouplingProblem>::ComputeTgasFromEint(rho, Egas_i));
 	}
 }
 
@@ -174,7 +177,7 @@ auto problem_main() -> int
 		std::vector<double> Tgas_exact(nmax);
 		std::vector<double> Tgas_rsla_exact(nmax);
 
-		const double initial_Tgas = RadSystem<CouplingProblem>::ComputeTgasFromEgas(rho0, Egas0);
+		const double initial_Tgas = quokka::EOS<CouplingProblem>::ComputeTgasFromEint(rho0, Egas0);
 		const auto kappa = RadSystem<CouplingProblem>::ComputePlanckOpacity(rho0, initial_Tgas);
 
 		for (int n = 0; n < nmax; ++n) {

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -92,7 +92,7 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
 		const double Trad = compute_exact_Trad(x - x0, initial_time);
-		const double Egas = RadSystem<PulseProblem>::ComputeEgasFromTgas(rho0, Trad);
+		const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho0, Trad);
 
 		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = erad_floor;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 0;
@@ -180,7 +180,7 @@ auto problem_main() -> int
 		Erad.at(i) = Erad_t;
 		Trad.at(i) = Trad_t;
 		Egas.at(i) = values.at(RadSystem<PulseProblem>::gasEnergy_index)[i];
-		Tgas.at(i) = RadSystem<PulseProblem>::ComputeTgasFromEgas(rho0, Egas.at(i));
+		Tgas.at(i) = quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho0, Egas.at(i));
 
 		auto Trad_val = compute_exact_Trad(x - x0, initial_time + sim.tNew_[0]);
 		auto Erad_val = a_rad * std::pow(Trad_val, 4);

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -26,13 +26,16 @@ constexpr double erad_floor = a_rad * (1.0e-8);
 // constexpr double Lx = 1.0; // dimensionless length
 constexpr double initial_time = 1.0e-8;
 
+template <> struct quokka::EOS_Traits<PulseProblem> {
+	static constexpr double mean_molecular_weight = 1.0;
+	static constexpr double boltzmann_constant = (2. / 3.);
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
-	static constexpr double mean_molecular_mass = 1.0;
-	static constexpr double boltzmann_constant = (2. / 3.);
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr bool compute_v_over_c_terms = false;
 };

--- a/src/RadShadow/test_radiation_shadow.cpp
+++ b/src/RadShadow/test_radiation_shadow.cpp
@@ -33,13 +33,16 @@ constexpr double T_initial = 290.;   // K
 constexpr double a_rad = 7.5646e-15; // erg cm^-3 K^-4
 constexpr double c = 2.99792458e10;  // cm s^-1
 
+template <> struct quokka::EOS_Traits<ShadowProblem> {
+	static constexpr double mean_molecular_weight = 10. * quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<ShadowProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = c;
 	static constexpr double radiation_constant = a_rad;
-	static constexpr double mean_molecular_mass = 10. * hydrogen_mass_cgs_;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
@@ -224,8 +227,8 @@ auto problem_main() -> int
 	// Print radiation epsilon ("stiffness parameter" from Su & Olson).
 	// (if epsilon is smaller than tolerance, there can be unphysical radiation shocks.)
 	const auto dt_CFL = CFL_number * std::min(Lx / nx, Ly / ny) / c;
-	const auto c_v = RadSystem_Traits<ShadowProblem>::boltzmann_constant /
-			 (RadSystem_Traits<ShadowProblem>::mean_molecular_mass * (RadSystem_Traits<ShadowProblem>::gamma - 1.0));
+	const auto c_v = quokka::EOS_Traits<ShadowProblem>::boltzmann_constant /
+			 (quokka::EOS_Traits<ShadowProblem>::mean_molecular_weight * (quokka::EOS_Traits<ShadowProblem>::gamma - 1.0));
 	const auto epsilon = 4.0 * a_rad * (T_initial * T_initial * T_initial) * sigma0 * (c * dt_CFL) / c_v;
 	amrex::Print() << "radiation epsilon (stiffness parameter) = " << epsilon << "\n";
 

--- a/src/RadShadow/test_radiation_shadow.cpp
+++ b/src/RadShadow/test_radiation_shadow.cpp
@@ -126,7 +126,7 @@ template <> void RadhydroSimulation<ShadowProblem>::setInitialConditionsOnGrid(q
 		amrex::Real const rho = rho_bg + (rho_clump - rho_bg) / (1.0 + std::exp(Delta));
 
 		amrex::Real const Erad = a_rad * std::pow(T_initial, 4);
-		amrex::Real const Egas = RadSystem<ShadowProblem>::ComputeEgasFromTgas(rho, T_initial);
+		amrex::Real const Egas = quokka::EOS<ShadowProblem>::ComputeEintFromTgas(rho, T_initial);
 
 		state_cc(i, j, k, RadSystem<ShadowProblem>::radEnergy_index) = Erad;
 		state_cc(i, j, k, RadSystem<ShadowProblem>::x1RadFlux_index) = 0;

--- a/src/RadStreaming/test_radiation_streaming.cpp
+++ b/src/RadStreaming/test_radiation_streaming.cpp
@@ -22,13 +22,16 @@ constexpr double chat = 0.2;	   // reduced speed of light
 constexpr double kappa0 = 1.0e-10; // opacity
 constexpr double rho = 1.0;
 
+template <> struct quokka::EOS_Traits<StreamingProblem> {
+	static constexpr double mean_molecular_weight = 1.0;
+	static constexpr double boltzmann_constant = 1.0;
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<StreamingProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = 1.0;
-	static constexpr double mean_molecular_mass = 1.0;
-	static constexpr double boltzmann_constant = 1.0;
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = initial_Erad;
 	static constexpr bool compute_v_over_c_terms = false;
 };

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -71,17 +71,17 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeRossela
 	return (kappa / rho);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeTgasFromEgas(const double /*rho*/, const double Egas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeEgasFromTgas(const double /*rho*/, const double Tgas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas) -> double
 {
 	return (alpha_SuOlson / 4.0) * (Tgas * Tgas * Tgas * Tgas);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeEgasTempDerivative(const double /*rho*/, const double Tgas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas) -> double
 {
 	// This is also known as the heat capacity, i.e.
 	// 		\del E_g / \del T = \rho c_v,
@@ -94,7 +94,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeEgasTem
 	return alpha_SuOlson * std::pow(Tgas, 3);
 }
 
-const auto initial_Egas = 1e-10 * RadSystem<MarshakProblem>::ComputeEgasFromTgas(rho0, T_hohlraum);
+const auto initial_Egas = 1e-10 * quokka::EOS<MarshakProblem>::ComputeEintFromTgas(rho0, T_hohlraum);
 const auto initial_Erad = 1e-10 * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum));
 
 template <>
@@ -237,7 +237,7 @@ auto problem_main() -> int
 			const auto Ekin = (x1GasMom * x1GasMom) / (2.0 * rho);
 			const auto Egas_t = Etot_t - Ekin;
 			Egas.at(i) = Egas_t;
-			Tgas.at(i) = RadSystem<MarshakProblem>::ComputeTgasFromEgas(rho, Egas_t);
+			Tgas.at(i) = quokka::EOS<MarshakProblem>::ComputeTgasFromEint(rho, Egas_t);
 		}
 
 		std::vector<double> xs_exact = {0.01, 0.1, 0.17783, 0.31623, 0.45, 0.5, 0.56234, 0.75, 1.0, 1.33352, 1.77828, 3.16228, 5.62341};
@@ -277,8 +277,8 @@ auto problem_main() -> int
 			Trad_exact_10.at(i) = std::pow(Erad_transport_exact_10p0.at(i) / a_rad, 1. / 4.);
 			Trad_exact_1.at(i) = std::pow(Erad_transport_exact_1p0.at(i) / a_rad, 1. / 4.);
 
-			Tgas_exact_10.at(i) = RadSystem<MarshakProblem>::ComputeTgasFromEgas(rho0, Egas_transport_exact_10p0.at(i));
-			Tgas_exact_1.at(i) = RadSystem<MarshakProblem>::ComputeTgasFromEgas(rho0, Egas_transport_exact_1p0.at(i));
+			Tgas_exact_10.at(i) = quokka::EOS<MarshakProblem>::ComputeTgasFromEint(rho0, Egas_transport_exact_10p0.at(i));
+			Tgas_exact_1.at(i) = quokka::EOS<MarshakProblem>::ComputeTgasFromEint(rho0, Egas_transport_exact_1p0.at(i));
 		}
 
 		// interpolate numerical solution onto exact solution tabulated points

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -84,12 +84,15 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeRosselan
 	return kappa;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeTgasFromEgas(const double rho, const double Egas) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double Egas) -> double
 {
 	return Egas / (rho * c_v);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeEgasFromTgas(const double rho, const double Tgas) -> double { return rho * c_v * Tgas; }
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double Tgas) -> double
+{
+	return rho * c_v * Tgas;
+}
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeEgasTempDerivative(const double rho, const double /*Tgas*/) -> double
 {
@@ -206,7 +209,7 @@ template <> void RadhydroSimulation<TophatProblem>::setInitialConditionsOnGrid(q
 			rho = rho_pipe;
 		}
 
-		const double Egas = RadSystem<TophatProblem>::ComputeEgasFromTgas(rho, T_initial);
+		const double Egas = quokka::EOS<TophatProblem>::ComputeEintFromTgas(rho, T_initial);
 
 		state_cc(i, j, k, RadSystem<TophatProblem>::radEnergy_index) = Erad;
 		state_cc(i, j, k, RadSystem<TophatProblem>::x1RadFlux_index) = 0;

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -37,13 +37,16 @@ constexpr double c_v = (1.0e15 * 1.0e-6 * kelvin_to_eV); // erg g^-1 K^-1
 constexpr double a_rad = 7.5646e-15; // erg cm^-3 K^-4
 constexpr double c = 2.99792458e10;  // cm s^-1
 
+template <> struct quokka::EOS_Traits<TophatProblem> {
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = 5. / 3.;
+};
+
 template <> struct RadSystem_Traits<TophatProblem> {
 	static constexpr double c_light = c_light_cgs_;
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
-	static constexpr double mean_molecular_mass = hydrogen_mass_cgs_;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = false;
 };
@@ -94,7 +97,7 @@ template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintFr
 	return rho * c_v * Tgas;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeEgasTempDerivative(const double rho, const double /*Tgas*/) -> double
+template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintTempDerivative(const double rho, const double /*Tgas*/) -> double
 {
 	// This is also known as the heat capacity, i.e.
 	// 		\del E_g / \del T = \rho c_v,

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -61,7 +61,7 @@ template <> struct Physics_Traits<TophatProblem> {
 	static constexpr bool is_mhd_enabled = false;
 };
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputePlanckOpacity(const double rho, const double /*Tgas*/) -> double
+template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputePlanckOpacity(const double rho, const double /*Tgas*/) -> double
 {
 	amrex::Real kappa = 0.;
 	if (rho == rho_pipe) {
@@ -74,7 +74,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputePlanckOp
 	return kappa;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeRosselandOpacity(const double rho, const double /*Tgas*/) -> double
+template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeRosselandOpacity(const double rho, const double /*Tgas*/) -> double
 {
 	amrex::Real kappa = 0.;
 	if (rho == rho_pipe) {
@@ -87,17 +87,18 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeRosselan
 	return kappa;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double Egas) -> double
+template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double Egas) -> double
 {
 	return Egas / (rho * c_v);
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double Tgas) -> double
+template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double Tgas) -> double
 {
 	return rho * c_v * Tgas;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintTempDerivative(const double rho, const double /*Tgas*/) -> double
+template <>
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintTempDerivative(const double rho, const double /*Tgas*/) -> double
 {
 	// This is also known as the heat capacity, i.e.
 	// 		\del E_g / \del T = \rho c_v,
@@ -106,7 +107,7 @@ template <> AMREX_GPU_HOST_DEVICE auto quokka::EOS<TophatProblem>::ComputeEintTe
 	return rho * c_v;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeEddingtonFactor(const double f_in) -> double
+template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProblem>::ComputeEddingtonFactor(const double f_in) -> double
 {
 	// compute Minerbo (1978) closure [piecewise approximation]
 	// (For unknown reasons, this closure tends to work better

--- a/src/RadTube/test_radiation_tube.cpp
+++ b/src/RadTube/test_radiation_tube.cpp
@@ -25,8 +25,8 @@
 struct TubeProblem {
 };
 
-constexpr double kappa0 = 100.;			 // cm^2 g^-1
-constexpr double mu = 2.33 * hydrogen_mass_cgs_; // g
+constexpr double kappa0 = 100.;				// cm^2 g^-1
+constexpr double mu = 2.33 * quokka::hydrogen_mass_cgs; // g
 constexpr double gamma_gas = 5. / 3.;
 
 constexpr double rho0 = 1.0;		    // g cm^-3
@@ -36,13 +36,16 @@ constexpr double T1 = 2.2609633884436745e7; // K
 
 constexpr double a0 = 4.0295519855200705e7; // cm s^-1
 
+template <> struct quokka::EOS_Traits<TubeProblem> {
+	static constexpr double mean_molecular_weight = mu;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
+	static constexpr double gamma = gamma_gas;
+};
+
 template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr double c_light = c_light_cgs_;
 	static constexpr double c_hat = 10.0 * a0;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
-	static constexpr double mean_molecular_mass = mu;
-	static constexpr double boltzmann_constant = boltzmann_constant_cgs_;
-	static constexpr double gamma = gamma_gas;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
@@ -179,7 +182,7 @@ AMRSimulation<TubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 		consVar(i, j, k, RadSystem<TubeProblem>::x2RadFlux_index) = 0.;
 		consVar(i, j, k, RadSystem<TubeProblem>::x3RadFlux_index) = 0.;
 
-		const double Egas = (boltzmann_constant_cgs_ / mu) * rho0 * T0 / (gamma_gas - 1.0);
+		const double Egas = (quokka::boltzmann_constant_cgs / mu) * rho0 * T0 / (gamma_gas - 1.0);
 		const double x1Mom = consVar(lo[0], j, k, RadSystem<TubeProblem>::x1GasMomentum_index);
 		const double Ekin = 0.5 * (x1Mom * x1Mom) / rho0;
 		consVar(i, j, k, RadSystem<TubeProblem>::gasEnergy_index) = Egas + Ekin;
@@ -198,7 +201,7 @@ AMRSimulation<TubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 		consVar(i, j, k, RadSystem<TubeProblem>::x2RadFlux_index) = 0;
 		consVar(i, j, k, RadSystem<TubeProblem>::x3RadFlux_index) = 0;
 
-		const double Egas = (boltzmann_constant_cgs_ / mu) * rho1 * T1 / (gamma_gas - 1.0);
+		const double Egas = (quokka::boltzmann_constant_cgs / mu) * rho1 * T1 / (gamma_gas - 1.0);
 		const double x1Mom = consVar(hi[0], j, k, RadSystem<TubeProblem>::x1GasMomentum_index);
 		const double Ekin = 0.5 * (x1Mom * x1Mom) / rho1;
 		consVar(i, j, k, RadSystem<TubeProblem>::gasEnergy_index) = Egas + Ekin;
@@ -286,10 +289,10 @@ auto problem_main() -> int
 		double x3GasMom = values.at(RadSystem<TubeProblem>::x3GasMomentum_index)[i];
 
 		double Eint_exact = RadSystem<TubeProblem>::ComputeEintFromEgas(rho_exact, x1GasMom_exact, x2GasMom_exact, x3GasMom_exact, Egas_exact);
-		double Tgas_exact = RadSystem<TubeProblem>::ComputeTgasFromEgas(rho_exact, Eint_exact);
+		double Tgas_exact = quokka::EOS<TubeProblem>::ComputeTgasFromEint(rho_exact, Eint_exact);
 
 		double Eint = RadSystem<TubeProblem>::ComputeEintFromEgas(rho, x1GasMom, x2GasMom, x3GasMom, Egas);
-		double Tgas = RadSystem<TubeProblem>::ComputeTgasFromEgas(rho, Eint);
+		double Tgas = quokka::EOS<TubeProblem>::ComputeTgasFromEint(rho, Eint);
 
 		Tgas_arr[i] = Tgas;
 		Tgas_err[i] = (Tgas - Tgas_exact) / Tgas_exact;

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -55,7 +55,7 @@ template <> struct RadSystem_Traits<ShellProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct HydroSystem_Traits<ShellProblem> {
+template <> struct EOS_Traits<ShellProblem> {
 	static constexpr double gamma = gamma_gas;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -44,19 +44,21 @@ constexpr double k_B = 1.380658e-16;  // erg K^-1
 constexpr double m_H = 1.6726231e-24; // mass of hydrogen atom [g]
 constexpr double gamma_gas = 5. / 3.;
 
+template <> struct quokka::EOS_Traits<ShellProblem> {
+	static constexpr double mean_molecular_weight = 2.2 * m_H;
+	static constexpr double boltzmann_constant = k_B;
+	static constexpr double gamma = gamma_gas;
+};
+
 template <> struct RadSystem_Traits<ShellProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
-	static constexpr double mean_molecular_mass = 2.2 * m_H;
-	static constexpr double boltzmann_constant = k_B;
-	static constexpr double gamma = gamma_gas;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct EOS_Traits<ShellProblem> {
-	static constexpr double gamma = gamma_gas;
+template <> struct HydroSystem_Traits<ShellProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -57,17 +57,14 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
-	static constexpr double mean_molecular_mass = mu;
-	static constexpr double boltzmann_constant = k_B;
-	static constexpr double gamma = gamma_gas;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
 template <> struct quokka::EOS_Traits<ShockProblem> {
+	static constexpr double mean_molecular_weight = mu;
+	static constexpr double boltzmann_constant = k_B;
 	static constexpr double gamma = gamma_gas;
-	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
-	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ShockProblem> {

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -64,9 +64,10 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct HydroSystem_Traits<ShockProblem> {
+template <> struct quokka::EOS_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
-	static constexpr bool reconstruct_eint = true;
+	static constexpr double mean_molecular_weight = quokka::hydrogen_mass_cgs;
+	static constexpr double boltzmann_constant = quokka::boltzmann_constant_cgs;
 };
 
 template <> struct Physics_Traits<ShockProblem> {
@@ -285,7 +286,7 @@ auto problem_main() -> int
 
 			const double Egas_t = (Etot_t - Ekin);
 			Egas.at(i) = Egas_t;
-			Tgas.at(i) = RadSystem<ShockProblem>::ComputeTgasFromEgas(rho, Egas_t) / T0; // dimensionless
+			Tgas.at(i) = quokka::EOS<ShockProblem>::ComputeTgasFromEint(rho, Egas_t) / T0; // dimensionless
 
 			gasDensity.at(i) = rho;
 			gasVelocity.at(i) = x1GasMom / rho;

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -60,16 +60,14 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
-	static constexpr double mean_molecular_mass = m_H;
-	static constexpr double boltzmann_constant = k_B;
-	static constexpr double gamma = gamma_gas;
 	static constexpr double Erad_floor = 0.;
 	static constexpr bool compute_v_over_c_terms = true;
 };
 
-template <> struct HydroSystem_Traits<ShockProblem> {
+template <> struct quokka::EOS_Traits<ShockProblem> {
+	static constexpr double mean_molecular_weight = m_H;
+	static constexpr double boltzmann_constant = k_B;
 	static constexpr double gamma = gamma_gas;
-	static constexpr bool reconstruct_eint = true;
 };
 
 template <> struct Physics_Traits<ShockProblem> {
@@ -285,7 +283,7 @@ auto problem_main() -> int
 
 			const double Egas_t = (Etot_t - Ekin);
 			Egas.at(i) = Egas_t;
-			Tgas.at(i) = RadSystem<ShockProblem>::ComputeTgasFromEgas(rho, Egas_t) / T0; // dimensionless
+			Tgas.at(i) = quokka::EOS<ShockProblem>::ComputeTgasFromEint(rho, Egas_t) / T0; // dimensionless
 		}
 
 		// read in exact solution

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -82,7 +82,7 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<RTProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<RTProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<RTProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<RTProblem>::x1Momentum_index) = rho * vx;

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -22,7 +22,7 @@
 struct RTProblem {
 };
 
-template <> struct HydroSystem_Traits<RTProblem> {
+template <> struct EOS_Traits<RTProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -22,8 +22,11 @@
 struct RTProblem {
 };
 
-template <> struct EOS_Traits<RTProblem> {
+template <> struct quokka::EOS_Traits<RTProblem> {
 	static constexpr double gamma = 1.4;
+};
+
+template <> struct HydroSystem_Traits<RTProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -22,7 +22,7 @@
 struct RTProblem {
 };
 
-template <> struct HydroSystem_Traits<RTProblem> {
+template <> struct EOS_Traits<RTProblem> {
 	static constexpr double gamma = 1.4;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -83,7 +83,7 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = HydroSystem<RTProblem>::gamma_;
+		const auto gamma = quokka::EOS_Traits<RTProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<RTProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<RTProblem>::x1Momentum_index) = rho * vx;

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -22,8 +22,11 @@
 struct RTProblem {
 };
 
-template <> struct EOS_Traits<RTProblem> {
+template <> struct quokka::EOS_Traits<RTProblem> {
 	static constexpr double gamma = 1.4;
+};
+
+template <> struct HydroSystem_Traits<RTProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -37,10 +37,10 @@ using amrex::Real;
 struct ShockCloud {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-constexpr double m_H = hydrogen_mass_cgs_;
+constexpr double m_H = quokka::hydrogen_mass_cgs;
 constexpr double seconds_in_year = 3.154e7;
 
-template <> struct EOS_Traits<ShockCloud> {
+template <> struct quokka::EOS_Traits<ShockCloud> {
 	static constexpr double gamma = 5. / 3.; // default value
 };
 
@@ -60,9 +60,9 @@ constexpr Real nH1 = 1.0e-1;		 // cm^-3
 constexpr Real R_cloud = 5.0 * 3.086e18; // cm [5 pc]
 constexpr Real M0 = 2.0;		 // Mach number of shock
 
-constexpr Real T_floor = 100.0;				   // K
-constexpr Real P0 = nH0 * Tgas0 * boltzmann_constant_cgs_; // erg cm^-3
-constexpr Real rho0 = nH0 * m_H;			   // g cm^-3
+constexpr Real T_floor = 100.0;					  // K
+constexpr Real P0 = nH0 * Tgas0 * quokka::boltzmann_constant_cgs; // erg cm^-3
+constexpr Real rho0 = nH0 * m_H;				  // g cm^-3
 constexpr Real rho1 = nH1 * m_H;
 
 // perturbation parameters

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -188,7 +188,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<ShockCloud>::setCustomBou
 	if (j >= jhi) {
 		// x2 upper boundary -- constant
 		// compute downstream shock conditions from rho0, P0, and M0
-		constexpr Real gamma = HydroSystem<ShockCloud>::gamma_;
+		constexpr Real gamma = quokka::EOS_Traits<ShockCloud>::gamma;
 		constexpr Real rho2 = rho0 * (gamma + 1.) * M0 * M0 / ((gamma - 1.) * M0 * M0 + 2.);
 		constexpr Real P2 = P0 * (2. * gamma * M0 * M0 - (gamma - 1.)) / (gamma + 1.);
 		Real const v2 = -M0 * std::sqrt(gamma * P2 / rho2);
@@ -251,7 +251,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valar
 	// unpack user_data
 	auto *udata = static_cast<ODEUserData *>(user_data);
 	const Real rho = udata->rho;
-	const Real gamma = HydroSystem<ShockCloud>::gamma_;
+	const Real gamma = quokka::EOS_Traits<ShockCloud>::gamma;
 	cloudyGpuConstTables const &tables = udata->tables;
 
 	// check whether temperature is out-of-bounds

--- a/src/ShockCloud/test_cloudy.cpp
+++ b/src/ShockCloud/test_cloudy.cpp
@@ -25,7 +25,7 @@ using amrex::Real;
 struct ShockCloud {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct EOS_Traits<ShockCloud> {
+template <> struct quokka::EOS_Traits<ShockCloud> {
 	static constexpr double gamma = 5. / 3.; // default value
 };
 
@@ -87,14 +87,15 @@ auto problem_main() -> int
 	const Real T = ComputeTgasFromEgas(rho, Eint, quokka::EOS_Traits<ShockCloud>::gamma, tables);
 
 	const Real rhoH = rho * cloudy_H_mass_fraction;
-	const Real nH = rhoH / hydrogen_mass_cgs_;
+	const Real nH = rhoH / quokka::hydrogen_mass_cgs;
 	const Real log_nH = std::log10(nH);
 
-	const Real C = (quokka::EOS_Traits<ShockCloud>::gamma - 1.) * Eint / (boltzmann_constant_cgs_ * (rho / hydrogen_mass_cgs_));
+	const Real C = (quokka::EOS_Traits<ShockCloud>::gamma - 1.) * Eint / (quokka::boltzmann_constant_cgs * (rho / quokka::hydrogen_mass_cgs));
 	const Real mu = interpolate2d(log_nH, std::log10(T), tables.log_nH, tables.log_Tgas, tables.meanMolWeight);
 	const Real relerr = std::abs((C * mu - T) / T);
 
-	const Real n_e = (rho / hydrogen_mass_cgs_) * (1.0 - mu * (X + Y / 4. + Z / mean_metals_A)) / (mu - (electron_mass_cgs / hydrogen_mass_cgs_));
+	const Real n_e =
+	    (rho / quokka::hydrogen_mass_cgs) * (1.0 - mu * (X + Y / 4. + Z / mean_metals_A)) / (mu - (electron_mass_cgs / quokka::hydrogen_mass_cgs));
 
 	printf("\nrho = %.17e, Eint = %.17e, mu = %f, Tgas = %e, relerr = %e\n", rho, Eint, mu, T, relerr);
 	printf("n_e = %e, n_e/n_H = %e\n", n_e, n_e / nH);

--- a/src/ShockCloud/test_cloudy.cpp
+++ b/src/ShockCloud/test_cloudy.cpp
@@ -41,7 +41,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valar
 	// unpack user_data
 	auto *udata = static_cast<ODEUserData *>(user_data);
 	const Real rho = udata->rho;
-	const Real gamma = HydroSystem<ShockCloud>::gamma_;
+	const Real gamma = quokka::EOS_Traits<ShockCloud>::gamma;
 	cloudyGpuConstTables &tables = udata->tables;
 
 	// check whether temperature is out-of-bounds

--- a/src/SphericalCollapse/spherical_collapse.cpp
+++ b/src/SphericalCollapse/spherical_collapse.cpp
@@ -26,8 +26,11 @@
 struct CollapseProblem {
 };
 
-template <> struct EOS_Traits<CollapseProblem> {
+template <> struct quokka::EOS_Traits<CollapseProblem> {
 	static constexpr double gamma = 5. / 3.;
+};
+
+template <> struct HydroSystem_Traits<CollapseProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 

--- a/src/SphericalCollapse/spherical_collapse.cpp
+++ b/src/SphericalCollapse/spherical_collapse.cpp
@@ -26,7 +26,7 @@
 struct CollapseProblem {
 };
 
-template <> struct HydroSystem_Traits<CollapseProblem> {
+template <> struct EOS_Traits<CollapseProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr bool reconstruct_eint = false;
 };

--- a/src/SphericalCollapse/spherical_collapse.cpp
+++ b/src/SphericalCollapse/spherical_collapse.cpp
@@ -70,7 +70,7 @@ template <> void RadhydroSimulation<CollapseProblem>::setInitialConditionsOnGrid
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		const amrex::Real gamma = HydroSystem<CollapseProblem>::gamma_;
+		const amrex::Real gamma = quokka::EOS_Traits<CollapseProblem>::gamma;
 		state_cc(i, j, k, HydroSystem<CollapseProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<CollapseProblem>::x1Momentum_index) = 0;
 		state_cc(i, j, k, HydroSystem<CollapseProblem>::x2Momentum_index) = 0;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -111,8 +111,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	// C++ does not allow constexpr to be uninitialized, even in a templated
 	// class!
-	static constexpr double gamma_ = quokka::EOS<problem_t>::gamma;
-	static constexpr double cs_iso_ = quokka::EOS<problem_t>::cs_isothermal;
+	static constexpr double gamma_ = quokka::EOS_Traits<problem_t>::gamma;
+	static constexpr double cs_iso_ = quokka::EOS_Traits<problem_t>::cs_isothermal;
 	static constexpr auto is_eos_isothermal() -> bool { return (gamma_ == 1.0); }
 
 	static constexpr bool reconstruct_eint = HydroSystem_Traits<problem_t>::reconstruct_eint;

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -30,8 +30,6 @@
 // this struct is specialized by the user application code
 //
 template <typename problem_t> struct HydroSystem_Traits {
-	static constexpr double gamma = 5. / 3.;     // default value
-	static constexpr double cs_isothermal = NAN; // only used when gamma = 1
 	// if true, reconstruct e_int instead of pressure
 	static constexpr bool reconstruct_eint = true;
 };
@@ -113,11 +111,11 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	// C++ does not allow constexpr to be uninitialized, even in a templated
 	// class!
-	static constexpr double gamma_ = HydroSystem_Traits<problem_t>::gamma;
-	static constexpr double cs_iso_ = HydroSystem_Traits<problem_t>::cs_isothermal;
-	static constexpr bool reconstruct_eint = HydroSystem_Traits<problem_t>::reconstruct_eint;
-
+	static constexpr double gamma_ = quokka::EOS<problem_t>::gamma;
+	static constexpr double cs_iso_ = quokka::EOS<problem_t>::cs_isothermal;
 	static constexpr auto is_eos_isothermal() -> bool { return (gamma_ == 1.0); }
+
+	static constexpr bool reconstruct_eint = HydroSystem_Traits<problem_t>::reconstruct_eint;
 };
 
 template <typename problem_t> void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost)

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -967,7 +967,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				}
 
 				// compute Jacobian elements
-				const double c_v = quokka::EOS<problem_t>::ComputeEgasTempDerivative(rho, T_gas);
+				const double c_v = quokka::EOS<problem_t>::ComputeEintTempDerivative(rho, T_gas);
 
 				drhs_dEgas = (rho * dt / c_v) * (kappa * dB_dTgas + dkappa_dTgas * (fourPiB - chat * Erad_guess));
 


### PR DESCRIPTION
This creates `EOS<problem_t>` and `EOS_Traits<problem_t>` classes.

These are currently used to compute gas temperature as a function of internal energy and density and vice versa within the radiation matter-energy exchange. The hydro solver also obtains the value of `gamma` and the value of the isothermal sound speed from `EOS_Traits<problem_t>`.