### PR TITLE
Define the grey-radiation advecting pulse test

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ add_subdirectory(RadhydroShockCGS)
 add_subdirectory(RadhydroShockMultigroup)
 add_subdirectory(RadhydroUniformAdvecting)
 add_subdirectory(RadhydroPulse)
+add_subdirectory(RadhydroPulseGrey)
 add_subdirectory(RadhydroPulseMG)
 
 add_subdirectory(BinaryOrbitCIC)

--- a/src/RadhydroPulseGrey/CMakeLists.txt
+++ b/src/RadhydroPulseGrey/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_SPACEDIM EQUAL 1)
+  add_executable(test_radhydro_pulse_grey test_radhydro_pulse_grey.cpp ../fextract.cpp ${QuokkaObjSources})
+
+  if(AMReX_GPU_BACKEND MATCHES "CUDA")
+      setup_target_for_cuda_compilation(test_radhydro_pulse_grey)
+  endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+
+  add_test(NAME RadhydroPulseGrey COMMAND test_radhydro_pulse_grey RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -24,7 +24,6 @@ constexpr double width = 24.0; // cm, width of the pulse
 constexpr double erad_floor = a_rad * T0 * T0 * T0 * T0 * 1.0e-10;
 constexpr double mu = 2.33 * C::m_u;
 constexpr double k_B = C::k_B;
-constexpr double v0_nonadv = 0.; // non-advecting pulse
 
 // static diffusion: tau = 2e3, beta = 3e-5, beta tau = 6e-2
 constexpr double kappa0 = 100.;	    // cm^2 g^-1
@@ -147,17 +146,16 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		const double Erad = a_rad * std::pow(Trad, 4);
 		const double rho = compute_exact_rho(x - x0);
 		const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho, Trad);
-		const double v0 = v0_nonadv;
+		const double v0 = 0.0;
 
-		// state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = (1. + 4. / 3. * (v0 * v0) / (c * c)) * Erad;
 		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = Erad;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 4. / 3. * v0 * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 0;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index) = 0;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index) = 0;
-		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho * v0 * v0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas;
 		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho;
 		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
@@ -213,10 +211,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		// periodic boundary condition in the x-direction will not work
-		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
+		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -99,35 +99,34 @@ auto compute_exact_rho(const double x) -> double
 	return rho0 * T0 / T + (a_rad * mu / 3. / k_B) * (std::pow(T0, 4) / T - std::pow(T, 3));
 }
 
-template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputePlanckOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputePlanckOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
 {
-  const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
-  quokka::valarray<double, nGroups_> kappaPVec{};
-  kappaPVec.fillin(sigma / rho);
-  return kappaPVec;
+	const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
+	quokka::valarray<double, nGroups_> kappaPVec{};
+	kappaPVec.fillin(sigma / rho);
+	return kappaPVec;
 }
 template <>
 AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputePlanckOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
 {
-  const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
-  quokka::valarray<double, nGroups_> kappaPVec{};
-  kappaPVec.fillin(sigma / rho);
-  return kappaPVec;
+	const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
+	quokka::valarray<double, nGroups_> kappaPVec{};
+	kappaPVec.fillin(sigma / rho);
+	return kappaPVec;
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
 {
-  const double sigma = 101.248 * std::pow(Tgas / T0, -3.5);
-  quokka::valarray<double, nGroups_> kappaPVec{};
-  kappaPVec.fillin(sigma / rho);
-  return kappaPVec;
+	const double sigma = 101.248 * std::pow(Tgas / T0, -3.5);
+	quokka::valarray<double, nGroups_> kappaPVec{};
+	kappaPVec.fillin(sigma / rho);
+	return kappaPVec;
 }
 template <>
 AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMeanOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
 {
-  return RadSystem<PulseProblem>::ComputeFluxMeanOpacity(rho, Tgas);
+	return RadSystem<PulseProblem>::ComputeFluxMeanOpacity(rho, Tgas);
 }
 
 template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
@@ -336,29 +335,29 @@ auto problem_main() -> int
 	// compute error norm
 	double err_norm = 0.;
 	double sol_norm = 0.;
-  // double Tmax = 0.;
+	// double Tmax = 0.;
 	for (size_t i = 0; i < xs2.size(); ++i) {
 		err_norm += std::abs(Tgas[i] - Trad[i]);
 		err_norm += std::abs(Trad2[i] - Trad[i]);
 		err_norm += std::abs(Tgas2[i] - Trad[i]);
 		sol_norm += std::abs(Trad[i]) * 3.0;
-    // Tmax = std::max(Tmax, Tgas2[i]);
+		// Tmax = std::max(Tmax, Tgas2[i]);
 	}
-  // const double Tmax_tol = 1.37e7;
+	// const double Tmax_tol = 1.37e7;
 	const double error_tol = 1e-3;
 	const double rel_error = err_norm / sol_norm;
 	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
 
-  // symmetry check
-  double symm_err = 0.;
-  double symm_norm = 0.;
-  const double symm_err_tol = 1.0e-3;
-  for (size_t i = 0; i < xs2.size(); ++i) {
-    symm_err += std::abs(Tgas2[i] - Tgas2[xs2.size() - 1 - i]);
-    symm_norm += std::abs(Tgas2[i]);
-  }
-  const double symm_rel_error = symm_err / symm_norm;
-  amrex::Print() << "Symmetry L1 error norm = " << symm_rel_error << std::endl;
+	// symmetry check
+	double symm_err = 0.;
+	double symm_norm = 0.;
+	const double symm_err_tol = 1.0e-3;
+	for (size_t i = 0; i < xs2.size(); ++i) {
+		symm_err += std::abs(Tgas2[i] - Tgas2[xs2.size() - 1 - i]);
+		symm_norm += std::abs(Tgas2[i]);
+	}
+	const double symm_rel_error = symm_err / symm_norm;
+	amrex::Print() << "Symmetry L1 error norm = " << symm_rel_error << std::endl;
 
 #ifdef HAVE_PYTHON
 	// plot temperature
@@ -377,13 +376,13 @@ auto problem_main() -> int
 	matplotlibcpp::plot(xs2, Tgas2, Tgas_args);
 	matplotlibcpp::xlabel("length x (cm)");
 	matplotlibcpp::ylabel("temperature (K)");
-  matplotlibcpp::ylim(0.98e7, 1.3499e7);
+	matplotlibcpp::ylim(0.98e7, 1.3499e7);
 	matplotlibcpp::legend();
 	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim2.tNew_[0]));
 	matplotlibcpp::tight_layout();
 	// matplotlibcpp::save("./radhydro_pulse_temperature_greynew.pdf");
-  // save to file with tNew_[0] in the name
-  matplotlibcpp::save(fmt::format("./radhydro_pulse_grey_temperature.pdf", sim2.tNew_[0]));
+	// save to file with tNew_[0] in the name
+	matplotlibcpp::save(fmt::format("./radhydro_pulse_grey_temperature.pdf", sim2.tNew_[0]));
 
 	// plot gas density profile
 	matplotlibcpp::clf();
@@ -419,7 +418,7 @@ auto problem_main() -> int
 
 	// Cleanup and exit
 	int status = 0;
