### PR TITLE
If microphysics burn fails, retry hydro

### DIFF
--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -165,7 +165,7 @@ template <typename problem_t> auto computeChemistry(amrex::MultiFab &mf, const R
 
 	if (!burn_success) {
 		// amrex::Abort("Burn failed in VODE. Aborting.");
-		amrex::Print() << "WARNNING: Unsuccessful burn. Retrying hydro step."
+		amrex::Print() << "\t>> WARNING: Unsuccessful burn. Retrying hydro step."
 			       << "\n";
 	}
 

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -26,177 +26,174 @@
 namespace quokka::chemistry
 {
 
-constexpr int max_retries = 5; // Maximum number of retries
+constexpr int max_retries = 5;		  // Maximum number of retries
 constexpr Real dt_reduction_factor = 0.5; // Factor by which to reduce the timestep
 
 AMREX_GPU_DEVICE void chemburner(burn_t &chemstate, Real dt);
 
 template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, Real dt, const Real max_density_allowed, const Real min_density_allowed)
 {
-    // Start off by assuming a successful burn.
-    int burn_success = 1;
+	// Start off by assuming a successful burn.
+	int burn_success = 1;
 
-    amrex::Gpu::Buffer<int> d_num_failed({0});
-    auto *p_num_failed = d_num_failed.data();
+	amrex::Gpu::Buffer<int> d_num_failed({0});
+	auto *p_num_failed = d_num_failed.data();
 
-    int num_failed = 0;
+	int num_failed = 0;
 
-    const BL_PROFILE("Chemistry::computeChemistry()");
+	const BL_PROFILE("Chemistry::computeChemistry()");
 
-    // Loop for retries
-    for (int retry = 0; retry < max_retries; ++retry)
-    {
-        burn_success = 1; // Reset burn_success flag
+	// Loop for retries
+	for (int retry = 0; retry < max_retries; ++retry) {
+		burn_success = 1; // Reset burn_success flag
 
-        // Loop over MultiFab
-        for (amrex::MFIter iter(mf); iter.isValid(); ++iter)
-        {
-            const amrex::Box &indexRange = iter.validbox();
-            auto const &state = mf.array(iter);
+		// Loop over MultiFab
+		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
+			const amrex::Box &indexRange = iter.validbox();
+			auto const &state = mf.array(iter);
 
-            // Perform burn computation
-            amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
-                const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-                const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-                const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-                const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
-                const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
+			// Perform burn computation
+			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+				const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
+				const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+				const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+				const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+				const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
+				const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
 
-                std::array<Real, NumSpec> chem = {-1.0};
-                std::array<Real, NumSpec> inmfracs = {-1.0};
-                Real insum = 0.0_rt;
+				std::array<Real, NumSpec> chem = {-1.0};
+				std::array<Real, NumSpec> inmfracs = {-1.0};
+				Real insum = 0.0_rt;
 
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
-                            rho; // state has partial densities, so divide by rho to get mass fractions
-                }
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
+						   rho; // state has partial densities, so divide by rho to get mass fractions
+				}
 
-                // do chemistry using microphysics
+				// do chemistry using microphysics
 
-                burn_t chemstate;
-                chemstate.success = true;
-                int burn_failed = 0;
+				burn_t chemstate;
+				chemstate.success = true;
+				int burn_failed = 0;
 
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    inmfracs[nn] = chem[nn] * rho / spmasses[nn];
-                    chemstate.xn[nn] = inmfracs[nn];
-                }
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					inmfracs[nn] = chem[nn] * rho / spmasses[nn];
+					chemstate.xn[nn] = inmfracs[nn];
+				}
 
-                // dont do chemistry in cells with densities below the minimum density specified
-                if (rho < min_density_allowed) {
-                    return;
-                }
+				// dont do chemistry in cells with densities below the minimum density specified
+				if (rho < min_density_allowed) {
+					return;
+				}
 
-                // stop the test if we have reached very high densities
-                if (rho > max_density_allowed) {
-                    amrex::Abort("Density exceeded max_density_allowed!");
-                }
+				// stop the test if we have reached very high densities
+				if (rho > max_density_allowed) {
+					amrex::Abort("Density exceeded max_density_allowed!");
+				}
 
-                // input density and eint in burn state
-                // Microphysics needs specific eint
-                chemstate.rho = rho;
-                chemstate.e = Eint / rho;
+				// input density and eint in burn state
+				// Microphysics needs specific eint
+				chemstate.rho = rho;
+				chemstate.e = Eint / rho;
 
-                // call the EOS to set initial internal energy e
-                eos(eos_input_re, chemstate);
+				// call the EOS to set initial internal energy e
+				eos(eos_input_re, chemstate);
 
-                // do the actual integration
-                // do it in .cpp so that it is not built at compile time for all tests
-                // which would otherwise slow down compilation due to the large RHS file
-                chemburner(chemstate, dt);
+				// do the actual integration
+				// do it in .cpp so that it is not built at compile time for all tests
+				// which would otherwise slow down compilation due to the large RHS file
+				chemburner(chemstate, dt);
 
-                if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
-                    amrex::Abort("Burner returned NAN");
-                }
+				if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
+					amrex::Abort("Burner returned NAN");
+				}
 
