### PR TITLE
fix AppleClang build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,9 @@ endif()
 find_package(HDF5 REQUIRED)
 
 # std::filesystem (required for GCC < 9)
-link_libraries(stdc++fs)
+if (NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+    link_libraries(stdc++fs)
+endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Coverage")
     # only works with gcc!

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -45,7 +45,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	// return temperature for an ideal gas
 	amrex::Real Tgas = NAN;
 	if constexpr (gamma_ != 1.0) {
-		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		Tgas = Eint / (rho * c_v);
 	}
 	return Tgas;
@@ -57,7 +57,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	// return internal energy density for a gamma-law ideal gas
 	amrex::Real Eint = NAN;
 	if constexpr (gamma_ != 1.0) {
-		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		Eint = rho * c_v * Tgas;
 	}
 	return Eint;
@@ -69,7 +69,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	// compute derivative of internal energy w/r/t temperature
 	amrex::Real dEint_dT = NAN;
 	if constexpr (gamma_ != 1.0) {
-		constexpr amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
+		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		dEint_dT = rho * c_v;
 	}
 	return dEint_dT;


### PR DESCRIPTION
Do not attempt to link `-lstdc++fs` when building with Apple Clang on macOS.