### PR TITLE
Add build configuration for Moth

### DIFF
--- a/scripts/moth.profile
+++ b/scripts/moth.profile
@@ -1,0 +1,12 @@
+module load mpi/openmpi-x86_64
+module load rocm/5.7.0
+
+# optimize ROCm/HIP compilation for MI210
+export AMREX_AMD_ARCH=gfx90a
+
+# compiler environment hints
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
+export CFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"

--- a/src/NSCBC/channel.cpp
+++ b/src/NSCBC/channel.cpp
@@ -77,7 +77,7 @@ AMREX_GPU_MANAGED Real u_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-
 AMREX_GPU_MANAGED Real v_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED Real w_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED GpuArray<Real, Physics_Traits<Channel>::numPassiveScalars> s_inflow{}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
-#if 0 // workaround AMDGPU compiler bug
+#if 0											 // workaround AMDGPU compiler bug
 };											 // namespace
 #endif
 

--- a/src/NSCBC/channel.cpp
+++ b/src/NSCBC/channel.cpp
@@ -64,8 +64,10 @@ template <> struct Physics_Traits<Channel> {
 };
 
 // global variables needed for Dirichlet boundary condition and initial conditions
+#if 0 // workaround AMDGPU compiler bug
 namespace
 {
+#endif
 Real rho0 = NAN;									 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 Real u0 = NAN;										 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 Real s0 = NAN;										 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
@@ -75,7 +77,9 @@ AMREX_GPU_MANAGED Real u_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-
 AMREX_GPU_MANAGED Real v_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED Real w_inflow = NAN;							 // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED GpuArray<Real, Physics_Traits<Channel>::numPassiveScalars> s_inflow{}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#if 0 // workaround AMDGPU compiler bug
 };											 // namespace
+#endif
 
 template <> void RadhydroSimulation<Channel>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {


### PR DESCRIPTION
This adds build settings for the AMD GPU node moth.anu.edu.au.

Build steps:
```
source scripts/moth.profile
mkdir build
cd build
cmake -DAMReX_GPU_BACKEND=HIP -DAMReX_SPACEDIM=3
make -j16
```