### PR TITLE
add "experimental" warning for AMD and Intel GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ which should end with output similar to the following:
 
 Total Test time (real) = 353.77 sec
 ```
-### AMD GPUs
-Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Your MPI library **must** support GPU-aware MPI for AMD GPUs. Quokka has been tested on MI100 and MI250X GPUs.
+### AMD GPUs *(experimental, use at your own risk)*
+Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 5.2.0 or newer. Your MPI library **must** support GPU-aware MPI for AMD GPUs. Quokka has been tested on MI100 and MI250X GPUs, but there are known compiler issues that affect the correctness of simulation results (see https://github.com/quokka-astro/quokka/issues/394 and https://github.com/quokka-astro/quokka/issues/447).
 
-### Intel GPUs
+### Intel GPUs *(experimental, use at your own risk)*
 Not tested. You can attempt this by compiling with `-DAMReX_GPU_BACKEND=SYCL`. Please start a Discussion if you encounter issues on Intel GPUs. Your MPI library **must** support GPU-aware MPI for Intel GPUs.
 
 ## Building a specific test problem


### PR DESCRIPTION
### Description
There are known issues for AMD GPUs, so this is noted in the README.

Intel GPUs remain untested. Based on the other two GPU platforms, it is extremely likely that there are as-yet-undiscovered issues that will affect the code.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
