### PR TITLE
ensure first-order flux correction is consistent at box boundaries

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -1029,6 +1029,9 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 				amrex::print_state(stateNew, cell_idx);
 			}
 
+			// synchronize redoFlag across ranks
+			redoFlag.FillBoundary(geom[lev].periodicity());
+
 			// replace fluxes around troubled cells with Godunov fluxes
 			replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
 			replaceFluxes(faceVel, FOfaceVel, redoFlag); // needed for dual energy
@@ -1106,6 +1109,9 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
 				amrex::print_state(stateFinal, cell_idx);
 			}
+
+			// synchronize redoFlag across ranks
+			redoFlag.FillBoundary(geom[lev].periodicity());
 
 			// replace fluxes around troubled cells with Godunov fluxes
 			replaceFluxes(flux_rk2, FOfluxArrays, redoFlag);


### PR DESCRIPTION
This adds 1 ghost cell to the `redoFlag` iMultiFab and communicates its ghost cells before doing flux correction. Then on each MPI rank, it loops over the entire `redoFlag` (including the ghost cells) and replaces the fluxes of adjacent valid cells.

Fixes https://github.com/quokka-astro/quokka/issues/374.