### PR TITLE
update SphericalCollapse parameters

### DIFF
--- a/tests/SphericalCollapse.in
+++ b/tests/SphericalCollapse.in
@@ -14,7 +14,7 @@ amr.v              = 1       # verbosity in Amr
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell          = 64 64 64
-amr.max_level       = 1     # number of levels = max_level + 1
+amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 32    # grid size must be divisible by this
 amr.max_grid_size   = 128   # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells

--- a/tests/SphericalCollapse.in
+++ b/tests/SphericalCollapse.in
@@ -15,8 +15,8 @@ amr.v              = 1       # verbosity in Amr
 # *****************************************************************
 amr.n_cell          = 64 64 64
 amr.max_level       = 1     # number of levels = max_level + 1
-amr.blocking_factor = 16    # grid size must be divisible by this
-amr.max_grid_size   = 64    # at least 128 for GPUs
+amr.blocking_factor = 32    # grid size must be divisible by this
+amr.max_grid_size   = 128   # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
 amr.grid_eff        = 0.7   # default
 


### PR DESCRIPTION
Use a larger blocking_factor and max_grid_size to improve GPU performance on the SphericalCollapse test. Also, don't use AMR, so that it runs in a reasonable amount of time.