### PR TITLE
change projection plotfile names

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2343,7 +2343,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlot
 			++iter;
 		}
 
-		const std::string basename = "proj" + dir_str;
+		const std::string basename = "proj_" + dir_str + "_plt";
 		const std::string filename = amrex::Concatenate(basename, istep[0], 5);
 		amrex::Print() << "Writing projection " << filename << "\n";
 		const amrex::Geometry mygeom(firstFab.box());


### PR DESCRIPTION
### Description
This changes the filename for projection plotfiles to `proj_x_plt00000`, `proj_y_plt00001`, etc.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/521.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
