### PR TITLE
Remove redundant parameter compute_v_over_c_terms

### DIFF
--- a/src/RadBeam/test_radiation_beam.cpp
+++ b/src/RadBeam/test_radiation_beam.cpp
@@ -37,7 +37,6 @@ template <> struct RadSystem_Traits<BeamProblem> {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -68,7 +68,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr double c_hat = 10. * (Mach1 * a0);
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = C::ev2erg;
 	static constexpr amrex::GpuArray<double, Physics_Traits<TubeProblem>::nGroups + 1> radBoundaries{0., 13.6, inf}; // eV
 	static constexpr int beta_order = 1;

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -41,8 +41,7 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 	static constexpr double c_hat = c;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <> struct Physics_Traits<SuOlsonProblem> {

--- a/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -38,8 +38,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = Erad_floor_;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {

--- a/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -43,7 +43,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -41,7 +41,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -43,7 +43,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr double c_hat = c_rsla;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadPulse/test_radiation_pulse.cpp
+++ b/src/RadPulse/test_radiation_pulse.cpp
@@ -39,8 +39,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/RadShadow/test_radiation_shadow.cpp
+++ b/src/RadShadow/test_radiation_shadow.cpp
@@ -40,7 +40,6 @@ template <> struct RadSystem_Traits<ShadowProblem> {
 	static constexpr double c_hat = c;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadStreaming/test_radiation_streaming.cpp
+++ b/src/RadStreaming/test_radiation_streaming.cpp
@@ -45,8 +45,7 @@ template <> struct RadSystem_Traits<StreamingProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = 1.0;
 	static constexpr double Erad_floor = initial_Erad;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <>

--- a/src/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/RadSuOlson/test_radiation_SuOlson.cpp
@@ -49,8 +49,7 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 	static constexpr double boltzmann_constant = 1.0;
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <> struct Physics_Traits<MarshakProblem> {

--- a/src/RadTophat/test_radiation_tophat.cpp
+++ b/src/RadTophat/test_radiation_tophat.cpp
@@ -45,8 +45,7 @@ template <> struct RadSystem_Traits<TophatProblem> {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = false;
-	static constexpr int beta_order = 1;
+	static constexpr int beta_order = 0;
 };
 
 template <> struct Physics_Traits<TophatProblem> {

--- a/src/RadTube/test_radiation_tube.cpp
+++ b/src/RadTube/test_radiation_tube.cpp
@@ -62,7 +62,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr double c_hat = 10.0 * a0;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = C::k_B;
 	static constexpr amrex::GpuArray<double, Physics_Traits<TubeProblem>::nGroups + 1> radBoundaries{0., 3.3 * T0, inf}; // Kelvin
 	static constexpr int beta_order = 1;

--- a/src/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/RadhydroPulse/test_radhydro_pulse.cpp
@@ -54,7 +54,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = beta_order_;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
@@ -62,7 +61,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = beta_order_;
 };
 

--- a/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -59,7 +59,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = beta_order_;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
@@ -67,7 +66,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = beta_order_;
 };
 

--- a/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -51,7 +51,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
@@ -59,7 +58,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 2;
 };
 

--- a/src/RadhydroPulseMG/test_radhydro_pulse_MG.cpp
+++ b/src/RadhydroPulseMG/test_radhydro_pulse_MG.cpp
@@ -106,7 +106,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = h_planck;
 	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = rad_boundaries_;
 	static constexpr int beta_order = 1;
@@ -116,7 +115,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = h_planck;
 	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = rad_boundaries_;
 	static constexpr int beta_order = 1;

--- a/src/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/RadhydroShell/test_radhydro_shell.cpp
@@ -55,7 +55,6 @@ template <> struct RadSystem_Traits<ShellProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/RadhydroShock/test_radhydro_shock.cpp
@@ -58,7 +58,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -59,7 +59,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 };
 

--- a/src/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -58,7 +58,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = Erad_floor_;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = C::hplanck; // set boundary unit to Hz
 	static constexpr amrex::GpuArray<double, Physics_Traits<ShockProblem>::nGroups + 1> radBoundaries{
 	    1.00000000e+15, 3.16227766e+15, 1.00000000e+16, 3.16227766e+16, 1.00000000e+17, 3.16227766e+17, 1.00000000e+18, 3.16227766e+18, 1.00000000e+19};

--- a/src/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -46,7 +46,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.0;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = beta_order_;
 };
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1197,7 +1197,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					lorentz_factor = 1.0 / sqrt(1.0 - betaSqr);
 					lorentz_factor_v = lorentz_factor;
 					lorentz_factor_v_v = lorentz_factor;
-				} 
+				}
 
 				// 1. Compute energy exchange
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1180,6 +1180,8 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(Egas0 > 0.0);
 
 				const double betaSqr = (x1GasMom0 * x1GasMom0 + x2GasMom0 * x2GasMom0 + x3GasMom0 * x3GasMom0) / (rho * rho * c * c);
