### PR TITLE
fix typo in TabulatedCooling

### DIFF
--- a/src/TabulatedCooling.cpp
+++ b/src/TabulatedCooling.cpp
@@ -26,8 +26,8 @@ void readCloudyData(std::string &hdf5_file, cloudy_tables &cloudyTables)
 	initialize_cloudy_data(cloudy, hdf5_file, my_units);
 	cloudyTables.T_min = cloudy.T_min;
 	cloudyTables.T_max = cloudy.T_max;
-	cloudyTables.mmw_min = cloudyTables.mmw_min;
-	cloudyTables.mmw_max = cloudyTables.mmw_max;
+	cloudyTables.mmw_min = cloudy.mmw_min;
+	cloudyTables.mmw_max = cloudy.mmw_max;
 	cloudyTables.log_nH = std::make_unique<amrex::TableData<double, 1>>(copy_1d_table(cloudy.grid_parameters[0]));
 	cloudyTables.log_Tgas = std::make_unique<amrex::TableData<double, 1>>(copy_1d_table(cloudy.grid_parameters[1]));
 	cloudyTables.cooling = std::make_unique<amrex::TableData<double, 2>>(extract_2d_table(cloudy.cooling_data));
@@ -46,6 +46,7 @@ auto cloudy_tables::const_tables() const -> cloudyGpuConstTables
 				    T_max,
 				    mmw_min,
 				    mmw_max};
+
 	return tables;
 }
 


### PR DESCRIPTION
### Description
PR https://github.com/quokka-astro/quokka/pull/599 had a typo that causes simulations with `cloudy_cooling_tools` cooling to fail.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
