### PR TITLE
avoid clang-tidy-review post on merged PRs

### DIFF
--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   build:
+    # avoid trying to post comments on a merged PR
+    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This avoids trying to post code style comments on PRs that have already been merged.