### PR TITLE
Update some default values for the PopIII test

### DIFF
--- a/tests/PopIII.in
+++ b/tests/PopIII.in
@@ -39,7 +39,7 @@ perturb.rms_velocity = 1.8050e5 #initial cloud rms velocity (to drive turbulence
 
 # params for jeans refinement
 jeansRefine.ncells = 64 #refine on these many cells per jeans length
-jeansRefine.density_threshold = 2e-20 #do not refine if density is less than this density
+jeansRefine.density_threshold = 5e-21 #do not refine if density is less than this density
 
 # density floor for popiii
 density_floor = 1e-25
@@ -59,7 +59,7 @@ primordial_chem.temperature = 0.26415744E+003
 primordial_chem.small_temp = 1.e1
 primordial_chem.small_dens = 1.e-60
 primordial_chem.max_density_allowed = 3e-6
-primordial_chem.min_density_allowed = 1e-21
+primordial_chem.min_density_allowed = 5e-21
 #format in krome fort22_wD.dat file: E H- D- H HE H2 HD D H+ HE+ H2+ D+ HD+ HE++
 #format in quokka: E H+ H H- D+ D H2+ D- H2 HD+ HD HE++ HE+ HE
 primordial_chem.primary_species_1 = 0.88499253E-006


### PR DESCRIPTION
### Description
Slightly lowering the jeans density refinement threshold and raising the density threshold for chemistry avoids a crash due to VODE in the background region.

### Related issues

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
