### PR TITLE
Newton iteration on new basis (Egas, R / tau0)

### DIFF
--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1096,9 +1096,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
+    quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt
-		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> tau0{}; // optical depth across c * dt at old state
+		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt at new state
 		quokka::valarray<double, nGroups_> D{};	   // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
@@ -1121,15 +1122,26 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			const double Etot0 = Egas0 + (c / chat) * (Erad0 + sum(Src));
 
 			// BEGIN NEWTON-RAPHSON LOOP
+      // Solve for the new radiation energy and gas internal energy using a Newton-Raphson method using the base variables (Egas, D_0, D_1, ...), where D_i = R_i / tau_i^(t) and tau_i^(t) = dt * rho * kappa_{P,i}^(t) * chat is the optical depth across chat * dt for group i at time t. 
+      // Compared with the old base (Egas, Erad_0, Erad_1, ...), this new base is more stable and converges faster. Furthermore, the PlanckOpacityTempDerivative term is not needed anymore since I assume d/dT (kappa_P / kappa_E) = 0 in the calculation of the Jacobian. Note that this assumption only affects the convergence rate of the Newton-Raphson iteration and does not affect the result at all. 
+      // 
+      // The Jacobian of F(E_g, D_i) is
+      // 
+      // dF_G / dE_g = 1
+      // dF_G / dD_i = c / chat * tau0_i
+      // dF_{D,i} / dE_g = 1 / (chat * C_v) * (kappa_{P,i} / kappa_{E,i}) * d/dT (4 \pi B_i)
+      // dF_{D,i} / dD_i = - (1 / (chat * dt * rho * kappa_{E,i}) + 1) * tau0_i
+
 			Egas_guess = Egas0;
 			T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 			AMREX_ASSERT(T_gas >= 0.);
 			fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 			kappaPVec = ComputePlanckOpacity(rho, T_gas);
+      kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 			AMREX_ASSERT(!kappaPVec.hasnan());
-			// note that I assume kappa_P = kappa_E here
+			AMREX_ASSERT(!kappaEVec.hasnan());
 			tau0 = dt * rho * kappaPVec * chat;
-			D = fourPiB / chat - Erad0Vec;
+			D = fourPiB / chat - (kappaEVec / kappaPVec) * Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
@@ -1139,7 +1151,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
 			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
 			quokka::valarray<double, nGroups_> deltaD{};