-                if (!chemstate.success) {
-                    burn_failed = 1;
-                }
+				if (!chemstate.success) {
+					burn_failed = 1;
+				}
 
-                if (burn_failed) {
-                    amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
-                }
+				if (burn_failed) {
+					amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
+				}
 
-                // ensure positivity and normalize
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-                    inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-                    insum += inmfracs[nn];
-                }
+				// ensure positivity and normalize
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+					inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+					insum += inmfracs[nn];
+				}
 
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    inmfracs[nn] /= insum;
-                    // update the number densities with conserved mass fractions
-                    chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-                }
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					inmfracs[nn] /= insum;
+					// update the number densities with conserved mass fractions
+					chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+				}
 
-                // update the number density of electrons due to charge conservation
-                // TODO(psharda): generalize this to other chem networks
-                chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
-                        chemstate.xn[9] + 2.0 * chemstate.xn[11];
+				// update the number density of electrons due to charge conservation
+				// TODO(psharda): generalize this to other chem networks
+				chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
+						  chemstate.xn[9] + 2.0 * chemstate.xn[11];
 
-                // reconserve mass fractions post charge conservation
-                insum = 0;
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-                    inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-                    insum += inmfracs[nn];
-                }
+				// reconserve mass fractions post charge conservation
+				insum = 0;
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+					inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+					insum += inmfracs[nn];
+				}
 
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    inmfracs[nn] /= insum;
-                    // update the number densities with conserved mass fractions
-                    chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-                }
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					inmfracs[nn] /= insum;
+					// update the number densities with conserved mass fractions
+					chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+				}
 
-                // get the updated specific eint
-                eos(eos_input_rt, chemstate);
+				// get the updated specific eint
+				eos(eos_input_rt, chemstate);
 
-                // get dEint
-                // Quokka uses rho*eint
-                const Real dEint = (chemstate.e * chemstate.rho) - Eint;
-                state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
-                state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
+				// get dEint
+				// Quokka uses rho*eint
+				const Real dEint = (chemstate.e * chemstate.rho) - Eint;
+				state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
+				state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
 
-                for (int nn = 0; nn < NumSpec; ++nn) {
-                    state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) = inmfracs[nn] * rho; // scale by rho to return partial densities
-                }
-            });
+				for (int nn = 0; nn < NumSpec; ++nn) {
+					state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) =
+					    inmfracs[nn] * rho; // scale by rho to return partial densities
+				}
+			});
 
 #if defined(AMREX_USE_HIP)
-            amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
+			amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
-        }
+		}
 
