### PR TITLE
fix clang-tidy comment-posting action

### DIFF
--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@9a32adc734e10e4d84baa60f2b7d7c021568c527
+      - uses: ZedThree/clang-tidy-review/post@v0.17.2
       # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
         # adjust options as necessary

--- a/.github/workflows/clang-tidy-comments.yml
+++ b/.github/workflows/clang-tidy-comments.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: ZedThree/clang-tidy-review/post@v0.17.2
+      - uses: ZedThree/clang-tidy-review/post@v0.18.0
       # lgtm_comment_body, max_comments, and annotations need to be set on the posting workflow in a split setup
         with:
         # adjust options as necessary

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: true
         fetch-depth: 0
 
-    - uses: ZedThree/clang-tidy-review@v0.17.2
+    - uses: ZedThree/clang-tidy-review@v0.18.0
       id: review
       with:
         config_file: src/.clang-tidy


### PR DESCRIPTION
### Description
This is another attempt to fix the clang-tidy action that posts comments on PRs.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
