### PR TITLE
Read cc and fc ncomp from Physics_Indices

### DIFF
--- a/src/Advection/test_advection.cpp
+++ b/src/Advection/test_advection.cpp
@@ -45,8 +45,9 @@ template <> void AdvectionSimulation<SawtoothProblem>::setInitialConditionsOnGri
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
+  const int ncomp_cc = Physics_Indices<SawtoothProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
-	amrex::ParallelFor(indexRange, ncomp_cc_,
+	amrex::ParallelFor(indexRange, ncomp_cc,
 			   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { ComputeExactSolution(i, j, k, n, state_cc, dx, prob_lo, prob_hi); });
 }
 

--- a/src/Advection/test_advection.cpp
+++ b/src/Advection/test_advection.cpp
@@ -26,6 +26,16 @@
 struct SawtoothProblem {
 };
 
+template <> struct Physics_Traits<SawtoothProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = false;
+	static constexpr bool is_chemistry_enabled = false;
+	static constexpr int numPassiveScalars = 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+};
+
 AMREX_GPU_DEVICE void ComputeExactSolution(int i, int j, int k, int n, amrex::Array4<amrex::Real> const &exact_arr,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)

--- a/src/Advection/test_advection.cpp
+++ b/src/Advection/test_advection.cpp
@@ -55,7 +55,7 @@ template <> void AdvectionSimulation<SawtoothProblem>::setInitialConditionsOnGri
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
-  const int ncomp_cc = Physics_Indices<SawtoothProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<SawtoothProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, ncomp_cc,
 			   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { ComputeExactSolution(i, j, k, n, state_cc, dx, prob_lo, prob_hi); });

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -31,6 +31,16 @@ using amrex::Real;
 struct SquareProblem {
 };
 
