### PR TITLE
Update Factory.H to use std::move

### DIFF
--- a/src/Factory.H
+++ b/src/Factory.H
@@ -71,7 +71,7 @@ template <class Base, class... Args> struct Factory {
 	static std::unique_ptr<Base> create(const std::string &key, Args... args)
 	{
 		key_exists_or_error(key);
-		auto ptr = table().at(key)(std::forward<Args>(args)...);
+		auto ptr = table().at(key)(std::move<Args>(args)...);
 		amrex::Print() << "Creating " << Base::base_identifier() << " instance: " << key << std::endl;
 		return ptr;
 	}
@@ -98,7 +98,7 @@ template <class Base, class... Args> struct Factory {
 		{
 			// TODO: Add checks against multiple registration
 			Factory::table()[T::identifier()] = [](Args... args) -> std::unique_ptr<Base> {
-				return std::unique_ptr<Base>(new T(std::forward<Args>(args)...));
+				return std::unique_ptr<Base>(new T(std::move<Args>(args)...));
 			};
 			return true;
 		}


### PR DESCRIPTION
### Description
Sonarcloud complained about the last PR using `std::forward` instead of `std::move`. It appears that `std::move` should be used instead.

### Related issues
[Sonarcloud issue](https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&types=BUG&id=BenWibking_TwoMomentRad&open=AY5UChgLLdUsq9L5VHlt&tab=code)

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
