### PR TITLE
fix macOS CI

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -39,8 +39,11 @@ jobs:
       run: |
         brew install openmpi hdf5 || true
 
-    - name: Output HDF5 configuration
+    - name: Output HDF5 configuration (verbose)
       run: h5cc -showconfig
+
+    - name: Output HDF5 compile flags
+      run: h5cc -show
 
     - name: Install pip dependencies
       run: python3 -m pip install --user numpy matplotlib

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Homebrew dependencies
       run: |
-        brew install openmpi hdf5 || true
+        brew install openmpi hdf5@1.10 || true
 
     - name: Output HDF5 configuration (verbose)
       run: h5cc -showconfig

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -38,6 +38,7 @@ jobs:
     - name: Install Homebrew dependencies
       run: |
         brew install openmpi hdf5@1.10 || true
+        brew link --force hdf5@1.10
 
     - name: Output HDF5 configuration (verbose)
       run: h5cc -showconfig

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+    
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip' # caching pip dependencies
 
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory
@@ -32,8 +37,7 @@ jobs:
 
     - name: Install Homebrew dependencies
       run: |
-        brew install python3 openmpi hdf5 || true
-        brew link --overwrite python@3.11
+        brew install openmpi hdf5 || true
 
     - name: Install pip dependencies
       run: python3 -m pip install --user numpy matplotlib

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -39,6 +39,9 @@ jobs:
       run: |
         brew install openmpi hdf5 || true
 
+    - name: Output HDF5 configuration
+      run: h5cc -showconfig
+
     - name: Install pip dependencies
       run: python3 -m pip install --user numpy matplotlib
 


### PR DESCRIPTION
### Description
The macOS GitHub runner is broken once again due to broken Homebrew packages.

We fix this by installing a specific version of Python using `actions/setup-python` instead of `brew install python3` and by specifying `brew install hdf5@1.10` (since the Homebrew `hdf5@1.14` package is broken due to https://github.com/Homebrew/homebrew-core/pull/159165).

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
