### PR TITLE
Fix GPU CI config

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -25,7 +25,7 @@ jobs:
     - task: CMake@1
       displayName: 'Build Quokka'
       inputs:
-        cmakeArgs: '--build .'
+        cmakeArgs: '--build . --parallel 16'
     
     - task: CMake@1
       displayName: 'Run CTest'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
     - task: CMake@1
       displayName: 'Build Quokka'
       inputs:
-        cmakeArgs: '--build .'
+        cmakeArgs: '--build --parallel 16 .'
     
     - task: CMake@1
       displayName: 'Run CTest'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -25,7 +25,7 @@ jobs:
     - task: CMake@1
       displayName: 'Build Quokka'
       inputs:
-        cmakeArgs: '--build --parallel 16 .'
+        cmakeArgs: '--build . --parallel 16'
     
     - task: CMake@1
       displayName: 'Run CTest'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     - task: CMake@1
       displayName: 'Configure CMake'
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF -G Ninja'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF'
     
     - task: CMake@1
       displayName: 'Build Quokka'


### PR DESCRIPTION
This simplifies the CMake options used on avatargpu. This also explicitly specifies to build in parallel with 16 processes on both GPU machines.