### PR TITLE
Using CMake object library to compile files needed by all tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,4 +10,4 @@
 [submodule "extern/Microphysics"]
 	path = extern/Microphysics
 	url = https://github.com/psharda/Microphysics
-	branch = networks-changes-dev
+	branch = development

--- a/src/Advection/CMakeLists.txt
+++ b/src/Advection/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection test_advection.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp)
+add_executable(test_advection test_advection.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection)

--- a/src/Advection2D/CMakeLists.txt
+++ b/src/Advection2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_advection2d ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_advection2d.cpp)
+    add_executable(test_advection2d test_advection2d.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_advection2d)
     endif()

--- a/src/AdvectionSemiellipse/CMakeLists.txt
+++ b/src/AdvectionSemiellipse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection_se test_advection_semiellipse.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp)
+add_executable(test_advection_se test_advection_semiellipse.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection_se)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ link_libraries(hdf5::hdf5)
 
 include(CTest)
 
+#create an object library for files that should be compiled with all test problems
 set (QuokkaObjSources "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/CloudyCooling.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/GrackleDataReader.cpp")
 add_library(QuokkaObj OBJECT ${QuokkaObjSources})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,7 +75,6 @@ endif(WARNINGS_AS_ERRORS)
 #   add_compile_options($<$<COMPILE_LANGUAGE:CUDA>:-Wno-unused-command-line-argument>)
 # endif()
 
-
 include_directories(${amrex_INCLUDE_DIRS_RET})
 include_directories(${fmt_INCLUDE_DIRS_RET})
 include_directories(${HDF5_INCLUDE_DIRS_RET})
@@ -88,6 +87,15 @@ link_libraries(fmt::fmt)
 link_libraries(hdf5::hdf5)
 
 include(CTest)
+
+set (QuokkaObjSources "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/CloudyCooling.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/GrackleDataReader.cpp")
+add_library(QuokkaObj OBJECT ${QuokkaObjSources})
+
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+    setup_target_for_cuda_compilation(QuokkaObj)
+endif()
+
+link_libraries(QuokkaObj)
 
 add_subdirectory(HydroShocktubeCMA)
 add_subdirectory(PrimordialChem)

--- a/src/Cooling/CMakeLists.txt
+++ b/src/Cooling/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_cooling ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_cooling.cpp)
+    add_executable(test_cooling test_cooling.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_cooling)

--- a/src/FCQuantities/CMakeLists.txt
+++ b/src/FCQuantities/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_fc_quantities ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_fc_quantities.cpp ../interpolate.cpp)
+add_executable(test_fc_quantities test_fc_quantities.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_fc_quantities)

--- a/src/HydroBlast2D/CMakeLists.txt
+++ b/src/HydroBlast2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_blast ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro2d_blast.cpp)
+    add_executable(test_hydro2d_blast test_hydro2d_blast.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_blast)
     endif()

--- a/src/HydroBlast3D/CMakeLists.txt
+++ b/src/HydroBlast3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_hydro3d_blast ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro3d_blast.cpp)
+    add_executable(test_hydro3d_blast test_hydro3d_blast.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro3d_blast)
     endif()

--- a/src/HydroContact/CMakeLists.txt
+++ b/src/HydroContact/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_contact test_hydro_contact.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp)
+add_executable(test_hydro_contact test_hydro_contact.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_contact)

--- a/src/HydroHighMach/CMakeLists.txt
+++ b/src/HydroHighMach/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_highmach test_hydro_highmach.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_highmach test_hydro_highmach.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_highmach)

--- a/src/HydroKelvinHelmholz/CMakeLists.txt
+++ b/src/HydroKelvinHelmholz/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_kh ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro2d_kh.cpp)
+    add_executable(test_hydro2d_kh test_hydro2d_kh.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_kh)
     endif()

--- a/src/HydroLeblanc/CMakeLists.txt
+++ b/src/HydroLeblanc/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_leblanc ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_leblanc.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_leblanc test_hydro_leblanc.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_leblanc)

