### PR TITLE
updated job scripts for Setonix

### DIFF
--- a/scripts/setonix-1node.submit
+++ b/scripts/setonix-1node.submit
@@ -14,11 +14,10 @@
 
 # load modules
 module load craype-accel-amd-gfx90a
-module load rocm/5.0.2
+module load rocm/5.4.3
 
-# this environment setting is currently needed to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# workaround no longer needed for AMReX 23.07+
+#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/setonix-64nodes.submit
+++ b/scripts/setonix-64nodes.submit
@@ -14,11 +14,10 @@
 
 # load modules
 module load craype-accel-amd-gfx90a
-module load rocm/5.0.2
+module load rocm/5.4.3
 
-# this environment setting is currently needed to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# workaround no longer needed for AMReX 23.07+
+#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/setonix-8nodes.submit
+++ b/scripts/setonix-8nodes.submit
@@ -14,11 +14,10 @@
 
 # load modules
 module load craype-accel-amd-gfx90a
-module load rocm/5.0.2
+module load rocm/5.4.3
 
-# this environment setting is currently needed to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# workaround no longer needed for AMReX 23.07+
+#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
With AMReX 23.07 adding a separate communication arena on device, the workaround to disable the libfabric memcache is no longer necessary. We also change the rocm version to 5.4.3.