-	if ((rel_error > error_tol) || std::isnan(rel_error) || (symm_rel_error > symm_err_tol) || std::isnan(symm_rel_error)){
+	if ((rel_error > error_tol) || std::isnan(rel_error) || (symm_rel_error > symm_err_tol) || std::isnan(symm_rel_error)) {
 		status = 1;
 	}
 	return status;

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -1,0 +1,445 @@
+/// \file test_radhydro_pulse.cpp
+/// \brief Defines a test problem for radiation in the diffusion regime with advection by gas.
+///
+
+#include "test_radhydro_pulse_grey.hpp"
+#include "AMReX_BC_TYPES.H"
+#include "AMReX_Print.H"
+#include "RadhydroSimulation.hpp"
+#include "fextract.hpp"
+#include "physics_info.hpp"
+
+struct PulseProblem {
+}; // dummy type to allow compile-type polymorphism via template specialization
+struct AdvPulseProblem {
+};
+
+// constexpr int64_t MaxStep = 1e3;
+constexpr int64_t MaxStep = 1e8;
+
+constexpr double T0 = 1.0e7; // K (temperature)
+constexpr double T1 = 2.0e7; // K (temperature)
+constexpr double rho0 = 1.2; // g cm^-3 (matter density)
+constexpr double a_rad = C::a_rad;
+constexpr double c = C::c_light; // speed of light (cgs)
+constexpr double chat = c;
+constexpr double width = 24.0; // cm, width of the pulse
+constexpr double erad_floor = a_rad * T0 * T0 * T0 * T0 * 1.0e-10;
+constexpr double mu = 2.33 * C::m_u;
+constexpr double k_B = C::k_B;
+constexpr double v0_nonadv = 0.; // non-advecting pulse
+
+// static diffusion: tau = 2e3, beta = 3e-5, beta tau = 6e-2
+constexpr double kappa0 = 100.;	    // cm^2 g^-1
+constexpr double v0_adv = 1.0e6;    // advecting pulse
+// constexpr double v0_adv = 0.0;    // advecting pulse
+constexpr double max_time = 4.8e-5; // max_time = 2.0 * width / v1;
+
+// dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
+// constexpr double kappa0 = 1000.; // cm^2 g^-1
+// constexpr double v0_adv = 1.0e8;    // advecting pulse
+// constexpr double max_time = 1.2e-4; // max_time = 2.0 * width / v1;
+
+template <> struct quokka::EOS_Traits<PulseProblem> {
+	static constexpr double mean_molecular_weight = mu;
+	static constexpr double boltzmann_constant = k_B;
+	static constexpr double gamma = 5. / 3.;
+};
+template <> struct quokka::EOS_Traits<AdvPulseProblem> {
+	static constexpr double mean_molecular_weight = mu;
+	static constexpr double boltzmann_constant = k_B;
+	static constexpr double gamma = 5. / 3.;
+};
+
+template <> struct RadSystem_Traits<PulseProblem> {
+	static constexpr double c_light = c;
+	static constexpr double c_hat = chat;
+	static constexpr double radiation_constant = a_rad;
+	static constexpr double Erad_floor = erad_floor;
+	static constexpr bool compute_v_over_c_terms = true;
+};
+template <> struct RadSystem_Traits<AdvPulseProblem> {
+	static constexpr double c_light = c;
+	static constexpr double c_hat = chat;
+	static constexpr double radiation_constant = a_rad;
+	static constexpr double Erad_floor = erad_floor;
+	static constexpr bool compute_v_over_c_terms = true;
+};
+
+template <> struct Physics_Traits<PulseProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = true;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+	static constexpr int nGroups = 1;
+};
+template <> struct Physics_Traits<AdvPulseProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = true;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+	static constexpr int nGroups = 1;
+};
+
+AMREX_GPU_HOST_DEVICE
+auto compute_initial_Tgas(const double x) -> double
+{
+	// compute temperature profile for Gaussian radiation pulse
+	const double sigma = width;
+	return T0 + (T1 - T0) * std::exp(-x * x / (2.0 * sigma * sigma));
+}
+
+AMREX_GPU_HOST_DEVICE
+auto compute_exact_rho(const double x) -> double
+{
+	// compute density profile for Gaussian radiation pulse
+	auto T = compute_initial_Tgas(x);
+	return rho0 * T0 / T + (a_rad * mu / 3. / k_B) * (std::pow(T0, 4) / T - std::pow(T, 3));
+}
+
+template <>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputePlanckOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
+{
+  const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
+  quokka::valarray<double, nGroups_> kappaPVec{};
+  kappaPVec.fillin(sigma / rho);
+  return kappaPVec;
+}
+template <>
+AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputePlanckOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
+{
+  const double sigma = 3063.96 * std::pow(Tgas / T0, -3.5);
+  quokka::valarray<double, nGroups_> kappaPVec{};
+  kappaPVec.fillin(sigma / rho);
+  return kappaPVec;
+}
+
+template <>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
+{
+  const double sigma = 101.248 * std::pow(Tgas / T0, -3.5);
+  quokka::valarray<double, nGroups_> kappaPVec{};
+  kappaPVec.fillin(sigma / rho);
+  return kappaPVec;
+}
+template <>
+AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMeanOpacity(const double rho, const double Tgas) -> quokka::valarray<double, nGroups_>
+{
+  return RadSystem<PulseProblem>::ComputeFluxMeanOpacity(rho, Tgas);
+}
+
+template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<PulseProblem>::ComputeEddingtonFactor(double /*f*/) -> double
+{
+	return (1. / 3.); // Eddington approximation
+}
+template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<AdvPulseProblem>::ComputeEddingtonFactor(double /*f*/) -> double
+{
+	return (1. / 3.); // Eddington approximation
+}
+
+template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+{
+	// extract variables required from the geom object
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	amrex::Real const x0 = prob_lo[0] + 0.5 * (prob_hi[0] - prob_lo[0]);
+
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		amrex::Real const x = prob_lo[0] + (i + static_cast<amrex::Real>(0.5)) * dx[0];
+		const double Trad = compute_initial_Tgas(x - x0);
+		const double Erad = a_rad * std::pow(Trad, 4);
+		const double rho = compute_exact_rho(x - x0);
+		const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho, Trad);
+		const double v0 = v0_nonadv;
+
+		// state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = (1. + 4. / 3. * (v0 * v0) / (c * c)) * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 4. / 3. * v0 * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index) = 0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index) = 0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho * v0 * v0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
+	});
+}
+template <> void RadhydroSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+{
+	// extract variables required from the geom object
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	amrex::Real const x0 = prob_lo[0] + 0.5 * (prob_hi[0] - prob_lo[0]);
+
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		amrex::Real const x = prob_lo[0] + (i + static_cast<amrex::Real>(0.5)) * dx[0];
+		const double Trad = compute_initial_Tgas(x - x0);
+		const double Erad = a_rad * std::pow(Trad, 4);
+		const double rho = compute_exact_rho(x - x0);
+		const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho, Trad);
+		const double v0 = v0_adv;
+
+		// state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = (1. + 4. / 3. * (v0 * v0) / (c * c)) * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 4. / 3. * v0 * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index) = 0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index) = 0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho * v0 * v0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
+	});
+}
+
+auto problem_main() -> int
+{
+	// This problem is a test of radiation diffusion plus advection by gas.
+	// This makes this problem a stringent test of the radiation advection
+	// in the diffusion limit.
+
+	// Problem parameters
+	// const int64_t max_timesteps = 1e8;
+	const int64_t max_timesteps = MaxStep;
+	const double CFL_number = 0.8;
+	// const int nx = 32;
+
+	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
+
+	// Boundary conditions
+	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
+	for (int n = 0; n < nvars; ++n) {
+		// periodic boundary condition in the x-direction will not work
+		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
+		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+		}
+	}
+
+	// Problem 1: non-advecting pulse
+
+	// Problem initialization
+	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+
+	sim.radiationReconstructionOrder_ = 3; // PPM
+	sim.stopTime_ = max_time;
+	sim.radiationCflNumber_ = CFL_number;
+	sim.maxDt_ = max_dt;
+	sim.maxTimesteps_ = max_timesteps;
+	sim.plotfileInterval_ = -1;
+
+	// initialize
+	sim.setInitialConditions();
+
+	// evolve
+	sim.evolve();
+
+	// read output variables
+	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
+	const int nx = static_cast<int>(position.size());
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = sim.geom[0].ProbLoArray();
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = sim.geom[0].ProbHiArray();
+
+	std::vector<double> xs(nx);
+	std::vector<double> Trad(nx);
+	std::vector<double> Tgas(nx);
+	std::vector<double> Vgas(nx);
+	std::vector<double> rhogas(nx);
+
+	for (int i = 0; i < nx; ++i) {
+		amrex::Real const x = position[i];
+		xs.at(i) = x;
+		const auto Erad_t = values.at(RadSystem<PulseProblem>::radEnergy_index)[i];
+		const auto Trad_t = std::pow(Erad_t / a_rad, 1. / 4.);
+		const auto rho_t = values.at(RadSystem<PulseProblem>::gasDensity_index)[i];
+		const auto v_t = values.at(RadSystem<PulseProblem>::x1GasMomentum_index)[i] / rho_t;
+		const auto Egas = values.at(RadSystem<PulseProblem>::gasInternalEnergy_index)[i];
+		rhogas.at(i) = rho_t;
+		Trad.at(i) = Trad_t;
+		Tgas.at(i) = quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho_t, Egas);
+		Vgas.at(i) = 1e-5 * v_t;
+	}
+	// END OF PROBLEM 1
+
+	// Problem 2: advecting radiation
+
+	// Problem initialization
+	RadhydroSimulation<AdvPulseProblem> sim2(BCs_cc);
+
+	sim2.radiationReconstructionOrder_ = 3; // PPM
+	sim2.stopTime_ = max_time;
+	sim2.radiationCflNumber_ = CFL_number;
+	sim2.maxDt_ = max_dt;
+	sim2.maxTimesteps_ = max_timesteps;
+	sim2.plotfileInterval_ = -1;
+
+	// initialize
+	sim2.setInitialConditions();
+
+	// evolve
+	sim2.evolve();
+
+	// read output variables
+	auto [position2, values2] = fextract(sim2.state_new_cc_[0], sim2.Geom(0), 0, 0.0);
+	prob_lo = sim2.geom[0].ProbLoArray();
+	prob_hi = sim2.geom[0].ProbHiArray();
+	// compute the pixel size
+	const double dx = (prob_hi[0] - prob_lo[0]) / static_cast<double>(nx);
+	const double move = v0_adv * sim2.tNew_[0];
+	const int n_p = static_cast<int>(move / dx);
+	const int half = static_cast<int>(nx / 2.0);
+	const double drift = move - static_cast<double>(n_p) * dx;
+	const int shift = n_p - static_cast<int>((n_p + half) / nx) * nx;
+
+	std::vector<double> xs2(nx);
+	std::vector<double> Trad2(nx);
+	std::vector<double> Tgas2(nx);
+	std::vector<double> Vgas2(nx);
+	std::vector<double> rhogas2(nx);
+
+	for (int i = 0; i < nx; ++i) {
+		int index_ = 0;
+		if (shift >= 0) {
+			if (i < shift) {
+				index_ = nx - shift + i;
+			} else {
+				index_ = i - shift;
+			}
+		} else {
+			if (i <= nx - 1 + shift) {
+				index_ = i - shift;
+			} else {
+				index_ = i - (nx + shift);
+			}
+		}
+		const amrex::Real x = position2[i];
+		const auto Erad_t = values2.at(RadSystem<PulseProblem>::radEnergy_index)[i];
+		const auto Trad_t = std::pow(Erad_t / a_rad, 1. / 4.);
+		const auto rho_t = values2.at(RadSystem<PulseProblem>::gasDensity_index)[i];
+		const auto v_t = values2.at(RadSystem<PulseProblem>::x1GasMomentum_index)[i] / rho_t;
+		const auto Egas = values2.at(RadSystem<PulseProblem>::gasInternalEnergy_index)[i];
+		xs2.at(i) = x - drift;
+		rhogas2.at(index_) = rho_t;
+		Trad2.at(index_) = Trad_t;
+		Tgas2.at(index_) = quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho_t, Egas);
+		Vgas2.at(index_) = 1e-5 * (v_t - v0_adv);
+	}
+	// END OF PROBLEM 2
+
+	// compute error norm
+	double err_norm = 0.;
+	double sol_norm = 0.;
+  double Tmax = 0.;
+	for (size_t i = 0; i < xs2.size(); ++i) {
+		err_norm += std::abs(Tgas[i] - Trad[i]);
+		err_norm += std::abs(Trad2[i] - Trad[i]);
+		err_norm += std::abs(Tgas2[i] - Trad[i]);
+		sol_norm += std::abs(Trad[i]) * 3.0;
+		// err_norm += std::abs(Tgas2[i] - Trad2[i]);
+		// sol_norm += std::abs(Trad2[i]);
+    // Tmax = std::max(Tmax, Tgas2[i]);
+	}
+  const double Tmax_tol = 1.37e7;
+	const double error_tol = 0.006;
+	const double rel_error = err_norm / sol_norm;
+	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
+
+  // // symmetry check
+  // double symm_err = 0.;
+  // double symm_norm = 0.;
+  // const double symm_err_tol = 1.0e-5;
+  // for (size_t i = 0; i < xs2.size(); ++i) {
+  //   symm_err += std::abs(Tgas2[i] - Tgas2[xs2.size() - 1 - i]);
+  //   symm_norm += std::abs(Tgas2[i]);
+  // }
+  // const double symm_rel_error = symm_err / symm_norm;
+  // amrex::Print() << "Symmetry relative error = " << symm_rel_error << std::endl;
+
+
+#ifdef HAVE_PYTHON
+	// plot temperature
+	matplotlibcpp::clf();
+	std::map<std::string, std::string> Trad_args;
+	std::map<std::string, std::string> Tgas_args;
+	Trad_args["label"] = "Trad (nonadvecting)";
+	Trad_args["linestyle"] = "-.";
+	Tgas_args["label"] = "Tgas (nonadvecting)";
+	Tgas_args["linestyle"] = "--";
+	matplotlibcpp::plot(xs, Trad, Trad_args);
+	matplotlibcpp::plot(xs, Tgas, Tgas_args);
+	Trad_args["label"] = "Trad (advecting)";
+	Tgas_args["label"] = "Tgas (advecting)";
+	matplotlibcpp::plot(xs2, Trad2, Trad_args);
+	matplotlibcpp::plot(xs2, Tgas2, Tgas_args);
+	matplotlibcpp::xlabel("length x (cm)");
+	matplotlibcpp::ylabel("temperature (K)");
+  matplotlibcpp::ylim(0.98e7, 2.0e7);
+	matplotlibcpp::legend();
+	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim2.tNew_[0]));
+	matplotlibcpp::tight_layout();
+	// matplotlibcpp::save("./radhydro_pulse_temperature_greynew.pdf");
+  // save to file with tNew_[0] in the name
+  matplotlibcpp::save(fmt::format("./radhydro_pulse_temperature_greynew_t{:.3g}.pdf", sim2.tNew_[0]));
+
+	// // plot gas density profile
+	// matplotlibcpp::clf();
+	// std::map<std::string, std::string> rho_args;
+	// rho_args["label"] = "gas density (non-advecting)";
+	// rho_args["linestyle"] = "-";
+	// matplotlibcpp::plot(xs, rhogas, rho_args);
+	// rho_args["label"] = "gas density (advecting))";
+	// matplotlibcpp::plot(xs2, rhogas2, rho_args);
+	// matplotlibcpp::xlabel("length x (cm)");
+	// matplotlibcpp::ylabel("density (g cm^-3)");
+	// matplotlibcpp::legend();
+	// matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
+	// matplotlibcpp::tight_layout();
+	// matplotlibcpp::save("./radhydro_pulse_density_greynew.pdf");
+
+	// plot gas velocity profile
+	matplotlibcpp::clf();
+	std::map<std::string, std::string> vgas_args;
+	vgas_args["label"] = "gas velocity (non-advecting)";
+	vgas_args["linestyle"] = "-";
+	matplotlibcpp::plot(xs, Vgas, vgas_args);
+	vgas_args["label"] = "gas velocity (advecting)";
+	matplotlibcpp::plot(xs2, Vgas2, vgas_args);
+	matplotlibcpp::xlabel("length x (cm)");
+	matplotlibcpp::ylabel("velocity (km s^-1)");
+	matplotlibcpp::legend();
+	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
+	matplotlibcpp::tight_layout();
+	matplotlibcpp::save("./radhydro_pulse_velocity_greynew.pdf");
+
+#endif
+
+	// Cleanup and exit
+	int status = 0;
+	if ((rel_error > error_tol) || std::isnan(rel_error)) {
+	// if ((rel_error > error_tol) || std::isnan(rel_error) || (Tmax > Tmax_tol) || (symm_err > symm_err_tol)) {
+	// if ((rel_error > error_tol) || std::isnan(rel_error) || (symm_rel_error > symm_err_tol)) {
+		status = 1;
+	}
+	return status;
+}

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.hpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.hpp
@@ -1,0 +1,21 @@
+#ifndef TEST_RADHYDRO_PULSE_HPP_ // NOLINT
+#define TEST_RADHYDRO_PULSE_HPP_
+/// \file test_radiation_marshak.hpp
+/// \brief Defines a test problem for radiation in the static diffusion regime.
+///
+
+// external headers
+#ifdef HAVE_PYTHON
+#include "matplotlibcpp.h"
+#endif
+#include <fmt/format.h>
+#include <fstream>
+
+// internal headers
+
+#include "interpolate.hpp"
+#include "radiation_system.hpp"
+
+// function definitions
+
+#endif // TEST_RADHYDRO_PULSE_HPP_

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.hpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.hpp
@@ -1,5 +1,5 @@
-#ifndef TEST_RADHYDRO_PULSE_HPP_ // NOLINT
-#define TEST_RADHYDRO_PULSE_HPP_
+#ifndef TEST_RADHYDRO_PULSE_GREY_HPP_ // NOLINT
+#define TEST_RADHYDRO_PULSE_GREY_HPP_
 /// \file test_radiation_marshak.hpp
 /// \brief Defines a test problem for radiation in the static diffusion regime.
 ///
