### PR TITLE
change initial condition of RadForce

### DIFF
--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -286,10 +286,8 @@ auto problem_main() -> int
 	std::vector<double> xs(nx);
 	std::vector<double> rho_arr(nx);
 	std::vector<double> rho_exact_arr(nx);
-	std::vector<double> rho_err(nx);
 	std::vector<double> vx_arr(nx);
 	std::vector<double> vx_exact_arr(nx);
-	std::vector<double> Frad_err(nx);
 
 	auto *const x_ptr = x_arr.data();
 	auto *const rho_ptr = rho_arr.data();
@@ -313,8 +311,6 @@ auto problem_main() -> int
 
 		vx_arr.at(i) = vx / a0;
 		vx_exact_arr.at(i) = vx_exact / a0;
-		Frad_err.at(i) = (Frad - Frad0) / Frad0;
-		rho_err.at(i) = (rho - rho_exact) / rho_exact;
 		rho_exact_arr.at(i) = rho_exact;
 		rho_arr.at(i) = rho;
 	}

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 
 #include "ArrayUtil.hpp"
+#include "NSCBC_outflow.hpp"
 #include "RadhydroSimulation.hpp"
 #include "fextract.hpp"
 #include "hydro_system.hpp"
@@ -22,7 +23,6 @@
 #include "physics_info.hpp"
 #include "radiation_system.hpp"
 #include "test_radiation_force.hpp"
-#include "NSCBC_outflow.hpp"
 #ifdef HAVE_PYTHON
 #include "matplotlibcpp.h"
 #endif

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -286,10 +286,8 @@ auto problem_main() -> int
 	std::vector<double> xs(nx);
 	std::vector<double> rho_arr(nx);
 	std::vector<double> rho_exact_arr(nx);
-	std::vector<double> rho_err(nx);
 	std::vector<double> vx_arr(nx);
 	std::vector<double> vx_exact_arr(nx);
-	std::vector<double> Frad_err(nx);
 
 	auto *const x_ptr = x_arr.data();
 	auto *const rho_ptr = rho_arr.data();
@@ -306,15 +304,12 @@ auto problem_main() -> int
 		xs.at(i) = position[i];
 		double const rho_exact = _rho;
 		double const rho = values.at(RadSystem<TubeProblem>::gasDensity_index)[i];
-		double const Frad = values.at(RadSystem<TubeProblem>::x1RadFlux_index)[i];
 		double const x1GasMom = values.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];
 		double const vx = x1GasMom / rho;
 		double const vx_exact = _vel;
 
 		vx_arr.at(i) = vx / a0;
 		vx_exact_arr.at(i) = vx_exact / a0;
-		Frad_err.at(i) = (Frad - Frad0) / Frad0;
-		rho_err.at(i) = (rho - rho_exact) / rho_exact;
 		rho_exact_arr.at(i) = rho_exact;
 		rho_arr.at(i) = rho;
 	}

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -163,7 +163,7 @@ template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quo
 		amrex::Real const D = interpolate_value(x, x_ptr, rho_ptr, x_size);
 		amrex::Real const Mach = interpolate_value(x, x_ptr, Mach_ptr, x_size);
 