-        num_failed = *(d_num_failed.copyToHost());
+		num_failed = *(d_num_failed.copyToHost());
 
-        burn_success = !num_failed;
-        amrex::ParallelDescriptor::ReduceIntMin(burn_success);
+		burn_success = !num_failed;
+		amrex::ParallelDescriptor::ReduceIntMin(burn_success);
 
-        // If burn was successful, break out of the retry loop
-        if (burn_success)
-            break;
+		// If burn was successful, break out of the retry loop
+		if (burn_success)
+			break;
 
-        // If burn was not successful and we haven't reached max retries, reduce the timestep
-        if (retry < max_retries - 1)
-        {
-            // Reduce timestep
-            Real new_dt = dt * dt_reduction_factor;
+		// If burn was not successful and we haven't reached max retries, reduce the timestep
+		if (retry < max_retries - 1) {
+			// Reduce timestep
+			Real new_dt = dt * dt_reduction_factor;
 
-            // Output information about reduced timestep
-            amrex::Print() << "Burn failed. Reducing timestep to " << new_dt << std::endl;
+			// Output information about reduced timestep
+			amrex::Print() << "Burn failed. Reducing timestep to " << new_dt << std::endl;
 
-            // Update dt for the next iteration
-            dt = new_dt;
-        }
-    }
+			// Update dt for the next iteration
+			dt = new_dt;
+		}
+	}
 
-    // If burn was not successful after max retries, abort
-    if (!burn_success)
-    {
-        amrex::Abort("Burn failed after max retries.");
-    }
+	// If burn was not successful after max retries, abort
+	if (!burn_success) {
+		amrex::Abort("Burn failed after max retries.");
+	}
 }
 
 } // namespace quokka::chemistry

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -26,146 +26,177 @@
 namespace quokka::chemistry
 {
 
+constexpr int max_retries = 5; // Maximum number of retries
+constexpr Real dt_reduction_factor = 0.5; // Factor by which to reduce the timestep
+
 AMREX_GPU_DEVICE void chemburner(burn_t &chemstate, Real dt);
 
-template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const Real dt, const Real max_density_allowed, const Real min_density_allowed)
+template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, Real dt, const Real max_density_allowed, const Real min_density_allowed)
 {
+    // Start off by assuming a successful burn.
+    int burn_success = 1;
 
-	// Start off by assuming a successful burn.
-	int burn_success = 1;
+    amrex::Gpu::Buffer<int> d_num_failed({0});
+    auto *p_num_failed = d_num_failed.data();
 
-	amrex::Gpu::Buffer<int> d_num_failed({0});
-	auto *p_num_failed = d_num_failed.data();
+    int num_failed = 0;
 
-	int num_failed = 0;
+    const BL_PROFILE("Chemistry::computeChemistry()");
 
-	const BL_PROFILE("Chemistry::computeChemistry()");
-	for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox();
-		auto const &state = mf.array(iter);
+    // Loop for retries
+    for (int retry = 0; retry < max_retries; ++retry)
+    {
+        burn_success = 1; // Reset burn_success flag
 
-		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
-			const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-			const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-			const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-			const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
-			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
+        // Loop over MultiFab
+        for (amrex::MFIter iter(mf); iter.isValid(); ++iter)
+        {
+            const amrex::Box &indexRange = iter.validbox();
+            auto const &state = mf.array(iter);
 
-			std::array<Real, NumSpec> chem = {-1.0};
-			std::array<Real, NumSpec> inmfracs = {-1.0};
-			Real insum = 0.0_rt;
+            // Perform burn computation
+            amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
+                const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+                const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+                const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+                const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
+                const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
 
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
-					   rho; // state has partial densities, so divide by rho to get mass fractions
-			}
+                std::array<Real, NumSpec> chem = {-1.0};
+                std::array<Real, NumSpec> inmfracs = {-1.0};
+                Real insum = 0.0_rt;
 
-			// do chemistry using microphysics
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
+                            rho; // state has partial densities, so divide by rho to get mass fractions
+                }
 
-			burn_t chemstate;
-			chemstate.success = true;
-			int burn_failed = 0;
+                // do chemistry using microphysics
 
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				inmfracs[nn] = chem[nn] * rho / spmasses[nn];
-				chemstate.xn[nn] = inmfracs[nn];
-			}
+                burn_t chemstate;
+                chemstate.success = true;
+                int burn_failed = 0;
 
