### PR TITLE
run CodeQL analysis with AMREX_SPACEDIM=3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,7 @@ jobs:
         if: ${{ matrix.language == 'cpp' }}
         run: |
           cmake -S . -B build                            \
+              -DAMReX_SPACEDIM=3                         \
               -DQUOKKA_PYTHON=OFF                        \
               -DCMAKE_VERBOSE_MAKEFILE=ON                \
               -DCMAKE_CXX_COMPILER="/usr/local/bin/g++"


### PR DESCRIPTION
### Description
This changes the CodeQL action so that it compiles Quokka with `AMREX_SPACEDIM=3`. This enables code analysis of 3D-only problems, which were not analyzed before.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
