### PR TITLE
update Setonix CMake settings

### DIFF
--- a/cmake/setonix.cmake
+++ b/cmake/setonix.cmake
@@ -1,11 +1,8 @@
 # host configuration
 # run with `cmake -C host_config.cmake ..` from inside build directory
 
-set(CMAKE_C_COMPILER "cc" CACHE PATH "")
-set(CMAKE_CXX_COMPILER "CC" CACHE PATH "")
 set(AMReX_GPU_BACKEND HIP CACHE STRING "")
 set(AMReX_AMD_ARCH gfx90a CACHE STRING "") # MI250X
-set(AMREX_GPUS_PER_NODE 8 CACHE STRING "")
 set(AMReX_ASCENT OFF BOOL STRING "")
 
 option(QUOKKA_PYTHON ON)

--- a/scripts/setonix-rocm5.3.0.profile
+++ b/scripts/setonix-rocm5.3.0.profile
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source /opt/cray/pe/cpe/22.09/restore_lmod_system_defaults.sh
+
+module load cmake/3.21.4
+module load craype-accel-amd-gfx90a
+
+. /software/projects/pawsey0807/bwibking/spack/share/spack/setup-env.sh
+spack load hip@5.3.0
+spack load rocrand@5.3.0
+spack load rocprim@5.3.0
+
+module load cray-mpich
+module load cce/14.0.3
+module load cray-hdf5
+module load cray-python/3.9.13.1
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# optimize ROCm/HIP compilation for MI250X
+export AMREX_AMD_ARCH=gfx90a
+
+# compiler environment hints
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
+export FC=$(which ftn)
+export CFLAGS="-I${ROCM_PATH}/include -I${MPICH_DIR}/include -I${HDF5_DIR}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include -I${MPICH_DIR}/include -I${HDF5_DIR}/include"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 -L${MPICH_DIR}/lib -lmpi -L${HDF5_DIR}/lib -lhdf5 ${PE_MPICH_GTL_DIR_amd_gfx90a} -lmpi_gtl_hsa"

--- a/scripts/setonix-rocm5.4.3.profile
+++ b/scripts/setonix-rocm5.4.3.profile
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source /opt/cray/pe/cpe/22.09/restore_lmod_system_defaults.sh
+
+module load PrgEnv-gnu
+module load cmake/3.21.4
+module load craype-accel-amd-gfx90a
+module load rocm/5.4.3
+module load cray-mpich
+module load cray-hdf5
+module load cray-python/3.9.13.1
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# optimize ROCm/HIP compilation for MI250X
+export AMREX_AMD_ARCH=gfx90a
+
+# compiler environment hints
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
+export FC=$(which ftn)
+export CFLAGS="-I${ROCM_PATH}/include -I${MPICH_DIR}/include -I${HDF5_DIR}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include -I${MPICH_DIR}/include -I${HDF5_DIR}/include"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 -L${MPICH_DIR}/lib -lmpi -L${HDF5_DIR}/lib -lhdf5 ${PE_MPICH_GTL_DIR_amd_gfx90a} -lmpi_gtl_hsa"

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -13,7 +13,15 @@
 #include <cassert>
 #include <csignal>
 #include <cstdio>
+#if __has_include(<filesystem>)
 #include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std
+{
+namespace filesystem = experimental::filesystem;
+}
+#endif
 #include <fstream>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
Adds Bash scripts to use ROCm 5.3.0 and ROCm 5.4.3. Also adds a conditional include for `<filesystem>`.

The recommended build procedure on Setonix is:
```
source scripts/setonix-rocm5.4.3.profile
mkdir build; cd build
cmake -C ../cmake/setonix.profile ..
make -j16
```

Then a single-node test job can be run with:
```
cd ..
sbatch scripts/setonix-1node.submit
```

Fixes https://github.com/quokka-astro/quokka/issues/312.