### PR TITLE
Fix GPU problems in pulse_MG.cpp 

### DIFF
--- a/src/RadhydroPulseMG/CMakeLists.txt
+++ b/src/RadhydroPulseMG/CMakeLists.txt
@@ -1,9 +1,7 @@
-if (AMReX_SPACEDIM EQUAL 1)
-  add_executable(test_radhydro_pulse_MG test_radhydro_pulse_MG.cpp ../fextract.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_pulse_MG test_radhydro_pulse_MG.cpp ../fextract.cpp ${QuokkaObjSources})
 
-  if(AMReX_GPU_BACKEND MATCHES "CUDA")
-      setup_target_for_cuda_compilation(test_radhydro_pulse_MG)
-  endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+		setup_target_for_cuda_compilation(test_radhydro_pulse_MG)
+endif(AMReX_GPU_BACKEND MATCHES "CUDA")
 
-  add_test(NAME RadhydroPulseMG COMMAND test_radhydro_pulse_MG RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
-endif()
+add_test(NAME RadhydroPulseMG COMMAND test_radhydro_pulse_MG RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/RadhydroPulseMG/test_radhydro_pulse_MG.cpp
+++ b/src/RadhydroPulseMG/test_radhydro_pulse_MG.cpp
@@ -60,7 +60,7 @@ constexpr double v0_nonadv = 0.; // non-advecting pulse
 // static diffusion: (for single group) tau = 2e3, beta = 3e-5, beta tau = 6e-2
 constexpr double v0_adv = 1.0e6;    // advecting pulse
 constexpr double max_time = 4.8e-5; // max_time = 0.02 * width / v1;
-constexpr int64_t max_timesteps = 10;
+constexpr int64_t max_timesteps = 30;
 
 // dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
 // constexpr double kappa0 = 1000.; // cm^2 g^-1

--- a/src/RadhydroPulseMGint/CMakeLists.txt
+++ b/src/RadhydroPulseMGint/CMakeLists.txt
@@ -1,15 +1,13 @@
-if (AMReX_SPACEDIM EQUAL 1)
-  add_executable(test_radhydro_pulse_MG_int test_radhydro_pulse_MG_int.cpp ../fextract.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_pulse_MG_int test_radhydro_pulse_MG_int.cpp ../fextract.cpp ${QuokkaObjSources})
 
-  if(AMReX_GPU_BACKEND MATCHES "CUDA")
-      setup_target_for_cuda_compilation(test_radhydro_pulse_MG_int)
-  endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+		setup_target_for_cuda_compilation(test_radhydro_pulse_MG_int)
+endif(AMReX_GPU_BACKEND MATCHES "CUDA")
 
-	# define variable WORK_PATH = {WORKSPACE}/sims
-	# set(WORK_PATH "${CMAKE_SOURCE_DIR}/tests/20240408-MG-int-v8.2")
+# define variable WORK_PATH = {WORKSPACE}/sims
+# set(WORK_PATH "${CMAKE_SOURCE_DIR}/tests/20240408-MG-int-v8.2")
 
-	# mkdir -p WORK_PATH
-	# file(MAKE_DIRECTORY ${WORK_PATH})
+# mkdir -p WORK_PATH
+# file(MAKE_DIRECTORY ${WORK_PATH})
 
-  add_test(NAME RadhydroPulseMGint COMMAND test_radhydro_pulse_MG_int RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
-endif()
+add_test(NAME RadhydroPulseMGint COMMAND test_radhydro_pulse_MG_int RadhydroPulse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -58,7 +58,8 @@ constexpr double k_B = C::k_B;
 // static diffusion: (for single group) tau = 2e3, beta = 3e-5, beta tau = 6e-2
 constexpr double kappa0 = 180.;	    // cm^2 g^-1
 constexpr double v0_adv = 1.0e6;    // advecting pulse
-constexpr double max_time = 4.8e-6; // max_time = 0.2 * width / v1;
+constexpr double max_time = 4.8e-5; // max_time = 2 * width / v1;
+constexpr int64_t max_timesteps = 10; // to make 3D test run fast on GPUs
 
 // dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
 // constexpr double kappa0 = 1000.; // cm^2 g^-1
@@ -273,7 +274,6 @@ auto problem_main() -> int
 	// This problem is based on the radhydro_pulse test and is a test of interpolation for variable opacity for multigroup radiation.
 
 	// Problem parameters
-	const int64_t max_timesteps = 1e8;
 	const double CFL_number = 0.8;
 	// const int nx = 32;
 

--- a/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -59,7 +59,7 @@ constexpr double k_B = C::k_B;
 constexpr double kappa0 = 180.;	      // cm^2 g^-1
 constexpr double v0_adv = 1.0e6;      // advecting pulse
 constexpr double max_time = 4.8e-5;   // max_time = 2 * width / v1;
-constexpr int64_t max_timesteps = 10; // to make 3D test run fast on GPUs
+constexpr int64_t max_timesteps = 30; // to make 3D test run fast on GPUs
 
 // dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60
 // constexpr double kappa0 = 1000.; // cm^2 g^-1

--- a/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -56,9 +56,9 @@ constexpr double h_planck = C::hplanck;
 constexpr double k_B = C::k_B;
 
 // static diffusion: (for single group) tau = 2e3, beta = 3e-5, beta tau = 6e-2
-constexpr double kappa0 = 180.;	    // cm^2 g^-1
-constexpr double v0_adv = 1.0e6;    // advecting pulse
-constexpr double max_time = 4.8e-5; // max_time = 2 * width / v1;
+constexpr double kappa0 = 180.;	      // cm^2 g^-1
+constexpr double v0_adv = 1.0e6;      // advecting pulse
+constexpr double max_time = 4.8e-5;   // max_time = 2 * width / v1;
 constexpr int64_t max_timesteps = 10; // to make 3D test run fast on GPUs
 
 // dynamic diffusion: tau = 2e4, beta = 3e-3, beta tau = 60


### PR DESCRIPTION
### Description

I discovered some GPU-related issues in radhydro_pulse_MG.cpp and fixed it. In the previous PR, I turned if off for 3D problems because it is too expensive. As a result, it didn't get to compile and run on nvcc or ROCm. I fixed some first-capture and undefined on device issues and turned this test (and radhydro_pulse_MG_int.cpp) on. I set `max_timesteps=10` in these tests in order to let them finish fast. We are not comparing with exact solutions any way (because there isn't one), so it's okay to run only a small number of time steps and show that the architecture is working. The accuracy of the multigroup implementation is tested by hand, and I will include it in a planned nightly unit test. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
