### PR TITLE
Make ComputeRadPressure return F and S

### DIFF
--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1246,18 +1246,18 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<quokka::valarray<double, 4>, 3> P{};
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[0] = F;
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[1] = F;
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[2] = F;
-        }
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[0] = F;
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[1] = F;
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[2] = F;
+				}
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -190,8 +190,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_DEVICE static void amendRadState(std::array<amrex::Real, nvarHyperbolic_> &cons);
 
 	template <FluxDir DIR>
-	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L,
-							double fy_L, double fz_L) -> std::array<double, 5>;
+	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
+	    -> std::array<double, 5>;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
@@ -695,11 +695,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz,
-							       const double fx, const double fy, const double fz) -> std::array<double, 5>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
+							       const double fy, const double fz) -> std::array<double, 5>
 {
-  // Compute the radiation pressure tensor and the maximum signal speed into a single array. The first four elements are 
-  // the components of the radiation pressure tensor, and the fifth element is the maximum signal speed.
+	// Compute the radiation pressure tensor and the maximum signal speed into a single array. The first four elements are
+	// the components of the radiation pressure tensor, and the fifth element is the maximum signal speed.
 
 	// check that states are physically admissible
 	AMREX_ASSERT(erad > 0.0);
@@ -884,17 +884,17 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 			// ComputeRadPressure returns F_L_and_S_L or F_R_and_S_R
 			auto const F_L_and_S_L = ComputeRadPressure<DIR>(erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
-      double S_L = -1. * F_L_and_S_L[numRadVars_]; // speed sign is -1
-      quokka::valarray<double, numRadVars_> F_L{};
-      for (int n = 0; n < numRadVars_; ++n) {
-        F_L[n] = F_L_and_S_L[n];
-      }
+			double S_L = -1. * F_L_and_S_L[numRadVars_]; // speed sign is -1
+			quokka::valarray<double, numRadVars_> F_L{};
+			for (int n = 0; n < numRadVars_; ++n) {
+				F_L[n] = F_L_and_S_L[n];
+			}
 			auto const F_R_and_S_R = ComputeRadPressure<DIR>(erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
-      double S_R = F_R_and_S_R[numRadVars_]; // speed sign is +1, S_R unchanged
-      quokka::valarray<double, numRadVars_> F_R{};
-      for (int n = 0; n < numRadVars_; ++n) {
-        F_R[n] = F_R_and_S_R[n];
-      }
+			double S_R = F_R_and_S_R[numRadVars_]; // speed sign is +1, S_R unchanged
+			quokka::valarray<double, numRadVars_> F_R{};
+			for (int n = 0; n < numRadVars_; ++n) {
+				F_R[n] = F_R_and_S_R[n];
+			}
 
 			// correct for reduced speed of light
 			F_L[0] *= c_hat_ / c_light_;
@@ -1246,18 +1246,18 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<std::array<double, numRadVars_>, 3> P{};
-        auto P_and_S = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-        for (int n = 0; n < numRadVars_; ++n) {
-          P[0][n] = P_and_S[n];
-        }
-        P_and_S = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-        for (int n = 0; n < numRadVars_; ++n) {
-          P[1][n] = P_and_S[n];
-        }
-        P_and_S = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-        for (int n = 0; n < numRadVars_; ++n) {
-          P[2][n] = P_and_S[n];
-        }
+				auto P_and_S = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+				for (int n = 0; n < numRadVars_; ++n) {
+					P[0][n] = P_and_S[n];
+				}
+				P_and_S = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+				for (int n = 0; n < numRadVars_; ++n) {
+					P[1][n] = P_and_S[n];
+				}
+				P_and_S = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+				for (int n = 0; n < numRadVars_; ++n) {
+					P[2][n] = P_and_S[n];
+				}
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -189,9 +189,9 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_DEVICE static void amendRadState(std::array<amrex::Real, nvarHyperbolic_> &cons);
 
-	template <FluxDir DIR, typename TARRAY>
-	AMREX_GPU_DEVICE static void ComputeRadPressure(TARRAY &F_L, double &S_L, double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L,
-							double fy_L, double fz_L);
+	template <FluxDir DIR>
+	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L,
+							double fy_L, double fz_L) -> std::array<double, 5>;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
@@ -694,10 +694,13 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 }
 
 template <typename problem_t>
-template <FluxDir DIR, typename TARRAY>
-AMREX_GPU_DEVICE void RadSystem<problem_t>::ComputeRadPressure(TARRAY &F, double &S, const double erad, const double Fx, const double Fy, const double Fz,
-							       const double fx, const double fy, const double fz)
+template <FluxDir DIR>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz,
+							       const double fx, const double fy, const double fz) -> std::array<double, 5>
 {
+  // Compute the radiation pressure tensor and the maximum signal speed into a single array. The first four elements are 
+  // the components of the radiation pressure tensor, and the fifth element is the maximum signal speed.
+
 	// check that states are physically admissible
 	AMREX_ASSERT(erad > 0.0);
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
@@ -786,9 +789,9 @@ AMREX_GPU_DEVICE void RadSystem<problem_t>::ComputeRadPressure(TARRAY &F, double
 	AMREX_ASSERT(Pny != NAN);
 	AMREX_ASSERT(Pnz != NAN);
 
-	F = {Fn, Pnx, Pny, Pnz};
+	const double S = std::max(0.1, std::sqrt(Tnormal));
 
-	S = std::max(0.1, std::sqrt(Tnormal));
+	return {Fn, Pnx, Pny, Pnz, S};
 }
 
 template <typename problem_t>
@@ -879,17 +882,19 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 				f_R = std::sqrt(fx_R * fx_R + fy_R * fy_R + fz_R * fz_R);
 			}
 
