### PR TITLE
treat all compiler warnings as errors

### DIFF
--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -20,7 +20,7 @@ jobs:
   - task: CMake@1
     displayName: 'Configure CMake'
     inputs:
-      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Debug -DWARNINGS_AS_ERRORS=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
 
   - task: CMake@1
     displayName: 'Build Quokka'

--- a/.ci/azure-pipelines-aarch64.yml
+++ b/.ci/azure-pipelines-aarch64.yml
@@ -20,7 +20,7 @@ jobs:
   - task: CMake@1
     displayName: 'Configure CMake'
     inputs:
-      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
+      cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DWARNINGS_AS_ERRORS=ON -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
 
   - task: CMake@1
     displayName: 'Build Quokka'

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -41,7 +41,7 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWARNINGS_AS_ERRORS=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,7 +47,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DENABLE_ASAN=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DENABLE_ASAN=ON -DWARNINGS_AS_ERRORS=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(AMReX_TINY_PROFILE ON CACHE BOOL "" FORCE)
 option(QUOKKA_PYTHON "Compile with Python support (on/off)" ON)
 option(DISABLE_FMAD "Disable fused multiply-add instructions on GPU (on/off)" ON)
 option(ENABLE_ASAN "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
   enable_language(CUDA)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,8 +60,8 @@ else()
   message(STATUS "Fused multiply-add (FMAD) is *enabled* for device code. Exact direction symmetry will NOT be preserved.")
 endif(DISABLE_FMAD)
 
-# this is necessary to prevent the host compiler from complaining about nv_pragmas
-#add_compile_options(-Wno-unknown-pragmas)
+# emit error if warnings are produced
+add_compile_options(-Werror -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas)
 
 # emit register usage per thread from CUDA assembler
 # if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ else()
 endif(DISABLE_FMAD)
 
 # emit error if warnings are produced
-add_compile_options(-Werror -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas)
+add_compile_options(-Werror -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-strict-aliasing)
 
 # emit register usage per thread from CUDA assembler
 # if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,9 @@ else()
 endif(DISABLE_FMAD)
 
 # emit error if warnings are produced
-add_compile_options(-Werror -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-strict-aliasing)
+if(WARNINGS_AS_ERRORS)
+  add_compile_options(-Werror -Wall -Wextra -Wno-unused-parameter -Wno-unknown-pragmas -Wno-strict-aliasing)
+endif(WARNINGS_AS_ERRORS)
 
 # emit register usage per thread from CUDA assembler
 # if(CMAKE_CUDA_COMPILER_ID STREQUAL "NVIDIA")

--- a/src/CloudyCooling.hpp
+++ b/src/CloudyCooling.hpp
@@ -20,6 +20,7 @@
 #include "GrackleDataReader.hpp"
 #include "Interpolate2D.hpp"
 #include "ODEIntegrate.hpp"
+#include "hydro_system.hpp"
 #include "radiation_system.hpp"
 #include "root_finding.hpp"
 

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -287,7 +287,7 @@ void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::Multi
 		}
 
 		std::vector<double> Pexact(xs_exact.size());
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			Pexact.at(i) = pressure_exact.at(i) / 10.;
 		}
 

--- a/src/ODEIntegrate.hpp
+++ b/src/ODEIntegrate.hpp
@@ -151,7 +151,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 	// integration loop
 	Real time = t0;
 	Real dt = std::isnan(dt_guess) ? (t1 - t0) : dt_guess;
-	const Real hmin = 1.0e-4;
 	quokka::valarray<Real, N> &y = y0;
 	quokka::valarray<Real, N> yerr{};
 	quokka::valarray<Real, N> ynew{};

