### PR TITLE
fix branch name in docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Docs
 
 on:
   push:
-    branches: [$default-branch]
+    branches: [development]
     
   pull_request:
 


### PR DESCRIPTION
The branch name must be hard-coded in GitHub Actions workflows. I tried to use `$default-branch`, which is not allowed in actions (only actions _templates_).

For my own future reference: https://stackoverflow.com/questions/64781462/github-actions-default-branch-variable