### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ By default, Quokka compiles itself to run only on CPUs. Quokka can run on either
 ### NVIDIA GPUs
 If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.7 is required. Quokka is only supported on Volta V100 GPUs or newer models. Your MPI library **must** support CUDA-aware MPI.*)
 ```
-cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMREX_GPUS_PER_NODE=N -G Ninja
+cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMReX_SPACEDIM=3 -G Ninja
 ninja -j6
 ```
 where $N$ is the number of GPUs available per compute node.

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.
 cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMReX_SPACEDIM=3 -G Ninja
 ninja -j6
 ```
+**All GPUs on a node must be visible from each MPI rank on the node for efficient GPU-aware MPI communication to take place via CUDA IPC.** When using the SLURM job scheduler, this means that `--gpu-bind` should be set to `none`.
 
 The compiled test problems are in the test problem subdirectories in `build/src/`. Example scripts for running Quokka on compute clusters are in the `scripts/` subdirectory.
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,6 @@ If you want to run on NVIDIA GPUs, re-build Quokka as shown below. (*CUDA >= 11.
 cmake .. -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=CUDA -DAMReX_SPACEDIM=3 -G Ninja
 ninja -j6
 ```
-where $N$ is the number of GPUs available per compute node.
-
-**It is necessary to use `-DAMREX_GPUS_PER_NODE` to specify the number of GPUs per compute node. Without this, performance will be very poor. All GPUs on a node must be visible from each MPI rank on the node for efficient GPU-aware MPI communication to take place via CUDA IPC.** When using the SLURM job scheduler, this means that `--gpu-bind` should be set to `none`.
 
 The compiled test problems are in the test problem subdirectories in `build/src/`. Example scripts for running Quokka on compute clusters are in the `scripts/` subdirectory.
 


### PR DESCRIPTION
Updated README because `AMREX_GPUS_PER_NODE` is not required anymore, and is not a valid keyword now.