### PR TITLE
Increase max timesteps to 300 for the PopIII Test

### DIFF
--- a/tests/PopIII.in
+++ b/tests/PopIII.in
@@ -22,7 +22,7 @@ amr.grid_eff        = 0.7   # default
 
 hydro.reconstruction_order = 3  # PPM
 cfl = 0.15
-max_timesteps = 10
+max_timesteps = 300
 stop_time = 1e16
 
 do_reflux = 1


### PR DESCRIPTION
### Description
This PR increases the maximum steps to run the PopIII test problem to 300, to compare the evolution on AMD and NVIDIA GPUs (which starts to differ around step 58).

### Related issues
Will further help debug #394 #447 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x ] I have added a description (see above).
- [x ] I have added a link to any related issues see (see above).
- [x ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x ] I have tested this PR on my local computer and all tests pass.
- [x ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x ] I have requested a reviewer for this PR.
