### PR TITLE
fix odd-even decoupling in radiation diffusion limit

### DIFF
--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -895,12 +895,24 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 			// adjust the wavespeeds
 			// (this factor cancels out except for the last term in the HLL flux)
-			// const quokka::valarray<double, nvarHyperbolic_> epsilon = {
-			//    S_corr, 1.0, 1.0, 1.0}; // Skinner et al. (2019)
-			// const quokka::valarray<double, nvarHyperbolic_> epsilon = {S_corr,
-			// S_corr,
-			//    S_corr, S_corr}; // Jiang et al. (2013)
-			const quokka::valarray<double, numRadVars_> epsilon = {S_corr * S_corr, S_corr, S_corr, S_corr}; // this code
+			// const quokka::valarray<double, numRadVars_> epsilon = {S_corr, 1.0, 1.0, 1.0}; // Skinner et al. (2019)
+			// const quokka::valarray<double, numRadVars_> epsilon = {S_corr, S_corr, S_corr, S_corr}; // Jiang et al. (2013)
+			quokka::valarray<double, numRadVars_> epsilon = {S_corr * S_corr, S_corr, S_corr, S_corr}; // this code
+
+			// fix odd-even instability that appears in the asymptotic diffusion limit
+			// [for details, see section 3.1: https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.1499R/abstract]
+			for (int idx = 0; idx < numRadVars_; ++idx) {
+				const double u_im2 = consVar(i - 2, j, k, idx + numRadVars_ * g);
+				const double u_im1 = consVar(i - 1, j, k, idx + numRadVars_ * g);
+				const double u_i   = consVar(i    , j, k, idx + numRadVars_ * g);
+				const double u_ip1 = consVar(i + 1, j, k, idx + numRadVars_ * g);
+				// check for local maximum/minimum
+				if (((u_im1 - u_im2) * (u_i - u_im1) < 0.) && ((u_i - u_im1) * (u_ip1 - u_i) < 0.)) {
+					// revert to more diffusive flux (has no effect in optically-thin limit)
+					epsilon /= S_corr;
+					break;
+				}
+			}
 
 			// compute the norm of the wavespeed vector
 			const double S_L = std::min(-0.1 * c_hat_, -c_hat_ * std::sqrt(Tnormal_L));

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -904,7 +904,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 			for (int idx = 0; idx < numRadVars_; ++idx) {
 				const double u_im2 = consVar(i - 2, j, k, idx + numRadVars_ * g);
 				const double u_im1 = consVar(i - 1, j, k, idx + numRadVars_ * g);
-				const double u_i   = consVar(i    , j, k, idx + numRadVars_ * g);
+				const double u_i = consVar(i, j, k, idx + numRadVars_ * g);
 				const double u_ip1 = consVar(i + 1, j, k, idx + numRadVars_ * g);
 				// check for local maximum/minimum
 				if (((u_im1 - u_im2) * (u_i - u_im1) < 0.) && ((u_i - u_im1) * (u_ip1 - u_i) < 0.)) {


### PR DESCRIPTION
This modifies the radiation Riemann solver in order to suppress the odd-even instability that appears in the asymptotic diffusion limit.

A modified equation analysis that explains why the problem occurs is given in section 3.1 of [Radice et al. (2022)](https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.1499R/abstract).

Fixes https://github.com/quokka-astro/quokka/issues/34.