-			// dont do chemistry in cells with densities below the minimum density specified
-			if (rho < min_density_allowed) {
-				return;
-			}
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    inmfracs[nn] = chem[nn] * rho / spmasses[nn];
+                    chemstate.xn[nn] = inmfracs[nn];
+                }
 
-			// stop the test if we have reached very high densities
-			if (rho > max_density_allowed) {
-				amrex::Abort("Density exceeded max_density_allowed!");
-			}
+                // dont do chemistry in cells with densities below the minimum density specified
+                if (rho < min_density_allowed) {
+                    return;
+                }
 
-			// input density and eint in burn state
-			// Microphysics needs specific eint
-			chemstate.rho = rho;
-			chemstate.e = Eint / rho;
+                // stop the test if we have reached very high densities
+                if (rho > max_density_allowed) {
+                    amrex::Abort("Density exceeded max_density_allowed!");
+                }
 
-			// call the EOS to set initial internal energy e
-			eos(eos_input_re, chemstate);
+                // input density and eint in burn state
+                // Microphysics needs specific eint
+                chemstate.rho = rho;
+                chemstate.e = Eint / rho;
 
-			// do the actual integration
-			// do it in .cpp so that it is not built at compile time for all tests
-			// which would otherwise slow down compilation due to the large RHS file
-			chemburner(chemstate, dt);
+                // call the EOS to set initial internal energy e
+                eos(eos_input_re, chemstate);
 
-			if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
-				amrex::Abort("Burner returned NAN");
-			}
+                // do the actual integration
+                // do it in .cpp so that it is not built at compile time for all tests
+                // which would otherwise slow down compilation due to the large RHS file
+                chemburner(chemstate, dt);
 
-			if (!chemstate.success) {
-				burn_failed = 1;
-			}
+                if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
+                    amrex::Abort("Burner returned NAN");
+                }
 
-			if (burn_failed) {
-				amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
-			}
+                if (!chemstate.success) {
+                    burn_failed = 1;
+                }
 
-			// ensure positivity and normalize
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-				inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-				insum += inmfracs[nn];
-			}
+                if (burn_failed) {
+                    amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
+                }
 
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				inmfracs[nn] /= insum;
-				// update the number densities with conserved mass fractions
-				chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-			}
+                // ensure positivity and normalize
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+                    inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+                    insum += inmfracs[nn];
+                }
 
-			// update the number density of electrons due to charge conservation
-			// TODO(psharda): generalize this to other chem networks
-			chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
-					  chemstate.xn[9] + 2.0 * chemstate.xn[11];
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    inmfracs[nn] /= insum;
+                    // update the number densities with conserved mass fractions
+                    chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+                }
 
-			// reconserve mass fractions post charge conservation
-			insum = 0;
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-				inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-				insum += inmfracs[nn];
-			}
+                // update the number density of electrons due to charge conservation
+                // TODO(psharda): generalize this to other chem networks
+                chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
+                        chemstate.xn[9] + 2.0 * chemstate.xn[11];
 
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				inmfracs[nn] /= insum;
-				// update the number densities with conserved mass fractions
-				chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-			}
+                // reconserve mass fractions post charge conservation
+                insum = 0;
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+                    inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+                    insum += inmfracs[nn];
+                }
 
-			// get the updated specific eint
-			eos(eos_input_rt, chemstate);
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    inmfracs[nn] /= insum;
+                    // update the number densities with conserved mass fractions
+                    chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+                }
 
