### PR TITLE
add chapter headings and developer guide to Sphinx docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,8 +1,8 @@
-.. API
+.. Doxygen
 
-API
+Doxygen documentation
 ==========================
 
-Documentation for the classes and functions in Quokka is here_.
+Auto-generated Doxygen documentation for the classes and functions in Quokka is here_.
 
 .. _here: https://quokka-code.readthedocs.io/en/latest/_static/html/files.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ import subprocess, os
 # -- Project information -----------------------------------------------------
 
 project = 'Quokka'
-copyright = '2020-2021, Ben Wibking and Quokka Developers'
+copyright = '2020-2023, Ben Wibking and Quokka Developers'
 author = 'Ben Wibking and Quokka Developers'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/debugging.rst
+++ b/docs/debugging.rst
@@ -1,0 +1,82 @@
+.. Debugging
+
+Debugging
+=====
+
+General guidelines
+-----------------------
+
+A good general guide to debugging simulation codes is `provided by WarpX <https://warpx.readthedocs.io/en/latest/usage/workflows/debugging.html>`_ (although some details are WarpX-specific).
+
+Common bugs
+-----------------------
+
+You might be reading this page because you have encountered a common type of bug:
+
+* an `out-of-bounds array access <https://www.geeksforgeeks.org/accessing-array-bounds-ccpp/>`_
+
+  This is when the code accesses an array with an index that corresponds to an element that doesn't actually exist. In C++, this causes the computer to access a memory location that is completely unrelated to the array that you intended to access. In a CPU code, this usually causes a silently incorrect result, but on GPU, this may actually cause the simulation to crash. However, if you are accessing an ``amrex::Array4`` object *and you have compiled in Debug mode*, then AMReX will issue an error message when this occurs. There is a significant performance cost to this error checking, so it does not occur when compiled in Release mode.
+
+* accessing a host variable from the GPU
+
+  The second most common type of bug encountered in Quokka is accessing a host variable (i.e., a variable that can only be accessed from code that runs on the CPU) from code running on the GPU (i.e., within a ``ParallelFor``). Sometimes the compiler will detect this situation and print an error message, but often this will only present an issue when actuallly running the code -- for instance, this can happen when the GPU code tries to dereference a pointer to an address in CPU memory. In that case, the only way to debug this error is to run Quokka under ``cuda-gdb`` (or, on AMD GPUs, ``rocgdb``).
+
+How to debug on GPUs
+-----------------------
+
+The best way to debug on GPUs is to... not debug on GPUs. That is, it is always easier to instead debug the problem on a CPU-only run. GPU debugging is very painful and itself quite buggy. This is unfortunately true for all GPU vendors.
+
+* Try to shrink the problem to a size that can run on a single node, or (even better) a single MPI rank / CPU core, but where it still exhibits the error that you are trying to debug.
+
+* Build Quokka without GPU support but with ``-DCMAKE_BUILD_TYPE=Debug`` and re-run. If there are any array out-of-bounds errors, it will stop and report exactly which array is being accessed out-of-bounds and what the indices are. The only downside is that Quokka will run very slowly in this mode.
+
+  * For more details, see the `AMReX debugging guide <https://amrex-codes.github.io/amrex/docs_html/Debugging.html>`_.
+
+* Build Quokka without GPU support but with ``-DCMAKE_BUILD_TYPE=Release -DENABLE_ASAN=ON``. This turns on the AddressSanitizer, which checks for out-of-bounds array accesses and other memory bugs. This is faster than the previous method, but it produces less informative error messages (e.g., no array indices).
+
+  * This method may produce a lot of messages about memory leaks, `which are not necessarily bugs <https://stackoverflow.com/a/654766>`_, and should not cause GPU crashes. These messages `can be disabled <https://stackoverflow.com/questions/51060801/how-to-suppress-leaksanitizer-report-when-running-under-fsanitize-address>`_ if you are looking for, e.g., out-of-bounds array accesses, which is a class of bug that can cause a GPU crash.
+
+  * It is recommended to set these environment variables when you run it: ``ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0``. Note that CTest appends its own options to this environment variable when running tests, so it is recommended to run the simulation manually (i.e., without ``make test``, ``ninja test``, or ``ctest``).
+
+  * For more information, see this `guide to using AddressSanitizer in an HPC context <https://www.osc.edu/resources/getting_started/howto/howto_use_address_sanitizer>`_.
+
+* On AMD GPUs, there is a `GPU-aware AddressSanitizer <https://rocm.docs.amd.com/en/latest/understand/using_gpu_sanitizer.html#compiling-for-address-sanitizer>`_. Currently, enabling this requires manually changing the compiler flags.
+
+How to actually debug on GPUs
+-----------------------
+
+As an *absolute last resort* if it is impossible to reproduce the error you are seeing on a CPU-only run, then the best option is to:
+
+* downsize the simulation to fit on a single GPU
+
+* start the simulation on an NVIDIA GPU from within CUDA-GDB
+  (see the `documentation <https://docs.nvidia.com/cuda/cuda-gdb/index.html>`_ and `slides <https://www.olcf.ornl.gov/wp-content/uploads/2021/06/cuda_training_series_cuda_debugging.pdf>`_).
+
+* hope CUDA-GDB does not itself crash
+
+* hope CUDA-GDB produces a useful error message that you can analyze
+
+NVIDIA also provides the ``compute-sanitizer`` tool that is essentially the equivalent of AddressSanitizer (see the `documentation <https://docs.nvidia.com/compute-sanitizer/ComputeSanitizer/index.html>`_). Unfortunately, it does not work as reliably as AddressSanitizer, and may itself crash while attempting to debug a GPU program.
+
+For AMD GPUs, you have to use the AMD-provided debugger ``rocgdb``. A tutorial its use is available `here <https://www.olcf.ornl.gov/wp-content/uploads/2021/04/rocgdb_hipmath_ornl_2021_v2.pdf>`_.
+
+AMD also provides a GPU-aware AddressSanitizer that can be enabled when building Quokka. Currently, the compiler flags must be manually modified in order to enable this. For details, see its `documentation <https://rocm.docs.amd.com/en/latest/understand/using_gpu_sanitizer.html#compiling-for-address-sanitizer>`_.
+
+GPU kernel asynchronicity
+-----------------------
+
+**By default, GPU kernels launch asynchronously, i.e., execution of CPU code continues before the kernel starts on the GPU. This can cause synchronization problems if there is an implicit assumption about the order of operations with respect to CPU and GPU code.**
+
+The easiest way to debug this is to set the environment variables:
+
+* ``CUDA_LAUNCH_BLOCKING=1`` on NVIDIA GPUs, or
+* ``HIP_LAUNCH_BLOCKING=1`` on AMD GPUs.
+
+This will cause the CPU to wait until the GPU kernel execution is complete before continuing past the call to ``ParallelFor``.
+
+For more details, refer to the `AMReX GPU debugging guide <https://amrex-codes.github.io/amrex/docs_html/Debugging.html#basic-gpu-debugging>`_.
+
+When all else fails: Debugging with ``printf``
+-----------------------
+
+If you have tried *all* of the above steps, then you have to resort to adding ``printf`` statements within the GPU code. Note that ``printf`` inside GPU code is different from the CPU-side ``printf`` function, as explained in the `NVIDIA documentation <https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#formatted-output>`_.

