### PR TITLE
build GitHub actions in parallel

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,8 +53,8 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      # Restrict to 1 build process at a time to avoid OOM kills.
-      run: cmake --build . --config $BUILD_TYPE --parallel 1
+      # Restrict to 2 build processes at a time to avoid OOM kills.
+      run: cmake --build . --config $BUILD_TYPE --parallel 2
 
     - name: Create test output directory
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,8 +53,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      # Restrict to 2 build processes at a time to avoid OOM kills.
-      run: cmake --build . --config $BUILD_TYPE --parallel 2
+      run: cmake --build . --config $BUILD_TYPE --parallel 4
 
     - name: Create test output directory
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests


### PR DESCRIPTION
### Description
This changes the Github actions builds to build in parallel with 4 processes, since the Github actions VMs are now more powerful: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/

The macOS actions runners are the same as before, so those should not be changed.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