-			// get dEint
-			// Quokka uses rho*eint
-			const Real dEint = (chemstate.e * chemstate.rho) - Eint;
-			state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
-			state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
+                // get the updated specific eint
+                eos(eos_input_rt, chemstate);
 
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) = inmfracs[nn] * rho; // scale by rho to return partial densities
-			}
-		});
+                // get dEint
+                // Quokka uses rho*eint
+                const Real dEint = (chemstate.e * chemstate.rho) - Eint;
+                state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
+                state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
+
+                for (int nn = 0; nn < NumSpec; ++nn) {
+                    state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) = inmfracs[nn] * rho; // scale by rho to return partial densities
+                }
+            });
 
 #if defined(AMREX_USE_HIP)
-		amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
+            amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
-	}
+        }
 
-	num_failed = *(d_num_failed.copyToHost());
+        num_failed = *(d_num_failed.copyToHost());
 
-	burn_success = !num_failed;
-	amrex::ParallelDescriptor::ReduceIntMin(burn_success);
+        burn_success = !num_failed;
+        amrex::ParallelDescriptor::ReduceIntMin(burn_success);
 
-	if (!burn_success) {
-		amrex::Abort("Burn failed in VODE. Aborting.");
-	}
+        // If burn was successful, break out of the retry loop
+        if (burn_success)
+            break;
+
+        // If burn was not successful and we haven't reached max retries, reduce the timestep
+        if (retry < max_retries - 1)
+        {
+            // Reduce timestep
+            Real new_dt = dt * dt_reduction_factor;
+
+            // Output information about reduced timestep
+            amrex::Print() << "Burn failed. Reducing timestep to " << new_dt << std::endl;
+
+            // Update dt for the next iteration
+            dt = new_dt;
+        }
+    }
+
+    // If burn was not successful after max retries, abort
+    if (!burn_success)
+    {
+        amrex::Abort("Burn failed after max retries.");
+    }
 }
 
 } // namespace quokka::chemistry

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -165,7 +165,8 @@ template <typename problem_t> auto computeChemistry(amrex::MultiFab &mf, const R
 
 	if (!burn_success) {
 		// amrex::Abort("Burn failed in VODE. Aborting.");
-		amrex::Print() << "WARNNING: Unsuccessful burn. Retrying hydro step." << "\n";
+		amrex::Print() << "WARNNING: Unsuccessful burn. Retrying hydro step."
+			       << "\n";
 	}
 
 	return burn_success;

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -174,8 +174,9 @@ template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, Real dt
 		amrex::ParallelDescriptor::ReduceIntMin(burn_success);
 
 		// If burn was successful, break out of the retry loop
-		if (burn_success)
+		if (burn_success) {
 			break;
+		}
 
 		// If burn was not successful and we haven't reached max retries, reduce the timestep
 		if (retry < max_retries - 1) {

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -28,7 +28,7 @@ namespace quokka::chemistry
 
 AMREX_GPU_DEVICE void chemburner(burn_t &chemstate, Real dt);
 
-template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const Real dt, const Real max_density_allowed, const Real min_density_allowed)
+template <typename problem_t> auto computeChemistry(amrex::MultiFab &mf, const Real dt, const Real max_density_allowed, const Real min_density_allowed) -> bool
 {
 
 	// Start off by assuming a successful burn.
@@ -164,8 +164,11 @@ template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const R
 	amrex::ParallelDescriptor::ReduceIntMin(burn_success);
 
 	if (!burn_success) {
-		amrex::Abort("Burn failed in VODE. Aborting.");
+		// amrex::Abort("Burn failed in VODE. Aborting.");
+		amrex::Print() << "WARNNING: Unsuccessful burn. Retrying hydro step." << "\n";
 	}
+
+	return burn_success;
 }
 
 } // namespace quokka::chemistry

