### PR TITLE
move cluster-specific instructions from wiki to Sphinx docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ run with high performance on either CPUs or GPUs.
 
    about
    installation
+   running_on_hpc_clusters
    equations
    flowchart
    tests/index

--- a/docs/running_on_hpc_clusters.rst
+++ b/docs/running_on_hpc_clusters.rst
@@ -1,0 +1,44 @@
+.. Running on HPC clusters
+
+Running on HPC clusters
+=====
+
+Instructions for running on various HPC clusters are given below.
+
+Gadi (NCI Australia)
+-----------------------
+
+Use the ``openmpi/4.1.4`` module (or newer), and build with ``gcc/system`` or ``gcc/11.1.0``, and use ``cuda/11.7.0`` (or newer).
+
+Using VisIt
+^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use VisIt in client/server mode with the following server-side `patch for the
+launcher script <https://gist.github.com/BenWibking/15645ff90819f2808fdb7a04b50b4a1e>`_.
+
+A host file is provided `here <https://gist.github.com/BenWibking/5fa4d6d419dd0adf5da0435e5057b335>`_.
+You must change the username, project code, and server-side VisIt path.
+
+Setonix (Pawsey)
+-----------------------
+
+The recommended build procedure on Setonix is: ::
+  
+  source scripts/setonix.profile
+  mkdir build; cd build
+  cmake .. -C ../cmake/setonix.cmake
+  make -j16
+
+Then a single-node test job can be run with: ::
+
+  cd ..
+  sbatch scripts/setonix-1node.submit
+
+Workaround for interconnect issues
+^^^^^^^^^^^^^^^^^^^^^^^
+
+If interconnect issues are observed, it is recommended to add the line ::
+
+  export FI_CXI_RX_MATCH_MODE=software
+
+to your job scripts.


### PR DESCRIPTION
### Description
This moves the content of the GitHub wiki pages on running on Gadi and Setonix to the Sphinx documentation for greater visibility.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
