### PR TITLE
Compute massScalars and use them in EOS routines

### DIFF
--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -82,9 +82,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 		}
 
 		eos(eos_input_re, chemstate);
-		amrex::Real Tgas = chemstate.T;
+		Tgas = chemstate.T;
 	} else {
-		amrex::Real Tgas = NAN;
 		if constexpr (gamma_ != 1.0) {
 			const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 			Tgas = Eint / (rho * c_v);
@@ -120,9 +119,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 		}
 
 		eos(eos_input_rt, chemstate);
-		amrex::Real const Eint = chemstate.e * chemstate.rho;
+		Eint = chemstate.e * chemstate.rho;
 	} else {
-		amrex::Real Eint = NAN;
 		if constexpr (gamma_ != 1.0) {
 			const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 			Eint = rho * c_v * Tgas;
@@ -157,9 +155,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 		}
 
 		eos(eos_input_rt, chemstate);
-		amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
+		dEint_dT = chemstate.dedT * chemstate.rho;
 	} else {
-		amrex::Real dEint_dT = NAN;
 		if constexpr (gamma_ != 1.0) {
 			const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 			dEint_dT = rho * c_v;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -63,7 +63,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
     -> amrex::Real
 {
 	// return temperature for an ideal gas
-	amrex::Real Tgas;
+	amrex::Real Tgas = NAN;
 
 	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;
@@ -99,7 +99,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
     -> amrex::Real
 {
 	// return internal energy density for a gamma-law ideal gas
-	amrex::Real Eint;
+	amrex::Real Eint = NAN;
 
 	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;
@@ -137,7 +137,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
     -> amrex::Real
 {
 	// compute derivative of internal energy w/r/t temperature
-	amrex::Real dEint_dT;
+	amrex::Real dEint_dT = NAN;
 
 	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -62,11 +62,11 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
-        chemstate.rho = rho;
-        chemstate.e = Eint / rho;
-        eos(eos_input_re, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass scalars in
-            // chemstate.xn
-        amrex::Real Tgas = chemstate.T;
+	chemstate.rho = rho;
+	chemstate.e = Eint / rho;
+	eos(eos_input_re, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
+				      // scalars in chemstate.xn
+	amrex::Real Tgas = chemstate.T;
 
 #else
 	amrex::Real Tgas = NAN;
@@ -87,11 +87,11 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 #ifdef PRIMORDIAL_CHEM
 
 	burn_t chemstate;
-        chemstate.rho = rho;
-        chemstate.T = Tgas;
-        eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass scalars in
-            // chemstate.xn
-        amrex::Real const Eint = chemstate.e * chemstate.rho;
+	chemstate.rho = rho;
+	chemstate.T = Tgas;
+	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
+				      // scalars in chemstate.xn
+	amrex::Real const Eint = chemstate.e * chemstate.rho;
 
 #else
 	amrex::Real Eint = NAN;
@@ -112,11 +112,11 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 #ifdef PRIMORDIAL_CHEM
 
 	burn_t chemstate;
-        chemstate.rho = rho;
-        chemstate.T = Tgas;
-        eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass scalars in
-            // chemstate.xn
-        amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
+	chemstate.rho = rho;
+	chemstate.T = Tgas;
+	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
+				      // scalars in chemstate.xn
+	amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
 
 #else
 	amrex::Real dEint_dT = NAN;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -90,9 +90,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
-        for (int nn = 0; nn < nmscalars_; ++nn) {
-        	chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
-        }
+	for (int nn = 0; nn < nmscalars_; ++nn) {
+		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+	}
 
 	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
 				      // scalars in chemstate.xn
@@ -117,9 +117,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
-        for (int nn = 0; nn < nmscalars_; ++nn) {
-        	chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
-        }
+	for (int nn = 0; nn < nmscalars_; ++nn) {
+		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+	}
 
 	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
 				      // scalars in chemstate.xn

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -93,8 +93,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
 	chemstate.rho = rho;
-        // Define and initialize Tgas here
-        amrex::Real Tgas_value = Tgas;
+	// Define and initialize Tgas here
+	amrex::Real Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
 
 	if (massScalars.has_value()) {
@@ -125,7 +125,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
 	chemstate.rho = rho;
-        // we don't need Tgas to find chemstate.dedT
+	// we don't need Tgas to find chemstate.dedT
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -125,7 +125,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
 	chemstate.rho = rho;
-	// we don't need Tgas to find chemstate.dedT
+	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
+	chemstate.T = NAN;
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -65,9 +65,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
 
-        for (int nn = 0; nn < nmscalars_; ++nn) {
-        	chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
-        }
+	for (int nn = 0; nn < nmscalars_; ++nn) {
+		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+	}
 	eos(eos_input_re, chemstate);
 	amrex::Real Tgas = chemstate.T;
 

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -101,9 +101,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	amrex::Real Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
 	// initialize array of number densities
-        for (int nn = 0; nn < NumSpec; ++nn) {
-        	chemstate.xn[nn] = -1.0;
-        }
+	for (int nn = 0; nn < NumSpec; ++nn) {
+		chemstate.xn[nn] = -1.0;
+	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
@@ -136,9 +136,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
 	chemstate.T = NAN;
 	// initialize array of number densities
-           for (int nn = 0; nn < NumSpec; ++nn) {
-                   chemstate.xn[nn] = -1.0;
-           }
+	for (int nn = 0; nn < NumSpec; ++nn) {
+		chemstate.xn[nn] = -1.0;
+	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -66,7 +66,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	chemstate.e = Eint / rho;
 
 	if (massScalars.has_value()) {
-		const auto& massArray = massScalars.value();
+		const auto &massArray = massScalars.value();
 		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
@@ -96,7 +96,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	chemstate.T = Tgas;
 
 	if (massScalars.has_value()) {
-		const auto& massArray = massScalars.value();
+		const auto &massArray = massScalars.value();
 		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
@@ -126,7 +126,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	chemstate.T = Tgas;
 
 	if (massScalars.has_value()) {
-		const auto& massArray = massScalars.value();
+		const auto &massArray = massScalars.value();
 		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -15,10 +15,11 @@
 #include "AMReX_REAL.H"
 #include "physics_info.hpp"
 
-#ifdef PRIMORDIAL_CHEM
 #include "burn_type.H"
 #include "eos.H"
 #include "extern_parameters.H"
+
+#ifdef PRIMORDIAL_CHEM
 constexpr bool PRIMORDIAL_CHEM = true;
 #else
 constexpr bool PRIMORDIAL_CHEM = false;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -20,9 +20,9 @@
 #include "extern_parameters.H"
 
 #ifdef PRIMORDIAL_CHEM
-constexpr bool PRIMORDIAL_CHEM = true;
+constexpr bool PRIMORDIAL_CHEM_ENABLED = true;
 #else
-constexpr bool PRIMORDIAL_CHEM = false;
+constexpr bool PRIMORDIAL_CHEM_ENABLED = false;
 #endif
 
 namespace quokka
@@ -63,8 +63,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
     -> amrex::Real
 {
 	// return temperature for an ideal gas
+	amrex::Real Tgas;
 
-	if constexpr (PRIMORDIAL_CHEM) {
+	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;
 		chemstate.rho = rho;
 		chemstate.e = Eint / rho;
@@ -98,7 +99,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
     -> amrex::Real
 {
 	// return internal energy density for a gamma-law ideal gas
-	if constexpr (PRIMORDIAL_CHEM) {
+	amrex::Real Eint;
+
+	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;
 		chemstate.rho = rho;
 		// Define and initialize Tgas here
@@ -134,7 +137,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
     -> amrex::Real
 {
 	// compute derivative of internal energy w/r/t temperature
-	if constexpr (PRIMORDIAL_CHEM) {
+	amrex::Real dEint_dT;
+
+	if constexpr (PRIMORDIAL_CHEM_ENABLED) {
 		burn_t chemstate;
 		chemstate.rho = rho;
 		// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -15,11 +15,14 @@
 #include "AMReX_REAL.H"
 #include "physics_info.hpp"
 
-if constexpr (PRIMORDIAL_CHEM) {
+#ifdef PRIMORDIAL_CHEM
 #include "burn_type.H"
 #include "eos.H"
 #include "extern_parameters.H"
-}
+constexpr bool PRIMORDIAL_CHEM = true;
+#else
+constexpr bool PRIMORDIAL_CHEM = false;
+#endif
 
 namespace quokka
 {

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -93,7 +93,9 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
 	chemstate.rho = rho;
-	chemstate.T = Tgas;
+        // Define and initialize Tgas here
+        amrex::Real Tgas_value = Tgas;
+	chemstate.T = Tgas_value;
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
@@ -123,7 +125,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 #ifdef PRIMORDIAL_CHEM
 	burn_t chemstate;
 	chemstate.rho = rho;
-	chemstate.T = Tgas;
+        // we don't need Tgas to find chemstate.dedT
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -64,6 +64,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
+	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
@@ -96,6 +97,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	// Define and initialize Tgas here
 	amrex::Real Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
+	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
@@ -127,6 +129,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	chemstate.rho = rho;
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
 	chemstate.T = NAN;
+	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -65,13 +65,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
 	// initialize array of number densities
-	for (int nn = 0; nn < NumSpec; ++nn) {
-		chemstate.xn[nn] = -1.0;
+	for (int ii = 0; ii < NumSpec; ++ii) {
+		chemstate.xn[ii] = -1.0;
 	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (nn = 0; nn < nmscalars_; ++nn) {
+		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}
@@ -101,13 +101,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	amrex::Real Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
 	// initialize array of number densities
-	for (int nn = 0; nn < NumSpec; ++nn) {
-		chemstate.xn[nn] = -1.0;
+	for (int ii = 0; ii < NumSpec; ++ii) {
+		chemstate.xn[ii] = -1.0;
 	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (nn = 0; nn < nmscalars_; ++nn) {
+		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}
@@ -136,13 +136,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
 	chemstate.T = NAN;
 	// initialize array of number densities
-	for (int nn = 0; nn < NumSpec; ++nn) {
-		chemstate.xn[nn] = -1.0;
+	for (int ii = 0; ii < NumSpec; ++ii) {
+		chemstate.xn[ii] = -1.0;
 	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (nn = 0; nn < nmscalars_; ++nn) {
+		for (int nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -64,13 +64,12 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
-
 	for (int nn = 0; nn < nmscalars_; ++nn) {
 		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 	}
+
 	eos(eos_input_re, chemstate);
 	amrex::Real Tgas = chemstate.T;
-
 #else
 	amrex::Real Tgas = NAN;
 	if constexpr (gamma_ != 1.0) {
@@ -88,14 +87,16 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 {
 	// return internal energy density for a gamma-law ideal gas
 #ifdef PRIMORDIAL_CHEM
-
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
+        for (int nn = 0; nn < nmscalars_; ++nn) {
+        	chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+        }
+
 	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
 				      // scalars in chemstate.xn
 	amrex::Real const Eint = chemstate.e * chemstate.rho;
-
 #else
 	amrex::Real Eint = NAN;
 	if constexpr (gamma_ != 1.0) {
@@ -113,14 +114,16 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 {
 	// compute derivative of internal energy w/r/t temperature
 #ifdef PRIMORDIAL_CHEM
-
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
+        for (int nn = 0; nn < nmscalars_; ++nn) {
+        	chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+        }
+
 	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
 				      // scalars in chemstate.xn
 	amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
-
 #else
 	amrex::Real dEint_dT = NAN;
 	if constexpr (gamma_ != 1.0) {

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -64,8 +64,12 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
-	for (int nn = 0; nn < nmscalars_; ++nn) {
-		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+
+	if (massScalars.has_value()) {
+		const auto& massArray = massScalars.value();
+		for (int nn = 0; nn < nmscalars_; ++nn) {
+			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+		}
 	}
 
 	eos(eos_input_re, chemstate);
@@ -90,8 +94,12 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
-	for (int nn = 0; nn < nmscalars_; ++nn) {
-		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+
+	if (massScalars.has_value()) {
+		const auto& massArray = massScalars.value();
+		for (int nn = 0; nn < nmscalars_; ++nn) {
+			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+		}
 	}
 
 	eos(eos_input_rt, chemstate);
@@ -116,8 +124,12 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.T = Tgas;
-	for (int nn = 0; nn < nmscalars_; ++nn) {
-		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+
+	if (massScalars.has_value()) {
+		const auto& massArray = massScalars.value();
+		for (int nn = 0; nn < nmscalars_; ++nn) {
+			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
+		}
 	}
 
 	eos(eos_input_rt, chemstate);

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -41,11 +41,11 @@ template <typename problem_t> class EOS
       public:
 	static constexpr int nmscalars_ = Physics_Traits<problem_t>::numMassScalars;
 	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto
-	ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massFractions = {}) -> amrex::Real;
+	ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massScalars = {}) -> amrex::Real;
 	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto
-	ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massFractions = {}) -> amrex::Real;
+	ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massScalars = {}) -> amrex::Real;
 	[[nodiscard]] AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE static auto
-	ComputeEintTempDerivative(amrex::Real rho, amrex::Real Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massFractions = {}) -> amrex::Real;
+	ComputeEintTempDerivative(amrex::Real rho, amrex::Real Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> massScalars = {}) -> amrex::Real;
 
       private:
 	static constexpr amrex::Real gamma_ = EOS_Traits<problem_t>::gamma;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -94,8 +94,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 	}
 
-	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
-				      // scalars in chemstate.xn
+	eos(eos_input_rt, chemstate);
 	amrex::Real const Eint = chemstate.e * chemstate.rho;
 #else
 	amrex::Real Eint = NAN;
@@ -121,8 +120,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 		chemstate.xn[nn] = massScalars[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 	}
 
-	eos(eos_input_rt, chemstate); // this will cause an error when primordial chem is run with hydro, because we also need to input values of the mass
-				      // scalars in chemstate.xn
+	eos(eos_input_rt, chemstate);
 	amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
 #else
 	amrex::Real dEint_dT = NAN;

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -104,7 +104,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 		burn_t chemstate;
 		chemstate.rho = rho;
 		// Define and initialize Tgas here
-		amrex::Real Tgas_value = Tgas;
+		amrex::Real const Tgas_value = Tgas;
 		chemstate.T = Tgas_value;
 		// initialize array of number densities
 		for (int ii = 0; ii < NumSpec; ++ii) {

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -15,11 +15,11 @@
 #include "AMReX_REAL.H"
 #include "physics_info.hpp"
 
-#ifdef PRIMORDIAL_CHEM
-#include "burn_type.H"
-#include "eos.H"
-#include "extern_parameters.H"
-#endif
+if constexpr (PRIMORDIAL_CHEM) {
+	#include "burn_type.H"
+	#include "eos.H"
+	#include "extern_parameters.H"
+	}
 
 namespace quokka
 {
@@ -60,7 +60,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 {
 	// return temperature for an ideal gas
 
-#ifdef PRIMORDIAL_CHEM
+if constexpr (PRIMORDIAL_CHEM) {
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
@@ -78,13 +78,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 
 	eos(eos_input_re, chemstate);
 	amrex::Real Tgas = chemstate.T;
-#else
+} else {
 	amrex::Real Tgas = NAN;
 	if constexpr (gamma_ != 1.0) {
 		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		Tgas = Eint / (rho * c_v);
 	}
-#endif
+}
 	return Tgas;
 }
 
@@ -94,7 +94,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
     -> amrex::Real
 {
 	// return internal energy density for a gamma-law ideal gas
-#ifdef PRIMORDIAL_CHEM
+if constexpr (PRIMORDIAL_CHEM) {
 	burn_t chemstate;
 	chemstate.rho = rho;
 	// Define and initialize Tgas here
@@ -114,13 +114,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 
 	eos(eos_input_rt, chemstate);
 	amrex::Real const Eint = chemstate.e * chemstate.rho;
-#else
+} else {
 	amrex::Real Eint = NAN;
 	if constexpr (gamma_ != 1.0) {
 		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		Eint = rho * c_v * Tgas;
 	}
-#endif
+}
 	return Eint;
 }
 
@@ -130,7 +130,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
     -> amrex::Real
 {
 	// compute derivative of internal energy w/r/t temperature
-#ifdef PRIMORDIAL_CHEM
+if constexpr (PRIMORDIAL_CHEM) {
 	burn_t chemstate;
 	chemstate.rho = rho;
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
@@ -149,13 +149,13 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 
 	eos(eos_input_rt, chemstate);
 	amrex::Real const dEint_dT = chemstate.dedT * chemstate.rho;
-#else
+} else {
 	amrex::Real dEint_dT = NAN;
 	if constexpr (gamma_ != 1.0) {
 		const amrex::Real c_v = boltzmann_constant_ / (mean_molecular_weight_ * (gamma_ - 1.0));
 		dEint_dT = rho * c_v;
 	}
-#endif
+}
 	return dEint_dT;
 }
 

--- a/src/EOS.hpp
+++ b/src/EOS.hpp
@@ -64,11 +64,14 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	burn_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
-	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
+	// initialize array of number densities
+	for (int nn = 0; nn < NumSpec; ++nn) {
+		chemstate.xn[nn] = -1.0;
+	}
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (int nn = 0; nn < nmscalars_; ++nn) {
+		for (nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}
@@ -97,11 +100,14 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	// Define and initialize Tgas here
 	amrex::Real Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
-	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
+	// initialize array of number densities
+        for (int nn = 0; nn < NumSpec; ++nn) {
+        	chemstate.xn[nn] = -1.0;
+        }
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (int nn = 0; nn < nmscalars_; ++nn) {
+		for (nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}
@@ -129,11 +135,14 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintTempDer
 	chemstate.rho = rho;
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
 	chemstate.T = NAN;
-	chemstate.xn[NumSpec] = {-1.0}; // initialize array of number densities
+	// initialize array of number densities
+           for (int nn = 0; nn < NumSpec; ++nn) {
+                   chemstate.xn[nn] = -1.0;
+           }
 
 	if (massScalars.has_value()) {
 		const auto &massArray = massScalars.value();
-		for (int nn = 0; nn < nmscalars_; ++nn) {
+		for (nn = 0; nn < nmscalars_; ++nn) {
 			chemstate.xn[nn] = massArray[nn] / spmasses[nn]; // massScalars are partial densities (massFractions * rho)
 		}
 	}

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -65,21 +65,21 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<SuOlsonProblem>::ComputeRossela
 static constexpr int nmscalars_ = Physics_Traits<SuOlsonProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/) -> double
+									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/) -> double
+									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas,
-										  std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+										  std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	// This is also known as the heat capacity, i.e.

--- a/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -70,7 +70,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<SuOlsonProblemCgs>::ComputeRoss
 static constexpr int nmscalars_ = Physics_Traits<SuOlsonProblemCgs>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblemCgs>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									       std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									       std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
@@ -78,7 +78,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblemCgs>::ComputeTgasFromEint(c
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblemCgs>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									       std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									       std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
@@ -86,7 +86,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblemCgs>::ComputeEintFromTgas(c
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<SuOlsonProblemCgs>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas,
-										     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+										     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	// This is also known as the heat capacity, i.e.

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -65,16 +65,14 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeRossel
 static constexpr int nmscalars_ = Physics_Traits<CouplingProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
-    -> double
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
-    -> double
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
 }

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -65,7 +65,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeRossel
 static constexpr int nmscalars_ = Physics_Traits<CouplingProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
@@ -73,7 +73,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(con
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
@@ -81,7 +81,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(con
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas,
-										   std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+										   std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	// This is also known as the heat capacity, i.e.

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -67,16 +67,14 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeRossel
 static constexpr int nmscalars_ = Physics_Traits<CouplingProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
-    -> double
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
-    -> double
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
 }

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -67,7 +67,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CouplingProblem>::ComputeRossel
 static constexpr int nmscalars_ = Physics_Traits<CouplingProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
@@ -75,7 +75,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeTgasFromEint(con
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+									     std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return (alpha_SuOlson / 4.0) * std::pow(Tgas, 4);
@@ -83,7 +83,7 @@ AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintFromTgas(con
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<CouplingProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas,
-										   std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+										   std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	// This is also known as the heat capacity, i.e.

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -75,21 +75,21 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputeRossela
 static constexpr int nmscalars_ = Physics_Traits<MarshakProblem>::numMassScalars;
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeTgasFromEint(const double /*rho*/, const double Egas,
-									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/) -> double
+									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return std::pow(4.0 * Egas / alpha_SuOlson, 1. / 4.);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeEintFromTgas(const double /*rho*/, const double Tgas,
-									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/) -> double
+									    std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	return (alpha_SuOlson / 4.0) * (Tgas * Tgas * Tgas * Tgas);
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto quokka::EOS<MarshakProblem>::ComputeEintTempDerivative(const double /*rho*/, const double Tgas,
-										  std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+										  std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	// This is also known as the heat capacity, i.e.

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -91,7 +91,7 @@ template <> AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto RadSystem<TophatProble
 static constexpr int nmscalars_ = Physics_Traits<TophatProblem>::numMassScalars;
 template <>
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto
-quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double Egas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double Egas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return Egas / (rho * c_v);
@@ -99,7 +99,7 @@ quokka::EOS<TophatProblem>::ComputeTgasFromEint(const double rho, const double E
 
 template <>
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto
-quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/)
+quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double Tgas, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/)
     -> double
 {
 	return rho * c_v * Tgas;
@@ -108,7 +108,7 @@ quokka::EOS<TophatProblem>::ComputeEintFromTgas(const double rho, const double T
 template <>
 AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto
 quokka::EOS<TophatProblem>::ComputeEintTempDerivative(const double rho, const double /*Tgas*/,
-						      std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massFractions*/) -> double
+						      std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> /*massScalars*/) -> double
 {
 	// This is also known as the heat capacity, i.e.
 	// 		\del E_g / \del T = \rho c_v,

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -74,6 +74,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	AMREX_GPU_DEVICE static auto ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
+	AMREX_GPU_DEVICE static auto ComputeMassScalars(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::GpuArray<amrex::Real, nmscalars_>;
+
 	AMREX_GPU_DEVICE static auto ComputeVelocityX1(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
 	AMREX_GPU_DEVICE static auto ComputeVelocityX2(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
@@ -302,6 +304,17 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputePressure
 	const auto thermal_energy = E - kinetic_energy;
 	const auto P = thermal_energy * (HydroSystem<problem_t>::gamma_ - 1.0);
 	return P;
+}
+
+template <typename problem_t>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputeMassScalars(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+    -> amrex::GpuArray<amrex::Real, nmscalars_>
+{
+    amrex::GpuArray<amrex::Real, nmscalars_> massScalars;
+    for (int n = 0; n < nmscalars_; ++n) {
+        massScalars[n] = cons(i, j, k, scalar0_index + n);
+    }
+    return massScalars;
 }
 
 template <typename problem_t>

--- a/src/hydro_system.hpp
+++ b/src/hydro_system.hpp
@@ -74,7 +74,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	AMREX_GPU_DEVICE static auto ComputePressure(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
-	AMREX_GPU_DEVICE static auto ComputeMassScalars(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::GpuArray<amrex::Real, nmscalars_>;
+	AMREX_GPU_DEVICE static auto ComputeMassScalars(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
+	    -> amrex::GpuArray<amrex::Real, nmscalars_>;
 
 	AMREX_GPU_DEVICE static auto ComputeVelocityX1(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k) -> amrex::Real;
 
@@ -310,11 +311,11 @@ template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::ComputeMassScalars(amrex::Array4<const amrex::Real> const &cons, int i, int j, int k)
     -> amrex::GpuArray<amrex::Real, nmscalars_>
 {
-    amrex::GpuArray<amrex::Real, nmscalars_> massScalars;
-    for (int n = 0; n < nmscalars_; ++n) {
-        massScalars[n] = cons(i, j, k, scalar0_index + n);
-    }
-    return massScalars;
+	amrex::GpuArray<amrex::Real, nmscalars_> massScalars;
+	for (int n = 0; n < nmscalars_; ++n) {
+		massScalars[n] = cons(i, j, k, scalar0_index + n);
+	}
+	return massScalars;
 }
 
 template <typename problem_t>


### PR DESCRIPTION
This PR continues the groundwork laid down in #291 to use massScalars while computing Eint from Tgas or vice-versa. Now, it adds a function that can be called to obtain values of massScalars, and pass them on to EOS.

I also replaced the word massFractions with massScalars since the latter is more appropriate given we store partial densities and not mass fractions.