--- a/src/Chemistry.hpp
+++ b/src/Chemistry.hpp
@@ -31,141 +31,141 @@ AMREX_GPU_DEVICE void chemburner(burn_t &chemstate, Real dt);
 template <typename problem_t> void computeChemistry(amrex::MultiFab &mf, const Real dt, const Real max_density_allowed, const Real min_density_allowed)
 {
 
-    // Start off by assuming a successful burn.
-    int burn_success = 1;
+	// Start off by assuming a successful burn.
+	int burn_success = 1;
 
-    amrex::Gpu::Buffer<int> d_num_failed({0});
-    auto *p_num_failed = d_num_failed.data();
+	amrex::Gpu::Buffer<int> d_num_failed({0});
+	auto *p_num_failed = d_num_failed.data();
 
-    int num_failed = 0;
+	int num_failed = 0;
 
-    const BL_PROFILE("Chemistry::computeChemistry()");
-    for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
-        const amrex::Box &indexRange = iter.validbox();
-        auto const &state = mf.array(iter);
+	const BL_PROFILE("Chemistry::computeChemistry()");
+	for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &state = mf.array(iter);
 
-        amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
-            const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-            const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-            const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-            const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
-            const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			const Real rho = state(i, j, k, HydroSystem<problem_t>::density_index);
+			const Real xmom = state(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+			const Real ymom = state(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+			const Real zmom = state(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+			const Real Ener = state(i, j, k, HydroSystem<problem_t>::energy_index);
+			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
 
-            std::array<Real, NumSpec> chem = {-1.0};
-            std::array<Real, NumSpec> inmfracs = {-1.0};
-            Real insum = 0.0_rt;
+			std::array<Real, NumSpec> chem = {-1.0};
+			std::array<Real, NumSpec> inmfracs = {-1.0};
+			Real insum = 0.0_rt;
 
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
-                       rho; // state has partial densities, so divide by rho to get mass fractions
-            }
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				chem[nn] = state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) /
+					   rho; // state has partial densities, so divide by rho to get mass fractions
+			}
 
-            // do chemistry using microphysics
+			// do chemistry using microphysics
 
-            burn_t chemstate;
-            chemstate.success = true;
-            int burn_failed = 0;
+			burn_t chemstate;
+			chemstate.success = true;
+			int burn_failed = 0;
 
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                inmfracs[nn] = chem[nn] * rho / spmasses[nn];
-                chemstate.xn[nn] = inmfracs[nn];
-            }
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				inmfracs[nn] = chem[nn] * rho / spmasses[nn];
+				chemstate.xn[nn] = inmfracs[nn];
+			}
 
-            // dont do chemistry in cells with densities below the minimum density specified
-            if (rho < min_density_allowed) {
-                return;
-            }
+			// dont do chemistry in cells with densities below the minimum density specified
+			if (rho < min_density_allowed) {
+				return;
+			}
 
-            // stop the test if we have reached very high densities
-            if (rho > max_density_allowed) {
-                amrex::Abort("Density exceeded max_density_allowed!");
-            }
+			// stop the test if we have reached very high densities
+			if (rho > max_density_allowed) {
+				amrex::Abort("Density exceeded max_density_allowed!");
+			}
 
-            // input density and eint in burn state
-            // Microphysics needs specific eint
-            chemstate.rho = rho;
-            chemstate.e = Eint / rho;
+			// input density and eint in burn state
+			// Microphysics needs specific eint
+			chemstate.rho = rho;
+			chemstate.e = Eint / rho;
 
-            // call the EOS to set initial internal energy e
-            eos(eos_input_re, chemstate);
+			// call the EOS to set initial internal energy e
+			eos(eos_input_re, chemstate);
 