-		amrex::Real const rho = D * rho0;
+		amrex::Real const rho = rho0;
 		amrex::Real const vel = Mach * a0;
 
 		for (int g = 0; g < Physics_Traits<TubeProblem>::nGroups; ++g) {

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -38,7 +38,6 @@ constexpr double tau = 1.0e-6;	     // optical depth (dimensionless)
 constexpr double rho0 = 1.0e5 * mu; // g cm^-3
 constexpr double Mach0 = 1.1;	    // Mach number at wind base
 constexpr double Mach1 = 2.128410288469465339;
-constexpr double rho1 = (Mach0 / Mach1) * rho0;
 
 constexpr double Frad0 = rho0 * a0 * c_light_cgs_ / tau; // erg cm^-2 s^-1
 constexpr double g0 = kappa0 * Frad0 / c_light_cgs_;	 // cm s^{-2}
@@ -275,7 +274,7 @@ auto problem_main() -> int
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 	const int nx_tot = static_cast<int>(position0.size());
 
-	// cut off at x = 1
+	// cut off at x = 1e16
 	int nx = 0;
 	for (int i = 0; i < nx_tot; ++i) {
 		if (position[i] < 0.98e16) {
@@ -292,21 +291,20 @@ auto problem_main() -> int
 	std::vector<double> vx_exact_arr(nx);
 	std::vector<double> Frad_err(nx);
 
-	auto const &x_ptr = x_arr_g.dataPtr();
-	auto const &rho_ptr = rho_arr_g.dataPtr();
-	auto const &Mach_ptr = Mach_arr_g.dataPtr();
-	int const x_size = static_cast<int>(x_arr_g.size());
+	auto const x_ptr = x_arr.data();
+	auto const rho_ptr = rho_arr.data();
+	auto const Mach_ptr = Mach_arr.data();
+	int const x_size = static_cast<int>(x_arr.size());
 
 	for (int i = 0; i < nx; ++i) {
-		amrex::Real const x_ = position[i] / Lx;
-		amrex::Real const D_ = interpolate_value(x_, x_ptr, rho_ptr, x_size);
-		amrex::Real const Mach_ = interpolate_value(x_, x_ptr, Mach_ptr, x_size);
-		amrex::Real const _rho = D_ * rho0;
-		amrex::Real const _vel = Mach_ * a0;
+		double const x_ = position[i] / Lx;
+		double const D_ = interpolate_value(x_, x_ptr, rho_ptr, x_size);
+		double const Mach_ = interpolate_value(x_, x_ptr, Mach_ptr, x_size);
+		double const _rho = D_ * rho0;
+		double const _vel = Mach_ * a0;
 
 		xs.at(i) = position[i];
 		double const rho_exact = _rho;
-		// double x1GasMom_exact = values0.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];
 		double const rho = values.at(RadSystem<TubeProblem>::gasDensity_index)[i];
 		double const Frad = values.at(RadSystem<TubeProblem>::x1RadFlux_index)[i];
 		double const x1GasMom = values.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -291,9 +291,9 @@ auto problem_main() -> int
 	std::vector<double> vx_exact_arr(nx);
 	std::vector<double> Frad_err(nx);
 
-	auto const x_ptr = x_arr.data();
-	auto const rho_ptr = rho_arr.data();
-	auto const Mach_ptr = Mach_arr.data();
+	auto *const x_ptr = x_arr.data();
+	auto *const rho_ptr = rho_arr.data();
+	auto *const Mach_ptr = Mach_arr.data();
 	int const x_size = static_cast<int>(x_arr.size());
 
 	for (int i = 0; i < nx; ++i) {

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -141,8 +141,6 @@ template <> void RadhydroSimulation<TubeProblem>::preCalculateInitialConditions(
 template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -160,11 +160,9 @@ template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quo
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		amrex::Real const x = (prob_lo[0] + (i + amrex::Real(0.5)) * dx[0]) / Lx;
-		amrex::Real const D = interpolate_value(x, x_ptr, rho_ptr, x_size);
 		amrex::Real const Mach = interpolate_value(x, x_ptr, Mach_ptr, x_size);
 
 		amrex::Real const rho = rho0;
-		amrex::Real const vel = Mach * a0;
 
 		for (int g = 0; g < Physics_Traits<TubeProblem>::nGroups; ++g) {
 			state_cc(i, j, k, RadSystem<TubeProblem>::radEnergy_index + Physics_NumVars::numRadVars * g) =
@@ -204,7 +202,6 @@ AMRSimulation<TubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
-	amrex::GpuArray<int, 3> hi = box.hiVect3d();
 
 	amrex::Real const Erad = Frad0 / c_light_cgs_;
 	amrex::Real const Frad = Frad0;
@@ -262,7 +259,7 @@ auto problem_main() -> int
 	}
 
 	// Read max_dt from parameter file
-	amrex::ParmParse pp;
+	amrex::ParmParse const pp;
 	pp.query("max_dt", max_dt);
 
 	// Problem initialization
@@ -311,20 +308,20 @@ auto problem_main() -> int
 	int const x_size = static_cast<int>(x_arr_g.size());
 
 	for (int i = 0; i < nx; ++i) {
-		amrex::Real const _x = position[i] / Lx;
-		amrex::Real const _D = interpolate_value(_x, x_ptr, rho_ptr, x_size);
-		amrex::Real const _Mach = interpolate_value(_x, x_ptr, Mach_ptr, x_size);
-		amrex::Real const _rho = _D * rho0;
-		amrex::Real const _vel = _Mach * a0;
+		amrex::Real const x_ = position[i] / Lx;
+		amrex::Real const D_ = interpolate_value(x_, x_ptr, rho_ptr, x_size);
+		amrex::Real const Mach_ = interpolate_value(x_, x_ptr, Mach_ptr, x_size);
+		amrex::Real const _rho = D_ * rho0;
+		amrex::Real const _vel = Mach_ * a0;
 
 		xs.at(i) = position[i];
-		double rho_exact = _rho;
+		double const rho_exact = _rho;
 		// double x1GasMom_exact = values0.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];
-		double rho = values.at(RadSystem<TubeProblem>::gasDensity_index)[i];
-		double Frad = values.at(RadSystem<TubeProblem>::x1RadFlux_index)[i];
-		double x1GasMom = values.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];
-		double vx = x1GasMom / rho;
-		double vx_exact = _vel;
+		double const rho = values.at(RadSystem<TubeProblem>::gasDensity_index)[i];
+		double const Frad = values.at(RadSystem<TubeProblem>::x1RadFlux_index)[i];
+		double const x1GasMom = values.at(RadSystem<TubeProblem>::x1GasMomentum_index)[i];
+		double const vx = x1GasMom / rho;
+		double const vx_exact = _vel;
 
 		vx_arr.at(i) = vx / a0;
 		vx_exact_arr.at(i) = vx_exact / a0;

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -146,11 +146,6 @@ template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quo
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	auto const &x_ptr = x_arr_g.dataPtr();
-	auto const &rho_ptr = rho_arr_g.dataPtr();
-	auto const &Mach_ptr = Mach_arr_g.dataPtr();
-	int x_size = static_cast<int>(x_arr_g.size());
-
 	// calculate radEnergyFractions
 	quokka::valarray<amrex::Real, Physics_Traits<TubeProblem>::nGroups> radEnergyFractions{};
 	for (int g = 0; g < Physics_Traits<TubeProblem>::nGroups; ++g) {
@@ -159,8 +154,6 @@ template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quo
 
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-		amrex::Real const x = (prob_lo[0] + (i + amrex::Real(0.5)) * dx[0]) / Lx;
-
 		amrex::Real const rho = rho0;
 
 		for (int g = 0; g < Physics_Traits<TubeProblem>::nGroups; ++g) {

--- a/src/RadForce/test_radiation_force.cpp
+++ b/src/RadForce/test_radiation_force.cpp
@@ -15,7 +15,6 @@
 #include "AMReX_REAL.H"
 
 #include "ArrayUtil.hpp"
-#include "NSCBC_outflow.hpp"
 #include "RadhydroSimulation.hpp"
 #include "fextract.hpp"
 #include "hydro_system.hpp"
@@ -193,7 +192,6 @@ AMRSimulation<TubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 
 	amrex::Box const &box = geom.Domain();
 	amrex::GpuArray<int, 3> lo = box.loVect3d();
-	amrex::GpuArray<int, 3> hi = box.hiVect3d();
 
 	amrex::Real const Erad = Frad0 / c_light_cgs_;
 	amrex::Real const Frad = Frad0;
@@ -223,11 +221,6 @@ AMRSimulation<TubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 		consVar(i, j, k, RadSystem<TubeProblem>::x1GasMomentum_index) = rho * vel;
 		consVar(i, j, k, RadSystem<TubeProblem>::x2GasMomentum_index) = 0.;
 		consVar(i, j, k, RadSystem<TubeProblem>::x3GasMomentum_index) = 0.;
-	} else if (i > hi[0]) {
-		// amrex::Real const pressure_R = rho_arr_g.back() * a0 * a0;
-		amrex::Real const rho_R = consVar(hi[0], j, k, RadSystem<TubeProblem>::gasDensity_index);
-		amrex::Real const pressure_R = rho_R * a0 * a0;
-		NSCBC::setOutflowBoundaryLowOrder<TubeProblem, FluxDir::X1, NSCBC::BoundarySide::Upper>(iv, consVar, geom, pressure_R);
 	}
 }
 
@@ -246,7 +239,7 @@ auto problem_main() -> int
 	for (int n = 0; n < nvars; ++n) {
 		// for x-axis:
 		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
 		// for y-, z- axes:
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			// periodic

--- a/tests/RadForce.in
+++ b/tests/RadForce.in
@@ -23,7 +23,7 @@ amr.max_grid_size_x = 128
 
 do_reflux = 0
 do_subcycle = 0
-suppress_output = 0
+suppress_output = 1
 
 cfl = 0.4
 radiation.cfl = 0.4

--- a/tests/RadForce.in
+++ b/tests/RadForce.in
@@ -5,6 +5,9 @@ geometry.prob_lo     =  0.0  0.0  0.0
 geometry.prob_hi     =  1.0263747986171498e16 1.0263747986171498e16 1.0263747986171498e16
 geometry.is_periodic =  0    1    1
 
+# for convergence test, start with max_dt = 1.0e8
+max_dt = 1.0e10
+
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
@@ -21,3 +24,6 @@ amr.max_grid_size_x = 128
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 0
+
+cfl = 0.4
+radiation.cfl = 0.4


### PR DESCRIPTION
### Description

The RadForce test can be improved to be more realistic and less `ad hoc`. Instead of initializing with the exact solution and letting the simulation maintain a static state, we start the simulation with a uniform density of rho0 and zero velocity. The left boundary condition is kept the same as before, but the right boundary is set to be foextrap. The end result is exactly the same as before: the radiation blows away the gas and the system comes to the static state given by the differential equation. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
