### PR TITLE
add Summit (OLCF) config

### DIFF
--- a/cmake/summit.cmake
+++ b/cmake/summit.cmake
@@ -1,0 +1,16 @@
+# host configuration
+# run with `cmake -C host_config.cmake ..` from inside build directory
+
+set(CMAKE_C_COMPILER "gcc" CACHE PATH "")
+set(CMAKE_CXX_COMPILER "g++" CACHE PATH "")
+set(CMAKE_CUDA_COMPILER "nvcc" CACHE PATH "")
+set(AMReX_GPU_BACKEND CUDA CACHE STRING "")
+set(CMAKE_CUDA_ARCHITECTURES 70 CACHE STRING "")
+set(AMReX_ASCENT ON CACHE BOOL "" FORCE)
+set(AMReX_CONDUIT ON CACHE BOOL "" FORCE)
+
+option(QUOKKA_PYTHON OFF)
+set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -O0 -ggdb -DNDEBUG" CACHE STRING "" FORCE)
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-gdwarf-4 -O2 -ggdb -DNDEBUG" CACHE STRING "" FORCE)
+
+set(AMReX_SPACEDIM 3 CACHE STRING "")

--- a/scripts/summit-1node.bsub
+++ b/scripts/summit-1node.bsub
@@ -21,6 +21,13 @@
 # make output group-readable by default
 umask 0027
 
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
 # fix problems with collectives since RHEL8 update: OLCFHELP-3545
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
@@ -30,4 +37,5 @@ export IBM_largeblock_io=true
 
 # GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
 # run Quokka
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_256.in amrex.use_gpu_aware_mpi=0
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_256.in amrex.use_gpu_aware_mpi=0
+

--- a/scripts/summit-1node.bsub
+++ b/scripts/summit-1node.bsub
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
+
+#BSUB -P ast183
+#BSUB -W 00:15
+#BSUB -nnodes 1
+#BSUB -alloc_flags smt4
+#BSUB -J quokka
+#BSUB -o benchmark-1node-o.%J
+#BSUB -e benchmark-1node-e.%J
+
+# make output group-readable by default
+umask 0027
+
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
+# ROMIO has a hint for GPFS named IBM_largeblock_io which optimizes I/O with operations on large blocks
+export IBM_largeblock_io=true
+
+# GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
+# run Quokka
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_256.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-4096node.bsub
+++ b/scripts/summit-4096node.bsub
@@ -21,6 +21,13 @@
 # make output group-readable by default
 umask 0027
 
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
 # fix problems with collectives since RHEL8 update: OLCFHELP-3545
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
@@ -30,4 +37,4 @@ export IBM_largeblock_io=true
 
 # GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
 # run Quokka
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_4096.in amrex.use_gpu_aware_mpi=0
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_4096.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-4096node.bsub
+++ b/scripts/summit-4096node.bsub
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
+
+#BSUB -P ast183
+#BSUB -W 00:15
+#BSUB -nnodes 4096
+#BSUB -alloc_flags smt4
+#BSUB -J quokka
+#BSUB -o benchmark-4096node-o.%J
+#BSUB -e benchmark-4096node-e.%J
+
+# make output group-readable by default
+umask 0027
+
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
+# ROMIO has a hint for GPFS named IBM_largeblock_io which optimizes I/O with operations on large blocks
+export IBM_largeblock_io=true
+
+# GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
+# run Quokka
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_4096.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-512node.bsub
+++ b/scripts/summit-512node.bsub
@@ -21,6 +21,13 @@
 # make output group-readable by default
 umask 0027
 
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
 # fix problems with collectives since RHEL8 update: OLCFHELP-3545
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
@@ -30,4 +37,4 @@ export IBM_largeblock_io=true
 
 # GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
 # run Quokka
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in amrex.use_gpu_aware_mpi=0
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-512node.bsub
+++ b/scripts/summit-512node.bsub
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
+
+#BSUB -P ast183
+#BSUB -W 00:15
+#BSUB -nnodes 512
+#BSUB -alloc_flags smt4
+#BSUB -J quokka
+#BSUB -o benchmark-512node-o.%J
+#BSUB -e benchmark-512node-e.%J
+
+# make output group-readable by default
+umask 0027
+
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
+# ROMIO has a hint for GPFS named IBM_largeblock_io which optimizes I/O with operations on large blocks
+export IBM_largeblock_io=true
+
+# GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
+# run Quokka
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-64node.bsub
+++ b/scripts/summit-64node.bsub
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
+
+#BSUB -P ast183
+#BSUB -W 00:15
+#BSUB -nnodes 64
+#BSUB -alloc_flags smt4
+#BSUB -J quokka
+#BSUB -o benchmark-64node-o.%J
+#BSUB -e benchmark-64node-e.%J
+
+# make output group-readable by default
+umask 0027
+
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
+# ROMIO has a hint for GPFS named IBM_largeblock_io which optimizes I/O with operations on large blocks
+export IBM_largeblock_io=true
+
+# GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
+# run Quokka
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-64node.bsub
+++ b/scripts/summit-64node.bsub
@@ -21,6 +21,13 @@
 # make output group-readable by default
 umask 0027
 
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
 # fix problems with collectives since RHEL8 update: OLCFHELP-3545
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
@@ -30,4 +37,4 @@ export IBM_largeblock_io=true
 
 # GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
 # run Quokka
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in amrex.use_gpu_aware_mpi=0
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-8node.bsub
+++ b/scripts/summit-8node.bsub
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copyright 2019-2020 Maxence Thevenet, Axel Huebl
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+#
+# Refs.:
+#   https://jsrunvisualizer.olcf.ornl.gov/?s4f0o11n6c7g1r11d1b1l0=
+#   https://docs.olcf.ornl.gov/systems/summit_user_guide.html#cuda-aware-mpi
+
+#BSUB -P ast183
+#BSUB -W 00:15
+#BSUB -nnodes 8
+#BSUB -alloc_flags smt4
+#BSUB -J quokka
+#BSUB -o benchmark-8node-o.%J
+#BSUB -e benchmark-8node-e.%J
+
+# make output group-readable by default
+umask 0027
+
+# fix problems with collectives since RHEL8 update: OLCFHELP-3545
+# disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
+export OMPI_MCA_coll_ibm_skip_barrier=true
+
+# ROMIO has a hint for GPFS named IBM_largeblock_io which optimizes I/O with operations on large blocks
+export IBM_largeblock_io=true
+
+# GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
+# run Quokka
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit-8node.bsub
+++ b/scripts/summit-8node.bsub
@@ -21,6 +21,13 @@
 # make output group-readable by default
 umask 0027
 
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
 # fix problems with collectives since RHEL8 update: OLCFHELP-3545
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
@@ -30,4 +37,4 @@ export IBM_largeblock_io=true
 
 # GPU-aware MPI does NOT work on Summit!! You MUST disable it by adding: amrex.use_gpu_aware_mpi=0
 # run Quokka
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in amrex.use_gpu_aware_mpi=0
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs build_summit/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in amrex.use_gpu_aware_mpi=0

