### PR TITLE
Load rocm for setonix CPUs

### DIFF
--- a/scripts/setonix-cpu.profile
+++ b/scripts/setonix-cpu.profile
@@ -14,6 +14,6 @@ export MPICH_GPU_SUPPORT_ENABLED=0
 
 # compiler environment hints
 export CC=$(which cc)
-export CXX="$(which CC) -fno-cray"
+export CXX="$(which CC)"
 export FC=$(which ftn)
-
+export CXXFLAGS="$CXXFLAGS -fno-cray"

--- a/scripts/setonix-cpu.profile
+++ b/scripts/setonix-cpu.profile
@@ -7,6 +7,7 @@ module load cray-mpich
 module load cce/15.0.1
 module load cray-hdf5
 module load cray-python/3.9.13.1
+module load rocm/5.4.3
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=0

--- a/scripts/setonix-cpu.profile
+++ b/scripts/setonix-cpu.profile
@@ -14,6 +14,6 @@ export MPICH_GPU_SUPPORT_ENABLED=0
 
 # compiler environment hints
 export CC=$(which cc)
-export CXX=$(which CC)
+export CXX="$(which CC) -fno-cray"
 export FC=$(which ftn)
 

--- a/scripts/setonix-gpu.profile
+++ b/scripts/setonix-gpu.profile
@@ -24,5 +24,5 @@ export CC=$(which cc)
 export CXX=$(which CC)
 export FC=$(which ftn)
 export CFLAGS="-I${ROCM_PATH}/include"
-export CXXFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include -fno-cray"
 


### PR DESCRIPTION
### Description
We need to load rocm while compiling on setonix CPUs.

### Related issues
Fixes #563 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
