### PR TITLE
don't run Azure Pipelines twice on the same commit

### DIFF
--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -3,8 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines-aarch64.yml
+++ b/.ci/azure-pipelines-aarch64.yml
@@ -3,8 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines-asan.yml
+++ b/.ci/azure-pipelines-asan.yml
@@ -3,8 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines-build-llvm.yml
+++ b/.ci/azure-pipelines-build-llvm.yml
@@ -1,5 +1,4 @@
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines-debug.yml
+++ b/.ci/azure-pipelines-debug.yml
@@ -3,8 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,8 +3,7 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-- development
+trigger: none
 
 pr:
   autoCancel: true


### PR DESCRIPTION
This only triggers running the Azure Pipeline CI on pull requests. It will not trigger on pushes to branches. This should eliminate the 'double triggering' seen previously for new commits added to pull requests.

Edit: This does not work.