### PR TITLE
avoid deprecated Python API call

### DIFF
--- a/src/matplotlibcpp.h
+++ b/src/matplotlibcpp.h
@@ -146,9 +146,16 @@ struct _interpreter {
 #else
 		char name[] = "plotting";
 #endif
+#if PY_VERSION_HEX < 0x03080000
 		Py_SetProgramName(name);
 		Py_Initialize();
-
+#else
+		PyConfig config;
+		PyConfig_InitPythonConfig(&config);
+		PyConfig_SetString(&config, &config.program_name, name);
+		Py_InitializeFromConfig(&config);
+		PyConfig_Clear(&config);
+#endif
 #ifndef WITHOUT_NUMPY
 		import_numpy(); // initialize numpy C-API
 #endif


### PR DESCRIPTION
We avoid using `Py_SetProgramName`, since that API call is deprecated as of Python 3.11. This only affects plotting with matplotlib.