-            // do the actual integration
-            // do it in .cpp so that it is not built at compile time for all tests
-            // which would otherwise slow down compilation due to the large RHS file
-            chemburner(chemstate, dt);
+			// do the actual integration
+			// do it in .cpp so that it is not built at compile time for all tests
+			// which would otherwise slow down compilation due to the large RHS file
+			chemburner(chemstate, dt);
 
-            if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
-                amrex::Abort("Burner returned NAN");
-            }
+			if (std::isnan(chemstate.xn[0]) || std::isnan(chemstate.rho)) {
+				amrex::Abort("Burner returned NAN");
+			}
 
-            if (!chemstate.success) {
-                burn_failed = 1;
-            }
+			if (!chemstate.success) {
+				burn_failed = 1;
+			}
 
-            if (burn_failed) {
-                amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
-            }
+			if (burn_failed) {
+				amrex::Gpu::Atomic::Add(p_num_failed, burn_failed);
+			}
 
-            // ensure positivity and normalize
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-                inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-                insum += inmfracs[nn];
-            }
+			// ensure positivity and normalize
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+				inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+				insum += inmfracs[nn];
+			}
 
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                inmfracs[nn] /= insum;
-                // update the number densities with conserved mass fractions
-                chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-            }
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				inmfracs[nn] /= insum;
+				// update the number densities with conserved mass fractions
+				chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+			}
 
-            // update the number density of electrons due to charge conservation
-            // TODO(psharda): generalize this to other chem networks
-            chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
-                      chemstate.xn[9] + 2.0 * chemstate.xn[11];
+			// update the number density of electrons due to charge conservation
+			// TODO(psharda): generalize this to other chem networks
+			chemstate.xn[0] = -chemstate.xn[3] - chemstate.xn[7] + chemstate.xn[1] + chemstate.xn[12] + chemstate.xn[6] + chemstate.xn[4] +
+					  chemstate.xn[9] + 2.0 * chemstate.xn[11];
 
-            // reconserve mass fractions post charge conservation
-            insum = 0;
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
-                inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
-                insum += inmfracs[nn];
-            }
+			// reconserve mass fractions post charge conservation
+			insum = 0;
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				chemstate.xn[nn] = amrex::max(chemstate.xn[nn], small_x);
+				inmfracs[nn] = spmasses[nn] * chemstate.xn[nn] / chemstate.rho;
+				insum += inmfracs[nn];
+			}
 
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                inmfracs[nn] /= insum;
-                // update the number densities with conserved mass fractions
-                chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
-            }
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				inmfracs[nn] /= insum;
+				// update the number densities with conserved mass fractions
+				chemstate.xn[nn] = inmfracs[nn] * chemstate.rho / spmasses[nn];
+			}
 
-            // get the updated specific eint
-            eos(eos_input_rt, chemstate);
+			// get the updated specific eint
+			eos(eos_input_rt, chemstate);
 
-            // get dEint
-            // Quokka uses rho*eint
-            const Real dEint = (chemstate.e * chemstate.rho) - Eint;
-            state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
-            state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
+			// get dEint
+			// Quokka uses rho*eint
+			const Real dEint = (chemstate.e * chemstate.rho) - Eint;
+			state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) += dEint;
+			state(i, j, k, HydroSystem<problem_t>::energy_index) += dEint;
 
-            for (int nn = 0; nn < NumSpec; ++nn) {
-                state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) = inmfracs[nn] * rho; // scale by rho to return partial densities
-            }
-        });
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				state(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) = inmfracs[nn] * rho; // scale by rho to return partial densities
+			}
+		});
 
 #if defined(AMREX_USE_HIP)
-        amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
+		amrex::Gpu::streamSynchronize(); // otherwise HIP may fail to allocate the necessary resources.
 #endif
-    }
+	}
 
-    num_failed = *(d_num_failed.copyToHost());
+	num_failed = *(d_num_failed.copyToHost());
 
-    burn_success = !num_failed;
-    amrex::ParallelDescriptor::ReduceIntMin(burn_success);
+	burn_success = !num_failed;
+	amrex::ParallelDescriptor::ReduceIntMin(burn_success);
 
