### PR TITLE
add multidimensional artificial viscosity

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -105,11 +105,12 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	amrex::Real errorNorm_ = NAN;
 	amrex::Real pressureFloor_ = 0.;
 
-	int integratorOrder_ = 2;	       // 1 == forward Euler; 2 == RK2-SSP (default)
-	int reconstructionOrder_ = 3;	       // 1 == donor cell; 2 == PLM; 3 == PPM (default)
-	int radiationReconstructionOrder_ = 3; // 1 == donor cell; 2 == PLM; 3 == PPM (default)
-	int useDualEnergy_ = 1;		       // 0 == disabled; 1 == use auxiliary internal energy equation (default)
-	int abortOnFofcFailure_ = 1;	       // 0 == keep going, 1 == abort hydro advance if FOFC fails
+	int integratorOrder_ = 2;		// 1 == forward Euler; 2 == RK2-SSP (default)
+	int reconstructionOrder_ = 3;		// 1 == donor cell; 2 == PLM; 3 == PPM (default)
+	int radiationReconstructionOrder_ = 3;	// 1 == donor cell; 2 == PLM; 3 == PPM (default)
+	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
+	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
+	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
 
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
@@ -280,6 +281,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::readParmParse(
 		hpp.query("reconstruction_order", reconstructionOrder_);
 		hpp.query("use_dual_energy", useDualEnergy_);
 		hpp.query("abort_on_fofc_failure", abortOnFofcFailure_);
+		hpp.query("artificial_viscosity_coefficient", artificialViscosityK_);
 	}
 
 	// set radiation runtime parameters
@@ -1105,7 +1107,7 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &pri
 	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
-	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar);
+	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
 }
 
 template <typename problem_t>
@@ -1158,7 +1160,7 @@ void RadhydroSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &p
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
-	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar);
+	HydroSystem<problem_t>::template ComputeFluxes<DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
 }
 
 template <typename problem_t> void RadhydroSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -916,6 +916,21 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		quokka::valarray<double, nvar_> F_canonical = quokka::Riemann::HLLC<nscalars_, nvar_>(sL, sR, gamma_, du, dw);
 		quokka::valarray<double, nvar_> F = F_canonical;
 
+		// add artificial viscosity
+		// following Colella & Woodward (1984), eq. (4.2)
+		const double K_visc = 0.1;
+		const double div_v = AMREX_D_TERM(du, +0.5 * (dvl + dvr), +0.5 * (dwl + dwr));
+		const double viscosity = K_visc * std::max(-div_v, 0.);
+
+		quokka::valarray<double, nvar_> U_L = {sL.rho, sL.rho * sL.u, sL.rho * sL.v, sL.rho * sL.w, sL.E, sL.Eint};
+		quokka::valarray<double, nvar_> U_R = {sR.rho, sR.rho * sR.u, sR.rho * sR.v, sR.rho * sR.w, sR.E, sR.Eint};
+		for (int n = 0; n < nscalars_; ++n) {
+			const int nstart = nvar_ - nscalars_;
+			U_L[nstart + n] = sL.scalar[n];
+			U_R[nstart + n] = sR.scalar[n];
+		}
+		F = F + viscosity * (U_L - U_R);
+
 		// permute momentum components according to flux direction DIR
 		F[velN_index] = F_canonical[x1Momentum_index];
 		F[velV_index] = F_canonical[x2Momentum_index];

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -101,7 +101,7 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	template <FluxDir DIR>
 	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf);
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc);
 
 	template <FluxDir DIR>
 	static void ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar, array_t &x1FluxDiffusive, amrex::Box const &indexRange);
@@ -747,7 +747,7 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 template <typename problem_t>
 template <FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf)
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc)
 {
 
 	// By convention, the interfaces are defined on the left edge of each
@@ -918,7 +918,6 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 
 		// add artificial viscosity
 		// following Colella & Woodward (1984), eq. (4.2)
-		const double K_visc = 0.1;
 		const double div_v = AMREX_D_TERM(du, +0.5 * (dvl + dvr), +0.5 * (dwl + dwr));
 		const double viscosity = K_visc * std::max(-div_v, 0.);
 

--- a/tests/blast_unigrid_128.in
+++ b/tests/blast_unigrid_128.in
@@ -22,3 +22,5 @@ amr.grid_eff        = 0.7   # default
 
 do_reflux = 0
 do_subcycle = 0
+
+hydro.artificial_viscosity_coefficient = 0.1


### PR DESCRIPTION
Adds an artificial viscosity term to `ComputeFluxes` following [1]. This may still be necessary for some difficult multidimensional problems.

[1] https://ui.adsabs.harvard.edu/abs/1984JCoPh..54..174C/abstract