### PR TITLE
Fix clang-tidy-review comment posting

### DIFF
--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.17.1
+      - uses: ZedThree/clang-tidy-review/post@9a32adc734e10e4d84baa60f2b7d7c021568c527
       # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
         # adjust options as necessary


### PR DESCRIPTION
### Description
This updates the clang-tidy-review comment-posting action in order to fix https://github.com/ZedThree/clang-tidy-review/issues/117.

### Related issues
https://github.com/ZedThree/clang-tidy-review/issues/117

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