--- a/docs/error_checking.rst
+++ b/docs/error_checking.rst
@@ -1,0 +1,21 @@
+.. Assertions and error checking
+
+Assertions and error checking
+==========================
+
+AMReX assert macros
+-----------------------
+
+AMReX provides several assertion macros:
+
+* `AMREX_ASSERT`: Works when `CMAKE_BUILD_TYPE=Debug`.
+* `AMREX_ALWAYS_ASSERT`: Always works on CPU. **Works on GPU only if "-DNDEBUG" is NOT added to the compiler flags. Note that CMake adds "-DNDEBUG" by default when "CMAKE_BUILD_TYPE=Release".** (See this `GitHub discussion <https://github.com/AMReX-Codes/amrex/discussions/2648>`_ for details.)
+
+Abort
+-----------------------
+
+Because the default CMake flags added in Release mode causes `AMREX_ALWAYS_ASSERT` not to function in GPU code, `amrex::Abort` is the best option to use if you want to abort a GPU kernel.
+
+`amrex::Abort` requires additional GPU register usage, so it should be used sparingly. The best strategy for error handling is often to set a value in an array that indicates an iterative solve failed in a given cell. (This is what Castro does for its nuclear burning networks.)
+
+For more details, see the `AMReX documentation on assertions and error checking <https://amrex-codes.github.io/amrex/docs_html/GPU.html#assertions-and-error-checking>`_.