@@ -18,4 +18,4 @@
 
 // function definitions
 
-#endif // TEST_RADHYDRO_PULSE_HPP_
+#endif // TEST_RADHYDRO_PULSE_GREY_HPP_

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1106,9 +1106,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
+    quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt
-		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> tau0{}; // optical depth across c * dt at old state
+		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt at new state
 		quokka::valarray<double, nGroups_> D{};	   // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
@@ -1131,15 +1132,30 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			const double Etot0 = Egas0 + (c / chat) * (Erad0 + sum(Src));
 
 			// BEGIN NEWTON-RAPHSON LOOP
+      // Solve for the new radiation energy and gas internal energy using a Newton-Raphson method using the base variables (Egas, D_0, D_1,
+			// ...), where D_i = R_i / tau_i^(t) and tau_i^(t) = dt * rho * kappa_{P,i}^(t) * chat is the optical depth across chat * dt for group i
+			// at time t. Compared with the old base (Egas, Erad_0, Erad_1, ...), this new base is more stable and converges faster. Furthermore,
+			// the PlanckOpacityTempDerivative term is not needed anymore since I assume d/dT (kappa_P / kappa_E) = 0 in the calculation of the
+			// Jacobian. Note that this assumption only affects the convergence rate of the Newton-Raphson iteration and does not affect the result
+			// at all.
+			//
+			// The Jacobian of F(E_g, D_i) is
+			//
+			// dF_G / dE_g = 1
+			// dF_G / dD_i = c / chat * tau0_i
+			// dF_{D,i} / dE_g = 1 / (chat * C_v) * (kappa_{P,i} / kappa_{E,i}) * d/dT (4 \pi B_i)
+			// dF_{D,i} / dD_i = - (1 / (chat * dt * rho * kappa_{E,i}) + 1) * tau0_i
+
 			Egas_guess = Egas0;
 			T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 			AMREX_ASSERT(T_gas >= 0.);
 			fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 			kappaPVec = ComputePlanckOpacity(rho, T_gas);
