### PR TITLE
add history file output

### DIFF
--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -82,6 +82,9 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
 
+	// compute statistics
+  	auto ComputeStatistics() -> std::map<std::string, amrex::Real> override;
+
 	void FixupState(int lev) override;
 
 	// tag cells for refinement
@@ -150,6 +153,13 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterT
 template <typename problem_t> void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const
 {
 	// user should implement
+}
+
+template <typename problem_t>
+auto AdvectionSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real>
+{
+	// user should implement
+	return std::map<std::string, amrex::Real>{};
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -191,6 +191,9 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
 
+	// compute statistics
+  	auto ComputeStatistics() -> std::map<std::string, amrex::Real> override;
+
 	// fix-up states
 	void FixupState(int level) override;
 
@@ -494,6 +497,13 @@ template <typename problem_t>
 void RadhydroSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
 {
 	// compute derived variables and save in 'mf' -- user should implement
+}
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real> 
+{
+	// compute statistics and return a std::map<std::string, amrex::Real> -- user should implement
+	return std::map<std::string, amrex::Real>{};
 }
 
 template <typename problem_t> void RadhydroSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -503,6 +503,7 @@ template <typename problem_t>
 auto RadhydroSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real> 
 {
 	// compute statistics and return a std::map<std::string, amrex::Real> -- user should implement
+	// IMPORTANT: the user is responsible for performing any necessary MPI reductions before returning
 	return std::map<std::string, amrex::Real>{};
 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1786,8 +1786,8 @@ void AMRSimulation<problem_t>::WriteStatisticsFile() {
 
     // write header
     if (!isHeaderWritten) {
-      std::time_t t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-      std::tm now = *std::localtime(&t);
+      const std::time_t t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+      const std::tm now = *std::localtime(&t); // NOLINT(concurrency-mt-unsafe)
       StatisticsFile << "## Simulation restarted at: " << std::put_time(&now, "%c %Z") << "\n";
       StatisticsFile << "# cycle time ";
       for (auto const &[key, value] : statistics) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1771,6 +1771,7 @@ void AMRSimulation<problem_t>::WriteStatisticsFile() {
   static bool isHeaderWritten = false;
 
   // compute statistics
+  // IMPORTANT: the user is responsible for performing any necessary MPI reductions inside ComputeStatistics
   std::map<std::string, amrex::Real> statistics = ComputeStatistics();
 
   // write to file


### PR DESCRIPTION
Add a "history file" output, inspired by the same feature in Athena.

This writes a text file named "history.txt" in the simulation working directory with scalar-valued statistics that can be computed by the problem generator in the `RadhydroSimulation<problem_t>::ComputeStatistics()` function. **The user is responsible for performing any needed MPI reductions inside this function before returning the computed statistics.**