### PR TITLE
add axis-aligned projection outputs

### DIFF
--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -81,6 +81,8 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
+	// compute projected vars
+  	[[nodiscard]] virtual auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
 
 	void FixupState(int lev) override;
 
@@ -150,6 +152,13 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterT
 template <typename problem_t> void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const
 {
 	// user should implement
+}
+
+template <typename problem_t>
+auto AdvectionSimulation<problem_t>::ComputeProjections(int /*dir*/) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
+{
+	// user should implement
+	return std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>{};
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)

--- a/src/AdvectionSimulation.hpp
+++ b/src/AdvectionSimulation.hpp
@@ -82,7 +82,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
 	// compute projected vars
-  	[[nodiscard]] virtual auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
+  	[[nodiscard]] auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
 
 	void FixupState(int lev) override;
 

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -193,7 +193,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
 
 	// compute projected vars
-  	[[nodiscard]] virtual auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
+  	[[nodiscard]] auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
 
 	// fix-up states
 	void FixupState(int level) override;

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -15,6 +15,7 @@
 #include <limits>
 #include <string>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 
 #include "AMReX.H"
@@ -190,6 +191,9 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
+
+	// compute projected vars
+  	[[nodiscard]] virtual auto ComputeProjections(int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
 
 	// fix-up states
 	void FixupState(int level) override;
@@ -494,6 +498,13 @@ template <typename problem_t>
 void RadhydroSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
 {
 	// compute derived variables and save in 'mf' -- user should implement
+}
+
+template <typename problem_t>
+auto RadhydroSimulation<problem_t>::ComputeProjections(int /*dir*/) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
+{
+	// compute projections and return as unordered_map -- user should implement
+	return std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>{};
 }
 
 template <typename problem_t> void RadhydroSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1824,7 +1824,7 @@ auto AMRSimulation<problem_t>::computePlaneProjection(F const &user_f, const int
 template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlotfile() const
 {
 	std::vector<std::string> dirs{};
-	amrex::ParmParse pp;
+	const amrex::ParmParse pp;
 	pp.queryarr("projection.dirs", dirs);
 
 	auto dir_from_string = [=](const std::string &dir_str) {
@@ -1846,9 +1846,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlot
 		std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> proj = ComputeProjections(dir);
 
 		auto const &firstFab = proj.begin()->second;
-		amrex::BoxArray ba(firstFab.box());
-		amrex::DistributionMapping dm(amrex::Vector<int>{0});
-		amrex::MultiFab mf_all(ba, dm, proj.size(), 0);
+		const amrex::BoxArray ba(firstFab.box());
+		const amrex::DistributionMapping dm(amrex::Vector<int>{0});
+		amrex::MultiFab mf_all(ba, dm, static_cast<int>(proj.size()), 0);
 		amrex::Vector<std::string> varnames;
 
 		// write 2D plotfiles
@@ -1857,8 +1857,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlot
 			const std::string &varname = iter->first;
 			const amrex::BaseFab<amrex::Real> &baseFab = iter->second;
 
-			amrex::BoxArray ba(baseFab.box());
-			amrex::DistributionMapping dm(amrex::Vector<int>{0});
+			const amrex::BoxArray ba(baseFab.box());
+			const amrex::DistributionMapping dm(amrex::Vector<int>{0});
 			amrex::MultiFab mf(ba, dm, 1, 0, amrex::MFInfo().SetAlloc(false));
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				mf.setFab(0, amrex::FArrayBox(baseFab.array()));
@@ -1871,7 +1871,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlot
 		const std::string basename = "proj" + dir_str;
 		const std::string filename = amrex::Concatenate(basename, istep[0], 5);
 		amrex::Print() << "Writing projection " << filename << "\n";
-		amrex::Geometry mygeom(firstFab.box());
+		const amrex::Geometry mygeom(firstFab.box());
 		amrex::WriteSingleLevelPlotfile(filename, mf_all, varnames, mygeom, tNew_[0], istep[0]);
 	}
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1853,7 +1853,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlot
 
 		// write 2D plotfiles
 		auto iter = proj.begin();
-		for (int icomp = 0; icomp < proj.size(); ++icomp) {
+		for (int icomp = 0; icomp < static_cast<int>(proj.size()); ++icomp) {
 			const std::string &varname = iter->first;
 			const amrex::BaseFab<amrex::Real> &baseFab = iter->second;
 


### PR DESCRIPTION
This outputs 2D axis-aligned projections as AMReX plotfiles prefixed with `proj`.

The problem generator must call `computePlaneProjection(F const &user_f, const int dir)` where `user_f` is a lambda function that returns the value to project and `dir` is the axis along which the projection is taken.