### PR TITLE
avoid using inf for limits

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -112,10 +112,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real abstolPoisson_ = 1.0e-10; // default
 	int doPoissonSolve_ = 0;	      // 1 == self-gravity enabled, 0 == disabled
 
-	amrex::Real densityFloor_ = 0.0;				     // in g cm-3, default
-	amrex::Real tempCeiling_ = std::numeric_limits<double>::infinity();  // default in K
-	amrex::Real tempFloor_ = 0.0;					     // default in K
-	amrex::Real speedCeiling_ = std::numeric_limits<double>::infinity(); // default in cm/s
+	amrex::Real densityFloor_ = 0.0;				// in g cm-3, default
+	amrex::Real tempCeiling_ = std::numeric_limits<double>::max();	// default in K
+	amrex::Real tempFloor_ = 0.0;					// default in K
+	amrex::Real speedCeiling_ = std::numeric_limits<double>::max(); // default in cm/s
 
 	// constructor
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -112,10 +112,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real abstolPoisson_ = 1.0e-10; // default
 	int doPoissonSolve_ = 0;	      // 1 == self-gravity enabled, 0 == disabled
 
-	amrex::Real densityFloor_ = 0.0;				// in g cm-3, default
-	amrex::Real tempCeiling_ = std::numeric_limits<double>::max();	// default in K
-	amrex::Real tempFloor_ = 0.0;					// default in K
-	amrex::Real speedCeiling_ = std::numeric_limits<double>::max(); // default in cm/s
+	amrex::Real densityFloor_ = 0.0;				// default
+	amrex::Real tempCeiling_ = std::numeric_limits<double>::max();	// default
+	amrex::Real tempFloor_ = 0.0;					// default
+	amrex::Real speedCeiling_ = std::numeric_limits<double>::max(); // default
 
 	// constructor
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }


### PR DESCRIPTION
This uses `std::numeric_limits<double>::max()` instead of using `inf` for the default ceilings.

This is because `inf` incurs a performance penalty [1]. The behavior should be unchanged, since no floating-point value can be larger than `std::numeric_limits<double>::max()` except for `inf` itself.

[1] https://randomascii.wordpress.com/2012/05/20/thats-not-normalthe-performance-of-odd-floats/ (This also seems to be true on NVIDIA GPUs in my tests, but I haven't found a reference for this.)