+      kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 			AMREX_ASSERT(!kappaPVec.hasnan());
-			// note that I assume kappa_P = kappa_E here
+			AMREX_ASSERT(!kappaEVec.hasnan());
 			tau0 = dt * rho * kappaPVec * chat;
-			D = fourPiB / chat - Erad0Vec;
+			D = fourPiB / chat - (kappaEVec / kappaPVec) * Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
@@ -1149,7 +1165,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
 			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
 			quokka::valarray<double, nGroups_> deltaD{};
-			quokka::valarray<double, nGroups_> F_R{};
+			quokka::valarray<double, nGroups_> F_D{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
 			const int maxIter = 400;
@@ -1161,16 +1177,17 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
+        kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 				AMREX_ASSERT(!kappaPVec.hasnan());
 
-				tau = dt * rho * kappaPVec * chat;
+				tau = dt * rho * kappaEVec * chat;
 				Rvec = tau0 * D;
-				EradVec_guess = fourPiB / chat - Rvec / tau;
+				EradVec_guess = (kappaPVec / kappaEVec) * fourPiB / chat - Rvec / tau;
 				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
-				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
+				F_D = EradVec_guess - Erad0Vec - (Rvec + Src);
 
 				// check relative convergence of the residuals
-				if ((std::abs(F_G / Etot0) < resid_tol) && ((c / chat) * sum(abs(F_R)) / Etot0 < resid_tol)) {
+				if ((std::abs(F_G / Etot0) < resid_tol) && ((c / chat) * sum(abs(F_D)) / Etot0 < resid_tol)) {
 					break;
 				}
 
@@ -1180,13 +1197,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
+        // I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption only
+				// affects the convergence rate of the Newton-Raphson iteration and does not affect the converged solution at all.
 				dFG_dEgas = 1.0;
 				dFG_dD = (c / chat) * tau0;
-				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_dEgas = 1.0 / (chat * c_v) * (kappaPVec / kappaEVec) * dfourPiB_dTgas;
 				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_D, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaD.hasnan());
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1096,9 +1096,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
-		quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> radEnergyFractions{};
+		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1121,20 +1122,23 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-			EradVec_guess = Erad0Vec;
+      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+      AMREX_ASSERT(T_gas >= 0.);
+      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			AMREX_ASSERT(!kappaPVec.hasnan());
+      // note that I assume kappa_P = kappa_E here
+      tau0 = dt * rho * kappaPVec * chat;
+      D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
 			double deltaEgas = NAN;
-			double Rtot = NAN;
-			double dRtot_dEgas = NAN;
 			quokka::valarray<double, nGroups_> Rvec{};
-			quokka::valarray<double, nGroups_> dRtot_dErad{};
-			quokka::valarray<double, nGroups_> dRvec_dEgas{};
-			quokka::valarray<double, nGroups_> dFG_dErad{};
+			quokka::valarray<double, nGroups_> dFG_dD{};
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
-			quokka::valarray<double, nGroups_> dFR_i_dErad_i{};
-			quokka::valarray<double, nGroups_> deltaErad{};
+			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
+			quokka::valarray<double, nGroups_> deltaD{};
 			quokka::valarray<double, nGroups_> F_R{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
@@ -1144,27 +1148,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute material temperature
 				T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 				AMREX_ASSERT(T_gas >= 0.);
-
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+			  AMREX_ASSERT(!kappaPVec.hasnan());
 
-				// compute derivatives w/r/t T_gas
-				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
-
-				// compute residuals
-				const auto absorption = chat * kappaEVec * EradVec_guess;
-				const auto emission = kappaPVec * fourPiB;
-				const auto Ediff = emission - absorption;
-				// auto tot_ediff = sum(abs(Ediff));
-				// if ((tot_ediff <= Erad_floor_) || (tot_ediff / (sum(absorption) + sum(emission)) < resid_tol)) {
-				//   break;
-				// }
-				Rvec = dt * rho * Ediff;
-				Rtot = sum(Rvec);
-				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
+        tau = dt * rho * kappaPVec * chat;
+        Rvec = tau0 * D;
+        EradVec_guess = fourPiB / chat - Rvec / tau;
+				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 
 				// check relative convergence of the residuals
@@ -1172,50 +1164,29 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					break;
 				}
 
-				quokka::valarray<double, nGroups_> dkappaP_dTgas = ComputePlanckOpacityTempDerivative(rho, T_gas);
-				quokka::valarray<double, nGroups_> dkappaE_dTgas = dkappaP_dTgas;
-				AMREX_ASSERT(!std::isnan(sum(dkappaP_dTgas)));
-
-				// prepare to compute Jacobian elements
 				const double c_v = quokka::EOS<problem_t>::ComputeEintTempDerivative(rho, T_gas, massScalars); // Egas = c_v * T
-				dRtot_dErad = -dt * rho * kappaEVec * chat;
-				dRvec_dEgas = dt * rho / c_v * (kappaPVec * dfourPiB_dTgas + dkappaP_dTgas * fourPiB - chat * dkappaE_dTgas * EradVec_guess);
-				// Equivalent of eta = (eta > 0.0) ? eta : 0.0, to ensure possitivity of Egas_guess
-				for (int g = 0; g < nGroups_; ++g) {
-					// AMREX_ASSERT(dRvec_dEgas[g] >= 0.0);
-					if (dRvec_dEgas[g] < 0.0) {
-						dRvec_dEgas[g] = 0.0;
-					}
-				}
-				dRtot_dEgas = sum(dRvec_dEgas);
+
+				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
+				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
-				dFG_dEgas = 1.0 + (c / chat) * dRtot_dEgas;
-				dFG_dErad = dRtot_dErad * (c / chat);
-				dFR_dEgas = -1.0 * dRvec_dEgas;
-				dFR_i_dErad_i = -1.0 * dRtot_dErad + 1.0;
-				AMREX_ASSERT(!std::isnan(dFG_dEgas));
-				AMREX_ASSERT(!dFG_dErad.hasnan());
-				AMREX_ASSERT(!dFR_dEgas.hasnan());
-				AMREX_ASSERT(!dFR_i_dErad_i.hasnan());
+				dFG_dEgas = 1.0;
+				dFG_dD = (c / chat) * tau0;
+				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dErad, dFR_dEgas, dFR_i_dErad_i, -F_G, -1. * F_R, deltaEgas, deltaErad);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
-				AMREX_ASSERT(!deltaErad.hasnan());
+				AMREX_ASSERT(!deltaD.hasnan());
 