--- a/src/HydroQuirk/CMakeLists.txt
+++ b/src/HydroQuirk/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_quirk ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_quirk.cpp)
+    add_executable(test_quirk test_quirk.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_quirk)
     endif()

--- a/src/HydroRichtmeyerMeshkov/CMakeLists.txt
+++ b/src/HydroRichtmeyerMeshkov/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_rm ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro2d_rm.cpp)
+    add_executable(test_hydro2d_rm test_hydro2d_rm.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_rm)
     endif()

--- a/src/HydroSMS/CMakeLists.txt
+++ b/src/HydroSMS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_sms ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_sms.cpp ../fextract.cpp)
+add_executable(test_hydro_sms test_hydro_sms.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_sms)

--- a/src/HydroShocktube/CMakeLists.txt
+++ b/src/HydroShocktube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shocktube ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_shocktube.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_shocktube test_hydro_shocktube.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shocktube)

--- a/src/HydroShocktubeCMA/CMakeLists.txt
+++ b/src/HydroShocktubeCMA/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shocktube_cma test_hydro_shocktube_cma.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_shocktube_cma test_hydro_shocktube_cma.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shocktube_cma)

--- a/src/HydroShuOsher/CMakeLists.txt
+++ b/src/HydroShuOsher/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shuosher ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_shuosher.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_shuosher test_hydro_shuosher.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shuosher)

--- a/src/HydroVacuum/CMakeLists.txt
+++ b/src/HydroVacuum/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_vacuum ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_vacuum.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_hydro_vacuum test_hydro_vacuum.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_vacuum)

--- a/src/HydroWave/CMakeLists.txt
+++ b/src/HydroWave/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_wave ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro_wave.cpp ../fextract.cpp)
+add_executable(test_hydro_wave test_hydro_wave.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_wave)

--- a/src/ODEIntegration/CMakeLists.txt
+++ b/src/ODEIntegration/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_ode ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_ode.cpp ../GrackleDataReader.cpp ../CloudyCooling.cpp)
+add_executable(test_ode test_ode.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_ode)

--- a/src/PassiveScalar/CMakeLists.txt
+++ b/src/PassiveScalar/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_scalars test_scalars.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../fextract.cpp)
+add_executable(test_scalars test_scalars.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_scalars)

--- a/src/PrimordialChem/CMakeLists.txt
+++ b/src/PrimordialChem/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_primordial_chem test_primordial_chem.cpp ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp ../Chemistry.cpp ${primordial_chem_sources})
+add_executable(test_primordial_chem test_primordial_chem.cpp ../Chemistry.cpp ${primordial_chem_sources})
 target_compile_definitions(test_primordial_chem PUBLIC PRIMORDIAL_CHEM) #this will add #define PRIMORDIAL_CHEM
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")

--- a/src/RadBeam/CMakeLists.txt
+++ b/src/RadBeam/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_beam ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_beam.cpp)
+    add_executable(test_radiation_beam test_radiation_beam.cpp)
     
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_beam)

--- a/src/RadForce/CMakeLists.txt
+++ b/src/RadForce/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_force ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_force.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_force test_radiation_force.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_force)

--- a/src/RadMarshak/CMakeLists.txt
+++ b/src/RadMarshak/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_marshak.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak test_radiation_marshak.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak)

--- a/src/RadMarshakAsymptotic/CMakeLists.txt
+++ b/src/RadMarshakAsymptotic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_asymptotic ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_marshak_asymptotic.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak_asymptotic test_radiation_marshak_asymptotic.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_asymptotic)

--- a/src/RadMarshakCGS/CMakeLists.txt
+++ b/src/RadMarshakCGS/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak_cgs ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_marshak_cgs.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_marshak_cgs test_radiation_marshak_cgs.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_cgs)

--- a/src/RadMatterCoupling/CMakeLists.txt
+++ b/src/RadMatterCoupling/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_matter_coupling ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_matter_coupling.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_matter_coupling test_radiation_matter_coupling.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling)

--- a/src/RadMatterCouplingRSLA/CMakeLists.txt
+++ b/src/RadMatterCouplingRSLA/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_matter_coupling_rsla ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_matter_coupling_rsla.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_matter_coupling_rsla test_radiation_matter_coupling_rsla.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling_rsla)

