### PR TITLE
run test suite with Intel oneAPI compiler on CPU

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -33,6 +33,8 @@ do
         intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mkl-devel \
         intel-oneapi-mpi-devel \
+        python3-dev python3-numpy python3-matplotlib \
+        libhdf5-mpi-dev \
         && { sudo apt-get clean; status=0; break; }  \
         || { sleep 10; }
 done

--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The AMReX Community
+#
+# License: BSD-3-Clause-LBNL
+# Authors: Axel Huebl
+
+set -eu -o pipefail
+
+# `man apt.conf`:
+#   Number of retries to perform. If this is non-zero APT will retry
+#   failed files the given number of times.
+echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
+
+# Ref.: https://github.com/rscohn2/oneapi-ci
+# intel-basekit intel-hpckit are too large in size
+
+# download the key to system keyring
+wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+| gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+# add signed entry to apt sources and configure the APT client to use Intel repository:
+echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+
+sudo apt-get update
+
+# try apt install up to five times, to avoid connection splits
+status=1
+for itry in {1..5}
+do
+    sudo apt-get install -y --no-install-recommends \
+        build-essential \
+        intel-oneapi-compiler-dpcpp-cpp \
+        intel-oneapi-mkl-devel \
+        intel-oneapi-mpi-devel \
+        && { sudo apt-get clean; status=0; break; }  \
+        || { sleep 10; }
+done
+if [[ ${status} -ne 0 ]]; then exit 1; fi

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,0 +1,65 @@
+name: intel
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-intel
+  cancel-in-progress: true
+
+jobs:
+  tests-oneapi-sycl:
+    name: oneAPI SYCL [tests]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Dependencies
+      run: |
+        .github/workflows/dependencies/dependencies_dpcpp.sh
+        .github/workflows/dependencies/dependencies_ccache.sh
+    - name: Set Up Cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+    - name: Build & Install
+      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
+      run: |
+        export CCACHE_COMPRESS=1
+        export CCACHE_COMPRESSLEVEL=10
+        export CCACHE_MAXSIZE=45M
+        export CCACHE_DEPEND=1
+        ccache -z
+
+        set +e
+        source /opt/intel/oneapi/setvars.sh
+        set -e
+        cmake -S . -B build                                \
+            -DCMAKE_VERBOSE_MAKEFILE=ON                    \
+            -DAMReX_EB=OFF                                 \
+            -DAMReX_ENABLE_TESTS=ON                        \
+            -DAMReX_GPU_BACKEND=SYCL                       \
+            -DCMAKE_C_COMPILER=$(which icx)                \
+            -DCMAKE_CXX_COMPILER=$(which icpx)             \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache           \
+            -DAMReX_PARALLEL_LINK_JOBS=4
+        cmake --build build --parallel 4
+
+        ccache -s
+        du -hs ~/.cache/ccache
+
+  save_pr_number:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > pr_number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+          retention-days: 1

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,9 +1,16 @@
 name: intel
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ development ]
+  merge_group:
+    branches: [ development ]
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.head_ref }}-intel
+  group: ${{ github.ref }}-${{ github.head_ref }}-cmake-intel
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -29,7 +29,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
              
     - name: Build & Install
-      env: {CXXFLAGS: "-ffp-model=precise -fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
+      env: {CXXFLAGS: "-ffp-model=precise -fno-operator-names"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -44,7 +44,7 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache           \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
         cmake --build build --parallel 4
 
         ccache -s

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -40,12 +40,11 @@ jobs:
         set -e
         cmake -S . -B build                                \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_EB=OFF                                 \
-            -DAMReX_ENABLE_TESTS=ON                        \
             -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache           \
+            -DCMAKE_CXX_FLAGS="-ffp-model=precise"         \
             -DAMReX_PARALLEL_LINK_JOBS=4
         cmake --build build --parallel 4
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -40,7 +40,6 @@ jobs:
         set -e
         cmake -S . -B build                                \
             -DCMAKE_VERBOSE_MAKEFILE=ON                    \
-            -DAMReX_GPU_BACKEND=SYCL                       \
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache           \

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -14,7 +14,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_dpcpp.sh
@@ -49,7 +48,17 @@ jobs:
 
         ccache -s
         du -hs ~/.cache/ccache
-
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ctest --output-on-failure -C $BUILD_TYPE
+    - name: Upload test output
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results
+        path: ${{github.workspace}}/tests
+        
   save_pr_number:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -57,7 +57,6 @@ jobs:
       
     - name: Run tests
       working-directory: ${{runner.workspace}}/build
-      shell: bash
       run: ctest --output-on-failure -C $BUILD_TYPE
       
     - name: Upload test output

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   tests-oneapi-sycl:
-    name: oneAPI SYCL [tests]
+    name: oneAPI CPU [tests]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -29,7 +29,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
              
     - name: Build & Install
-      env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
+      env: {CXXFLAGS: "-ffp-model=precise -fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
       run: |
         export CCACHE_COMPRESS=1
         export CCACHE_COMPRESSLEVEL=10
@@ -45,8 +45,6 @@ jobs:
             -DCMAKE_C_COMPILER=$(which icx)                \
             -DCMAKE_CXX_COMPILER=$(which icpx)             \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache           \
-            -DCMAKE_CXX_FLAGS="-ffp-model=precise"         \
-            -DAMReX_PARALLEL_LINK_JOBS=4
         cmake --build build --parallel 4
 
         ccache -s
@@ -56,7 +54,7 @@ jobs:
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests
       
     - name: Run tests
-      working-directory: ${{runner.workspace}}/build
+      working-directory: ${{runner.workspace}}/quokka/build
       run: ctest --output-on-failure -C $BUILD_TYPE
       
     - name: Upload test output

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
+
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_dpcpp.sh

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -14,10 +14,12 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        
     - name: Dependencies
       run: |
         .github/workflows/dependencies/dependencies_dpcpp.sh
         .github/workflows/dependencies/dependencies_ccache.sh
+        
     - name: Set Up Cache
       uses: actions/cache@v4
       with:
@@ -25,6 +27,7 @@ jobs:
         key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
         restore-keys: |
              ccache-${{ github.workflow }}-${{ github.job }}-git-
+             
     - name: Build & Install
       env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual -Wextra-semi -Wunreachable-code -Wnon-virtual-dtor"}
       run: |
@@ -48,10 +51,15 @@ jobs:
 
         ccache -s
         du -hs ~/.cache/ccache
-    - name: Test
+        
+    - name: Create output directory
+      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
+      
+    - name: Run tests
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: ctest --output-on-failure -C $BUILD_TYPE
+      
     - name: Upload test output
       if: always()
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Description
This adds a GitHub action that compiles Quokka and runs the test suite with the Intel oneAPI compiler on CPU. This is needed in order to use a compute allocation on Stampede3.

Note that this compiler is LLVM-based and is *not* the old Intel `icc` compiler (which cannot compile Quokka).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