--- a/src/PrimordialChem/test_primordial_chem.cpp
+++ b/src/PrimordialChem/test_primordial_chem.cpp
@@ -130,9 +130,6 @@ template <> void RadhydroSimulation<PrimordialChemTest>::preCalculateInitialCond
 template <> void RadhydroSimulation<PrimordialChemTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const prob_lo = grid_elem.prob_lo_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const prob_hi = grid_elem.prob_hi_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -286,7 +286,7 @@ auto problem_main() -> int
 		const double t = sim.tNew_[0];
 		const double xmax = c * t;
 		amrex::Print() << "diffusion length = " << xmax << std::endl;
-		for (int i = 0; i < xs.size(); ++i) {
+		for (size_t i = 0; i < xs.size(); ++i) {
 			if (xs[i] < xmax) {
 				err_norm += std::abs(Trad[i] - Trad_exact_interp[i]);
 				sol_norm += std::abs(Trad_exact_interp[i]);

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -304,7 +304,7 @@ auto problem_main() -> int
 
 	double err_norm = 0.;
 	double sol_norm = 0.;
-	for (int i = 0; i < xs_exact.size(); ++i) {
+	for (size_t i = 0; i < xs_exact.size(); ++i) {
 		err_norm += std::abs(Tmat_interp[i] - Tmat_exact[i]);
 		sol_norm += std::abs(Tmat_exact[i]);
 	}

--- a/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -301,7 +301,7 @@ auto problem_main() -> int
 		const double t = sim.tNew_[0];
 		const double xmax = c_light_cgs_ * t;
 		amrex::Print() << "diffusion length = " << xmax << std::endl;
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			if (xs_exact[i] < xmax) {
 				err_norm += std::abs(Trad_interp[i] - Trad_exact[i]);
 				sol_norm += std::abs(Trad_exact[i]);

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -200,7 +200,7 @@ auto problem_main() -> int
 		// compute L2 error norm
 		double err_norm = 0.;
 		double sol_norm = 0.;
-		for (int i = 0; i < sim.userData_.t_vec_.size(); ++i) {
+		for (size_t i = 0; i < sim.userData_.t_vec_.size(); ++i) {
 			err_norm += std::abs(sim.userData_.Tgas_vec_[i] - Tgas_exact_interp[i]);
 			sol_norm += std::abs(Tgas_exact_interp[i]);
 		}
@@ -247,7 +247,7 @@ auto problem_main() -> int
 		matplotlibcpp::clf();
 
 		std::vector<double> frac_err(t.size());
-		for (int i = 0; i < t.size(); ++i) {
+		for (size_t i = 0; i < t.size(); ++i) {
 			frac_err.at(i) = Tgas_exact_interp.at(i) / Tgas.at(i) - 1.0;
 		}
 		matplotlibcpp::plot(t, frac_err);

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -212,7 +212,7 @@ auto problem_main() -> int
 		// compute L1 error norm
 		double err_norm = 0.;
 		double sol_norm = 0.;
-		for (int i = 0; i < t.size(); ++i) {
+		for (size_t i = 0; i < t.size(); ++i) {
 			err_norm += std::abs(Tgas[i] - Tgas_rsla_exact[i]);
 			sol_norm += std::abs(Tgas_rsla_exact[i]);
 		}
@@ -259,7 +259,7 @@ auto problem_main() -> int
 		matplotlibcpp::clf();
 
 		std::vector<double> frac_err(t.size());
-		for (int i = 0; i < t.size(); ++i) {
+		for (size_t i = 0; i < t.size(); ++i) {
 			frac_err.at(i) = Tgas_rsla_exact.at(i) / Tgas.at(i) - 1.0;
 		}
 		matplotlibcpp::plot(t, frac_err);

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -196,7 +196,7 @@ auto problem_main() -> int
 	// compute error norm
 	double err_norm = 0.;
 	double sol_norm = 0.;
-	for (int i = 0; i < xs.size(); ++i) {
+	for (size_t i = 0; i < xs.size(); ++i) {
 		err_norm += std::abs(Trad[i] - Trad_exact[i]);
 		sol_norm += std::abs(Trad_exact[i]);
 	}

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -274,7 +274,7 @@ auto problem_main() -> int
 		std::vector<double> Tgas_exact_10(Egas_transport_exact_10p0);
 		std::vector<double> Tgas_exact_1(Egas_transport_exact_10p0);
 
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			Trad_exact_10.at(i) = std::pow(Erad_transport_exact_10p0.at(i) / a_rad, 1. / 4.);
 			Trad_exact_1.at(i) = std::pow(Erad_transport_exact_1p0.at(i) / a_rad, 1. / 4.);
 
@@ -291,7 +291,7 @@ auto problem_main() -> int
 		// compute L1 error norm
 		double err_norm = 0.;
 		double sol_norm = 0.;
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			err_norm += std::abs(Tgas_numerical_interp[i] - Tgas_exact_10[i]);
 			sol_norm += std::abs(Tgas_exact_10[i]);
 		}

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -331,7 +331,7 @@ auto problem_main() -> int
 
 		double err_norm = 0.;
 		double sol_norm = 0.;
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			err_norm += std::abs(Trad_interp[i] - Trad_exact[i]);
 			sol_norm += std::abs(Trad_exact[i]);
 		}

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -331,7 +331,7 @@ auto problem_main() -> int
 
 			double err_norm = 0.;
 			double sol_norm = 0.;
-			for (int i = 0; i < xs_exact.size(); ++i) {
+			for (size_t i = 0; i < xs_exact.size(); ++i) {
 				err_norm += std::abs(Trad_interp[i] - Trad_exact[i]);
 				sol_norm += std::abs(Trad_exact[i]);
 			}
@@ -349,10 +349,10 @@ auto problem_main() -> int
 #ifdef HAVE_PYTHON
 		std::vector<double> xs_scaled(xs.size());
 		std::vector<double> xs_exact_scaled(xs_exact.size());
-		for (int i = 0; i < xs.size(); ++i) {
+		for (size_t i = 0; i < xs.size(); ++i) {
 			xs_scaled.at(i) = xs.at(i) / Lx;
 		}
-		for (int i = 0; i < xs_exact.size(); ++i) {
+		for (size_t i = 0; i < xs_exact.size(); ++i) {
 			xs_exact_scaled.at(i) = xs_exact.at(i) / Lx;
 		}
 

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -1166,7 +1166,6 @@ auto RadhydroSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &
 
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
-	const int flatteningGhost = 2;
 	const int reconstructRange = 1;
 
 	// allocate temporary MultiFabs

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -743,8 +743,8 @@ auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F 
 
 	// normalize profile
 	amrex::Long numCells = domain.numPts() / domain.length(axis);
-	for (size_t i = 0; i < profile.size(); ++i) {
-		profile[i] /= static_cast<amrex::Real>(numCells);
+	for (double & bin : profile) {
+		bin /= static_cast<amrex::Real>(numCells);
 	}
 
 	return profile;

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -743,7 +743,7 @@ auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F 
 
 	// normalize profile
 	amrex::Long numCells = domain.numPts() / domain.length(axis);
-	for (double & bin : profile) {
+	for (double &bin : profile) {
 		bin /= static_cast<amrex::Real>(numCells);
 	}
 

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -743,7 +743,7 @@ auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F 
 
 	// normalize profile
 	amrex::Long numCells = domain.numPts() / domain.length(axis);
-	for (int i = 0; i < profile.size(); ++i) {
+	for (size_t i = 0; i < profile.size(); ++i) {
 		profile[i] /= static_cast<amrex::Real>(numCells);
 	}
 
@@ -757,7 +757,6 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 	// timestep retries
 	const int max_retries = 4;
 	bool success = false;
-	amrex::Real cur_time;
 
 	// save the pre-advance fine flux register state in originalFineData
 	amrex::MultiFab originalFineData;
@@ -771,7 +770,6 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 		// reduce timestep by a factor of 2^retry_count
 		const int nsubsteps = std::pow(2, retry_count);
 		const amrex::Real dt_step = dt_lev / nsubsteps;
-		cur_time = time;
 
 		if (retry_count > 0 && Verbose()) {
 			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (nsubsteps = " << nsubsteps
@@ -801,7 +799,6 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 			}
 
 			success = advanceHydroAtLevel(state_old_cc_tmp, fr_as_crse, fr_as_fine, lev, time, dt_step);
-			cur_time += dt_step;
 
 			if (!success) {
 				if (Verbose()) {

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -13,6 +13,7 @@
 #include <cmath>
 
 // library headers
+#include "AMReX.H"
 #include "AMReX_Arena.H"
 #include "AMReX_Array4.H"
 #include "AMReX_BLassert.H"
@@ -572,6 +573,13 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 		x1RightState(i, j, k, n) = new_a_minus;
 		x1LeftState(i + 1, j, k, n) = new_a_plus;
 	});
+	
+	if constexpr (AMREX_SPACEDIM < 2) {
+		amrex::ignore_unused(x2Chi_in);
+	}
+	if constexpr (AMREX_SPACEDIM < 3) {
+		amrex::ignore_unused(x3Chi_in);
+	}
 }
 
 // to ensure that physical quantities are within reasonable

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -573,7 +573,7 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 		x1RightState(i, j, k, n) = new_a_minus;
 		x1LeftState(i + 1, j, k, n) = new_a_plus;
 	});
-	
+
 	if constexpr (AMREX_SPACEDIM < 2) {
 		amrex::ignore_unused(x2Chi_in);
 	}

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -25,7 +25,6 @@
 // internal headers
 #include "ArrayView.hpp"
 #include "EOS.hpp"
-#include "hydro_system.hpp"
 #include "hyperbolic_system.hpp"
 #include "simulation.hpp"
 #include "valarray.hpp"
@@ -1081,7 +1080,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::ComputeSourceTermsExplicit(arrayconst_t &consPrev, arrayconst_t &radEnergySource, array_t &src, amrex::Box const &indexRange,
+void RadSystem<problem_t>::ComputeSourceTermsExplicit(arrayconst_t &consPrev, arrayconst_t & /*radEnergySource*/, array_t &src, amrex::Box const &indexRange,
 						      amrex::Real dt)
 {
 	const double chat = c_hat_;
@@ -1107,9 +1106,6 @@ void RadSystem<problem_t>::ComputeSourceTermsExplicit(arrayconst_t &consPrev, ar
 		// compute opacity, emissivity
 		const auto kappa = RadSystem<problem_t>::ComputeOpacity(rho, T_gas);
 		const auto fourPiB = chat * a_rad * std::pow(T_gas, 4);
-
-		// constant radiation energy source term
-		const auto Src = dt * (chat * radEnergySource(i, j, k));
 
 		// compute reaction term
 		const auto rhs = dt * (rho * kappa) * (fourPiB - chat * Erad0);

--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -9,13 +9,15 @@
 /// \brief A container for a vector with addition, multiplication with expression templates
 /// (This is necessary because std::valarray is not defined in CUDA C++!)
 
-// library headers
-#include "AMReX_Extension.H"
-#include <AMReX_GpuQualifiers.H>
+#include <algorithm>
 #include <cmath>
 #include <cstddef>
 #include <iterator>
 #include <limits>
+
+// library headers
+#include "AMReX_Extension.H"
+#include <AMReX_GpuQualifiers.H>
 
 namespace quokka
 {
@@ -28,7 +30,7 @@ template <typename T, int d> class valarray
 	// (although not cppcore-compliant)
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(std::initializer_list<T> list) // NOLINT
 	{
-		const int max_count = std::min(list.size(), static_cast<size_t>(d));
+		const size_t max_count = std::min(list.size(), static_cast<size_t>(d));
 
 		T const *input = std::data(list); // requires nvcc to be in C++17 mode! (if it fails, the
 						  // compiler flags are wrong, probably due to a CMake issue.)


### PR DESCRIPTION
This turns on `-Werror` when compiling the CI tests. This means that the code must compile without warnings to pass the CI tests.