### PR TITLE
add YAML metadata I/O

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1816,14 +1816,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
-	std::string MetadataFileName(chkfilename + "/metadata.yaml");
+const 
 
 	// read YAML file into simulationMetadata_ std::map
 	YAML::Node metadata = YAML::LoadFile(MetadataFileName);
 	amrex::Print() << "Reading " << MetadataFileName << "...\n";
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
-		std::string key = it->first.as<std::string>();
+const 
 		std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
 		std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1817,16 +1817,16 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
-	std::string MetadataFileName(chkfilename + "/metadata.yaml");
+	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
 
 	// read YAML file into simulationMetadata_ std::map
-	YAML::Node metadata = YAML::LoadFile(MetadataFileName);
+	const YAML::Node metadata = YAML::LoadFile(MetadataFileName);
 	amrex::Print() << "Reading " << MetadataFileName << "...\n";
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
-		std::string key = it->first.as<std::string>();
-		std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
-		std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
+		const auto key = it->first.as<std::string>();
+		const std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
+		const std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 
 		if (value_real) {
 			simulationMetadata_[key] = value_real.value();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -264,7 +264,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	[[nodiscard]] auto GetPlotfileVarNames() const -> amrex::Vector<std::string>;
 	[[nodiscard]] auto PlotFileMF() -> amrex::Vector<amrex::MultiFab>;
 	[[nodiscard]] auto PlotFileMFAtLevel(int lev) -> amrex::MultiFab;
-	void WriteMetadataFile(std::string const &plotfilename) const;
+	void WriteMetadataFile(std::string const &MetadataFileName) const;
 	void ReadMetadataFile(std::string const &chkfilename);
 	void WriteStatisticsFile();
 	void WritePlotFile();
@@ -1875,6 +1875,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << fmt::format("\t{} has unknown type! skipping this entry.\n", key);
 		}
 	}
+}
 
 template <typename problem_t>
 void AMRSimulation<problem_t>::WriteStatisticsFile() {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1816,15 +1816,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
-const 
+	const
 
-	// read YAML file into simulationMetadata_ std::map
-	YAML::Node metadata = YAML::LoadFile(MetadataFileName);
+	    // read YAML file into simulationMetadata_ std::map
+	    YAML::Node metadata = YAML::LoadFile(MetadataFileName);
 	amrex::Print() << "Reading " << MetadataFileName << "...\n";
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
-const 
-		std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
+		const std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
 		std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 
 		if (value_real) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1817,14 +1817,15 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
-	const
+const 
 
-	    // read YAML file into simulationMetadata_ std::map
-	    YAML::Node metadata = YAML::LoadFile(MetadataFileName);
+	// read YAML file into simulationMetadata_ std::map
+	YAML::Node metadata = YAML::LoadFile(MetadataFileName);
 	amrex::Print() << "Reading " << MetadataFileName << "...\n";
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
-		const std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
+const 
+		std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
 		std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 
 		if (value_real) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -27,6 +27,7 @@ namespace filesystem = experimental::filesystem;
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <stdexcept>
 #include <tuple>

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1817,14 +1817,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
-const 
+	std::string MetadataFileName(chkfilename + "/metadata.yaml");
 
 	// read YAML file into simulationMetadata_ std::map
 	YAML::Node metadata = YAML::LoadFile(MetadataFileName);
 	amrex::Print() << "Reading " << MetadataFileName << "...\n";
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
-const 
+		std::string key = it->first.as<std::string>();
 		std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
 		std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 


### PR DESCRIPTION
Reads and write YAML metadata for checkpoints. Writes YAML metadata for plotfiles. In all cases, the YAML file is saved as `chkXXXXX/metadata.yaml` or `pltXXXXX/metadata.yaml`.

At any time during the simulation, the user can save or access metadata stored in `simulationMetadata_` using syntax similar to Python dictionaries. The dictionary contents are then saved with plotfiles/checkpoints and re-read when restarting from a checkpoint. It currently supports `amrex::Real` or `std::string` values.

**It is assumed that `simulationMetadata_` is identical on all MPI ranks. If the code saves different values to `simulationMetadata_` on different ranks, the behavior is undefined.**

Example usage:
```
  // getting a value
  const amrex::Real delta_x = std::get<amrex::Real>(simulationMetadata_["delta_x"]);
  // storing a value
  simulationMetadata_["delta_x"] = delta_x;
```