### PR TITLE
add additional metadata to openPMD outputs

### DIFF
--- a/src/openPMD.cpp
+++ b/src/openPMD.cpp
@@ -80,8 +80,8 @@ void SetupMeshComponent(openPMD::Mesh &mesh, amrex::Geometry &full_geom)
 auto GetMeshComponentName(int meshLevel, std::string const &field_name) -> std::string
 {
 	std::string new_field_name = field_name;
-	// TODO(bwibking): convert dash to underscore
-
+	// convert dashes to underscores
+	std::replace(new_field_name.begin(), new_field_name.end(), '-', '_');
 	if (meshLevel > 0) {
 		new_field_name += std::string("_lvl").append(std::to_string(meshLevel));
 	}
@@ -95,7 +95,7 @@ void WriteFile(const std::vector<std::string> &varnames, int const output_levels
 	       amrex::Vector<amrex::Geometry> &geom, const std::string &output_basename, amrex::Real const time, int const file_number)
 {
 	// open file
-	std::string const filename = output_basename + "%05T.h5";
+	std::string const filename = output_basename + "%05T.bp";
 	auto series = openPMD::Series(filename, openPMD::Access::CREATE, amrex::ParallelDescriptor::Communicator());
 	series.setSoftware("Quokka", "1.0");
 	series.setIterationEncoding(openPMD::IterationEncoding::fileBased);

--- a/src/openPMD.cpp
+++ b/src/openPMD.cpp
@@ -16,6 +16,7 @@
 #include "AMReX_MultiFab.H"
 
 // openPMD headers
+#include "openPMD/IterationEncoding.hpp"
 #include "openPMD/openPMD.hpp"
 
 namespace quokka::OpenPMDOutput
@@ -79,6 +80,8 @@ void SetupMeshComponent(openPMD::Mesh &mesh, amrex::Geometry &full_geom)
 auto GetMeshComponentName(int meshLevel, std::string const &field_name) -> std::string
 {
 	std::string new_field_name = field_name;
+	// TODO(bwibking): convert dash to underscore
+
 	if (meshLevel > 0) {
 		new_field_name += std::string("_lvl").append(std::to_string(meshLevel));
 	}
@@ -92,9 +95,10 @@ void WriteFile(const std::vector<std::string> &varnames, int const output_levels
 	       amrex::Vector<amrex::Geometry> &geom, const std::string &output_basename, amrex::Real const time, int const file_number)
 {
 	// open file
-	std::string const filename = output_basename + ".bp";
+	std::string const filename = output_basename + "%05T.h5";
 	auto series = openPMD::Series(filename, openPMD::Access::CREATE, amrex::ParallelDescriptor::Communicator());
 	series.setSoftware("Quokka", "1.0");
+	series.setIterationEncoding(openPMD::IterationEncoding::fileBased);
 
 	auto series_iteration = series.iterations[file_number];
 	series_iteration.open();

--- a/src/openPMD.cpp
+++ b/src/openPMD.cpp
@@ -92,7 +92,7 @@ void WriteFile(const std::vector<std::string> &varnames, int const output_levels
 	       amrex::Vector<amrex::Geometry> &geom, const std::string &output_basename, amrex::Real const time, int const file_number)
 {
 	// open file
-	std::string const filename = output_basename + ".h5";
+	std::string const filename = output_basename + ".bp";
 	auto series = openPMD::Series(filename, openPMD::Access::CREATE, amrex::ParallelDescriptor::Communicator());
 	series.setSoftware("Quokka", "1.0");
 

--- a/src/openPMD.cpp
+++ b/src/openPMD.cpp
@@ -59,11 +59,14 @@ void SetupMeshComponent(openPMD::Mesh &mesh, amrex::Geometry &full_geom)
 	auto global_size = getReversedVec(global_box.size());
 	std::vector<double> const grid_spacing = getReversedVec(full_geom.CellSize());
 	std::vector<double> const global_offset = getReversedVec(full_geom.ProbLo());
+	std::vector<std::string> const coordinateLabels{AMREX_D_DECL("x", "y", "z")};
+	std::vector<std::string> const grid_axes{coordinateLabels.rbegin(), coordinateLabels.rend()}; // reverse order
 
 	// Prepare the type of dataset that will be written
 	mesh.setDataOrder(openPMD::Mesh::DataOrder::C);
 	mesh.setGridSpacing(grid_spacing);
 	mesh.setGridGlobalOffset(global_offset);
+	mesh.setAxisLabels(grid_axes); // use C-ordering
 	mesh.setAttribute("fieldSmoothing", "none");
 
 	auto mesh_comp = mesh[openPMD::MeshRecordComponent::SCALAR];
@@ -89,7 +92,7 @@ void WriteFile(const std::vector<std::string> &varnames, int const output_levels
 	       amrex::Vector<amrex::Geometry> &geom, const std::string &output_basename, amrex::Real const time, int const file_number)
 {
 	// open file
-	std::string const filename = output_basename + ".bp";
+	std::string const filename = output_basename + ".h5";
 	auto series = openPMD::Series(filename, openPMD::Access::CREATE, amrex::ParallelDescriptor::Communicator());
 	series.setSoftware("Quokka", "1.0");
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1852,7 +1852,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	amrex::Print() << "Writing plotfile " << plotfilename << "\n";
 
 #ifdef QUOKKA_USE_OPENPMD
-	quokka::OpenPMDOutput::WriteFile(varnames, finest_level + 1, mf_ptr, Geom(), plotfilename, tNew_[0], istep[0]);
+	quokka::OpenPMDOutput::WriteFile(varnames, finest_level + 1, mf_ptr, Geom(), plot_file, tNew_[0], istep[0]);
 	WriteMetadataFile(plotfilename + ".yaml");
 #else
 	amrex::WriteMultiLevelPlotfile(plotfilename, finest_level + 1, mf_ptr, varnames, Geom(), tNew_[0], istep, refRatio());


### PR DESCRIPTION
### Description
openPMD expects additional metadata to be compliant with its standard that wasn't included in the initial implementation of openPMD support.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
