### PR TITLE
Fixed bug in PopIII refinement

### DIFF
--- a/tests/PopIII.in
+++ b/tests/PopIII.in
@@ -39,7 +39,7 @@ perturb.rms_velocity = 1.8050e5 #initial cloud rms velocity (to drive turbulence
 
 # params for jeans refinement
 jeansRefine.ncells = 64 #refine on these many cells per jeans length
-jeansRefine.jeans_density_threshold = 2e-20 #do not refine if density is less than this density
+jeansRefine.density_threshold = 2e-20 #do not refine if density is less than this density
 
 # density floor for popiii
 density_floor = 1e-25


### PR DESCRIPTION
### Description
Fixed a bug in the name of the refinement runtime parameter for PopIII. The simulation wasn't refining because of the mismatch in the name.

### Related issues
No

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
