### PR TITLE
compile warnings with AMREX_SPACEDIM=3

### DIFF
--- a/.github/workflows/warnings.yml
+++ b/.github/workflows/warnings.yml
@@ -40,14 +40,10 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      # Note the current convention is to use the -S and -B options here to specify source 
-      # and build directories, but this is only available with CMake 3.13 and higher.  
-      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DWARNINGS_AS_ERRORS=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DWARNINGS_AS_ERRORS=ON -DAMReX_SPACEDIM=3
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      # Restrict to 1 build process at a time to avoid OOM kills.
-      run: cmake --build . --config $BUILD_TYPE --parallel 1
+      run: cmake --build . --config $BUILD_TYPE --parallel 4

--- a/src/Cooling/test_cooling.cpp
+++ b/src/Cooling/test_cooling.cpp
@@ -7,23 +7,14 @@
 /// \brief Defines a test problem for SUNDIALS cooling.
 ///
 #include <random>
-#include <vector>
 
 #include "AMReX_BC_TYPES.H"
-#include "AMReX_BLProfiler.H"
 #include "AMReX_BLassert.H"
-#include "AMReX_FabArray.H"
 #include "AMReX_GpuDevice.H"
-#include "AMReX_MultiFab.H"
-#include "AMReX_ParallelContext.H"
-#include "AMReX_ParallelDescriptor.H"
-#include "AMReX_SPACE.H"
 #include "AMReX_TableData.H"
 
 #include "RadhydroSimulation.hpp"
-#include "hydro_system.hpp"
 #include "radiation_system.hpp"
-#include "test_cooling.hpp"
 
 using amrex::Real;
 
@@ -101,14 +92,12 @@ template <> void RadhydroSimulation<CoolingTest>::setInitialConditionsOnGrid(quo
 	const auto &phase_table = userData_.table_data->const_table();
 
 	Real const Lx = (prob_hi[0] - prob_lo[0]);
-	Real const Ly = (prob_hi[1] - prob_lo[1]);
-	Real const Lz = (prob_hi[2] - prob_lo[2]);
 
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		Real const x = prob_lo[0] + (i + Real(0.5)) * dx[0];
-		Real const y = prob_lo[1] + (j + Real(0.5)) * dx[1];
-		Real const z = prob_lo[2] + (k + Real(0.5)) * dx[2];
+		Real const x = prob_lo[0] + (i + static_cast<Real>(0.5)) * dx[0];
+		Real const y = prob_lo[1] + (j + static_cast<Real>(0.5)) * dx[1];
+		Real const z = prob_lo[2] + (k + static_cast<Real>(0.5)) * dx[2];
 
 		// compute perturbations
 		Real delta_rho = 0;
@@ -118,9 +107,9 @@ template <> void RadhydroSimulation<CoolingTest>::setInitialConditionsOnGrid(quo
 					if ((ki == 0) && (kj == 0) && (kk == 0)) {
 						continue;
 					}
-					Real const kx = 2.0 * M_PI * Real(ki) / Lx;
-					Real const ky = 2.0 * M_PI * Real(kj) / Lx;
-					Real const kz = 2.0 * M_PI * Real(kk) / Lx;
+					Real const kx = 2.0 * M_PI * static_cast<Real>(ki) / Lx;
+					Real const ky = 2.0 * M_PI * static_cast<Real>(kj) / Lx;
+					Real const kz = 2.0 * M_PI * static_cast<Real>(kk) / Lx;
 					delta_rho += A * std::sin(x * kx + y * ky + z * kz + phase_table(ki, kj, kk));
 				}
 			}
