### PR TITLE
Fallback to zero-gradient extrapolation when NSCBC fails

### DIFF
--- a/src/NSCBC_outflow.hpp
+++ b/src/NSCBC_outflow.hpp
@@ -328,10 +328,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundary(const amrex::IntVect
 
 	// compute centered ghost values
 	dQ_dx *= (SIDE == BoundarySide::Lower) ? -1.0 : 1.0;
-	quokka::valarray<amrex::Real, N> const Q_ip1 = Q_im1 + 2.0 * dx * dQ_dx;
-	quokka::valarray<amrex::Real, N> const Q_ip2 = -2.0 * Q_im1 - 3.0 * Q_i + 6.0 * Q_ip1 - 6.0 * dx * dQ_dx;
-	quokka::valarray<amrex::Real, N> const Q_ip3 = 3.0 * Q_im1 + 10.0 * Q_i - 18.0 * Q_ip1 + 6.0 * Q_ip2 + 12.0 * dx * dQ_dx;
-	quokka::valarray<amrex::Real, N> const Q_ip4 = -2.0 * Q_im1 - 13.0 * Q_i + 24.0 * Q_ip1 - 12.0 * Q_ip2 + 4.0 * Q_ip3 - 12.0 * dx * dQ_dx;
+	quokka::valarray<amrex::Real, N> Q_ip1 = Q_im1 + 2.0 * dx * dQ_dx;
+	quokka::valarray<amrex::Real, N> Q_ip2 = -2.0 * Q_im1 - 3.0 * Q_i + 6.0 * Q_ip1 - 6.0 * dx * dQ_dx;
+	quokka::valarray<amrex::Real, N> Q_ip3 = 3.0 * Q_im1 + 10.0 * Q_i - 18.0 * Q_ip1 + 6.0 * Q_ip2 + 12.0 * dx * dQ_dx;
+	quokka::valarray<amrex::Real, N> Q_ip4 = -2.0 * Q_im1 - 13.0 * Q_i + 24.0 * Q_ip1 - 12.0 * Q_ip2 + 4.0 * Q_ip3 - 12.0 * dx * dQ_dx;
 
 	// set cell values
 	const int ip1 = (SIDE == BoundarySide::Lower) ? ibr - 1 : ibr + 1;

--- a/src/NSCBC_outflow.hpp
+++ b/src/NSCBC_outflow.hpp
@@ -251,6 +251,18 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto unpermute_vel(quokka::valarray<amrex::R
 	}
 	return newPrim;
 }
+
+template <typename problem_t>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto isStateValid(quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Q) -> bool
+{
+	const amrex::Real rho = Q[0];
+	const amrex::Real u = Q[1];
+	const amrex::Real v = Q[2];
+	const amrex::Real w = Q[3];
+	const amrex::Real P = Q[4];
+	// check whether density and pressure are positive
+	return ((rho > 0.) && (P > 0.));
+}
 } // namespace detail
 
 template <typename problem_t, FluxDir DIR, BoundarySide SIDE>

--- a/src/NSCBC_outflow.hpp
+++ b/src/NSCBC_outflow.hpp
@@ -256,9 +256,6 @@ template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto isStateValid(quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Q) -> bool
 {
 	const amrex::Real rho = Q[0];
-	const amrex::Real u = Q[1];
-	const amrex::Real v = Q[2];
-	const amrex::Real w = Q[3];
 	const amrex::Real P = Q[4];
 	// check whether density and pressure are positive
 	return ((rho > 0.) && (P > 0.));

--- a/src/NSCBC_outflow.hpp
+++ b/src/NSCBC_outflow.hpp
@@ -327,6 +327,15 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundary(const amrex::IntVect
 	const int ip3 = (SIDE == BoundarySide::Lower) ? ibr - 3 : ibr + 3;
 	const int ip4 = (SIDE == BoundarySide::Lower) ? ibr - 4 : ibr + 4;
 
+	// reset to zero-gradient outflow if any state Q_{ip1...ip4} is invalid
+	if (!(detail::isStateValid<problem_t>(Q_ip1) && detail::isStateValid<problem_t>(Q_ip2) && detail::isStateValid<problem_t>(Q_ip3) &&
+	      detail::isStateValid<problem_t>(Q_ip4))) {
+		Q_ip1 = Q_i;
+		Q_ip2 = Q_i;
+		Q_ip3 = Q_i;
+		Q_ip4 = Q_i;
+	}
+
 	quokka::valarray<amrex::Real, N> consCell{};
 	if (idx[static_cast<int>(DIR)] == ip1) {
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip1);


### PR DESCRIPTION
### Description
This implemented a fallback to zero-gradient extrapolation when the NSCBC outflow boundary condition produces ghost cells with negative density or pressure.

This is necessary to prevent the simulation from crashing when NSCBC outflow is used for the cloud acceleration problem. There does not appear to be anything better that can be done when this happens (Zingale, personal communication). This only is needed for an extremely small fraction of ghost cells. 

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