--- a/docs/howto_clang_tidy.rst
+++ b/docs/howto_clang_tidy.rst
@@ -1,0 +1,20 @@
+.. How to use clang-tidy
+
+How to use ``clang-tidy``
+==========================
+
+``clang-tidy`` is `a command-line tool <https://clang.llvm.org/extra/clang-tidy/>`_ that automatically enforces certain aspects of code style and provides warnings for common programming mistakes. It automatically runs on every pull request in the Quokka GitHub repository.
+
+Using clang-tidy with VSCode
+-----------------------
+
+The easiest way to use ``clang-tidy`` on your own computer is to install the `clangd extension for Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd>`_ (VSCode).
+
+(VSCode itself can be downloaded `here <https://code.visualstudio.com/>`_.)
+
+Command-line alternative
+-----------------------
+
+You can also run ``clang-tidy`` from the command line (see the `documentation <https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy>`_).
+
+To see the ``clang-tidy`` warnings that are relevant only to the code changes you've made, you can use the `clang-tidy-diff.py` `Python script <https://clang.llvm.org/extra/doxygen/clang-tidy-diff_8py_source.html>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,31 +3,75 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Quokka's documentation!
+QUOKKA
 ========================================
 
-Quokka is a high-resolution shock capturing AMR radiation hydrodynamics code using the AMReX
-library :cite:`AMReX_JOSS` to provide patch-based adaptive mesh functionality.
+**Quadrilateral, Umbra-producing, Orthogonal, Kangaroo-conserving Kode for Astrophysics!**
+
+Quokka is a two-moment radiation hydrodynamics code that uses the piecewise-parabolic method,
+with AMR and subcycling in time. Runs on CPUs (MPI+vectorized) or NVIDIA GPUs (MPI+CUDA) with a single-source codebase.
+Written in C++17. (100% Fortran-free.)
+
+.. note::
+   The Quokka methods paper is now `available on arXiv <https://arxiv.org/abs/2110.01792>`_.
+
+We use the AMReX library :cite:`AMReX_JOSS` to provide patch-based adaptive mesh functionality.
 We take advantage of the C++ loop abstractions in AMReX in order to
 run with high performance on either CPUs or GPUs.
 
+Example simulation set-ups are included in the GitHub repository for many astrophysical
+problems of interest related to star formation and the interstellar medium.
+
+.. _contact:
+
+Contact
+^^^^^^^
+
+All communication takes place on the `Quokka GitHub repository <https://github.com/quokka-astro/quokka>`_.
+You can start a `Discussion <https://github.com/quokka-astro/quokka/discussions>`_ for technical support, or open an `Issue <https://github.com/quokka-astro/quokka/issues>`_ for any bug reports.
+
+
+.. raw:: html
+
+   <style>
+   /* front page: hide chapter titles
+    * needed for consistent HTML-PDF-EPUB chapters
+    */
+   section#user-guide,
+   section#developer-guide {
+       display:none;
+   }
+   </style>
+
 .. toctree::
-   :maxdepth: 2
+   :hidden:
 
    about
-   installation
    equations
-   flowchart
+   bibliography
+
+User Guide
+------------
+.. toctree::
+   :caption: USER GUIDE
+   :maxdepth: 1
+   :hidden:
+
+   installation
    tests/index
    parameters
+
+Developer Guide
+-----------
+.. toctree::
+   :caption: DEVELOPER GUIDE
+   :maxdepth: 1
+   :hidden:
+
+   flowchart
+   debugging
+   error_checking
+   performance
+   howto_clang_tidy
    api
-   bibliography
    
