### PR TITLE
Defined advecting pulse test in dynamic diffusion regime

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -172,6 +172,7 @@ add_subdirectory(RadhydroShockCGS)
 add_subdirectory(RadhydroShockMultigroup)
 add_subdirectory(RadhydroUniformAdvecting)
 add_subdirectory(RadhydroPulse)
+add_subdirectory(RadhydroPulseDyn)
 add_subdirectory(RadhydroPulseGrey)
 add_subdirectory(RadhydroPulseMG)
 

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -326,7 +326,7 @@ auto problem_main() -> int
 		sol_norm += std::abs(Tmat_exact[i]);
 	}
 
-	const double error_tol = 0.05; // 5 per cent
+	const double error_tol = 0.09;
 	const double rel_error = err_norm / sol_norm;
 	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
 

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.hpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.hpp
@@ -5,7 +5,7 @@
 // Copyright 2020 Benjamin Wibking.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
-/// \file test_radiation_marshak.hpp
+/// \file test_radiation_marshak_asymptotic.hpp
 /// \brief Defines a test problem for radiation in the static diffusion regime.
 ///
 

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -213,7 +213,7 @@ auto problem_main() -> int
 		err_norm += std::abs(Trad[i] - Trad_exact[i]);
 		sol_norm += std::abs(Trad_exact[i]);
 	}
-	const double error_tol = 0.005;
+	const double error_tol = 0.01;
 	const double rel_error = err_norm / sol_norm;
 	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
 

--- a/src/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/RadhydroPulse/test_radhydro_pulse.cpp
@@ -352,7 +352,7 @@ auto problem_main() -> int
 	Trad_args["linestyle"] = "-.";
 	Tgas_args["label"] = "Tgas (non-advecting)";
 	Tgas_args["linestyle"] = "--";
-matplotlibcpp::ylim(0.95e7, 1.6e7);
+	matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::plot(xs, Trad, Trad_args);
 	matplotlibcpp::plot(xs, Tgas, Tgas_args);
 	Trad_args["label"] = "Trad (advecting)";
@@ -366,14 +366,15 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_temperature.pdf");
 
-  // Save xs, Trad, Tgas, xs2, Trad2, Tgas2 to csv file
-  std::ofstream file;
-  file.open("radhydro_pulse_temperature.csv");
-  file << "xs,Trad,Tgas,xs2,Trad2,Tgas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << Trad[i] << "," << Tgas[i] << "," << xs2[i] << "," << Trad2[i] << "," << Tgas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, Trad, Tgas, xs2, Trad2, Tgas2 to csv file
+	std::ofstream file;
+	file.open("radhydro_pulse_temperature.csv");
+	file << "xs,Trad,Tgas,xs2,Trad2,Tgas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << Trad[i] << "," << Tgas[i] << "," << xs2[i] << "," << Trad2[i] << ","
+		     << Tgas2[i] << "\n";
+	}
+	file.close();
 
 	// plot gas density profile
 	matplotlibcpp::clf();
@@ -390,13 +391,13 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_density.pdf");
 
-  // Save xs, rhogas, xs2, rhogas2 to csv file with format %.12e
-  file.open("radhydro_pulse_density.csv");
-  file << "xs,rhogas,xs2,rhogas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << rhogas[i] << "," << xs2[i] << "," << rhogas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, rhogas, xs2, rhogas2 to csv file with format %.12e
+	file.open("radhydro_pulse_density.csv");
+	file << "xs,rhogas,xs2,rhogas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << rhogas[i] << "," << xs2[i] << "," << rhogas2[i] << "\n";
+	}
+	file.close();
 
 	// plot gas velocity profile
 	matplotlibcpp::clf();
@@ -413,13 +414,13 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_velocity.pdf");
 
