### PR TITLE
Changed parameters in pulse_grey test to reduce runtime

### DIFF
--- a/src/RadhydroPulseGrey/CMakeLists.txt
+++ b/src/RadhydroPulseGrey/CMakeLists.txt
@@ -5,5 +5,5 @@ if (AMReX_SPACEDIM EQUAL 1)
       setup_target_for_cuda_compilation(test_radhydro_pulse_grey)
   endif(AMReX_GPU_BACKEND MATCHES "CUDA")
 
-  add_test(NAME RadhydroPulseGrey COMMAND test_radhydro_pulse_grey RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  add_test(NAME RadhydroPulseGrey COMMAND test_radhydro_pulse_grey RadhydroPulseGrey.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/tests/RadhydroPulseGrey.in
+++ b/tests/RadhydroPulseGrey.in
@@ -1,0 +1,29 @@
+kappa0 = 100.0
+v0_adv = 1.0e6
+max_time = 1e-5
+
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -512.0  0.0  0.0 
+geometry.prob_hi     =  512.0  1.0  1.0
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 64 4 4
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 4     # grid size must be divisible by this
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 4
+amr.max_grid_size_z = 4
+
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 1


### PR DESCRIPTION
### Description

Address issue #624 . I reduced `max_time` of the test_radhydro_pulse_grey test by ~5. Now the runtime of this test on my Mac Studio reduced from 28 s to 6 s. 

### Related issues

Fixes #624.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
