### PR TITLE
Update dependencies_hip.sh to use ROCm 5.4.3

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -17,9 +17,10 @@ set -eu -o pipefail
 #   failed files the given number of times.
 echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
-# Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
-curl -O https://repo.radeon.com/rocm/rocm.gpg.key
-sudo apt-key add rocm.gpg.key
+# Ref.: https://rocmdocs.amd.com/en/latest/deploy/linux/os-native/install.html
+sudo mkdir --parents --mode=0755 /etc/apt/keyrings
+wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+    gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
 for ver in 5.4.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -20,11 +20,14 @@ echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
 curl -O https://repo.radeon.com/rocm/rocm.gpg.key
 sudo apt-key add rocm.gpg.key
-echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
-  | sudo tee /etc/apt/sources.list.d/rocm.list
+
+for ver in 5.4.3 5.5.1; do
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
+    | sudo tee --append /etc/apt/sources.list.d/rocm.list
+done
+
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
   | sudo tee -a /etc/profile.d/rocm.sh
-
 # we should not need to export HIP_PATH=/opt/rocm/hip with those installs
 
 sudo apt-get update
@@ -39,11 +42,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev        \
-    roctracer-dev   \
-    rocprofiler-dev \
-    rocrand-dev     \
-    rocprim-dev
+    rocm-dev5.4.3        \
+    roctracer-dev5.4.3   \
+    rocprofiler-dev5.4.3 \
+    rocrand-dev5.4.3     \
+    rocprim-dev5.4.3
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -22,7 +22,7 @@ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-for ver in 5.2 5.4.3 5.5.1; do
+for ver in 5.3.3 5.4.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
     | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
@@ -43,11 +43,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev5.2        \
-    roctracer-dev5.2   \
-    rocprofiler-dev5.2 \
-    rocrand-dev5.2     \
-    rocprim-dev5.2
+    rocm-dev5.3.3        \
+    roctracer-dev5.3.3   \
+    rocprofiler-dev5.3.3 \
+    rocrand-dev5.3.3     \
+    rocprim-dev5.3.3
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -43,11 +43,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev5.3.3        \
-    roctracer-dev5.3.3   \
-    rocprofiler-dev5.3.3 \
-    rocrand-dev5.3.3     \
-    rocprim-dev5.3.3
+    rocm-dev5.4.3        \
+    roctracer-dev5.4.3   \
+    rocprofiler-dev5.4.3 \
+    rocrand-dev5.4.3     \
+    rocprim-dev5.4.3
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -22,7 +22,7 @@ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-for ver in 5.4.3 5.5.1; do
+for ver in 5.2 5.4.3 5.5.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
     | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
@@ -43,11 +43,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev5.4.3        \
-    roctracer-dev5.4.3   \
-    rocprofiler-dev5.4.3 \
-    rocrand-dev5.4.3     \
-    rocprim-dev5.4.3
+    rocm-dev5.2        \
+    roctracer-dev5.2   \
+    rocprofiler-dev5.2 \
+    rocrand-dev5.2     \
+    rocprim-dev5.2
 
 # activate
 #


### PR DESCRIPTION
This changes the HIP CI action to use ROCm 5.4.3 rather than the latest ROCm version (currently 5.5.1), since this is the latest version available on Setonix and Frontier.