--- a/src/RadPulse/CMakeLists.txt
+++ b/src/RadPulse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_pulse ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_pulse.cpp ../fextract.cpp)
+add_executable(test_radiation_pulse test_radiation_pulse.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_pulse)

--- a/src/RadShadow/CMakeLists.txt
+++ b/src/RadShadow/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_shadow ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_shadow.cpp)
+    add_executable(test_radiation_shadow test_radiation_shadow.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_shadow)

--- a/src/RadStreaming/CMakeLists.txt
+++ b/src/RadStreaming/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_streaming ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_streaming.cpp ../fextract.cpp)
+add_executable(test_radiation_streaming test_radiation_streaming.cpp ../fextract.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_streaming)

--- a/src/RadSuOlson/CMakeLists.txt
+++ b/src/RadSuOlson/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_SuOlson ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_SuOlson.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_SuOlson test_radiation_SuOlson.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_SuOlson)

--- a/src/RadTophat/CMakeLists.txt
+++ b/src/RadTophat/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_radiation_tophat ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_tophat.cpp)
+    add_executable(test_radiation_tophat test_radiation_tophat.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radiation_tophat)
     endif()

--- a/src/RadTube/CMakeLists.txt
+++ b/src/RadTube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_tube ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radiation_tube.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radiation_tube test_radiation_tube.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_tube)

--- a/src/RadhydroShell/CMakeLists.txt
+++ b/src/RadhydroShell/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_radhydro3d_shell ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radhydro_shell.cpp ../interpolate.cpp)
+    add_executable(test_radhydro3d_shell test_radhydro_shell.cpp ../interpolate.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radhydro3d_shell)

--- a/src/RadhydroShock/CMakeLists.txt
+++ b/src/RadhydroShock/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radhydro_shock.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radhydro_shock test_radhydro_shock.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock)

--- a/src/RadhydroShockCGS/CMakeLists.txt
+++ b/src/RadhydroShockCGS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock_cgs ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_radhydro_shock_cgs.cpp ../fextract.cpp ../interpolate.cpp)
+add_executable(test_radhydro_shock_cgs test_radhydro_shock_cgs.cpp ../fextract.cpp ../interpolate.cpp)
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock_cgs)

--- a/src/RayleighTaylor2D/CMakeLists.txt
+++ b/src/RayleighTaylor2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_hydro2d_rt ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro2d_rt.cpp)
+    add_executable(test_hydro2d_rt test_hydro2d_rt.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro2d_rt)
     endif()

--- a/src/RayleighTaylor3D/CMakeLists.txt
+++ b/src/RayleighTaylor3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_hydro3d_rt ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_hydro3d_rt.cpp)
+    add_executable(test_hydro3d_rt test_hydro3d_rt.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_hydro3d_rt)
     endif()

--- a/src/ShockCloud/CMakeLists.txt
+++ b/src/ShockCloud/CMakeLists.txt
@@ -1,6 +1,6 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 3)
-    add_executable(shock_cloud ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp cloud.cpp)
-    add_executable(test_cloudy ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp test_cloudy.cpp)
+    add_executable(shock_cloud cloud.cpp)
+    add_executable(test_cloudy test_cloudy.cpp)
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(shock_cloud)

--- a/src/SphericalCollapse/CMakeLists.txt
+++ b/src/SphericalCollapse/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(spherical_collapse ../main.cpp ../CloudyCooling.cpp ../GrackleDataReader.cpp spherical_collapse.cpp)
+    add_executable(spherical_collapse spherical_collapse.cpp)
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(spherical_collapse)
     endif()


### PR DESCRIPTION
Currently, we have to include `main.cpp` `CloudyCooling.cpp` and `GrackleDataReader.cpp` by hand in every test problem, via `add_executable()`. So, when we compile Quokka, these three files are being compiled multiple times - once each for every test problem.

This PR removes duplicate compilation of these files by compiling them only once as part of an object library that we can link to each test problem. On GPUs, this is made possible by using `setup_target_for_cuda_compilation` function in amrex.