### PR TITLE
cancel in-progress CI builds on new push

### DIFF
--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -6,6 +6,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 jobs:
 - job: BuildAndTest
   timeoutInMinutes: 120 # how long to run the job before automatically cancelling

--- a/.ci/azure-pipelines-aarch64.yml
+++ b/.ci/azure-pipelines-aarch64.yml
@@ -6,6 +6,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 jobs:
 - job: BuildAndTest
   timeoutInMinutes: 120 # how long to run the job before automatically cancelling

--- a/.ci/azure-pipelines-asan.yml
+++ b/.ci/azure-pipelines-asan.yml
@@ -6,6 +6,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 pool: avatar
 
 steps:

--- a/.ci/azure-pipelines-build-llvm.yml
+++ b/.ci/azure-pipelines-build-llvm.yml
@@ -1,6 +1,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 pool: avatar
 
 steps:

--- a/.ci/azure-pipelines-debug.yml
+++ b/.ci/azure-pipelines-debug.yml
@@ -6,6 +6,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 pool: avatar
 
 steps:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -6,6 +6,12 @@
 trigger:
 - development
 
+pr:
+  autoCancel: true
+  branches:
+    include:
+    - development
+
 pool: avatar
 
 steps:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -3,6 +3,10 @@ name: clang-tidy-review
 # You can be more specific, but it currently only works on pull requests
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-clang-tidy
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -7,6 +7,10 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ development ]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-cmake-macos
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,10 @@ on:
   merge_group:
     branches: [ development ]
 
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-cmake-linux
+  cancel-in-progress: true
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release


### PR DESCRIPTION
This auto-cancels any existing in-progress tests for the same pull request.

When pushing new commits to a PR, new CI builds will be triggered automatically. By default, the any existing CI builds running for the same PR keep running, but this is usually pointless.