-  // Save xs, Vgas, xs2, Vgas2 to csv file
-  file.open("radhydro_pulse_velocity.csv");
-  file << "xs,Vgas,xs2,Vgas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << Vgas[i] << "," << xs2[i] << "," << Vgas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, Vgas, xs2, Vgas2 to csv file
+	file.open("radhydro_pulse_velocity.csv");
+	file << "xs,Vgas,xs2,Vgas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << Vgas[i] << "," << xs2[i] << "," << Vgas2[i] << "\n";
+	}
+	file.close();
 
 #endif
 

--- a/src/RadhydroPulse/test_radhydro_pulse.hpp
+++ b/src/RadhydroPulse/test_radhydro_pulse.hpp
@@ -1,7 +1,7 @@
 #ifndef TEST_RADHYDRO_PULSE_HPP_ // NOLINT
 #define TEST_RADHYDRO_PULSE_HPP_
-/// \file test_radiation_marshak.hpp
-/// \brief Defines a test problem for radiation in the static diffusion regime.
+/// \file test_radhydro_pulse.hpp
+/// \brief Defines a test problem for radiation in the static diffusion regime with advection by gas.
 ///
 
 // external headers

--- a/src/RadhydroPulseDyn/CMakeLists.txt
+++ b/src/RadhydroPulseDyn/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_SPACEDIM EQUAL 1)
+  add_executable(test_radhydro_pulse_dyn test_radhydro_pulse_dyn.cpp ../fextract.cpp ${QuokkaObjSources})
+
+  if(AMReX_GPU_BACKEND MATCHES "CUDA")
+      setup_target_for_cuda_compilation(test_radhydro_pulse_dyn)
+  endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+
+  add_test(NAME RadhydroPulseDyn COMMAND test_radhydro_pulse_dyn RadhydroPulseDyn.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -24,7 +24,6 @@ constexpr double width = 24.0; // cm, width of the pulse
 constexpr double erad_floor = a_rad * T0 * T0 * T0 * T0 * 1.0e-10;
 constexpr double mu = 2.33 * C::m_u;
 constexpr double k_B = C::k_B;
-constexpr double v0_nonadv = 0.; // non-advecting pulse
 
 // Static diffusion: tau = 2e3, beta = 3e-5, beta tau = 6e-2
 // constexpr double kappa0 = 100.;	    // cm^2 g^-1
@@ -40,7 +39,7 @@ constexpr double v0_nonadv = 0.; // non-advecting pulse
 // Width of the pulse = sqrt(c max_time / kappa0) = 85 if max_time = 2.4e-4
 constexpr double kappa0 = 500.;	 // cm^2 g^-1
 constexpr double v0_adv = 3.0e7; // advecting pulse
-constexpr double max_time = 4.8e-5;
+constexpr double max_time = 4.8e-6;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double mean_molecular_weight = mu;
@@ -153,7 +152,6 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		const double Erad = a_rad * std::pow(Trad, 4);
 		const double rho = compute_exact_rho(x - x0);
 		const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho, Trad);
-		const double v0 = v0_nonadv;
 
 		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = Erad;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 0.;
@@ -345,7 +343,7 @@ auto problem_main() -> int
 		err_norm += std::abs(Tgas2[i] - Trad[i]);
 		sol_norm += std::abs(Trad[i]) * 3.0;
 	}
-	const double error_tol = 0.006;
+	const double error_tol = 0.002;
 	const double rel_error = err_norm / sol_norm;
 	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
 

--- a/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -1,8 +1,8 @@
-/// \file test_radhydro_pulse.cpp
-/// \brief Defines a test problem for radiation in the static diffusion regime with advection by gas.
+/// \file test_radhydro_pulse_dyn.cpp
+/// \brief Defines a test problem for radiation in the dynamic diffusion regime with advection by gas.
 ///
 
-#include "test_radhydro_pulse.hpp"
+#include "test_radhydro_pulse_dyn.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
 #include "RadhydroSimulation.hpp"
@@ -26,15 +26,21 @@ constexpr double mu = 2.33 * C::m_u;
 constexpr double k_B = C::k_B;
 constexpr double v0_nonadv = 0.; // non-advecting pulse
 
