### PR TITLE
add GitHub CI for macOS

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -1,0 +1,58 @@
+name: CMake (macOS)
+
+on: [push, pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install Homebrew dependencies
+      run: brew install python3 openmpi hdf5
+
+    - name: Install pip dependencies
+      run: python3 -m pip install --user numpy matplotlib
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+    - name: Create test output directory
+      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest --output-on-failure -C $BUILD_TYPE
+
+    - name: Upload test output
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: test-results
+        path: ${{github.workspace}}/tests


### PR DESCRIPTION
Builds Quokka and runs the test suite using AppleClang on macOS 12.

Closes https://github.com/quokka-astro/quokka/issues/231.