-				EradVec_guess += deltaErad;
-				Egas_guess += deltaEgas;
-				AMREX_ASSERT(min(EradVec_guess) >= 0.);
-				AMREX_ASSERT(Egas_guess > 0.);
+        Egas_guess += deltaEgas;
+				D += deltaD;
 
 				// check relative and absolute convergence of E_r
-				// if ((sum(abs(deltaEgas / Egas_guess)) < 1e-7) || (sum(abs(deltaErad)) <= Erad_floor_)) {
+				// if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
 				// 	break;
 				// }
-				if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
-					break;
-				}
 			} // END NEWTON-RAPHSON LOOP
 
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1097,9 +1097,9 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt
 		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
-		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
+		quokka::valarray<double, nGroups_> D{};	   // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1122,14 +1122,14 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
-      AMREX_ASSERT(T_gas >= 0.);
-      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+			AMREX_ASSERT(T_gas >= 0.);
+			fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+			kappaPVec = ComputePlanckOpacity(rho, T_gas);
 			AMREX_ASSERT(!kappaPVec.hasnan());
-      // note that I assume kappa_P = kappa_E here
-      tau0 = dt * rho * kappaPVec * chat;
-      D = fourPiB / chat - Erad0Vec;
+			// note that I assume kappa_P = kappa_E here
+			tau0 = dt * rho * kappaPVec * chat;
+			D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
@@ -1152,11 +1152,11 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-			  AMREX_ASSERT(!kappaPVec.hasnan());
+				AMREX_ASSERT(!kappaPVec.hasnan());
 
