### PR TITLE
Use macOS 13 on GitHub Actions

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-12
+    runs-on: macos-13-xl
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-13-xl
+    runs-on: macos-13
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Use a virtual machine running macOS 13 for macOS testing (previously macOS 12).