-    if (!burn_success) {
-        amrex::Abort("Burn failed in VODE. Aborting.");
-    }
+	if (!burn_success) {
+		amrex::Abort("Burn failed in VODE. Aborting.");
+	}
 }
 
 } // namespace quokka::chemistry

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -1041,7 +1041,6 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 		return burn_success_first;
 	}
 
-
 	// create temporary multifab for intermediate state
 	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 	state_inter_cc_.setVal(0); // prevent assert in fillBoundaryConditions when radiation is enabled

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -230,7 +230,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 				 amrex::Real time, amrex::Real dt_lev) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev);
-	void addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev);
+	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
 
 	auto isCflViolated(int lev, amrex::Real time, amrex::Real dt_actual) -> bool;
 
@@ -507,8 +507,12 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::addStrangSplit
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt)
+auto RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt) -> bool
 {
+
+	// start by assuming chemistry burn is successful.
+	bool burn_success = true;
+
 	if (enableCooling_ == 1) {
 		// compute cooling
 		if (coolingTableType_ == "grackle") {
@@ -523,12 +527,14 @@ void RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::Mult
 #ifdef PRIMORDIAL_CHEM
 	if (enableChemistry_ == 1) {
 		// compute chemistry
-		quokka::chemistry::computeChemistry<problem_t>(state, dt, max_density_allowed, min_density_allowed);
+		burn_success = quokka::chemistry::computeChemistry<problem_t>(state, dt, max_density_allowed, min_density_allowed);
 	}
 #endif
 
 	// compute user-specified sources
 	addStrangSplitSources(state, lev, time, dt);
+
+	return burn_success;
 }
 
 template <typename problem_t>
@@ -1028,7 +1034,7 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 	auto dx = geom[lev].CellSizeArray();
 
 	// do Strang split source terms (first half-step)
-	addStrangSplitSourcesWithBuiltin(state_old_cc_tmp, lev, time, 0.5 * dt_lev);
+	auto burn_success_first = addStrangSplitSourcesWithBuiltin(state_old_cc_tmp, lev, time, 0.5 * dt_lev);
 
 	// create temporary multifab for intermediate state
 	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
@@ -1290,10 +1296,10 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 #endif
 
 	// do Strang split source terms (second half-step)
-	addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
+	auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
 
-	// check if we have violated the CFL timestep
-	return !isCflViolated(lev, time, dt_lev);
+	// check if we have violated the CFL timestep or burn failed in chemistry
+	return (!isCflViolated(lev, time, dt_lev) && burn_success_first && burn_success_second);
 }
 
 template <typename problem_t>

--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -511,7 +511,7 @@ auto RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::Mult
 {
 
 	// start by assuming chemistry burn is successful.
-	bool burn_success = true;
+	bool burn_success = true; // NOLINT
 
 	if (enableCooling_ == 1) {
 		// compute cooling

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1269,7 +1269,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 
 	if (Verbose()) {
 		amrex::Print() << "[Level " << lev << " step " << istep[lev] + 1 << "] ";
-		amrex::Print() << "ADVANCE with time = " << tNew_[lev] << " dt = " << dt_[lev] << '\n';
+		amrex::Print() << "ADVANCE with time = " << std::scientific << tNew_[lev] << " dt = " << std::scientific << dt_[lev] << '\n';
 	}
 
 	// Advance a single level for a single time step, and update flux registers


### PR DESCRIPTION
### Description
If the (VODE) burn fails in microphysics, we should retry hydro with a reduced timestep, just like we retry hydro with a reduced timestep if the CFL is violated.

These changes have been successfully tested on CPUs and GPUs.

### Related issues
PopIII test on NVIDIA GPUs crashes due to a burn failure in VODE. This did not occur on AMD GPUs at the same timestep.

Resolves #372 for chemistry

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