-        tau = dt * rho * kappaPVec * chat;
-        Rvec = tau0 * D;
-        EradVec_guess = fourPiB / chat - Rvec / tau;
+				tau = dt * rho * kappaPVec * chat;
+				Rvec = tau0 * D;
+				EradVec_guess = fourPiB / chat - Rvec / tau;
 				Rtot = sum(Rvec); // TODO: remove Rtot here
 				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
@@ -1182,7 +1182,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!std::isnan(deltaEgas));
 				AMREX_ASSERT(!deltaD.hasnan());
 
-        Egas_guess += deltaEgas;
+				Egas_guess += deltaEgas;
 				D += deltaD;
 
 				// check relative and absolute convergence of E_r

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -204,8 +204,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
 	    -> RadPressureResult;
 
-	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(double fx_L, double fy_L, double fz_L)
-	    -> std::array<std::array<double, 3>, 3>;
+	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(double fx_L, double fy_L, double fz_L) -> std::array<std::array<double, 3>, 3>;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
@@ -772,7 +771,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 		}
 	}
 
-  return T;
+	return T;
 }
 
 template <typename problem_t>
@@ -785,8 +784,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 	// check that states are physically admissible
 	AMREX_ASSERT(erad > 0.0);
 
-  // Compute the Eddington tensor
-  auto T = ComputeEddingtonTensor(fx, fy, fz);
+	// Compute the Eddington tensor
+	auto T = ComputeEddingtonTensor(fx, fy, fz);
 
 	// frozen Eddington tensor approximation, following Balsara
 	// (1999) [JQSRT Vol. 61, No. 5, pp. 617–627, 1999], Eq. 46.
@@ -1162,11 +1161,11 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-			  AMREX_ASSERT(!kappaPVec.hasnan());
+				AMREX_ASSERT(!kappaPVec.hasnan());
 
-        tau = dt * rho * kappaPVec * chat;
-        Rvec = tau0 * D;
-        EradVec_guess = fourPiB / chat - Rvec / tau;
+				tau = dt * rho * kappaPVec * chat;
+				Rvec = tau0 * D;
+				EradVec_guess = fourPiB / chat - Rvec / tau;
 				F_G = Egas_guess - Egas0 + (c / chat) * sum(Rvec);
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 
@@ -1245,16 +1244,16 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fy = Fy / (c_light_ * erad);
 				auto fz = Fz / (c_light_ * erad);
 
-        auto Tedd = ComputeEddingtonTensor(fx, fy, fz);
+				auto Tedd = ComputeEddingtonTensor(fx, fy, fz);
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {
 					double lastTwoTerms = gasMtm[n] * kappaPVec[g] * (realFourPiB[g] / c - erad) * chat;
 					// loop over the second rank of the radiation pressure tensor
 					for (int z = 0; z < 3; ++z) {
-            lastTwoTerms += chat * kappaFVec[g] * gasMtm[z] * Tedd[n][z] * erad;
+						lastTwoTerms += chat * kappaFVec[g] * gasMtm[z] * Tedd[n][z] * erad;
 					}
-          lastTwoTerms += chat * kappaFVec[g] * gasMtm[n] * erad;
+					lastTwoTerms += chat * kappaFVec[g] * gasMtm[n] * erad;
 					Frad_t1[n] = (Frad_t0[n] + (dt * lastTwoTerms)) / (1.0 + rho * kappaFVec[g] * chat * dt);
 
 					// Compute conservative gas momentum update

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1096,9 +1096,10 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
-		quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
-		quokka::valarray<double, nGroups_> radEnergyFractions{};
+		quokka::valarray<double, nGroups_> tau{}; // optical depth across c * dt
+		quokka::valarray<double, nGroups_> tau0{}; // tau at (t)
+		quokka::valarray<double, nGroups_> D{}; // D = S / tau0
 
 		for (int g = 0; g < nGroups_; ++g) {
 			EradVec_guess[g] = NAN;
@@ -1121,20 +1122,24 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 			// BEGIN NEWTON-RAPHSON LOOP
 			Egas_guess = Egas0;
-			EradVec_guess = Erad0Vec;
+      T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
+      AMREX_ASSERT(T_gas >= 0.);
+      fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
+      kappaPVec = ComputePlanckOpacity(rho, T_gas);
+			AMREX_ASSERT(!kappaPVec.hasnan());
+      // note that I assume kappa_P = kappa_E here
+      tau0 = dt * rho * kappaPVec * chat;
+      D = fourPiB / chat - Erad0Vec;
 
 			double F_G = NAN;
 			double dFG_dEgas = NAN;
 			double deltaEgas = NAN;
 			double Rtot = NAN;
-			double dRtot_dEgas = NAN;
 			quokka::valarray<double, nGroups_> Rvec{};
-			quokka::valarray<double, nGroups_> dRtot_dErad{};
-			quokka::valarray<double, nGroups_> dRvec_dEgas{};
-			quokka::valarray<double, nGroups_> dFG_dErad{};
+			quokka::valarray<double, nGroups_> dFG_dD{};
 			quokka::valarray<double, nGroups_> dFR_dEgas{};
-			quokka::valarray<double, nGroups_> dFR_i_dErad_i{};
-			quokka::valarray<double, nGroups_> deltaErad{};
+			quokka::valarray<double, nGroups_> dFR_i_dD_i{};
+			quokka::valarray<double, nGroups_> deltaD{};
 			quokka::valarray<double, nGroups_> F_R{};
 
 			const double resid_tol = 1.0e-13; // 1.0e-15;
@@ -1144,26 +1149,15 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute material temperature
 				T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 				AMREX_ASSERT(T_gas >= 0.);
-
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
-
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+			  AMREX_ASSERT(!kappaPVec.hasnan());
 
-				// compute derivatives w/r/t T_gas
-				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
-
-				// compute residuals
-				const auto absorption = chat * kappaEVec * EradVec_guess;
-				const auto emission = kappaPVec * fourPiB;
-				const auto Ediff = emission - absorption;
-				// auto tot_ediff = sum(abs(Ediff));
-				// if ((tot_ediff <= Erad_floor_) || (tot_ediff / (sum(absorption) + sum(emission)) < resid_tol)) {
-				//   break;
-				// }
-				Rvec = dt * rho * Ediff;
-				Rtot = sum(Rvec);
+        tau = dt * rho * kappaPVec * chat;
+        Rvec = tau0 * D;
+        EradVec_guess = fourPiB / chat - Rvec / tau;
+				Rtot = sum(Rvec); // TODO: remove Rtot here
 				F_G = Egas_guess - Egas0 + (c / chat) * Rtot;
 				F_R = EradVec_guess - Erad0Vec - (Rvec + Src);
 
@@ -1172,50 +1166,29 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					break;
 				}
 
-				quokka::valarray<double, nGroups_> dkappaP_dTgas = ComputePlanckOpacityTempDerivative(rho, T_gas);
-				quokka::valarray<double, nGroups_> dkappaE_dTgas = dkappaP_dTgas;
-				AMREX_ASSERT(!std::isnan(sum(dkappaP_dTgas)));
-
-				// prepare to compute Jacobian elements
 				const double c_v = quokka::EOS<problem_t>::ComputeEintTempDerivative(rho, T_gas, massScalars); // Egas = c_v * T
-				dRtot_dErad = -dt * rho * kappaEVec * chat;
-				dRvec_dEgas = dt * rho / c_v * (kappaPVec * dfourPiB_dTgas + dkappaP_dTgas * fourPiB - chat * dkappaE_dTgas * EradVec_guess);
-				// Equivalent of eta = (eta > 0.0) ? eta : 0.0, to ensure possitivity of Egas_guess
-				for (int g = 0; g < nGroups_; ++g) {
-					// AMREX_ASSERT(dRvec_dEgas[g] >= 0.0);
-					if (dRvec_dEgas[g] < 0.0) {
-						dRvec_dEgas[g] = 0.0;
-					}
-				}
-				dRtot_dEgas = sum(dRvec_dEgas);
+
+				const auto dfourPiB_dTgas = chat * ComputeThermalRadiationTempDerivative(T_gas, radBoundaries_g_copy);
+				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
-				dFG_dEgas = 1.0 + (c / chat) * dRtot_dEgas;
-				dFG_dErad = dRtot_dErad * (c / chat);
-				dFR_dEgas = -1.0 * dRvec_dEgas;
-				dFR_i_dErad_i = -1.0 * dRtot_dErad + 1.0;
-				AMREX_ASSERT(!std::isnan(dFG_dEgas));
-				AMREX_ASSERT(!dFG_dErad.hasnan());
-				AMREX_ASSERT(!dFR_dEgas.hasnan());
-				AMREX_ASSERT(!dFR_i_dErad_i.hasnan());
+				dFG_dEgas = 1.0;
+				dFG_dD = (c / chat) * tau0;
+				dFR_dEgas = 1.0 / (chat * c_v) * dfourPiB_dTgas;
+				dFR_i_dD_i = -1.0 * (1.0 / tau + 1.0) * tau0;
 
 				// update variables
-				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dErad, dFR_dEgas, dFR_i_dErad_i, -F_G, -1. * F_R, deltaEgas, deltaErad);
+				RadSystem<problem_t>::SolveLinearEqs(dFG_dEgas, dFG_dD, dFR_dEgas, dFR_i_dD_i, -F_G, -1. * F_R, deltaEgas, deltaD);
 				AMREX_ASSERT(!std::isnan(deltaEgas));
