### PR TITLE
Run only one test per commit

### DIFF
--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -30,7 +30,7 @@ jobs:
   - task: CMake@1
     displayName: 'Run CTest'
     inputs:
-      cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
+      cmakeArgs: '-E chdir . ctest -j 2 -T Test --output-on-failure'
 
   - task: PublishTestResults@2
     inputs:

--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -25,7 +25,7 @@ jobs:
   - script: cmake --build .
     displayName: 'Build Quokka'
 
-  - script: ctest -j 2 -T Test --output-on-failure
+  - script: ctest -j 2 -I 1,1 -T Test --output-on-failure
     displayName: 'Run CTest'
 
   - task: PublishTestResults@2

--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -27,10 +27,8 @@ jobs:
     inputs:
       cmakeArgs: '--build .'
 
-  - task: CMake@1
+  - script: ctest -j 2 -T Test --output-on-failure
     displayName: 'Run CTest'
-    inputs:
-      cmakeArgs: '-E chdir . ctest -j 2 -T Test --output-on-failure'
 
   - task: PublishTestResults@2
     inputs:

--- a/.ci/azure-pipelines-aarch64-debug.yml
+++ b/.ci/azure-pipelines-aarch64-debug.yml
@@ -22,10 +22,8 @@ jobs:
     inputs:
       cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=1'
 
-  - task: CMake@1
+  - script: cmake --build .
     displayName: 'Build Quokka'
-    inputs:
-      cmakeArgs: '--build .'
 
   - script: ctest -j 2 -T Test --output-on-failure
     displayName: 'Run CTest'

--- a/.ci/azure-pipelines-aarch64.yml
+++ b/.ci/azure-pipelines-aarch64.yml
@@ -30,7 +30,7 @@ jobs:
   - task: CMake@1
     displayName: 'Run CTest'
     inputs:
-      cmakeArgs: '-E chdir . ctest -T Test --output-on-failure'
+      cmakeArgs: '-E chdir . ctest -j 2 -T Test --output-on-failure'
 
   - task: PublishTestResults@2
     inputs:


### PR DESCRIPTION
#317 used 2 cores to run azure pipelines, but they trigger 2 tests each, so each commit is being tested four times. This PR can ensure each commit only triggers one test but uses both cores.