### PR TITLE
output multifab to disk if hydro update fails

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -907,7 +907,9 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 #endif
 		amrex::ParallelDescriptor::Barrier();
 		
-		amrex::Abort();
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::ParallelDescriptor::Abort();
+		}
 	}
 }
 

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -892,6 +892,21 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"
 			       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"
 			       << std::endl;
+
+		// write plotfile or Ascent Blueprint file
+		amrex::ParallelDescriptor::Barrier();
+#ifdef AMREX_USE_ASCENT
+		conduit::Node mesh;
+		amrex::SingleLevelToBlueprint(state_new_cc_[lev], componentNames_cc_, geom[lev], time, istep[lev] + 1, mesh);
+		conduit::Node bpMeshHost;
+		bpMeshHost.set(mesh); // copy to host mem (needed for Blueprint HDF5 output)
+		amrex::WriteBlueprintFiles(bpMeshHost, "debug_hydro_state_fatal", istep[lev] + 1, "hdf5");
+#else
+		WriteSingleLevelPlotfile(CustomPlotFileName("debug_hydro_state_fatal", istep[lev] + 1), state_new_cc_[lev], componentNames_cc_, geom[lev], time,
+			 istep[lev] + 1);
+#endif
+		amrex::ParallelDescriptor::Barrier();
+		
 		amrex::Abort();
 	}
 }


### PR DESCRIPTION
This writes a plotfile or Ascent Blueprint file to disk if the hydro update fails, before crashing.

This is intended to allow the user to examine the hydro state in order to diagnose what caused the simulation to fail. **However, if the FOFC failure occurs in stage 1 of the RK integrator, then this output will not correspond to the relevant MultiFab. This outputs the state from stage 2 of the integrator.**