-			// compute radiation pressure F_L and F_R using ComputeRadPressure
-			quokka::valarray<double, numRadVars_> F_L{};
-			quokka::valarray<double, numRadVars_> F_R{};
-			double S_L = NAN;
-			double S_R = NAN;
-			// ComputeRadPressure will modify F_L and S_L
-			ComputeRadPressure<DIR>(F_L, S_L, erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
-			S_L *= -1.; // speed sign is -1
-				    // ComputeRadPressure will modify F_R and S_R
-			ComputeRadPressure<DIR>(F_R, S_R, erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
-			// speed sign is +1, S_R unchanged.
+			// ComputeRadPressure returns F_L_and_S_L or F_R_and_S_R
+			auto const F_L_and_S_L = ComputeRadPressure<DIR>(erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
+      double S_L = -1. * F_L_and_S_L[numRadVars_]; // speed sign is -1
+      quokka::valarray<double, numRadVars_> F_L{};
+      for (int n = 0; n < numRadVars_; ++n) {
+        F_L[n] = F_L_and_S_L[n];
+      }
+			auto const F_R_and_S_R = ComputeRadPressure<DIR>(erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
+      double S_R = F_R_and_S_R[numRadVars_]; // speed sign is +1, S_R unchanged
+      quokka::valarray<double, numRadVars_> F_R{};
+      for (int n = 0; n < numRadVars_; ++n) {
+        F_R[n] = F_R_and_S_R[n];
+      }
 
 			// correct for reduced speed of light
 			F_L[0] *= c_hat_ / c_light_;
@@ -1241,12 +1246,18 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<std::array<double, numRadVars_>, 3> P{};
-				double S = NAN;
-				// loop DIR over {FluxDir::X1, FluxDir::X2, FluxDir::X3}
-				// ComputeRadPressure will modify P[DIR] and S
-				ComputeRadPressure<FluxDir::X1>(P[0], S, erad, Fx, Fy, Fz, fx, fy, fz);
-				ComputeRadPressure<FluxDir::X2>(P[1], S, erad, Fx, Fy, Fz, fx, fy, fz);
-				ComputeRadPressure<FluxDir::X3>(P[2], S, erad, Fx, Fy, Fz, fx, fy, fz);
+        auto P_and_S = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+        for (int n = 0; n < numRadVars_; ++n) {
+          P[0][n] = P_and_S[n];
+        }
+        P_and_S = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+        for (int n = 0; n < numRadVars_; ++n) {
+          P[1][n] = P_and_S[n];
+        }
+        P_and_S = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+        for (int n = 0; n < numRadVars_; ++n) {
+          P[2][n] = P_and_S[n];
+        }
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -65,8 +65,8 @@ template <typename problem_t> struct RadSystem_Traits {
 
 // A struct to hold the results of the ComputeRadPressure function.
 struct RadPressureResult {
-  quokka::valarray<double, 4> F;  // components of radiation pressure tensor
-  double S; // maximum wavespeed for the radiation system
+	quokka::valarray<double, 4> F; // components of radiation pressure tensor
+	double S;		       // maximum wavespeed for the radiation system
 };
 
 /// Class for the radiation moment equations
@@ -704,7 +704,7 @@ template <FluxDir DIR>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
 							       const double fy, const double fz) -> RadPressureResult
 {
-	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct. 
+	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct.
 
 	// check that states are physically admissible
 	AMREX_ASSERT(erad > 0.0);
@@ -1246,18 +1246,18 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<std::array<double, numRadVars_>, 3> P{};
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[0] = F;
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[1] = F;
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-          P[2] = F;
-        }
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[0] = F;
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[1] = F;
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+					P[2] = F;
+				}
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -65,8 +65,8 @@ template <typename problem_t> struct RadSystem_Traits {
 
 // A struct to hold the results of the ComputeRadPressure function.
 struct RadPressureResult {
-    quokka::valarray<double, 4> F;
-    double S;
+    quokka::valarray<double, 4> F;  // components of radiation pressure tensor
+    double S; // maximum wavespeed for the radiation system
 };
 
 /// Class for the radiation moment equations
@@ -704,8 +704,7 @@ template <FluxDir DIR>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
 							       const double fy, const double fz) -> RadPressureResult
 {
-	// Compute the radiation pressure tensor and the maximum signal speed into a single array. The first four elements are
-	// the components of the radiation pressure tensor, and the fifth element is the maximum signal speed.
+	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct. 
 
 	// check that states are physically admissible
 	AMREX_ASSERT(erad > 0.0);
@@ -1249,21 +1248,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				std::array<std::array<double, numRadVars_>, 3> P{};
         {
           auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[0][n] = F[n];
-          }
+          P[0] = F;
         }
         {
           auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[1][n] = F[n];
-          }
+          P[1] = F;
         }
         {
           auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[2][n] = F[n];
-          }
+          P[2] = F;
         }
 
 				// loop over spatial dimensions

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -65,8 +65,8 @@ template <typename problem_t> struct RadSystem_Traits {
 
 // A struct to hold the results of the ComputeRadPressure function.
 struct RadPressureResult {
-    quokka::valarray<double, 4> F;
-    double S;
+	quokka::valarray<double, 4> F;
+	double S;
 };
 
 /// Class for the radiation moment equations
@@ -797,11 +797,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 
 	const double S = std::max(0.1, std::sqrt(Tnormal));
 
-  RadPressureResult result{};
-  result.F = {Fn, Pnx, Pny, Pnz};
-  result.S = std::max(0.1, std::sqrt(Tnormal));
+	RadPressureResult result{};
+	result.F = {Fn, Pnx, Pny, Pnz};
+	result.S = std::max(0.1, std::sqrt(Tnormal));
 
-  return result;
+	return result;
 }
 
 template <typename problem_t>
@@ -894,7 +894,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 			// ComputeRadPressure returns F_L_and_S_L or F_R_and_S_R
 			auto [F_L, S_L] = ComputeRadPressure<DIR>(erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
-      S_L *= -1.; // speed sign is -1
+			S_L *= -1.; // speed sign is -1
 			auto [F_R, S_R] = ComputeRadPressure<DIR>(erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
 
 			// correct for reduced speed of light
@@ -1247,24 +1247,24 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<std::array<double, numRadVars_>, 3> P{};
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[0][n] = F[n];
-          }
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[1][n] = F[n];
-          }
-        }
-        {
-          auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-          for (int n = 0; n < numRadVars_; ++n) {
-            P[2][n] = F[n];
-          }
-        }
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+					for (int n = 0; n < numRadVars_; ++n) {
+						P[0][n] = F[n];
+					}
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+					for (int n = 0; n < numRadVars_; ++n) {
+						P[1][n] = F[n];
+					}
+				}
+				{
+					auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+					for (int n = 0; n < numRadVars_; ++n) {
+						P[2][n] = F[n];
+					}
+				}
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -63,6 +63,12 @@ template <typename problem_t> struct RadSystem_Traits {
 	static constexpr amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups + 1> radBoundaries = {0., inf};
 };
 