-				AMREX_ASSERT(!deltaErad.hasnan());
+				AMREX_ASSERT(!deltaD.hasnan());
 
-				EradVec_guess += deltaErad;
-				Egas_guess += deltaEgas;
-				AMREX_ASSERT(min(EradVec_guess) >= 0.);
-				AMREX_ASSERT(Egas_guess > 0.);
+        Egas_guess += deltaEgas;
+				D += deltaD;
 
 				// check relative and absolute convergence of E_r
-				// if ((sum(abs(deltaEgas / Egas_guess)) < 1e-7) || (sum(abs(deltaErad)) <= Erad_floor_)) {
+				// if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
 				// 	break;
 				// }
-				if (std::abs(deltaEgas / Egas_guess) < 1e-7) {
-					break;
-				}
 			} // END NEWTON-RAPHSON LOOP
 
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -203,6 +203,9 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	template <FluxDir DIR>
 	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
 	    -> RadPressureResult;
+
+	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(double fx_L, double fy_L, double fz_L)
+	    -> std::array<std::array<double, 3>, 3>;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
@@ -728,14 +731,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 }
 
 template <typename problem_t>
-template <FluxDir DIR>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
-							       const double fy, const double fz) -> RadPressureResult
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double fx, const double fy, const double fz) -> std::array<std::array<double, 3>, 3>
 {
-	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct.
+	// Compute the radiation pressure tensor
 
-	// check that states are physically admissible
-	AMREX_ASSERT(erad > 0.0);
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
@@ -765,17 +764,29 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 
 	// assemble Eddington tensor
 	std::array<std::array<double, 3>, 3> T{};
-	std::array<std::array<double, 3>, 3> P{};
 
 	for (int ii = 0; ii < 3; ++ii) {
 		for (int jj = 0; jj < 3; ++jj) {
 			const double delta_ij = (ii == jj) ? 1 : 0;
 			T[ii][jj] = Tdiag * delta_ij + Tf * (n[ii] * n[jj]);
-			// compute the elements of the total radiation pressure
-			// tensor
-			P[ii][jj] = T[ii][jj] * erad;
 		}
 	}
+
+  return T;
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
+							       const double fy, const double fz) -> RadPressureResult
+{
+	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct.
+
+	// check that states are physically admissible
+	AMREX_ASSERT(erad > 0.0);
+
+  // Compute the Eddington tensor
+  auto T = ComputeEddingtonTensor(fx, fy, fz);
 
 	// frozen Eddington tensor approximation, following Balsara
 	// (1999) [JQSRT Vol. 61, No. 5, pp. 617–627, 1999], Eq. 46.
@@ -789,41 +800,41 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 	}
 
 	// compute fluxes F_L, F_R
-	// P_nx, P_ny, P_nz indicate components where 'n' is the direction of the
-	// face normal F_n is the radiation flux component in the direction of the
+	// T_nx, T_ny, T_nz indicate components where 'n' is the direction of the
+	// face normal. F_n is the radiation flux component in the direction of the
 	// face normal
 	double Fn = NAN;
-	double Pnx = NAN;
-	double Pny = NAN;
-	double Pnz = NAN;
+	double Tnx = NAN;
+	double Tny = NAN;
+	double Tnz = NAN;
 
 	if constexpr (DIR == FluxDir::X1) {
 		Fn = Fx;
 
-		Pnx = P[0][0];
-		Pny = P[0][1];
-		Pnz = P[0][2];
+		Tnx = T[0][0];
+		Tny = T[0][1];
+		Tnz = T[0][2];
 	} else if constexpr (DIR == FluxDir::X2) {
 		Fn = Fy;
 
-		Pnx = P[1][0];
-		Pny = P[1][1];
-		Pnz = P[1][2];
+		Tnx = T[1][0];
+		Tny = T[1][1];
+		Tnz = T[1][2];
 	} else if constexpr (DIR == FluxDir::X3) {
 		Fn = Fz;
 
-		Pnx = P[2][0];
-		Pny = P[2][1];
-		Pnz = P[2][2];
+		Tnx = T[2][0];
+		Tny = T[2][1];
+		Tnz = T[2][2];
 	}
 
 	AMREX_ASSERT(Fn != NAN);
-	AMREX_ASSERT(Pnx != NAN);
-	AMREX_ASSERT(Pny != NAN);
-	AMREX_ASSERT(Pnz != NAN);
+	AMREX_ASSERT(Tnx != NAN);
+	AMREX_ASSERT(Tny != NAN);
+	AMREX_ASSERT(Tnz != NAN);
 
 	RadPressureResult result{};
-	result.F = {Fn, Pnx, Pny, Pnz};
+	result.F = {Fn, Tnx * erad, Tny * erad, Tnz * erad};
 	result.S = std::max(0.1, std::sqrt(Tnormal));
 
 	return result;