+template <> struct Physics_Traits<SquareProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = false;
+	static constexpr bool is_chemistry_enabled = false;
+	static constexpr int numPassiveScalars = 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+};
+
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto exactSolutionAtIndex(int i, int j, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo,
 							      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
 							      amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx) -> Real

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -56,7 +56,7 @@ template <> void AdvectionSimulation<SquareProblem>::setInitialConditionsOnGrid(
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 	// loop over the grid and set the initial condition
-	amrex::ParallelFor(indexRange, ncomp_cc_,
+	amrex::ParallelFor(indexRange, Physics_Indices<SquareProblem>::nvarTotal_cc,
 			   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { state_cc(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx); });
 }
 
@@ -70,8 +70,9 @@ void AdvectionSimulation<SquareProblem>::computeReferenceSolution(amrex::MultiFa
 	for (amrex::MFIter iter(state_old_cc_[0]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
 		auto const &state = ref.array(iter);
+    const int ncomp_cc = Physics_Indices<SquareProblem>::nvarTotal_cc;
 
-		amrex::ParallelFor(indexRange, ncomp_cc_,
+		amrex::ParallelFor(indexRange, ncomp_cc,
 				   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { state(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx); });
 	}
 }

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -80,7 +80,7 @@ void AdvectionSimulation<SquareProblem>::computeReferenceSolution(amrex::MultiFa
 	for (amrex::MFIter iter(state_old_cc_[0]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
 		auto const &state = ref.array(iter);
-    const int ncomp_cc = Physics_Indices<SquareProblem>::nvarTotal_cc;
+		const int ncomp_cc = Physics_Indices<SquareProblem>::nvarTotal_cc;
 
 		amrex::ParallelFor(indexRange, ncomp_cc,
 				   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { state(i, j, k, n) = exactSolutionAtIndex(i, j, prob_lo, prob_hi, dx); });

--- a/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -25,6 +25,16 @@
 struct SemiellipseProblem {
 };
 
+template <> struct Physics_Traits<SemiellipseProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = false;
+	static constexpr bool is_chemistry_enabled = false;
+	static constexpr int numPassiveScalars = 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+};
+
 AMREX_GPU_DEVICE void ComputeExactSolution(int i, int j, int k, int n, amrex::Array4<amrex::Real> const &exact_arr,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {

--- a/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -53,10 +53,9 @@ template <> void AdvectionSimulation<SemiellipseProblem>::setInitialConditionsOn
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
-  const int ncomp_cc = Physics_Indices<SemiellipseProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<SemiellipseProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
-	amrex::ParallelFor(indexRange, ncomp_cc,
-			   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { ComputeExactSolution(i, j, k, n, state_cc, dx, prob_lo); });
+	amrex::ParallelFor(indexRange, ncomp_cc, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { ComputeExactSolution(i, j, k, n, state_cc, dx, prob_lo); });
 }
 
 template <>

--- a/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -43,8 +43,9 @@ template <> void AdvectionSimulation<SemiellipseProblem>::setInitialConditionsOn
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
+  const int ncomp_cc = Physics_Indices<SemiellipseProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
-	amrex::ParallelFor(indexRange, ncomp_cc_,
+	amrex::ParallelFor(indexRange, ncomp_cc,
 			   [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) { ComputeExactSolution(i, j, k, n, state_cc, dx, prob_lo); });
 }
 

--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -66,10 +66,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	using AMRSimulation<problem_t>::DistributionMap;
 	using AMRSimulation<problem_t>::InterpHookNone;
 
-	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc)
-	{
-		componentNames_cc_.push_back({"density"});
-	}
+	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { componentNames_cc_.push_back({"density"}); }
 
 	void computeMaxSignalLocal(int level) override;
 	auto computeExtraPhysicsTimestep(int level) -> amrex::Real override;
@@ -279,7 +276,8 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		auto fluxArrays = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Stage 1 of RK2-SSP
-		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(), Physics_Indices<problem_t>::nvarTotal_cc);
+		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
+							      Physics_Indices<problem_t>::nvarTotal_cc);
 
 		if (do_reflux) {
 #ifdef USE_YAFLUXREGISTER

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -265,9 +265,9 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 
 	// Problem initialization
-	constexpr int nvars = RadhydroSimulation<CoolingTest>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	constexpr int ncomp_cc = Physics_Indices<CoolingTest>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
 		BCs_cc[n].setLo(1, amrex::BCType::foextrap); // extrapolate

--- a/src/FCQuantities/test_fc_quantities.cpp
+++ b/src/FCQuantities/test_fc_quantities.cpp
@@ -80,7 +80,7 @@ template <> void RadhydroSimulation<FCQuantities>::setInitialConditionsOnGrid(qu
 	const quokka::direction dir = grid_elem.dir_;
 
 	if (cen == quokka::centering::cc) {
-		const int ncomp_cc = ncomp_cc_;
+		const int ncomp_cc = Physics_Indices<FCQuantities>::nvarTotal_cc;
 		// loop over the grid and set the initial condition
 		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 			for (int n = 0; n < ncomp_cc; ++n) {
@@ -134,9 +134,9 @@ void checkMFs(amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const
 auto problem_main() -> int
 {
 	// Problem initialization
-	const int nvars_cc = Physics_Indices<FCQuantities>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int n = 0; n < nvars_cc; ++n) {
+	const int ncomp_cc = Physics_Indices<FCQuantities>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -141,9 +141,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<BlastProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = RadhydroSimulation<BlastProblem>::nvarTotal_cc_;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if (reflecting_boundary) {
 				if (isNormalComp(n, i)) {

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -254,9 +254,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<SedovProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<SedovProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if constexpr (simulate_full_box) { // periodic boundaries
 				BCs_cc[n].setLo(i, amrex::BCType::int_dir);

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -46,7 +46,7 @@ template <> void RadhydroSimulation<ContactProblem>::setInitialConditionsOnGrid(
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	int ncomp = ncomp_cc_;
+	int ncomp_cc = Physics_Indices<ContactProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -69,7 +69,7 @@ template <> void RadhydroSimulation<ContactProblem>::setInitialConditionsOnGrid(
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto gamma = HydroSystem<ContactProblem>::gamma_;
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 		state_cc(i, j, k, HydroSystem<ContactProblem>::density_index) = rho;
@@ -182,9 +182,9 @@ void RadhydroSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFa
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int nvars = RadhydroSimulation<ContactProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ContactProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -244,9 +244,9 @@ void RadhydroSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiF
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int nvars = RadhydroSimulation<HighMachProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<HighMachProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -116,9 +116,9 @@ template <> void RadhydroSimulation<KelvinHelmholzProblem>::ErrorEst(int lev, am
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int nvars = RadhydroSimulation<KelvinHelmholzProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<KelvinHelmholzProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir); // periodic

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -51,7 +51,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	const int ncomp = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -72,7 +72,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 
@@ -340,9 +340,9 @@ auto problem_main() -> int
 	const int max_timesteps = 50000;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<ShocktubeProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
 		BCs_cc[0].setHi(0, amrex::BCType::foextrap);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -246,9 +246,9 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 auto problem_main() -> int
 {
 	// Boundary conditions
-	const int nvars = RadhydroSimulation<QuirkProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<QuirkProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		// outflow
 		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
 		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -41,11 +41,12 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::computeAfterTimes
 {
 #ifdef DEBUG_SYMMETRY
 	// this code does not actually work with Nranks > 1 ...
+  const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
 
 	// copy all FABs to a local FAB across the entire domain
 	amrex::BoxArray localBoxes(domain_);
 	amrex::DistributionMapping localDistribution(localBoxes, 1);
-	amrex::MultiFab state_mf(localBoxes, localDistribution, ncomp_cc_, 0);
+	amrex::MultiFab state_mf(localBoxes, localDistribution, ncomp_cc, 0);
 	state_mf.ParallelCopy(state_new_cc_);
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
@@ -57,7 +58,7 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::computeAfterTimes
 		auto nx = nx_;
 		auto ny = ny_;
 		auto nz = nz_;
-		auto ncomp = ncomp_cc_;
+		auto ncomp = ncomp_cc;
 		for (int i = 0; i < nx; ++i) {
 			for (int j = 0; j < ny; ++j) {
 				for (int k = 0; k < nz; ++k) {
@@ -162,9 +163,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<RichtmeyerMeshkovProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) {
 				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -41,7 +41,7 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::computeAfterTimes
 {
 #ifdef DEBUG_SYMMETRY
 	// this code does not actually work with Nranks > 1 ...
-  const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
 
 	// copy all FABs to a local FAB across the entire domain
 	amrex::BoxArray localBoxes(domain_);

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -44,7 +44,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	const int ncomp = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -64,7 +64,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 
 		double Eint = E - 0.5 * (m * m) / rho;
 
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
@@ -261,9 +261,9 @@ auto problem_main() -> int
 	const int max_timesteps = 20000;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<ShocktubeProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
 		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -55,7 +55,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	const int ncomp = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -77,7 +77,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto gamma = HydroSystem<ShocktubeProblem>::gamma_;
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 		state_cc(i, j, k, HydroSystem<ShocktubeProblem>::density_index) = rho;
@@ -347,7 +347,7 @@ auto problem_main() -> int
 	const int max_timesteps = 8000;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<ShocktubeProblem>::nvarTotal_cc_;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -348,8 +348,8 @@ auto problem_main() -> int
 
 	// Problem initialization
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
 		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -46,7 +46,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	const int ncomp = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -281,9 +281,9 @@ auto problem_main() -> int
 	const int max_timesteps = 20000;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<ShocktubeProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
 		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -68,7 +68,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(P));
 
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -47,7 +47,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
-	const int ncomp = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
@@ -65,7 +65,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGri
 			P = 0.4;
 		}
 
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
 
@@ -303,9 +303,9 @@ auto problem_main() -> int
 	const int max_timesteps = 5000;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<ShocktubeProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
 		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -72,10 +72,10 @@ template <> void RadhydroSimulation<WaveProblem>::setInitialConditionsOnGrid(quo
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
-	const int ncomp = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<WaveProblem>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		for (int n = 0; n < ncomp; ++n) {
+		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0; // fill unused components with zeros
 		}
 		computeWaveSolution(i, j, k, state_cc, dx, prob_lo);
@@ -95,9 +95,9 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 
 	// Problem initialization
-	const int nvars = RadhydroSimulation<WaveProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<WaveProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -239,9 +239,9 @@ template <> void RadhydroSimulation<ScalarProblem>::ErrorEst(int lev, amrex::Tag
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int nvars = RadhydroSimulation<ScalarProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ScalarProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -138,9 +138,9 @@ auto problem_main() -> int
 	const double constant_dt = 1.0e-8; // s
 
 	// Problem initialization
-	constexpr int nvars = RadhydroSimulation<CouplingProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	constexpr int ncomp_cc = Physics_Indices<CouplingProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::foextrap); // extrapolate
 			BCs_cc[n].setHi(i, amrex::BCType::foextrap);

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -140,9 +140,9 @@ auto problem_main() -> int
 	const double constant_dt = 1.0e-8; // s
 
 	// Problem initialization
-	constexpr int nvars = RadhydroSimulation<CouplingProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	constexpr int ncomp_cc = Physics_Indices<CouplingProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::foextrap); // extrapolate
 			BCs_cc[n].setHi(i, amrex::BCType::foextrap);

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -255,9 +255,9 @@ auto problem_main() -> int
 	};
 
 	// boundary conditions
-	constexpr int nvars = RadhydroSimulation<TophatProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	constexpr int ncomp_cc = Physics_Indices<TophatProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- Marshak
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -381,9 +381,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<ShellProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<ShellProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if constexpr (simulate_full_box) {
 				// periodic boundaries

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -47,6 +47,7 @@
 #include "SimulationData.hpp"
 #include "hydro_system.hpp"
 #include "hyperbolic_system.hpp"
+#include "physics_info.hpp"
 #include "radiation_system.hpp"
 #include "simulation.hpp"
 
@@ -58,7 +59,6 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	using AMRSimulation<problem_t>::state_new_cc_;
 	using AMRSimulation<problem_t>::max_signal_speed_;
 
-	using AMRSimulation<problem_t>::ncomp_cc_;
 	using AMRSimulation<problem_t>::nghost_cc_;
 	using AMRSimulation<problem_t>::areInitialConditionsDefined_;
 	using AMRSimulation<problem_t>::BCs_cc_;
@@ -232,19 +232,16 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::defineComponen
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
 		std::vector<std::string> hydroNames = {"gasDensity", "x-GasMomentum", "y-GasMomentum", "z-GasMomentum", "gasEnergy", "gasInternalEnergy"};
 		componentNames_cc_.insert(componentNames_cc_.end(), hydroNames.begin(), hydroNames.end());
-		ncomp_cc_ += hydroNames.size();
 	}
 	// add passive scalar variables
 	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
 		std::vector<std::string> scalarNames = getScalarVariableNames();
 		componentNames_cc_.insert(componentNames_cc_.end(), scalarNames.begin(), scalarNames.end());
-		ncomp_cc_ += scalarNames.size();
 	}
 	// add radiation state variables
 	if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
 		std::vector<std::string> radNames = {"radEnergy", "x-RadFlux", "y-RadFlux", "z-RadFlux"};
 		componentNames_cc_.insert(componentNames_cc_.end(), radNames.begin(), radNames.end());
-		ncomp_cc_ += radNames.size();
 	}
 
 	// face-centred
@@ -737,8 +734,8 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 		}
 
 		// create temporary multifab for old state
-		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], ncomp_cc_, nghost_cc_);
-		amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, ncomp_cc_, nghost_cc_);
+		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+		amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 
 		// subcycle advanceHydroAtLevel, checking return value
 		for (int substep = 0; substep < nsubsteps; ++substep) {
@@ -809,7 +806,7 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 	addStrangSplitSources(state_old_cc_tmp, lev, time, 0.5 * dt_lev);
 
 	// create temporary multifab for intermediate state
-	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], ncomp_cc_, nghost_cc_);
+	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 	state_inter_cc_.setVal(0); // prevent assert in fillBoundaryConditions when radiation is enabled
 
 	// Stage 1 of RK2-SSP

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -172,9 +172,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<RTProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<RTProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		// periodic in x-direction
 		BCs_cc[n].setLo(0, amrex::BCType::int_dir);
 		BCs_cc[n].setHi(0, amrex::BCType::int_dir);

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -202,9 +202,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<RTProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<RTProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		// periodic in x- and y-directions
 		for (int i = 0; i < (AMREX_SPACEDIM - 1); ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir);

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -423,9 +423,9 @@ auto problem_main() -> int
 	const int max_timesteps = 1e5;
 
 	// Problem initialization
-	constexpr int nvars = RadhydroSimulation<ShockCloud>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	constexpr int ncomp_cc = Physics_Indices<ShockCloud>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
 

--- a/src/SphericalCollapse/spherical_collapse.cpp
+++ b/src/SphericalCollapse/spherical_collapse.cpp
@@ -115,9 +115,9 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int nvars = RadhydroSimulation<CollapseProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
+	const int ncomp_cc = Physics_Indices<CollapseProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) {
 				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -16,20 +16,21 @@ template <typename problem_t> struct Physics_Traits {
 
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {
-  // number of cc quantities required for advection problems
-  static const int nvarTotal_cc_adv = 1;
-  // number of cc quantities required for rad /+ hydro problem
-  static const int nvarTotal_cc_radhydro = Physics_Traits<problem_t>::numPassiveScalars +
-          Physics_NumVars::numHydroVars * static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) +
-					Physics_NumVars::numRadVars   * static_cast<int>(Physics_Traits<problem_t>::is_radiation_enabled);
+	// number of cc quantities required for advection problems
+	static const int nvarTotal_cc_adv = 1;
+	// number of cc quantities required for rad /+ hydro problem
+	static const int nvarTotal_cc_radhydro =
+	    Physics_Traits<problem_t>::numPassiveScalars +
+	    Physics_NumVars::numHydroVars * static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) +
+	    Physics_NumVars::numRadVars * static_cast<int>(Physics_Traits<problem_t>::is_radiation_enabled);
 	// cell-centered
-  static const int nvarTotal_cc      = nvarTotal_cc_radhydro > 0 ? nvarTotal_cc_radhydro : nvarTotal_cc_adv;
-  static const int hydroFirstIndex   = 0;
+	static const int nvarTotal_cc = nvarTotal_cc_radhydro > 0 ? nvarTotal_cc_radhydro : nvarTotal_cc_adv;
+	static const int hydroFirstIndex = 0;
 	static const int pscalarFirstIndex = Physics_NumVars::numHydroVars;
-	static const int radFirstIndex     = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
+	static const int radFirstIndex = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
 	// face-centered
 	static const int nvarPerDim_fc = Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
-	static const int nvarTotal_fc  = Physics_NumVars::numMHDVars_tot     * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
+	static const int nvarTotal_fc = Physics_NumVars::numMHDVars_tot * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
 	static const int mhdFirstIndex = 0;
 };
 

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -16,15 +16,20 @@ template <typename problem_t> struct Physics_Traits {
 
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {
+  // number of cc quantities required for advection problems
+  static const int nvarTotal_cc_adv = 1;
+  // number of cc quantities required for rad /+ hydro problem
+  static const int nvarTotal_cc_radhydro = Physics_Traits<problem_t>::numPassiveScalars +
+          Physics_NumVars::numHydroVars * static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) +
+					Physics_NumVars::numRadVars   * static_cast<int>(Physics_Traits<problem_t>::is_radiation_enabled);
 	// cell-centered
-	static const int nvarTotal_cc = Physics_NumVars::numHydroVars + Physics_Traits<problem_t>::numPassiveScalars +
-					static_cast<int>(Physics_Traits<problem_t>::is_radiation_enabled) * Physics_NumVars::numRadVars;
-	static const int hydroFirstIndex = 0;
+  static const int nvarTotal_cc      = nvarTotal_cc_radhydro > 0 ? nvarTotal_cc_radhydro : nvarTotal_cc_adv;
+  static const int hydroFirstIndex   = 0;
 	static const int pscalarFirstIndex = Physics_NumVars::numHydroVars;
-	static const int radFirstIndex = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
+	static const int radFirstIndex     = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
 	// face-centered
-	static const int nvarPerDim_fc = static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled) * Physics_NumVars::numMHDVars_per_dim;
-	static const int nvarTotal_fc = static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled) * Physics_NumVars::numMHDVars_tot;
+	static const int nvarPerDim_fc = Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
+	static const int nvarTotal_fc  = Physics_NumVars::numMHDVars_tot     * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
 	static const int mhdFirstIndex = 0;
 };
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -240,7 +240,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	// Nghost = number of ghost cells for each array
 	int nghost_cc_ = 4; // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4
 	int nghost_fc_ = 4;
-	int ncomp_cc_ = 0; // = number of components (conserved variables) for each array
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_;
 	amrex::Vector<std::string> derivedNames_;
@@ -629,11 +628,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 #endif
 	int last_plot_file_step = 0;
 	int last_chk_file_step = 0;
+  const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
-	amrex::Vector<amrex::Real> init_sum_cons(ncomp_cc_);
-	for (int n = 0; n < ncomp_cc_; ++n) {
+	amrex::Vector<amrex::Real> init_sum_cons(ncomp_cc);
+	for (int n = 0; n < ncomp_cc; ++n) {
 		const int lev = 0;
 		init_sum_cons[n] = state_new_cc_[lev].sum(n) * vol;
 	}
@@ -707,7 +707,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	computeAfterEvolve(init_sum_cons);
 
 	// compute conservation error
-	for (int n = 0; n < ncomp_cc_; ++n) {
+	for (int n = 0; n < ncomp_cc; ++n) {
 		amrex::Real const final_sum = state_new_cc_[0].sum(n) * vol;
 		amrex::Real const abs_err = (final_sum - init_sum_cons[n]);
 		amrex::Print() << "Initial " << componentNames_cc_[n] << " = " << init_sum_cons[n] << std::endl;
@@ -1181,7 +1181,7 @@ void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::Multi
 
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditionsAtLevel_cc(int level, amrex::Real time)
 {
-	const int ncomp_cc = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 	const int nghost_cc = nghost_cc_;
 	// itterate over the domain
 	for (amrex::MFIter iter(state_new_cc_[level]); iter.isValid(); ++iter) {
@@ -1232,7 +1232,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real ti
 	// define empty MultiFab containers with the right number of components and ghost-zones
 
 	// cell-centred
-	const int ncomp_cc = ncomp_cc_;
+	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 	const int nghost_cc = nghost_cc_;
 	state_new_cc_[level].define(ba, dm, ncomp_cc, nghost_cc);
 	state_old_cc_[level].define(ba, dm, ncomp_cc, nghost_cc);
@@ -1861,8 +1861,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		SetDistributionMap(lev, dm);
 
 		// build MultiFab and FluxRegister data
-		int ncomp_cc = ncomp_cc_;
-		int nghost_cc = nghost_cc_;
+		const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
+		const int nghost_cc = nghost_cc_;
 		state_old_cc_[lev].define(grids[lev], dmap[lev], ncomp_cc, nghost_cc);
 		state_new_cc_[lev].define(grids[lev], dmap[lev], ncomp_cc, nghost_cc);
 		max_signal_speed_[lev].define(ba, dm, 1, nghost_cc);
@@ -1872,8 +1872,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 										 refRatio(lev - 1), lev, ncomp_cc);
 		}
 
-		int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;
-		int nghost_fc = nghost_fc_;
+		const int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;
+		const int nghost_fc = nghost_fc_;
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				state_new_fc_[lev][idim] =

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -628,7 +628,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 #endif
 	int last_plot_file_step = 0;
 	int last_chk_file_step = 0;
-  const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);


### PR DESCRIPTION
Removed the member variable `ncomp_cc_` from `AMRSimulation` and updated all references to this member variable to instead query `Physics_Indices<problem>::nvarTotal_cc`, which computes at compile time how many cc and fc quantities need to be defined for a particular problem configuration (see `Physics_Traits`).