-   
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`search`
-
-

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -1,0 +1,53 @@
+.. Performance
+
+Performance tips
+=====
+
+Prerequisites
+-----------------------
+
+You should:
+
+* Understand what a `GPU kernel <https://en.wikipedia.org/wiki/Compute_kernel>`_ is. (For reference, consult these `notes <https://cvw.cac.cornell.edu/gpu-architecture/gpu-characteristics/kernel_sm>`_.)
+
+* Understand what a `processor register <https://en.wikipedia.org/wiki/Processor_register>`_ is.
+
+* Know that calling `amrex::ParallelFor` launches a GPU kernel (when GPU support is enabled at compile time).
+
+GPU hardware characteristics
+-----------------------
+
+GPUs have hardware design features that make their performance characteristics significantly different from CPUs. In practice, two factors dominate GPU performance behavior:
+
+* *Kernel launch latency:* this is a fundamental hardware characteristic of GPUs. It takes several microseconds (typically 3-10 microseconds, but it can vary depending on the compute kernel, the GPU hardware, the CPU hardware, and the driver) to launch a GPU kernel (i.e., to start running the code within an `amrex::ParallelFor` on the GPU). In practice, latency is generally longer for AMD and Intel GPUs.
+
+* *Register pressure:* the number of registers per thread available for use by a given kernel is limited to the size of the GPU register file divided by the number of threads. If a kernel needs more registers than are available in the register file, the compiler will "spill" registers to memory, which will then make the kernel run very slowly. Alternatively, the number of concurrent threads can be reduced, which increases the number of registers available per thread.
+  
+  * For more details, see these `AMD website notes <https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-register-pressure-readme/>`_ and OLCF `training materials <https://www.olcf.ornl.gov/wp-content/uploads/Intro_Register_pressure_ORNL_20220812_2083.pdf>`_.
+
+MPI communication latency vs. bandwidth
+-----------------------
+
+A traditional rule of thumb for CPU-based MPI codes is that communication latency often limits performance when scaling to large number of CPU cores (or, equivalently, MPI ranks). We have found that this is *not* the case for Quokka when running on GPU nodes (by, e.g., adding additional dummy variables to the state arrays).
+
+Communication performance appears to (virtually always) be *bandwidth limited*. There are two likely reasons for this:
+
+* GPU node performance is about 10x faster than CPU node performance, whereas network bandwidth is only 2-4x larger on GPU nodes compared to CPU nodes. The network bandwidth to compute ratio is therefore *lower* on GPU nodes than on CPU nodes.
+* GPU kernel launch latency (3-10 microseconds) is often larger than the minimum MPI message latency (i.e., the latency for small messages to travel between nodes) of 2-3 microseconds.
+
+Guidelines
+-----------------------
+
+* Combine operations into fewer kernels in order to reduce the fraction of time lost to kernel launch latency
+  
+  * This can also be done by using the `MultiFab` version of `ParallelFor` that operates on all of the FABs at once, rather than launching a separate kernel for each FAB. This should not increase register pressure.
+  
+  * *However,* combining multiple kernels can increase register pressure, which can decrease performance. There is no real way to know a priori whether there will be a net performance gain or loss without trying it out. The strategy that yields the best performance may be different for GPUs from different vendors!
+
+* Split operations into multiple kernels in order to decrease register pressure
+  
+  * *However,* this may increase the time lost due to kernel launch latency. This is an engineering trade-off that must be determined by performance measurements on the GPU hardware. This trade-off may be different on GPUs from different vendors!
+
+* In order to decrease register pressure, avoid using `printf`, `assert`, and `amrex::Abort` in GPU code . All of these functions require using additional registers that could instead be allocated to the useful computations does in a kernel. This may require a significant code rewrite to handle errors in a different way. (You should *not* just ignore errors, e.g. in an iterative solver.)
+
+* *Experts only:* Manually tune the number of GPU threads per block on a kernel-by-kernel basis. This can reduce register pressure by allowing each thread to use more registers. Note that this is an advanced optimization and should only be done with careful performance measurements done on multiple GPUs. The `AMReX documentation <https://amrex-codes.github.io/amrex/docs_html/GPU.html#gpu-block-size>`_ provides guidance on how to do this.


### PR DESCRIPTION
### Description
This is a major update to the Sphinx documentation that rewrites the introduction to be more consistent with `README.md`, adds chapter headings for the User Guide and the Developer Guide, and moves the developer-oriented content from the GitHub wiki to the Sphinx documentation.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
