### PR TITLE
fix publish docs action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,5 +69,6 @@ jobs:
     needs: build
     steps:
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.repository == 'quokka-astro/quokka' && github.ref == 'refs/heads/development'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,6 +62,7 @@ jobs:
           retention-days: 1
 
   deploy:
+    if: github.event_name == 'push' && github.repository == 'quokka-astro/quokka' && github.ref == 'refs/heads/development'
     environment:
       name: github-pages
       url: quokka-astro.github.io
@@ -69,6 +70,5 @@ jobs:
     needs: build
     steps:
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.repository == 'quokka-astro/quokka' && github.ref == 'refs/heads/development'
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,26 @@
-name: Build and Deploy
+name: Build and Deploy Docs
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [$default-branch]
+    
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,13 +38,36 @@ jobs:
         run: |
           ./build_docs.sh
 
-      - name: Deploy
-        if: github.event_name == 'push' && github.repository == 'quokka-astro/quokka' && github.ref == 'refs/heads/development'
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - name: Archive artifact
+        shell: sh
+        run: |
+          chmod -c -R +rX "$INPUT_PATH" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+          tar \
+            --dereference --hard-dereference \
+            --directory "$INPUT_PATH" \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+        env:
+          INPUT_PATH: ./docs/_build/html
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@main
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACCESS_TOKEN: ${{ secrets.DEPLOY_DOCS }}
-          REPOSITORY_NAME: quokka-astro/quokka-astro.github.io
-          BRANCH: main # The branch the action should deploy to.
-          FOLDER: docs/_build/html # The folder the action should deploy.
-          CLEAN: false # Do not remove existing files from the deploy target.
+          name: 'github-pages'
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: quokka-astro.github.io
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
This uses GitHub-native mechanisms to deploy to GitHub Pages: i) it uploads a build artefact that contains a *.tar file with the static HTML files for the documentation, ii) it triggers deployment to the `github-pages` environment if pushed to `development` on the official quokka-astro/quokka repository.

Due to the repository permissions, no other branch (or repository) is allowed to publish files to `quokka-astro.github.io`, which is why there are errors below about deployment failures. (Hopefully, these will not occur once this is merged into development.)

This will hopefully fix deployment to GitHub Pages, which is currently broken.