-			quokka::valarray<double, nGroups_> F_R{};
+			quokka::valarray<double, nGroups_> F_D{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
 			const int maxIter = 400;
@@ -1151,16 +1163,17 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
+				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 			  AMREX_ASSERT(!kappaPVec.hasnan());
 
-        tau = dt * rho * kappaPVec * chat;
+        tau = dt * rho * kappaEVec * chat;
         Rvec = tau0 * D;
-        EradVec_guess = fourPiB / chat - Rvec / tau;
+        EradVec_guess = (kappaPVec / kappaEVec) * fourPiB / chat - Rvec / tau;
 				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
-				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
+				F_D = EradVec_guess - Erad0Vec - (Rvec + Src);
 
 				// check relative convergence of the residuals
-				if ((std::abs(F_G / Etot0) < resid_tol) && ((c / chat) * sum(abs(F_R)) / Etot0 < resid_tol)) {
+				if ((std::abs(F_G / Etot0) < resid_tol) && ((c / chat) * sum(abs(F_D)) / Etot0 < resid_tol)) {
 					break;
 				}
 
@@ -1170,13 +1183,14 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
+        // I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption only affects the convergence rate of the Newton-Raphson iteration and does not affect the converged solution at all. 
 				dFG_dEgas = 1.0;
 				dFG_dD = (c / chat) * tau0;
-				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_dEgas = 1.0 / (chat * c_v) * (kappaPVec / kappaEVec) * dfourPiB_dTgas;
 				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_D, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaD.hasnan());
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1096,9 +1096,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
-		quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> radEnergyFractions{};
+		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1121,20 +1122,23 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-			EradVec_guess = Erad0Vec;
+      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+      AMREX_ASSERT(T_gas >= 0.);
+      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			AMREX_ASSERT(!kappaPVec.hasnan());
+      // note that I assume kappa_P = kappa_E here
+      tau0 = dt * rho * kappaPVec * chat;
+      D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
 			double deltaEgas = NAN;
-			double Rtot = NAN;
-			double dRtot_dEgas = NAN;
 			quokka::valarray<double, nGroups_> Rvec{};
-			quokka::valarray<double, nGroups_> dRtot_dErad{};
-			quokka::valarray<double, nGroups_> dRvec_dEgas{};
-			quokka::valarray<double, nGroups_> dFG_dErad{};
+			quokka::valarray<double, nGroups_> dFG_dD{};
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
-			quokka::valarray<double, nGroups_> dFR_i_dErad_i{};
-			quokka::valarray<double, nGroups_> deltaErad{};
+			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
+			quokka::valarray<double, nGroups_> deltaD{};
 			quokka::valarray<double, nGroups_> F_R{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
@@ -1144,27 +1148,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute material temperature
 				T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 				AMREX_ASSERT(T_gas >= 0.);
-
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+			  AMREX_ASSERT(!kappaPVec.hasnan());
 
-				// compute derivatives w/r/t T_gas
-				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
-
-				// compute residuals
-				const auto absorption = chat * kappaEVec * EradVec_guess;
-				const auto emission = kappaPVec * fourPiB;
-				const auto Ediff = emission - absorption;
-				// auto tot_ediff = sum(abs(Ediff));
-				// if ((tot_ediff <= Erad_floor_) || (tot_ediff / (sum(absorption) + sum(emission)) < resid_tol)) {
-				//   break;
-				// }
-				Rvec = dt * rho * Ediff;
-				Rtot = sum(Rvec);
-				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
+        tau = dt * rho * kappaPVec * chat;
+        Rvec = tau0 * D;
+        EradVec_guess = fourPiB / chat - Rvec / tau;
+				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 
 				// check relative convergence of the residuals
@@ -1172,50 +1164,29 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					break;
 				}
 
-				quokka::valarray<double, nGroups_> dkappaP_dTgas = ComputePlanckOpacityTempDerivative(rho, T_gas);
-				quokka::valarray<double, nGroups_> dkappaE_dTgas = dkappaP_dTgas;
-				AMREX_ASSERT(!std::isnan(sum(dkappaP_dTgas)));
-
-				// prepare to compute Jacobian elements
 				const double c_v = quokka::EOS<problem_t>::ComputeEintTempDerivative(rho, T_gas, massScalars); // Egas = c_v * T
-				dRtot_dErad = -dt * rho * kappaEVec * chat;
-				dRvec_dEgas = dt * rho / c_v * (kappaPVec * dfourPiB_dTgas + dkappaP_dTgas * fourPiB - chat * dkappaE_dTgas * EradVec_guess);
-				// Equivalent of eta = (eta > 0.0) ? eta : 0.0, to ensure possitivity of Egas_guess
-				for (int g = 0; g < nGroups_; ++g) {
-					// AMREX_ASSERT(dRvec_dEgas[g] >= 0.0);
-					if (dRvec_dEgas[g] < 0.0) {
-						dRvec_dEgas[g] = 0.0;
-					}
-				}
-				dRtot_dEgas = sum(dRvec_dEgas);
+
+				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
+				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
-				dFG_dEgas = 1.0 + (c / chat) * dRtot_dEgas;
-				dFG_dErad = dRtot_dErad * (c / chat);
-				dFR_dEgas = -1.0 * dRvec_dEgas;
-				dFR_i_dErad_i = -1.0 * dRtot_dErad + 1.0;
-				AMREX_ASSERT(!std::isnan(dFG_dEgas));
-				AMREX_ASSERT(!dFG_dErad.hasnan());
-				AMREX_ASSERT(!dFR_dEgas.hasnan());
-				AMREX_ASSERT(!dFR_i_dErad_i.hasnan());
+				dFG_dEgas = 1.0;
+				dFG_dD = (c / chat) * tau0;
+				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dErad, dFR_dEgas, dFR_i_dErad_i, -F_G, -1. * F_R, deltaEgas, deltaErad);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
-				AMREX_ASSERT(!deltaErad.hasnan());
+				AMREX_ASSERT(!deltaD.hasnan());
 
-				EradVec_guess += deltaErad;
-				Egas_guess += deltaEgas;
-				AMREX_ASSERT(min(EradVec_guess) >= 0.);
-				AMREX_ASSERT(Egas_guess > 0.);
+        Egas_guess += deltaEgas;
+				D += deltaD;
 
 				// check relative and absolute convergence of E_r
-				// if ((sum(abs(deltaEgas / Egas_guess)) < 1e-7) || (sum(abs(deltaErad)) <= Erad_floor_)) {
+				// if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
 				// 	break;
 				// }
-				if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
-					break;
-				}
 			} // END NEWTON-RAPHSON LOOP
 
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1097,9 +1097,9 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt
 		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
-		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
+		quokka::valarray<double, nGroups_> D{};	   // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1122,14 +1122,14 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
-      AMREX_ASSERT(T_gas >= 0.);
-      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+			AMREX_ASSERT(T_gas >= 0.);
+			fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+			kappaPVec = ComputePlanckOpacity(rho, T_gas);
 			AMREX_ASSERT(!kappaPVec.hasnan());
