### PR TITLE
Fix the convergence problem of the Newton-Raphson

### DIFF
--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -23,7 +23,7 @@ constexpr double rho0 = 1.0;	  // g cm^-3 (matter density)
 constexpr double a_rad = 4.0e-10; // radiation constant == 4sigma_SB/c (dimensionless)
 constexpr double c = 1.0e8;	  // speed of light (dimensionless)
 constexpr double chat = 1.0e7;
-constexpr double erad_floor = a_rad * (1.0e-8);
+constexpr double erad_floor = a_rad * (1.0e-10);
 
 // constexpr double Lx = 1.0; // dimensionless length
 constexpr double initial_time = 1.0e-8;

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1091,7 +1091,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			quokka::valarray<double, nGroups_> deltaErad;
 			quokka::valarray<double, nGroups_> F_R;
 
-			const double resid_tol = 1.0e-10; // 1.0e-15;
+			const double resid_tol = 1.0e-13; // 1.0e-15;
 			const int maxIter = 400;
 			int n = 0;
 			for (; n < maxIter; ++n) {
@@ -1161,6 +1161,12 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dErad, dFR_dEgas, dFR_i_dErad_i, -F_G, -1. * F_R, deltaEgas, deltaErad);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaErad.hasnan());
+
+        // check relative and absolute convergence of E_r 
+        if ((max(abs(deltaErad / Erad0Vec)) < resid_tol) || (max(abs(deltaErad)) < 0.1 * Erad_floor_)) {
+          break;
+        }
+
 				EradVec_guess += deltaErad;
 				Egas_guess += deltaEgas;
 				AMREX_ASSERT(min(EradVec_guess) >= 0.);

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1162,10 +1162,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaErad.hasnan());
 
-        // check relative and absolute convergence of E_r 
-        if ((max(abs(deltaErad / Erad0Vec)) < resid_tol) || (max(abs(deltaErad)) < 0.1 * Erad_floor_)) {
-          break;
-        }
+				// check relative and absolute convergence of E_r
+				if ((max(abs(deltaErad / Erad0Vec)) < resid_tol) || (max(abs(deltaErad)) < 0.1 * Erad_floor_)) {
+					break;
+				}
 
 				EradVec_guess += deltaErad;
 				Egas_guess += deltaEgas;


### PR DESCRIPTION
### Description

Fix the convergence problem of the Newton-Raphson iteration at high opatical depth by adding relative and absolute checks of Erad. This solves the problem of the Newton-Raphson iteration fails to converge when `c dt kappa rho >~ 10^4`. Now, all tests pass even with `resid_tol = 1e-13` while originally the RadTube test will fail with this resid_tol. 

### Related issues

Fix #451 

### Checklist

_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_

- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.