@@ -1225,7 +1236,6 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index + numRadVars_ * g);
 			Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index + numRadVars_ * g);
 
-			// compute radiation pressure F using ComputeRadPressure
 			if constexpr ((compute_v_over_c_terms_) && (compute_G_last_two_terms) && (gamma_ != 1.0)) {
 				auto erad = EradVec_guess[g];
 				auto Fx = Frad_t0[0];
@@ -1235,27 +1245,16 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				auto fy = Fy / (c_light_ * erad);
 				auto fz = Fz / (c_light_ * erad);
 
-				std::array<quokka::valarray<double, 4>, 3> P{};
-				{
-					auto [F, S] = ComputeRadPressure<FluxDir::X1>(erad, Fx, Fy, Fz, fx, fy, fz);
-					P[0] = F;
-				}
-				{
-					auto [F, S] = ComputeRadPressure<FluxDir::X2>(erad, Fx, Fy, Fz, fx, fy, fz);
-					P[1] = F;
-				}
-				{
-					auto [F, S] = ComputeRadPressure<FluxDir::X3>(erad, Fx, Fy, Fz, fx, fy, fz);
-					P[2] = F;
-				}
+        auto Tedd = ComputeEddingtonTensor(fx, fy, fz);
 
 				// loop over spatial dimensions
 				for (int n = 0; n < 3; ++n) {
-					double lastTwoTerms = gasMtm[n] * kappaPVec[g] * realFourPiB[g] * chat / c;
+					double lastTwoTerms = gasMtm[n] * kappaPVec[g] * (realFourPiB[g] / c - erad) * chat;
 					// loop over the second rank of the radiation pressure tensor
 					for (int z = 0; z < 3; ++z) {
-						lastTwoTerms += chat * kappaFVec[g] * gasMtm[z] * P[n][z + 1];
+            lastTwoTerms += chat * kappaFVec[g] * gasMtm[z] * Tedd[n][z] * erad;
 					}
+          lastTwoTerms += chat * kappaFVec[g] * gasMtm[n] * erad;
 					Frad_t1[n] = (Frad_t0[n] + (dt * lastTwoTerms)) / (1.0 + rho * kappaFVec[g] * chat * dt);
 
 					// Compute conservative gas momentum update

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1106,7 +1106,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		quokka::valarray<double, nGroups_> fourPiB{};
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> kappaPVec{};
-    quokka::valarray<double, nGroups_> kappaEVec{};
+		quokka::valarray<double, nGroups_> kappaEVec{};
 		quokka::valarray<double, nGroups_> kappaFVec{};
 		quokka::valarray<double, nGroups_> tau0{}; // optical depth across c * dt at old state
 		quokka::valarray<double, nGroups_> tau{};  // optical depth across c * dt at new state
@@ -1132,7 +1132,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			const double Etot0 = Egas0 + (c / chat) * (Erad0 + sum(Src));
 
 			// BEGIN NEWTON-RAPHSON LOOP
-      // Solve for the new radiation energy and gas internal energy using a Newton-Raphson method using the base variables (Egas, D_0, D_1,
+			// Solve for the new radiation energy and gas internal energy using a Newton-Raphson method using the base variables (Egas, D_0, D_1,
 			// ...), where D_i = R_i / tau_i^(t) and tau_i^(t) = dt * rho * kappa_{P,i}^(t) * chat is the optical depth across chat * dt for group i
 			// at time t. Compared with the old base (Egas, Erad_0, Erad_1, ...), this new base is more stable and converges faster. Furthermore,
 			// the PlanckOpacityTempDerivative term is not needed anymore since I assume d/dT (kappa_P / kappa_E) = 0 in the calculation of the
@@ -1151,7 +1151,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			AMREX_ASSERT(T_gas >= 0.);
 			fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 			kappaPVec = ComputePlanckOpacity(rho, T_gas);
-      kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+			kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 			AMREX_ASSERT(!kappaPVec.hasnan());
 			AMREX_ASSERT(!kappaEVec.hasnan());
 			tau0 = dt * rho * kappaPVec * chat;
@@ -1177,7 +1177,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				// compute opacity, emissivity
 				fourPiB = chat * ComputeThermalRadiation(T_gas, radBoundaries_g_copy);
 				kappaPVec = ComputePlanckOpacity(rho, T_gas);
-        kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
+				kappaEVec = ComputeEnergyMeanOpacity(rho, T_gas);
 				AMREX_ASSERT(!kappaPVec.hasnan());
 
 				tau = dt * rho * kappaEVec * chat;
@@ -1197,7 +1197,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!dfourPiB_dTgas.hasnan());
 
 				// compute Jacobian elements
-        // I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption only
+				// I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption only
 				// affects the convergence rate of the Newton-Raphson iteration and does not affect the converged solution at all.
 				dFG_dEgas = 1.0;
 				dFG_dD = (c / chat) * tau0;

--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -175,6 +175,16 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto opera
 	return scalardiv;
 }
 
+// scalar / array
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
+{
+  quokka::valarray<T, d> scalardiv;
+  for (size_t i = 0; i < v.size(); ++i) {
+    scalardiv[i] = scalar / v[i];
+  }
+  return scalardiv;
+}
+
 // array /= scalar
 template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void operator/=(quokka::valarray<T, d> &v, T const &scalar)
 {

--- a/src/valarray.hpp
+++ b/src/valarray.hpp
@@ -178,11 +178,11 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto opera
 // scalar / array
 template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
 {
-  quokka::valarray<T, d> scalardiv;
-  for (size_t i = 0; i < v.size(); ++i) {
-    scalardiv[i] = scalar / v[i];
-  }
-  return scalardiv;
+	quokka::valarray<T, d> scalardiv;
+	for (size_t i = 0; i < v.size(); ++i) {
+		scalardiv[i] = scalar / v[i];
+	}
+	return scalardiv;
 }
 
 // array /= scalar


### PR DESCRIPTION
### Description
Define the advecting pulse test (Krumholz2017) under grey-radiation approximation. The setup of the test is exactly the same as Sec. 4.1.6 of CASTRO III ([Zhang+2013](https://ui.adsabs.harvard.edu/abs/2013ApJS..204....7Z/abstract)). 

### Related issues
This PR corrected the formula of the v/c terms in the radiation flux update. The correct formula for the space-like component of the radiation four-force to order $\beta$ is

```math
-\boldsymbol{G} =-\rho \kappa_F \frac{\boldsymbol{F}_r}{c} + \rho \kappa_P\left(\frac{4 \pi B}{c} - E\right) \frac{\boldsymbol{v}}{c}+\rho \kappa_F \left (\frac{\boldsymbol{v}}{c} E + \frac{\boldsymbol{v} :\boldsymbol{P}_r}{c} \right).
```

instead of Eq. (8) of the Quokka paper, i.e.

```math
-\boldsymbol{G} =-\rho \kappa_F \frac{\boldsymbol{F}_r}{c} + \rho \kappa_P\left(\frac{4 \pi B}{c} \right) \frac{\boldsymbol{v}}{c}+\rho \kappa_F  \frac{\boldsymbol{v} :\boldsymbol{P}_r}{c} .
```


### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