+
+				static_assert(beta_order_ <= 3);
 				if constexpr ((beta_order_ == 0) || (beta_order_ == 1)) {
 					lorentz_factor = 1.0;
 					lorentz_factor_v = 1.0;
@@ -1191,13 +1193,11 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					lorentz_factor = 1.0 + 0.5 * betaSqr;
 					lorentz_factor_v = 1.0 + 0.5 * betaSqr;
 					lorentz_factor_v_v = 1.0;
-				} else if constexpr (beta_order_ < 0) {
+				} else {
 					lorentz_factor = 1.0 / sqrt(1.0 - betaSqr);
 					lorentz_factor_v = lorentz_factor;
 					lorentz_factor_v_v = lorentz_factor;
-				} else {
-					AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "Invalid beta_order_ value.");
-				}
+				} 
 
 				// 1. Compute energy exchange
 

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -53,7 +53,6 @@ template <typename problem_t> struct RadSystem_Traits {
 	static constexpr double c_hat = c_light_cgs_;
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
-	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr double energy_unit = C::ev2erg;
 	static constexpr amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups + 1> radBoundaries = {0., inf};
 	static constexpr double beta_order = 1;
@@ -105,8 +104,6 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static constexpr double c_light_ = RadSystem_Traits<problem_t>::c_light;
 	static constexpr double c_hat_ = RadSystem_Traits<problem_t>::c_hat;
 	static constexpr double radiation_constant_ = RadSystem_Traits<problem_t>::radiation_constant;
-
-	static constexpr bool compute_v_over_c_terms_ = RadSystem_Traits<problem_t>::compute_v_over_c_terms;
 
 	static constexpr int beta_order_ = RadSystem_Traits<problem_t>::beta_order;
 
@@ -1183,7 +1180,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(Egas0 > 0.0);
 
 				const double betaSqr = (x1GasMom0 * x1GasMom0 + x2GasMom0 * x2GasMom0 + x3GasMom0 * x3GasMom0) / (rho * rho * c * c);
-				if constexpr (beta_order_ == 1) {
+				if constexpr ((beta_order_ == 0) || (beta_order_ == 1)) {
 					lorentz_factor = 1.0;
 					lorentz_factor_v = 1.0;
 				} else if constexpr (beta_order_ == 2) {
@@ -1199,7 +1196,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 					lorentz_factor_v = lorentz_factor;
 					lorentz_factor_v_v = lorentz_factor;
 				} else {
-					AMREX_ASSERT(false);
+					AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "Invalid beta_order_ value.");
 				}
 
 				// 1. Compute energy exchange
@@ -1231,7 +1228,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				AMREX_ASSERT(!kappaPVec.hasnan());
 				AMREX_ASSERT(!kappaEVec.hasnan());
 
-				if constexpr ((compute_v_over_c_terms_) && (include_work_term_in_source)) {
+				if constexpr ((beta_order_ != 0) && (include_work_term_in_source)) {
 					// compute the work term at the old state
 					// const double gamma = 1.0 / sqrt(1.0 - vsqr / (c * c));
 					if (ite == 0) {
@@ -1338,7 +1335,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index + numRadVars_ * g);
 				Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index + numRadVars_ * g);
 
-				if constexpr ((compute_v_over_c_terms_) && (gamma_ != 1.0) && (beta_order_ != 0)) {
+				if constexpr ((gamma_ != 1.0) && (beta_order_ != 0)) {
 					auto erad = EradVec_guess[g];
 					std::array<double, 3> gasVel{};
 					std::array<double, 3> v_terms{};
@@ -1436,7 +1433,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 			amrex::Real x3GasMom1 = consPrev(i, j, k, x3GasMomentum_index) + dMomentum[2];
 
 			// 3. Deal with the work term.
-			if constexpr ((gamma_ != 1.0) && (compute_v_over_c_terms_)) {
+			if constexpr ((gamma_ != 1.0) && (beta_order_ != 0)) {
 				// compute difference in gas kinetic energy before and after momentum update
 				amrex::Real const Egastot1 = ComputeEgasFromEint(rho, x1GasMom1, x2GasMom1, x3GasMom1, Egas_guess);
 				amrex::Real const Ekin1 = Egastot1 - Egas_guess;
@@ -1482,7 +1479,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				}
 			} // End of step 3
 
-			if constexpr ((!compute_v_over_c_terms_) || (gamma_ == 1.0) || (!include_work_term_in_source)) {
+			if constexpr ((beta_order_ == 0) || (gamma_ == 1.0) || (!include_work_term_in_source)) {
 				break;
 			}
 


### PR DESCRIPTION
### Description

I removed the redundant parameter `compute_v_over_c_terms` since now by setting `beta_order = 0` we achieve exactly the same effect as `compute_v_over_c_terms = false`. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
