### PR TITLE
Remove is_chemistry_enabled

### DIFF
--- a/src/Advection/test_advection.cpp
+++ b/src/Advection/test_advection.cpp
@@ -29,7 +29,6 @@ struct SawtoothProblem {
 template <> struct Physics_Traits<SawtoothProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/Advection2D/test_advection2d.cpp
+++ b/src/Advection2D/test_advection2d.cpp
@@ -34,7 +34,6 @@ struct SquareProblem {
 template <> struct Physics_Traits<SquareProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -28,7 +28,6 @@ struct SemiellipseProblem {
 template <> struct Physics_Traits<SemiellipseProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -42,7 +42,6 @@ template <> struct quokka::EOS_Traits<CoolingTest> {
 template <> struct Physics_Traits<CoolingTest> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/FCQuantities/test_fc_quantities.cpp
+++ b/src/FCQuantities/test_fc_quantities.cpp
@@ -34,7 +34,6 @@ template <> struct quokka::EOS_Traits<FCQuantities> {
 template <> struct Physics_Traits<FCQuantities> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/HydroBlast2D/test_hydro2d_blast.cpp
@@ -34,7 +34,6 @@ template <> struct quokka::EOS_Traits<BlastProblem> {
 template <> struct Physics_Traits<BlastProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -45,7 +45,6 @@ template <> struct HydroSystem_Traits<SedovProblem> {
 template <> struct Physics_Traits<SedovProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroContact/test_hydro_contact.cpp
+++ b/src/HydroContact/test_hydro_contact.cpp
@@ -30,7 +30,6 @@ template <> struct quokka::EOS_Traits<ContactProblem> {
 template <> struct Physics_Traits<ContactProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 2; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/HydroHighMach/test_hydro_highmach.cpp
@@ -37,7 +37,6 @@ template <> struct quokka::EOS_Traits<HighMachProblem> {
 template <> struct Physics_Traits<HighMachProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -35,7 +35,6 @@ template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
 template <> struct Physics_Traits<KelvinHelmholzProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/HydroLeblanc/test_hydro_leblanc.cpp
@@ -37,7 +37,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -54,7 +54,6 @@ template <> struct HydroSystem_Traits<QuirkProblem> {
 template <> struct Physics_Traits<QuirkProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -34,7 +34,6 @@ template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 template <> struct Physics_Traits<RichtmeyerMeshkovProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroSMS/test_hydro_sms.cpp
+++ b/src/HydroSMS/test_hydro_sms.cpp
@@ -30,7 +30,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/HydroShocktube/test_hydro_shocktube.cpp
@@ -35,7 +35,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -40,7 +40,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 3;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/HydroShuOsher/test_hydro_shuosher.cpp
@@ -32,7 +32,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/HydroVacuum/test_hydro_vacuum.cpp
@@ -34,7 +34,6 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 template <> struct Physics_Traits<ShocktubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/HydroWave/test_hydro_wave.cpp
+++ b/src/HydroWave/test_hydro_wave.cpp
@@ -30,7 +30,6 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 template <> struct Physics_Traits<WaveProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/NSCBC/channel.cpp
+++ b/src/NSCBC/channel.cpp
@@ -56,7 +56,6 @@ template <> struct quokka::EOS_Traits<Channel> {
 
 template <> struct Physics_Traits<Channel> {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars

--- a/src/NSCBC/vortex.cpp
+++ b/src/NSCBC/vortex.cpp
@@ -53,7 +53,6 @@ template <> struct quokka::EOS_Traits<Vortex> {
 
 template <> struct Physics_Traits<Vortex> {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars

--- a/src/PassiveScalar/test_scalars.cpp
+++ b/src/PassiveScalar/test_scalars.cpp
@@ -32,7 +32,6 @@ template <> struct quokka::EOS_Traits<ScalarProblem> {
 template <> struct Physics_Traits<ScalarProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/PrimordialChem/test_primordial_chem.cpp
+++ b/src/PrimordialChem/test_primordial_chem.cpp
@@ -43,7 +43,6 @@ struct PrimordialChemTest {
 template <> struct Physics_Traits<PrimordialChemTest> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;	     // in the future, this could point to microphysics, and set to true
 	static constexpr int numMassScalars = NumSpec;		     // number of chemical species
 	static constexpr int numPassiveScalars = numMassScalars + 0; // we only have mass scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -49,7 +49,6 @@ template <> struct RadSystem_Traits<BeamProblem> {
 template <> struct Physics_Traits<BeamProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -61,7 +61,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 template <> struct Physics_Traits<TubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -47,7 +47,6 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 template <> struct Physics_Traits<SuOlsonProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -42,7 +42,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -49,7 +49,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -47,7 +47,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 template <> struct Physics_Traits<CouplingProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -49,7 +49,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 template <> struct Physics_Traits<CouplingProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -44,7 +44,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 template <> struct Physics_Traits<PulseProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadStreaming/test_radiation_streaming.cpp
+++ b/src/RadStreaming/test_radiation_streaming.cpp
@@ -39,7 +39,6 @@ template <> struct RadSystem_Traits<StreamingProblem> {
 template <> struct Physics_Traits<StreamingProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -54,7 +54,6 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 template <> struct Physics_Traits<MarshakProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -54,7 +54,6 @@ template <> struct RadSystem_Traits<TophatProblem> {
 template <> struct Physics_Traits<TophatProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadTube/test_radiation_tube.cpp
+++ b/src/RadTube/test_radiation_tube.cpp
@@ -53,7 +53,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 template <> struct Physics_Traits<TubeProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -65,7 +65,6 @@ template <> struct HydroSystem_Traits<ShellProblem> {
 template <> struct Physics_Traits<ShellProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -70,7 +70,6 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 template <> struct Physics_Traits<ShockProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -71,7 +71,6 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 template <> struct Physics_Traits<ShockProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -275,8 +275,6 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 
 template <typename problem_t> void RadhydroSimulation<problem_t>::defineComponentNames()
 {
-	// check modules cannot be enabled if they are not been implemented yet
-	static_assert(!Physics_Traits<problem_t>::is_chemistry_enabled, "Chemistry is not supported, yet.");
 
 	// cell-centred
 	// add hydro state variables

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -35,7 +35,6 @@ template <> struct HydroSystem_Traits<RTProblem> {
 template <> struct Physics_Traits<RTProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -35,7 +35,6 @@ template <> struct HydroSystem_Traits<RTProblem> {
 template <> struct Physics_Traits<RTProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/ShockCloud/cloud.cpp
+++ b/src/ShockCloud/cloud.cpp
@@ -46,7 +46,6 @@ template <> struct quokka::EOS_Traits<ShockCloud> {
 template <> struct Physics_Traits<ShockCloud> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/SphericalCollapse/spherical_collapse.cpp
+++ b/src/SphericalCollapse/spherical_collapse.cpp
@@ -39,7 +39,6 @@ template <> struct HydroSystem_Traits<CollapseProblem> {
 template <> struct Physics_Traits<CollapseProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/StarCluster/star_cluster.cpp
+++ b/src/StarCluster/star_cluster.cpp
@@ -48,7 +48,6 @@ template <> struct HydroSystem_Traits<StarCluster> {
 template <> struct Physics_Traits<StarCluster> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -7,7 +7,6 @@
 template <typename problem_t> struct Physics_Traits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
-	static constexpr bool is_chemistry_enabled = false;
 	static constexpr int numMassScalars = 0;
 	static constexpr int numPassiveScalars = numMassScalars + 0;
 	static constexpr bool is_radiation_enabled = false;


### PR DESCRIPTION
We don't need the Physics_Trait `is_chemistry_enabled` anymore.