-// static diffusion: tau = 2e3, beta = 3e-5, beta tau = 6e-2
-constexpr double kappa0 = 100.;	    // cm^2 g^-1
-constexpr double v0_adv = 1.0e6;    // advecting pulse
-constexpr double max_time = 4.8e-5; // max_time = 2.0 * width / v1;
+// Static diffusion: tau = 2e3, beta = 3e-5, beta tau = 6e-2
+// constexpr double kappa0 = 100.;	    // cm^2 g^-1
+// constexpr double v0_adv = 1.0e6;    // advecting pulse
+// constexpr double max_time = 4.8e-5; // max_time = 2.0 * width / v1;
 
-// dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
+// Dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
 // constexpr double kappa0 = 1000.; // cm^2 g^-1
 // constexpr double v0_adv = 1.0e8;    // advecting pulse
-// constexpr double max_time = 1.2e-4; // max_time = 2.0 * width / v1;
+// constexpr double max_time = 4.8e-4;
+
+// Dynamic diffusion: tau = 1e4, beta = 1e-3, beta tau = 10. 
+// Width of the pulse = sqrt(c max_time / kappa0) = 85 if max_time = 2.4e-4
+constexpr double kappa0 = 500.; // cm^2 g^-1
+constexpr double v0_adv = 3.0e7;    // advecting pulse
+constexpr double max_time = 4.8e-5;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double mean_molecular_weight = mu;
@@ -150,13 +156,13 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		const double v0 = v0_nonadv;
 
 		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = Erad;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 4. / 3. * v0 * Erad;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index) = 0;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index) = 0;
-		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho * v0 * v0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas;
 		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho;
 		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
@@ -352,7 +358,7 @@ auto problem_main() -> int
 	Trad_args["linestyle"] = "-.";
 	Tgas_args["label"] = "Tgas (non-advecting)";
 	Tgas_args["linestyle"] = "--";
-matplotlibcpp::ylim(0.95e7, 1.6e7);
+  matplotlibcpp::ylim(0.95e7, 2.0e7);
 	matplotlibcpp::plot(xs, Trad, Trad_args);
 	matplotlibcpp::plot(xs, Tgas, Tgas_args);
 	Trad_args["label"] = "Trad (advecting)";
@@ -364,11 +370,11 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::legend();
 	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
-	matplotlibcpp::save("./radhydro_pulse_temperature.pdf");
+	matplotlibcpp::save("./radhydro_pulse_dyndiff_temperature.pdf");
 
   // Save xs, Trad, Tgas, xs2, Trad2, Tgas2 to csv file
   std::ofstream file;
