### PR TITLE
disable readability-function-cognitive-complexity warning

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,*,-fuchsia-*,-llvmlibc-*,-altera-*,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-non-private-member-variables-in-classes,-google-runtime-references,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-pro-bounds-constant-array-index'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,*,-fuchsia-*,-llvmlibc-*,-altera-*,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-non-private-member-variables-in-classes,-google-runtime-references,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-pro-bounds-constant-array-index,-readability-function-cognitive-complexity'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
This disables the `readability-function-cognitive-complexity` warning in the clang-tidy settings file [1].

We have a lot of kernels that are very long, and splitting them up into separate functions in order to avoid this warning does not make sense.

[1] https://clang.llvm.org/extra/clang-tidy/checks/readability/function-cognitive-complexity.html