### PR TITLE
add build profile for AMDGPU ASAN

### DIFF
--- a/scripts/moth-sanitizer.profile
+++ b/scripts/moth-sanitizer.profile
@@ -1,0 +1,17 @@
+module load mpi/openmpi-x86_64
+module load rocm/5.7.0
+
+# set CMake envs
+export CMAKE_GENERATOR="Unix Makefiles"
+
+## for GPU ASAN on MI210 GPUs:
+export AMREX_AMD_ARCH=gfx90a:xnack+
+export HSA_XNACK=1
+export LD_LIBRARY_PATH=/opt/rocm-5.7.0/llvm/lib/clang/17.0.0/lib/linux:$LD_LIBRARY_PATH
+
+# compiler environment hints
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
+export CFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-fsanitize=address -shared-libsan -g -I${ROCM_PATH}/include"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"


### PR DESCRIPTION
This adds a build configuration profile that can be sourced as a Bash script (e.g., `source scripts/moth-sanitizer.profile`) that configures Quokka to be built with AMD's AddressSanitizer enabled. Then Quokka can be built as normal, and will print debugging information about memory bugs at runtime (and then crash).

**Warning: when this is enabled, expect the build to take 10-20 hours per executable.**

For details, see: https://rocm.docs.amd.com/en/latest/understand/using_gpu_sanitizer.html