-  file.open("radhydro_pulse_temperature.csv");
+  file.open("radhydro_pulse_dyndiff_temperature.csv");
   file << "xs,Trad,Tgas,xs2,Trad2,Tgas2\n";
   for (size_t i = 0; i < xs.size(); ++i) {
     file << std::scientific << std::setprecision(12) << xs[i] << "," << Trad[i] << "," << Tgas[i] << "," << xs2[i] << "," << Trad2[i] << "," << Tgas2[i] << "\n";
@@ -388,10 +394,10 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::legend();
 	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
-	matplotlibcpp::save("./radhydro_pulse_density.pdf");
+	matplotlibcpp::save("./radhydro_pulse_dyndiff_density.pdf");
 
   // Save xs, rhogas, xs2, rhogas2 to csv file with format %.12e
-  file.open("radhydro_pulse_density.csv");
+  file.open("radhydro_pulse_dyndiff_density.csv");
   file << "xs,rhogas,xs2,rhogas2\n";
   for (size_t i = 0; i < xs.size(); ++i) {
     file << std::scientific << std::setprecision(12) << xs[i] << "," << rhogas[i] << "," << xs2[i] << "," << rhogas2[i] << "\n";
@@ -411,10 +417,10 @@ matplotlibcpp::ylim(0.95e7, 1.6e7);
 	matplotlibcpp::legend();
 	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
-	matplotlibcpp::save("./radhydro_pulse_velocity.pdf");
+	matplotlibcpp::save("./radhydro_pulse_dyndiff_velocity.pdf");
 
   // Save xs, Vgas, xs2, Vgas2 to csv file
-  file.open("radhydro_pulse_velocity.csv");
+  file.open("radhydro_pulse_dyndiff_velocity.csv");
   file << "xs,Vgas,xs2,Vgas2\n";
   for (size_t i = 0; i < xs.size(); ++i) {
     file << std::scientific << std::setprecision(12) << xs[i] << "," << Vgas[i] << "," << xs2[i] << "," << Vgas2[i] << "\n";

--- a/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -36,10 +36,10 @@ constexpr double v0_nonadv = 0.; // non-advecting pulse
 // constexpr double v0_adv = 1.0e8;    // advecting pulse
 // constexpr double max_time = 4.8e-4;
 
-// Dynamic diffusion: tau = 1e4, beta = 1e-3, beta tau = 10. 
+// Dynamic diffusion: tau = 1e4, beta = 1e-3, beta tau = 10.
 // Width of the pulse = sqrt(c max_time / kappa0) = 85 if max_time = 2.4e-4
-constexpr double kappa0 = 500.; // cm^2 g^-1
-constexpr double v0_adv = 3.0e7;    // advecting pulse
+constexpr double kappa0 = 500.;	 // cm^2 g^-1
+constexpr double v0_adv = 3.0e7; // advecting pulse
 constexpr double max_time = 4.8e-5;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {
@@ -358,7 +358,7 @@ auto problem_main() -> int
 	Trad_args["linestyle"] = "-.";
 	Tgas_args["label"] = "Tgas (non-advecting)";
 	Tgas_args["linestyle"] = "--";
-  matplotlibcpp::ylim(0.95e7, 2.0e7);
+	matplotlibcpp::ylim(0.95e7, 2.0e7);
 	matplotlibcpp::plot(xs, Trad, Trad_args);
 	matplotlibcpp::plot(xs, Tgas, Tgas_args);
 	Trad_args["label"] = "Trad (advecting)";
@@ -372,14 +372,15 @@ auto problem_main() -> int
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_dyndiff_temperature.pdf");
 
-  // Save xs, Trad, Tgas, xs2, Trad2, Tgas2 to csv file
-  std::ofstream file;
-  file.open("radhydro_pulse_dyndiff_temperature.csv");
-  file << "xs,Trad,Tgas,xs2,Trad2,Tgas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << Trad[i] << "," << Tgas[i] << "," << xs2[i] << "," << Trad2[i] << "," << Tgas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, Trad, Tgas, xs2, Trad2, Tgas2 to csv file
+	std::ofstream file;
+	file.open("radhydro_pulse_dyndiff_temperature.csv");
+	file << "xs,Trad,Tgas,xs2,Trad2,Tgas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << Trad[i] << "," << Tgas[i] << "," << xs2[i] << "," << Trad2[i] << ","
+		     << Tgas2[i] << "\n";
+	}
+	file.close();
 
 	// plot gas density profile
 	matplotlibcpp::clf();
@@ -396,13 +397,13 @@ auto problem_main() -> int
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_dyndiff_density.pdf");
 
-  // Save xs, rhogas, xs2, rhogas2 to csv file with format %.12e
-  file.open("radhydro_pulse_dyndiff_density.csv");
-  file << "xs,rhogas,xs2,rhogas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << rhogas[i] << "," << xs2[i] << "," << rhogas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, rhogas, xs2, rhogas2 to csv file with format %.12e
+	file.open("radhydro_pulse_dyndiff_density.csv");
+	file << "xs,rhogas,xs2,rhogas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << rhogas[i] << "," << xs2[i] << "," << rhogas2[i] << "\n";
+	}
+	file.close();
 
 	// plot gas velocity profile
 	matplotlibcpp::clf();
@@ -419,13 +420,13 @@ auto problem_main() -> int
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./radhydro_pulse_dyndiff_velocity.pdf");
 
-  // Save xs, Vgas, xs2, Vgas2 to csv file
-  file.open("radhydro_pulse_dyndiff_velocity.csv");
-  file << "xs,Vgas,xs2,Vgas2\n";
-  for (size_t i = 0; i < xs.size(); ++i) {
-    file << std::scientific << std::setprecision(12) << xs[i] << "," << Vgas[i] << "," << xs2[i] << "," << Vgas2[i] << "\n";
-  }
-  file.close();
+	// Save xs, Vgas, xs2, Vgas2 to csv file
+	file.open("radhydro_pulse_dyndiff_velocity.csv");
+	file << "xs,Vgas,xs2,Vgas2\n";
+	for (size_t i = 0; i < xs.size(); ++i) {
+		file << std::scientific << std::setprecision(12) << xs[i] << "," << Vgas[i] << "," << xs2[i] << "," << Vgas2[i] << "\n";
+	}
+	file.close();
 
 #endif
 

--- a/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.hpp
+++ b/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.hpp
@@ -1,0 +1,21 @@
+#ifndef TEST_RADHYDRO_PULSE_DYN_HPP_ // NOLINT
+#define TEST_RADHYDRO_PULSE_DYN_HPP_
+/// \file test_radhydro_pulse_dyn.hpp
+/// \brief Defines a test problem for radiation in the dynamic diffusion regime with advection by gas.
+///
+
+// external headers
+#ifdef HAVE_PYTHON
+#include "matplotlibcpp.h"
+#endif
+#include <fmt/format.h>
+#include <fstream>
+
+// internal headers
+
+#include "interpolate.hpp"
+#include "radiation_system.hpp"
+
+// function definitions
+
+#endif // TEST_RADHYDRO_PULSE_DYN_HPP_

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -953,15 +953,15 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 			// adjust the wavespeeds
 			// (this factor cancels out except for the last term in the HLL flux)
-			// const quokka::valarray<double, numRadVars_> epsilon = {S_corr, 1.0, 1.0, 1.0}; // Skinner et al. (2019)
-			// const quokka::valarray<double, numRadVars_> epsilon = {S_corr, S_corr, S_corr, S_corr}; // Jiang et al. (2013)
-			quokka::valarray<double, numRadVars_> epsilon = {S_corr * S_corr, S_corr, S_corr, S_corr}; // this code
+			quokka::valarray<double, numRadVars_> epsilon = {S_corr, 1.0, 1.0, 1.0}; // Skinner et al. (2019)
+			// quokka::valarray<double, numRadVars_> epsilon = {S_corr, S_corr, S_corr, S_corr}; // Jiang et al. (2013)
+			// quokka::valarray<double, numRadVars_> epsilon = {S_corr * S_corr, S_corr, S_corr, S_corr}; // this code
 
 			// fix odd-even instability that appears in the asymptotic diffusion limit
 			// [for details, see section 3.1: https://ui.adsabs.harvard.edu/abs/2022MNRAS.512.1499R/abstract]
 			if ((i + j + k) % 2 == 1) {
 				// revert to more diffusive flux (has no effect in optically-thin limit)
-				epsilon = {S_corr, 1.0, 1.0, 1.0};
+				epsilon = {1.0, 1.0, 1.0, 1.0};
 			}
 
 			AMREX_ASSERT(std::abs(S_L) <= c_hat_); // NOLINT

--- a/tests/RadhydroPulseDyn.in
+++ b/tests/RadhydroPulseDyn.in
@@ -1,0 +1,25 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -512.0  0.0  0.0 
+geometry.prob_hi     =  512.0  1.0  1.0
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 128 4 4
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 4     # grid size must be divisible by this
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 4
+amr.max_grid_size_z = 4
+
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 1


### PR DESCRIPTION
1. Defined advecting pulse test in the dynamic diffusion regime. 
2. Use a new odd-even correction: S_corr = (1/tau, 1, 1, 1) at high tau and (1, 1, 1, 1) otherwise. 
3. Increased error_tol in some tests as we use a new odd-even correction

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
