### PR TITLE
fix clang-tidy-review from forks

### DIFF
--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.12.2
+      - uses: ZedThree/clang-tidy-review/post@v0.12.3
       # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
         # adjust options as necessary

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,7 +13,7 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: ZedThree/clang-tidy-review@v0.12.2
+    - uses: ZedThree/clang-tidy-review@v0.12.3
       id: review
       with:
         config_file: src/.clang-tidy
@@ -23,7 +23,7 @@ jobs:
         split_workflow: true
 
     # Uploads an artefact containing clang_fixes.json
-    - uses: ZedThree/clang-tidy-review/upload@v0.12.2
+    - uses: ZedThree/clang-tidy-review/upload@v0.12.3
 
     # If there are any comments, fail the check
     - if: steps.review.outputs.total_comments > 0


### PR DESCRIPTION
Fixes a bug that prevented posting `clang-tidy` comments on PRs from forks (https://github.com/ZedThree/clang-tidy-review/issues/82).