-      // note that I assume kappa_P = kappa_E here
-      tau0 = dt * rho * kappaPVec * chat;
-      D = fourPiB / chat - Erad0Vec;
+			// note that I assume kappa_P = kappa_E here
+			tau0 = dt * rho * kappaPVec * chat;
+			D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
@@ -1152,11 +1152,11 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-			  AMREX_ASSERT(!kappaPVec.hasnan());
+				AMREX_ASSERT(!kappaPVec.hasnan());
 
-        tau = dt * rho * kappaPVec * chat;
-        Rvec = tau0 * D;
-        EradVec_guess = fourPiB / chat - Rvec / tau;
+				tau = dt * rho * kappaPVec * chat;
+				Rvec = tau0 * D;
+				EradVec_guess = fourPiB / chat - Rvec / tau;
 				Rtot = sum(Rvec); // TODO: remove Rtot here
 				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
@@ -1182,7 +1182,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaD.hasnan());
 
-        Egas_guess += deltaEgas;
+				Egas_guess += deltaEgas;
 				D += deltaD;
 
 				// check relative and absolute convergence of E_r

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1151,11 +1151,11 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-			  AMREX_ASSERT(!kappaPVec.hasnan());
+				AMREX_ASSERT(!kappaPVec.hasnan());
 
-        tau = dt * rho * kappaPVec * chat;
-        Rvec = tau0 * D;
-        EradVec_guess = fourPiB / chat - Rvec / tau;
+				tau = dt * rho * kappaPVec * chat;
+				Rvec = tau0 * D;
+				EradVec_guess = fourPiB / chat - Rvec / tau;
 				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1096,9 +1096,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
-		quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> radEnergyFractions{};
+		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1121,20 +1122,24 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-			EradVec_guess = Erad0Vec;
+      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+      AMREX_ASSERT(T_gas >= 0.);
+      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			AMREX_ASSERT(!kappaPVec.hasnan());
+      // note that I assume kappa_P = kappa_E here
+      tau0 = dt * rho * kappaPVec * chat;
+      D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
 			double deltaEgas = NAN;
 			double Rtot = NAN;
-			double dRtot_dEgas = NAN;
 			quokka::valarray<double, nGroups_> Rvec{};
-			quokka::valarray<double, nGroups_> dRtot_dErad{};
-			quokka::valarray<double, nGroups_> dRvec_dEgas{};
-			quokka::valarray<double, nGroups_> dFG_dErad{};
+			quokka::valarray<double, nGroups_> dFG_dD{};
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
-			quokka::valarray<double, nGroups_> dFR_i_dErad_i{};
-			quokka::valarray<double, nGroups_> deltaErad{};
+			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
+			quokka::valarray<double, nGroups_> deltaD{};
 			quokka::valarray<double, nGroups_> F_R{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
@@ -1144,26 +1149,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute material temperature
 				T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 				AMREX_ASSERT(T_gas >= 0.);
-
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+			  AMREX_ASSERT(!kappaPVec.hasnan());
 
-				// compute derivatives w/r/t T_gas
-				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
-
-				// compute residuals
-				const auto absorption = chat * kappaEVec * EradVec_guess;
-				const auto emission = kappaPVec * fourPiB;
-				const auto Ediff = emission - absorption;
-				// auto tot_ediff = sum(abs(Ediff));
-				// if ((tot_ediff <= Erad_floor_) || (tot_ediff / (sum(absorption) + sum(emission)) < resid_tol)) {
-				//   break;
-				// }
-				Rvec = dt * rho * Ediff;
-				Rtot = sum(Rvec);
+        tau = dt * rho * kappaPVec * chat;
+        Rvec = tau0 * D;
+        EradVec_guess = fourPiB / chat - Rvec / tau;
+				Rtot = sum(Rvec); // TODO: remove Rtot here
 				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 
@@ -1172,50 +1166,29 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					break;
 				}
 
-				quokka::valarray<double, nGroups_> dkappaP_dTgas = ComputePlanckOpacityTempDerivative(rho, T_gas);
-				quokka::valarray<double, nGroups_> dkappaE_dTgas = dkappaP_dTgas;
-				AMREX_ASSERT(!std::isnan(sum(dkappaP_dTgas)));
-
-				// prepare to compute Jacobian elements
 				const double c_v = quokka::EOS<problem_t>::ComputeEintTempDerivative(rho, T_gas, massScalars); // Egas = c_v * T