--- a/scripts/summit.profile
+++ b/scripts/summit.profile
@@ -1,0 +1,50 @@
+# please set your project account
+export proj=" " # FILL THIS IN
+
+# required dependencies
+module load cmake/3.20.2
+module load gcc/9.3.0 # newer versions conflict with HDF5 modules
+module load cuda/11.7.1
+module load hdf5/1.12.2
+
+# optional: faster re-builds
+module load ccache
+module load ninja
+
+# often unstable at runtime with dependencies
+module unload darshan-runtime
+
+# optional: Ascent in situ support
+export Ascent_DIR=/sw/summit/ums/ums010/ascent/0.8.0_warpx/summit/cuda/gnu/ascent-install/
+
+# optional: for Python bindings or libEnsemble
+module load python/3.8.10
+module load freetype/2.10.4     # matplotlib
+
+# set tuning vars for maximizing network bandwidth
+# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
+export PAMI_ENABLE_STRIPING=1
+export PAMI_IBV_ADAPTER_AFFINITY=1
+export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
+# an alias to request an interactive batch node for two hours
+#   for paralle execution, start on the batch node: jsrun <command>
+alias getNode="bsub -q debug -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"
+
+# an alias to run a command on a batch node
+#   usage: runNode <command>
+alias runNode="bsub -q debug -P $proj -W 2:00 -nnodes 1 -I"
+
+# make output group-readable by default
+umask 0027
+
+# optimize CUDA compilation for V100
+export AMREX_CUDA_ARCH=7.0
+
+# compiler environment hints
+export CC=$(which gcc)
+export CXX=$(which g++)
+export FC=$(which gfortran)
+export CUDACXX=$(which nvcc)
+export CUDAHOSTCXX=$(which g++)

--- a/scripts/summit.profile
+++ b/scripts/summit.profile
@@ -21,13 +21,6 @@ export Ascent_DIR=/sw/summit/ums/ums010/ascent/0.8.0_warpx/summit/cuda/gnu/ascen
 module load python/3.8.10
 module load freetype/2.10.4     # matplotlib
 
-# set tuning vars for maximizing network bandwidth
-# https://docs.olcf.ornl.gov/systems/summit_user_guide.html#spectrum-mpi-tunings-needed-for-maximum-bandwidth
-export PAMI_ENABLE_STRIPING=1
-export PAMI_IBV_ADAPTER_AFFINITY=1
-export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
-export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
-
 # an alias to request an interactive batch node for two hours
 #   for paralle execution, start on the batch node: jsrun <command>
 alias getNode="bsub -q debug -P $proj -W 2:00 -nnodes 1 -Is /bin/bash"

--- a/tests/benchmark_unigrid_256.in
+++ b/tests/benchmark_unigrid_256.in
@@ -1,0 +1,25 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.2  1.2  1.2
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 256 256 256
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.max_grid_size   = 128   # at least 128 for GPUs
+amr.blocking_factor = 128   # grid size must be divisible by this
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 0.7   # default
+
+do_reflux = 0
+do_subcycle = 0
+max_timesteps = 1000

--- a/tests/benchmark_unigrid_4096.in
+++ b/tests/benchmark_unigrid_4096.in
@@ -1,0 +1,25 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.2  1.2  1.2
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 4096 4096 4096
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.max_grid_size   = 128   # at least 128 for GPUs
+amr.blocking_factor = 128   # grid size must be divisible by this
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 0.7   # default
+
+do_reflux = 0
+do_subcycle = 0
+max_timesteps = 1000


### PR DESCRIPTION
This adds a build configuration with the appropriate modules for running on [Summit](https://docs.olcf.ornl.gov/systems/summit_user_guide.html) at Oak Ridge National Laboratory.

Scripts to run scaling tests are included. Note that GPU-aware MPI does not work on Summit with the CUDA version that we need for Quokka.

Original scaling plot _(see updated scaling plot in comment below)_:
![chart](https://github.com/quokka-astro/quokka/assets/1781919/cc8c35da-54f1-4f62-84bf-9415fef4fcb8)