@@ -165,7 +154,6 @@ AMRSimulation<CoolingTest>::setCustomBoundaryConditions(const amrex::IntVect &iv
 #endif
 
 	amrex::Box const &box = geom.Domain();
-	amrex::GpuArray<int, 3> lo = box.loVect3d();
 	amrex::GpuArray<int, 3> hi = box.hiVect3d();
 
 	if (j >= hi[1]) {

--- a/src/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/HydroBlast3D/test_hydro3d_blast.cpp
@@ -56,7 +56,6 @@ template <> struct Physics_Traits<SedovProblem> {
 // declare global variables
 double rho = 1.0;	   // g cm^-3
 double E_blast = 0.851072; // ergs
-double R0 = 0.025;	   // cm
 
 template <> void RadhydroSimulation<SedovProblem>::preCalculateInitialConditions()
 {
@@ -81,7 +80,6 @@ template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(qu
 	const Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
 	double rho_copy = rho;
 	double E_blast_copy = E_blast;
-	double R0_copy = R0;
 
 	amrex::Real x0 = NAN;
 	amrex::Real y0 = NAN;
@@ -99,19 +97,6 @@ template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(qu
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		double rho_e = NAN;
-#if 0
-    amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
-    amrex::Real const y = prob_lo[1] + (j + amrex::Real(0.5)) * dx[1];
-    amrex::Real const z = prob_lo[2] + (k + amrex::Real(0.5)) * dx[2];
-    amrex::Real const r = std::sqrt(
-        std::pow(x - x0, 2) + std::pow(y - y0, 2) + std::pow(z - z0, 2));
-
-    if (r < R0_copy) {
-      rho_e = 1.0;
-    } else {
-      rho_e = 1.0e-10;
-    }
-#endif
 		static_assert(!simulate_full_box, "single-cell initialization is only "
 						  "implemented for octant symmetry!");
 		if ((i == 0) && (j == 0) && (k == 0)) {
@@ -126,7 +111,6 @@ template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(qu
 		for (int n = 0; n < state_cc.nComp(); ++n) {
 			state_cc(i, j, k, n) = 0.; // zero fill all components
 		}
-		const auto gamma = quokka::EOS_Traits<SedovProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<SedovProblem>::density_index) = rho_copy;
 		state_cc(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index) = 0;

--- a/src/HydroQuirk/test_quirk.cpp
+++ b/src/HydroQuirk/test_quirk.cpp
@@ -7,19 +7,17 @@
 /// \brief Defines a test problem for the odd-even decoupling instability.
 ///
 
+#include <algorithm>
+#include <vector>
+
 #include "AMReX.H"
-#include "AMReX_Arena.H"
 #include "AMReX_Array.H"
 #include "AMReX_BCRec.H"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_Box.H"
-#include "AMReX_Config.H"
-#include "AMReX_FArrayBox.H"
 #include "AMReX_FabArrayBase.H"
-#include "AMReX_FabArrayUtility.H"
 #include "AMReX_GpuAsyncArray.H"
-#include "AMReX_GpuContainers.H"
 #include "AMReX_GpuQualifiers.H"
 #include "AMReX_IntVect.H"
 #include "AMReX_MultiFab.H"
@@ -27,14 +25,10 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
-#include "AMReX_TagBox.H"
 
 #include "RadhydroSimulation.hpp"
 #include "hydro_system.hpp"
 #include "radiation_system.hpp"
-#include "test_quirk.hpp"
-#include <algorithm>
-#include <vector>
 
 using Real = amrex::Real;
 
@@ -80,7 +74,7 @@ template <> void RadhydroSimulation<QuirkProblem>::setInitialConditionsOnGrid(qu
 
 	Real xshock = 0.4;
 	int ishock = 0;
-	for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + Real(0.5))) < xshock; ++ishock) {
+	for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + static_cast<Real>(0.5))) < xshock; ++ishock) {
 	}
 	ishock--;
 	amrex::Print() << "ishock = " << ishock << "\n";
@@ -119,7 +113,6 @@ template <> void RadhydroSimulation<QuirkProblem>::setInitialConditionsOnGrid(qu
 		AMREX_ASSERT(!std::isnan(P));
 
 		const auto v_sq = vx * vx + vy * vy + vz * vz;
-		const auto gamma = quokka::EOS_Traits<QuirkProblem>::gamma;
 
 		state_cc(i, j, k, HydroSystem<QuirkProblem>::density_index) = rho;
 		state_cc(i, j, k, HydroSystem<QuirkProblem>::x1Momentum_index) = rho * vx;
@@ -281,6 +274,6 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
+	amrex::Print() << "Finished." << '\n';
 	return 0;
 }

--- a/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -9,14 +9,12 @@
 
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 
 #include "RadhydroSimulation.hpp"
 #include "hydro_system.hpp"
-#include "test_hydro2d_rm.hpp"
 
 struct RichtmeyerMeshkovProblem {
 };
@@ -106,14 +104,13 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::setInitialConditi
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
-		amrex::Real const y = prob_lo[1] + (j + amrex::Real(0.5)) * dx[1];
+		amrex::Real const x = prob_lo[0] + (i + static_cast<amrex::Real>(0.5)) * dx[0];
+		amrex::Real const y = prob_lo[1] + (j + static_cast<amrex::Real>(0.5)) * dx[1];
 
 		double vx = 0.;
 		double vy = 0.;
@@ -148,12 +145,6 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::setInitialConditi
 
 auto problem_main() -> int
 {
-	// Problem parameters
-	// amrex::IntVect gridDims{AMREX_D_DECL(1024, 1024, 4)};
-	// amrex::RealBox boxSize{
-	//    {AMREX_D_DECL(amrex::Real(0.0), amrex::Real(0.0), amrex::Real(0.0))},
-	//    {AMREX_D_DECL(amrex::Real(0.3), amrex::Real(0.3), amrex::Real(1.0))}};
-
 	auto isNormalComp = [=](int n, int dim) {
 		if ((n == HydroSystem<RichtmeyerMeshkovProblem>::x1Momentum_index) && (dim == 0)) {
 			return true;
@@ -196,6 +187,6 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
+	amrex::Print() << "Finished." << '\n';
 	return 0;
 }

--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -7,19 +7,13 @@
 /// \brief Defines a test problem for radiation in the streaming regime.
 ///
 
-#include <csignal>
-#include <tuple>
-
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
-#include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
 #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
 #include "RadhydroSimulation.hpp"
 #include "radiation_system.hpp"
-#include "test_radiation_beam.hpp"
 
 struct BeamProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -92,8 +86,8 @@ AMRSimulation<BeamProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
 
-	amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
-	amrex::Real const y = prob_lo[1] + (j + amrex::Real(0.5)) * dx[1];
+	amrex::Real const x = prob_lo[0] + (i + static_cast<amrex::Real>(0.5)) * dx[0]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+	amrex::Real const y = prob_lo[1] + (j + static_cast<amrex::Real>(0.5)) * dx[1]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
 
 	if ((i < lo[0]) && !(j < lo[1])) {
 		// streaming boundary condition
@@ -222,8 +216,6 @@ AMRSimulation<BeamProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 template <> void RadhydroSimulation<BeamProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
@@ -315,6 +307,6 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
+	amrex::Print() << "Finished." << '\n';
 	return 0;
 }

--- a/src/RadShadow/test_radiation_shadow.cpp
+++ b/src/RadShadow/test_radiation_shadow.cpp
@@ -7,20 +7,15 @@
 /// \brief Defines a 2D test problem for radiation in the transport regime.
 ///
 
-#include <limits>
-#include <tuple>
-
-#include "AMReX_Array.H"
+#include "AMReX_BCRec.H"
 #include "AMReX_BC_TYPES.H"
-#include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
-#include "AMReX_IntVect.H"
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 
+#include "RadhydroSimulation.hpp"
 #include "physics_info.hpp"
 #include "radiation_system.hpp"
-#include "test_radiation_shadow.hpp"
+#include "simulation.hpp"
 
 struct ShadowProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -102,9 +97,6 @@ AMRSimulation<ShadowProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 		const double Fx_bdry = c * E_inc; // free-streaming (F/cE == 1)
 		const double Fy_bdry = 0.;
 		const double Fz_bdry = 0.;
-
-		const amrex::Real Fnorm = std::sqrt(Fx_bdry * Fx_bdry + Fy_bdry * Fy_bdry + Fz_bdry * Fz_bdry);
-		AMREX_ASSERT((Fnorm / (c * E_inc)) <= 1.0); // flux-limiting condition
 
 		// x1 left side boundary (streaming)
 		consVar(i, j, k, RadSystem<ShadowProblem>::radEnergy_index) = E_inc;
@@ -262,6 +254,6 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
+	amrex::Print() << "Finished." << '\n';
 	return 0;
 }

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -7,18 +7,15 @@
 /// \brief Defines a test problem for radiation in the diffusion regime.
 ///
 
-#include <tuple>
-
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
 #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
+#include "RadhydroSimulation.hpp"
 #include "radiation_system.hpp"
 #include "simulation.hpp"
-#include "test_radiation_tophat.hpp"
 
 struct TophatProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -178,8 +175,6 @@ AMRSimulation<TophatProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 			Fy_bdry = Fy_0;
 			Fz_bdry = Fz_0;
 		}
-		const amrex::Real Fnorm = std::sqrt(Fx_bdry * Fx_bdry + Fy_bdry * Fy_bdry + Fz_bdry * Fz_bdry);
-		AMREX_ASSERT((Fnorm / (c * E_inc)) < 1.0); // flux-limiting condition
 
 		// x1 left side boundary (Marshak)
 		consVar(i, j, k, RadSystem<TophatProblem>::radEnergy_index) = E_inc;
@@ -242,10 +237,6 @@ auto problem_main() -> int
 	const int max_timesteps = 10000;
 	const double CFL_number = 0.4;
 	const double max_time = 5.0e-10; // s
-	// const int nx = 700;
-	// const int ny = 200;
-	// const double Lx = 7.0;	// cm
-	// const double Ly = 2.0;	// cm
 
 	auto isNormalComp = [=](int n, int dim) {
 		if ((n == RadSystem<TophatProblem>::x1RadFlux_index) && (dim == 0)) {
@@ -302,6 +293,6 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// Cleanup and exit
-	amrex::Print() << "Finished." << std::endl;
+	amrex::Print() << "Finished." << '\n';
 	return 0;
 }

--- a/src/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -10,14 +10,10 @@
 #include <cmath>
 
 #include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
-#include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
-#include "AMReX_Print.H"
 
 #include "RadhydroSimulation.hpp"
 #include "hydro_system.hpp"
-#include "test_hydro2d_rt.hpp"
 
 struct RTProblem {
 };
@@ -52,7 +48,6 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_hi = grid_elem.prob_hi_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
@@ -60,8 +55,7 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 
 	// loop over the grid and set the initial condition
 	amrex::ParallelForRNG(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::RandomEngine const &rng) noexcept {
-		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];
-		amrex::Real const y = prob_lo[1] + (j + amrex::Real(0.5)) * dx[1];
+		amrex::Real const y = prob_lo[1] + (j + static_cast<amrex::Real>(0.5)) * dx[1];
 
 		double rho = NAN;
 		double scalar = NAN;
@@ -100,7 +94,8 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 	});
 }
 
-template <> void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int lev, const amrex::Real time, const amrex::Real dt)
+template <>
+void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int /*lev*/, const amrex::Real /*time*/, const amrex::Real dt)
 {
 	// add gravitational source terms
 	const auto state = state_mf.arrays();

--- a/src/TurbDataReader.cpp
+++ b/src/TurbDataReader.cpp
@@ -55,7 +55,6 @@ void initialize_turbdata(turb_data &data, std::string &data_file)
 	amrex::Print() << "Initializing turbulence data...\n";
 	amrex::Print() << fmt::format("data_file: {}.\n", data_file);
 
-	herr_t status = 0;
 	herr_t const h5_error = -1;
 
 	// open file


### PR DESCRIPTION
### Description
This adds `-DAMReX_SPACEDIM=3` to the CMake flags for the GitHub action that emits compiler warnings. This will allow us to catch compiler warnings for problems that are only built in 3D.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