+// A struct to hold the results of the ComputeRadPressure function.
+struct RadPressureResult {
+    quokka::valarray<double, 4> F;
+    double S;
+};
+
 /// Class for the radiation moment equations
 ///
 template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_t>
@@ -191,7 +197,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	template <FluxDir DIR>
 	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
-	    -> std::array<double, 5>;
+	    -> RadPressureResult;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
@@ -696,7 +702,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
-							       const double fy, const double fz) -> std::array<double, 5>
+							       const double fy, const double fz) -> RadPressureResult
 {
 	// Compute the radiation pressure tensor and the maximum signal speed into a single array. The first four elements are
 	// the components of the radiation pressure tensor, and the fifth element is the maximum signal speed.
@@ -791,7 +797,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 
 	const double S = std::max(0.1, std::sqrt(Tnormal));
 
-	return {Fn, Pnx, Pny, Pnz, S};
+  RadPressureResult result{};
+  result.F = {Fn, Pnx, Pny, Pnz};
+  result.S = std::max(0.1, std::sqrt(Tnormal));
+
+  return result;
 }
 
 template <typename problem_t>
@@ -883,18 +893,9 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 			}
 
 			// ComputeRadPressure returns F_L_and_S_L or F_R_and_S_R
-			auto const F_L_and_S_L = ComputeRadPressure<DIR>(erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
-			double S_L = -1. * F_L_and_S_L[numRadVars_]; // speed sign is -1
-			quokka::valarray<double, numRadVars_> F_L{};
-			for (int n = 0; n < numRadVars_; ++n) {
-				F_L[n] = F_L_and_S_L[n];
-			}
-			auto const F_R_and_S_R = ComputeRadPressure<DIR>(erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
-			double S_R = F_R_and_S_R[numRadVars_]; // speed sign is +1, S_R unchanged
-			quokka::valarray<double, numRadVars_> F_R{};
-			for (int n = 0; n < numRadVars_; ++n) {
-				F_R[n] = F_R_and_S_R[n];
-			}
+			auto [F_L, S_L] = ComputeRadPressure<DIR>(erad_L, Fx_L, Fy_L, Fz_L, fx_L, fy_L, fz_L);
+      S_L *= -1.; // speed sign is -1
+			auto [F_R, S_R] = ComputeRadPressure<DIR>(erad_R, Fx_R, Fy_R, Fz_R, fx_R, fy_R, fz_R);
 
 			// correct for reduced speed of light
 			F_L[0] *= c_hat_ / c_light_;
@@ -1246,18 +1247,24 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fz = Fz / (c_light_ * erad);
 
 				std::array<std::array<double, numRadVars_>, 3> P{};
-				auto P_and_S = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-				for (int n = 0; n < numRadVars_; ++n) {
-					P[0][n] = P_and_S[n];
-				}
-				P_and_S = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-				for (int n = 0; n < numRadVars_; ++n) {
-					P[1][n] = P_and_S[n];
-				}
-				P_and_S = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-				for (int n = 0; n < numRadVars_; ++n) {
-					P[2][n] = P_and_S[n];
-				}
+        {
+          auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
+          for (int n = 0; n < numRadVars_; ++n) {
+            P[0][n] = F[n];
+          }
+        }
+        {
+          auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
+          for (int n = 0; n < numRadVars_; ++n) {
+            P[1][n] = F[n];
+          }
+        }
+        {
+          auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
+          for (int n = 0; n < numRadVars_; ++n) {
+            P[2][n] = F[n];
+          }
+        }
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1245,7 +1245,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fy = Fy / (c_light_ * erad);
 				auto fz = Fz / (c_light_ * erad);
 
-				std::array<std::array<double, numRadVars_>, 3> P{};
+				std::array<quokka::valarray<double, 4>, 3> P{};
         {
           auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
           P[0] = F;


### PR DESCRIPTION
### Description
Make ComputeRadPressure in radiation_system.hpp return F and S instead of modifying them at place.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
