### PR TITLE
Update GPU CI timeout

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -12,31 +12,30 @@ pr:
     include:
     - development
 
-pool: avatar
-
-timeoutInMinutes: 90
-
-steps:
-
-- task: CMake@1
-  displayName: 'Configure CMake'
-  inputs:
-    cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF -G Ninja'
-
-- task: CMake@1
-  displayName: 'Build Quokka'
-  inputs:
-    cmakeArgs: '--build .'
-
-- task: CMake@1
-  displayName: 'Run CTest'
-  inputs:
-    cmakeArgs: '-E chdir . ctest -E "MatterEnergyExchange*" -T Test --output-on-failure'
-
-- task: PublishTestResults@2
-  inputs:
-    testResultsFormat: cTest
-    testResultsFiles: build/Testing/*/Test.xml
-    testRunTitle: $(Agent.JobName)
-  condition: succeededOrFailed()
-  displayName: Publish test results
+jobs:
+  - job: GPU CI (CUDA, 3D)
+    pool: avatar
+    timeoutInMinutes: 90
+    steps:
+    - task: CMake@1
+      displayName: 'Configure CMake'
+      inputs:
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF -G Ninja'
+    
+    - task: CMake@1
+      displayName: 'Build Quokka'
+      inputs:
+        cmakeArgs: '--build .'
+    
+    - task: CMake@1
+      displayName: 'Run CTest'
+      inputs:
+        cmakeArgs: '-E chdir . ctest -E "MatterEnergyExchange*" -T Test --output-on-failure'
+    
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: cTest
+        testResultsFiles: build/Testing/*/Test.xml
+        testRunTitle: $(Agent.JobName)
+      condition: succeededOrFailed()
+      displayName: Publish test results

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - development
 
 jobs:
-  - job: CUDA-Build-Test
+  - job: CUDA_Build_Test
     pool: avatar
     timeoutInMinutes: 90
     steps:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -14,6 +14,8 @@ pr:
 
 pool: avatar
 
+timeoutInMinutes: 90
+
 steps:
 
 - task: CMake@1

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -13,7 +13,7 @@ pr:
     - development
 
 jobs:
-  - job: GPU CI (CUDA, 3D)
+  - job: CUDA-Build-Test
     pool: avatar
     timeoutInMinutes: 90
     steps:


### PR DESCRIPTION
Set timeout to 90 minutes (increased from the default value of 60 minutes).

Fixes https://github.com/quokka-astro/quokka/issues/415.