### PR TITLE
increase azure-pipelines CI time limit

### DIFF
--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -6,29 +6,30 @@
 trigger:
 - development
 
-pool: oracle-cloud
+jobs:
+- job: BuildAndTest
+  timeoutInMinutes: 120 # how long to run the job before automatically cancelling
+  pool: oracle-cloud
+  steps:
+  - task: CMake@1
+    displayName: 'Configure CMake'
+    inputs:
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
 
-steps:
+  - task: CMake@1
+    displayName: 'Build Quokka'
+    inputs:
+      cmakeArgs: '--build . --parallel 1'
 
-- task: CMake@1
-  displayName: 'Configure CMake'
-  inputs:
-    cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
+  - task: CMake@1
+    displayName: 'Run CTest'
+    inputs:
+      cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
 
-- task: CMake@1
-  displayName: 'Build Quokka'
-  inputs:
-    cmakeArgs: '--build . --parallel 1'
-
-- task: CMake@1
-  displayName: 'Run CTest'
-  inputs:
-    cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
-
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: cTest
-    testResultsFiles: build/Testing/*/Test.xml
-    testRunTitle: $(Agent.JobName)
-  condition: succeededOrFailed()
-  displayName: Publish test results
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: cTest
+      testResultsFiles: build/Testing/*/Test.xml
+      testRunTitle: $(Agent.JobName)
+    condition: succeededOrFailed()
+    displayName: Publish test results

--- a/.ci/azure-pipelines-aarch64.yml
+++ b/.ci/azure-pipelines-aarch64.yml
@@ -6,29 +6,30 @@
 trigger:
 - development
 
-pool: oracle-cloud
+jobs:
+- job: BuildAndTest
+  timeoutInMinutes: 120 # how long to run the job before automatically cancelling
+  pool: oracle-cloud
+  steps:
+  - task: CMake@1
+    displayName: 'Configure CMake'
+    inputs:
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
 
-steps:
+  - task: CMake@1
+    displayName: 'Build Quokka'
+    inputs:
+      cmakeArgs: '--build . --parallel 1'
 
-- task: CMake@1
-  displayName: 'Configure CMake'
-  inputs:
-    cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
+  - task: CMake@1
+    displayName: 'Run CTest'
+    inputs:
+      cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
 
-- task: CMake@1
-  displayName: 'Build Quokka'
-  inputs:
-    cmakeArgs: '--build . --parallel 1'
-
-- task: CMake@1
-  displayName: 'Run CTest'
-  inputs:
-    cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
-
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: cTest
-    testResultsFiles: build/Testing/*/Test.xml
-    testRunTitle: $(Agent.JobName)
-  condition: succeededOrFailed()
-  displayName: Publish test results
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: cTest
+      testResultsFiles: build/Testing/*/Test.xml
+      testRunTitle: $(Agent.JobName)
+    condition: succeededOrFailed()
+    displayName: Publish test results


### PR DESCRIPTION
Increase the timeout limit from the default 60 minutes to 120 minutes.

This is necessary because building the chemistry network takes a _very_ long time to build on the Oracle Cloud VMs.