### PR TITLE
(do not merge) test Microphysics update

### DIFF
--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -40,7 +40,7 @@ template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const R
 			amrex::Abort("Cannot do chemistry with dt < 0!");
 		}
 
-		amrex::ParallelFor<64>(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+		amrex::ParallelFor<1>(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 			const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
 			const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
 			const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -40,7 +40,7 @@ template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const R
 			amrex::Abort("Cannot do chemistry with dt < 0!");
 		}
 
-		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+		amrex::ParallelFor<64>(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 			const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
 			const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
 			const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -10,7 +10,15 @@
 /// timestepping, solving, and I/O of a simulation for radiation moments.
 
 #include <array>
+#if __has_include(<filesystem>)
 #include <filesystem>
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std
+{
+namespace filesystem = experimental::filesystem;
+}
+#endif
 #include <limits>
 #include <memory>
 #include <string>

--- a/tests/PopIII.in
+++ b/tests/PopIII.in
@@ -59,7 +59,8 @@ primordial_chem.temperature = 0.26415744E+003
 primordial_chem.small_temp = 1.e1
 primordial_chem.small_dens = 1.e-60
 primordial_chem.max_density_allowed = 3e-6
-primordial_chem.min_density_allowed = 1e-21
+primordial_chem.min_density_allowed = 1e-30
+
 #format in krome fort22_wD.dat file: E H- D- H HE H2 HD D H+ HE+ H2+ D+ HD+ HE++
 #format in quokka: E H+ H H- D+ D H2+ D- H2 HD+ HD HE++ HE+ HE
 primordial_chem.primary_species_1 = 0.88499253E-006


### PR DESCRIPTION
### Partial workaround

It's a compiler bug after all!
* Use ROCm 5.3.0.
* Launch with 1 thread per block on GPU using `amrex::ParallelFor<1>`. (However, this runs *much* slower than even on the CPU.)

However, it still does not give the right answer. The calculation will turn into NaNs by timestep 58 (which does not happen when running on NVIDIA or CPU platforms).

### Bug reproducer

```console
module load rocm/6.0.0
export AMREX_AMD_ARCH=gfx90a
export CC=$(which hipcc)
export CXX=$(which hipcc)
export CFLAGS="-I${ROCM_PATH}/include"
export CXXFLAGS="-I${ROCM_PATH}/include"
export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"

git clone --recursive git@github.com:quokka-astro/quokka.git
cd quokka
git checkout BenWibking/test-noinline-microphysics
git submodule update
mkdir build; cd build
cmake .. -DAMReX_GPU_BACKEND=HIP -DAMReX_SPACEDIM=3
make -j16 popiii
cd ../src
python3 perturbation.py --kmin=2 --kmax=64 --size=128 --alpha=2 --f_solenoidal=1.0
mv zdrv.hdf5 ../tests
cd ../tests
../build/src/PopIII/popiii PopIII.in
```