### PR TITLE
Avoid imaginary roe average sound speed

### DIFF
--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -54,8 +54,14 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars, N_ms
 		// equation A.5b of Kershaw+1998
 		const double C_tilde_P = 0.5 * ((sL.Eint / sL.rho) * drdp_L + (sR.Eint / sR.rho) * drdp_R + sL.rho * dedp_L + sR.rho * dedp_R);
 
-		// equation 4.12 of Kershaw+1998
-		cs_tilde = std::sqrt((1.0 / C_tilde_P) * (H_tilde - 0.5 * vsq_tilde - C_tilde_rho));
+		// avoid NAN cs_tilde
+		if (H_tilde - 0.5*vsq_tilde - C_tilde_rho < 0) {
+			// fall back to the gamma=1 case
+			cs_tilde = 0.5 * (sL.cs + sR.cs);
+		} else {
+			// equation 4.12 of Kershaw+1998
+			cs_tilde = std::sqrt((1.0 / C_tilde_P) * (H_tilde - 0.5 * vsq_tilde - C_tilde_rho));
+		}
 
 		const double s_NL = 0.5 * G_L * std::max(dU, 0.); // second-order wavespeed correction
 		const double s_NR = 0.5 * G_R * std::max(dU, 0.);

--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -55,12 +55,13 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars, N_ms
 		const double C_tilde_P = 0.5 * ((sL.Eint / sL.rho) * drdp_L + (sR.Eint / sR.rho) * drdp_R + sL.rho * dedp_L + sR.rho * dedp_R);
 
 		// avoid NAN cs_tilde
-		if (H_tilde - 0.5 * vsq_tilde - C_tilde_rho < 0) {
-			// fall back to the gamma=1 case
+		const double cs_exp = H_tilde - 0.5 * vsq_tilde - C_tilde_rho;
+		if (cs_exp <= 0) {
+			// take the average of the left and right states
 			cs_tilde = 0.5 * (sL.cs + sR.cs);
 		} else {
 			// equation 4.12 of Kershaw+1998
-			cs_tilde = std::sqrt((1.0 / C_tilde_P) * (H_tilde - 0.5 * vsq_tilde - C_tilde_rho));
+			cs_tilde = std::sqrt((1.0 / C_tilde_P) * cs_exp);
 		}
 
 		const double s_NL = 0.5 * G_L * std::max(dU, 0.); // second-order wavespeed correction

--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -55,7 +55,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars, N_ms
 		const double C_tilde_P = 0.5 * ((sL.Eint / sL.rho) * drdp_L + (sR.Eint / sR.rho) * drdp_R + sL.rho * dedp_L + sR.rho * dedp_R);
 
 		// avoid NAN cs_tilde
-		if (H_tilde - 0.5*vsq_tilde - C_tilde_rho < 0) {
+		if (H_tilde - 0.5 * vsq_tilde - C_tilde_rho < 0) {
 			// fall back to the gamma=1 case
 			cs_tilde = 0.5 * (sL.cs + sR.cs);
 		} else {

--- a/src/HLLC.hpp
+++ b/src/HLLC.hpp
@@ -61,7 +61,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLC(quokka::HydroState<N_scalars, N_ms
 			cs_tilde = 0.5 * (sL.cs + sR.cs);
 		} else {
 			// equation 4.12 of Kershaw+1998
-			cs_tilde = std::sqrt((1.0 / C_tilde_P) * cs_exp);
+			cs_tilde = std::sqrt(cs_exp / C_tilde_P);
 		}
 
 		const double s_NL = 0.5 * G_L * std::max(dU, 0.); // second-order wavespeed correction


### PR DESCRIPTION
### Description
There can be instances when the Roe-averaged sound speed (`cs_tilde` in `HLLC.hpp`) can be negative. In such cases, the current implementation will generate a NAN cs_tilde, which is handled differently by different compilers (e.g., GCC versus HIPCC). This was one of the causes of StarCluster and PopIII problems failing on HIPCC-based CPUs and AMD GPUs.

### Related issues
Fixes #555.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
