### PR TITLE
use frexp and ldexp in FastMath

### DIFF
--- a/src/FastMath.hpp
+++ b/src/FastMath.hpp
@@ -1,7 +1,7 @@
 #ifndef FASTMATH_HPP_ // NOLINT
 #define FASTMATH_HPP_
 //======================================================================
-// © 2022. Triad National Security, LLC. All rights reserved.  This
+// © 2021-2023. Triad National Security, LLC. All rights reserved.  This
 // program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
 // National Security, LLC for the U.S.  Department of Energy/National
@@ -17,10 +17,11 @@
 // Code taken from singularity-eos
 // https://github.com/lanl/singularity-eos
 
-#include "AMReX_Extension.H"
-#include "AMReX_GpuQualifiers.H"
 #include <cassert>
 #include <cmath>
+
+#include "AMReX_Extension.H"
+#include "AMReX_GpuQualifiers.H"
 
 // this speeds up the *total walltime* for problems with cooling by ~30% on a
 // single V100
@@ -30,69 +31,30 @@
 namespace FastMath
 {
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto as_int(double f)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto fastlg(const double x) -> double
 {
-	return *reinterpret_cast<int64_t *>(&f); // NOLINT
+	int n = 0;
+	assert(x > 0 && "log divergent for x <= 0");
+	const double y = frexp(x, &n);
+	return 2 * (y - 1) + n;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto as_double(int64_t i)
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto fastpow2(const double x) -> double
 {
-	return *reinterpret_cast<double *>(&i); // NOLINT
+	const int flr = std::floor(x);
+	const double remainder = x - flr;
+	const double mantissa = 0.5 * (remainder + 1);
+	const int exponent = flr + 1;
+	return ldexp(mantissa, exponent);
 }
-
-// Reference implementations, however the integer cast implementation
-// below is probably faster.
-/*
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-double lg(const double x) {
-  int n;
-  assert(x > 0 && "log divergent for x <= 0");
-  const double y = frexp(x, &n);
-  return 2 * (y - 1) + n;
-}
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-double pow2(const double x) {
-  const int flr = std::floor(x);
-  const double remainder = x - flr;
-  const double mantissa = 0.5 * (remainder + 1);
-  const double exponent = flr + 1;
-  return ldexp(mantissa, exponent);
-}
-*/
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto lg(const double x) -> double
 {
-	// Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
-	// these are floating point numbers as reinterpreted as integers.
-	// as_int(1.0)
-	constexpr int64_t one_as_int = 4607182418800017408;
-	// 1./static_cast<double>(as_int(2.0) - as_int(1.0))
-	constexpr double scale_down = 2.22044604925031e-16;
-	return static_cast<double>(as_int(x) - one_as_int) * scale_down;
+	assert(x > 0 && "log divergent for x <= 0");
+	return fastlg(x);
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto pow2(const double x) -> double
-{
-	// Magic numbers constexpr because C++ doesn't constexpr reinterpret casts
-	// these are floating point numbers as reinterpreted as integers.
-	// as_int(1.0)
-	constexpr int64_t one_as_int = 4607182418800017408;
-	// as_int(2.0) - as_int(1.0)
-	constexpr double scale_up = 4503599627370496;
-	return as_double(static_cast<int64_t>(x * scale_up) + one_as_int);
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ln(const double x) -> double
-{
-	constexpr double ILOG2E = 0.6931471805599453;
-	return ILOG2E * lg(x);
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto exp(const double x) -> double
-{
-	constexpr double LOG2E = 1.4426950408889634;
-	return pow2(LOG2E * x);
-}
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto pow2(const double x) -> double { return fastpow2(x); }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto log10(const double x) -> double
 {
@@ -104,12 +66,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto pow10(const double x) -> double
 {
 	constexpr double LOG10OLOG2 = 3.321928094887362626;
 	return pow2(LOG10OLOG2 * x);
-}
-
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto tanh(const double x) -> double
-{
-	const double expx = exp(2 * x);
-	return (expx - 1) / (expx + 1);
 }
 
 } // namespace FastMath


### PR DESCRIPTION
### Description
This avoids `reinterpret_cast` in FastMath.hpp, which is undefined behavior. Instead, we use `ldexp` and `frexp` to manipulate the floating-point mantissa and exponent for the fast approximate log functions.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/333.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
