### PR TITLE
Fix Newton-Rasphon convergence bug when tau = 0

### DIFF
--- a/src/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -50,7 +50,7 @@ template <> struct Physics_Traits<ShockProblem> {
 	static constexpr bool is_radiation_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = false;
-	static constexpr int nGroups = 8;
+	static constexpr int nGroups = 5;
 };
 
 template <> struct RadSystem_Traits<ShockProblem> {
@@ -59,8 +59,8 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = Erad_floor_;
 	static constexpr double energy_unit = C::hplanck; // set boundary unit to Hz
-	static constexpr amrex::GpuArray<double, Physics_Traits<ShockProblem>::nGroups + 1> radBoundaries{
-	    1.00000000e+15, 3.16227766e+15, 1.00000000e+16, 3.16227766e+16, 1.00000000e+17, 3.16227766e+17, 1.00000000e+18, 3.16227766e+18, 1.00000000e+19};
+	static constexpr amrex::GpuArray<double, Physics_Traits<ShockProblem>::nGroups + 1> radBoundaries{1.00000000e+15, 1.00000000e+16, 1.00000000e+17,
+													  1.00000000e+18, 1.00000000e+19, 1.00000000e+20};
 	static constexpr int beta_order = 1;
 };
 
@@ -75,9 +75,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<ShockProblem>::ComputePl
     -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> kappaPVec{};
-	for (int i = 0; i < nGroups_; ++i) {
+	for (int i = 0; i < nGroups_ - 1; ++i) {
 		kappaPVec[i] = kappa / rho;
 	}
+	kappaPVec[nGroups_ - 1] = 0.0;
 	return kappaPVec;
 }
 


### PR DESCRIPTION
### Description

This is a replacement of #595 .

Since we base our Newton-Rasphon iteration on (E_gas, R), where R = tau (4 pi B / c - E), when tau = 0, E is not deducible from R. This causes division-by-zero error and E = NAN, which causes the iteration fail to converge. In this PR, I fixed this issue by enforcing d E_g = 0 when tau_g = 0. Here E_g is the radiation energy of the g'th photon group.

To validate this fix, I modified the ShockMultigroup test to include an extra redundant photon bin where kappa is set to 0.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