-				dRtot_dErad = -dt * rho * kappaEVec * chat;
-				dRvec_dEgas = dt * rho / c_v * (kappaPVec * dfourPiB_dTgas + dkappaP_dTgas * fourPiB - chat * dkappaE_dTgas * EradVec_guess);
-				// Equivalent of eta = (eta > 0.0) ? eta : 0.0, to ensure possitivity of Egas_guess
-				for (int g = 0; g < nGroups_; ++g) {
-					// AMREX_ASSERT(dRvec_dEgas[g] >= 0.0);
-					if (dRvec_dEgas[g] < 0.0) {
-						dRvec_dEgas[g] = 0.0;
-					}
-				}
-				dRtot_dEgas = sum(dRvec_dEgas);
+
+				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
+				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
-				dFG_dEgas = 1.0 + (c / chat) * dRtot_dEgas;
-				dFG_dErad = dRtot_dErad * (c / chat);
-				dFR_dEgas = -1.0 * dRvec_dEgas;
-				dFR_i_dErad_i = -1.0 * dRtot_dErad + 1.0;
-				AMREX_ASSERT(!std::isnan(dFG_dEgas));
-				AMREX_ASSERT(!dFG_dErad.hasnan());
-				AMREX_ASSERT(!dFR_dEgas.hasnan());
-				AMREX_ASSERT(!dFR_i_dErad_i.hasnan());
+				dFG_dEgas = 1.0;
+				dFG_dD = (c / chat) * tau0;
+				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dErad, dFR_dEgas, dFR_i_dErad_i, -F_G, -1. * F_R, deltaEgas, deltaErad);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
-				AMREX_ASSERT(!deltaErad.hasnan());
+				AMREX_ASSERT(!deltaD.hasnan());
 
-				EradVec_guess += deltaErad;
-				Egas_guess += deltaEgas;
-				AMREX_ASSERT(min(EradVec_guess) >= 0.);
-				AMREX_ASSERT(Egas_guess > 0.);
+        Egas_guess += deltaEgas;
+				D += deltaD;
 
 				// check relative and absolute convergence of E_r
-				// if ((sum(abs(deltaEgas / Egas_guess)) < 1e-7) || (sum(abs(deltaErad)) <= Erad_floor_)) {
+				// if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
 				// 	break;
 				// }
-				if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
-					break;
-				}
 			} // END NEWTON-RAPHSON LOOP
 
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");

--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -175,6 +175,16 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto opera
 	return scalardiv;
 }
 
+// scalar / array
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
+{
+  quokka::valarray<T, d> scalardiv;
+  for (size_t i = 0; i < v.size(); ++i) {
+    scalardiv[i] = scalar / v[i];
+  }
+  return scalardiv;
+}
+
 // array /= scalar
 template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void operator/=(quokka::valarray<T, d> &v, T const &scalar)
 {

--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -178,11 +178,11 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto opera
 // scalar / array
 template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
 {
-  quokka::valarray<T, d> scalardiv;
-  for (size_t i = 0; i < v.size(); ++i) {
-    scalardiv[i] = scalar / v[i];
-  }
-  return scalardiv;
+	quokka::valarray<T, d> scalardiv;
+	for (size_t i = 0; i < v.size(); ++i) {
+		scalardiv[i] = scalar / v[i];
+	}
+	return scalardiv;
 }
 
 // array /= scalar


### PR DESCRIPTION
### Description
Use a new basis in the Newton-Raphson iteration for the radiation-matter exchange. Instead of (Egas, Erad), we use the new basis (Egas, D), where D = R / tau0 and tau0 = c dt rho kappa^(t). This makes the iteration converge SO much faster. The code is also much simpler. The basis (Egas, R) may work equally well, but the 1/tau0 factor scales the second coordinate to the same scale as the first coordinate and should speed up the convergence rate and improve stability. 

The Jacobian of $F$ with respect to (Egas, R) is

```math
\begin{aligned}
    \frac{\partial F_G}{\partial E_g} &= 1 \\
    \frac{\partial F_G}{\partial R_i} &= \frac{c}{\hat{c}} \\
    \frac{\partial F_{R,i}}{\partial E_g} &= \frac{\partial E_{r,i}}{\partial E_g} |_{R_i = {\rm const.}} = \frac{1}{\hat{c}} \frac{1}{C_v} \frac{\partial}{\partial T} \left( \frac{\kappa_{P,i}}{\kappa_{E,i}} 4 \pi B_i \right) \\
    \frac{\partial F_{R,i}}{\partial R_i} &= \frac{\partial E_{r,i}}{\partial R_i}|_{T = {\rm const.}} - 1 = - \frac{1}{\hat{c} \Delta t \rho \kappa_{E,i}} - 1
\end{aligned}
```

For (Egas, D), simply multiple the second and fourth lines by $\tau_i^{(t)}$. 

If we assume $\kappa_{P, i} / \kappa_{E, i} = $ const., we can take this term out of the derivative, and we don't need to compute the derivative of opacity with respect to temperature at all. 

### Related issues
Should solve most 'Newton iteration fail to converge' error, even when error_tol = 1e-13. No extra break condition is required other than the one used in the original version of QUOKKA.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
