### PR TITLE
Fix gas mtm update bug when hydro is off

### DIFF
--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -244,6 +244,7 @@ auto problem_main() -> int
 		std::vector<double> Tgas(nx);
 		std::vector<double> Erad(nx);
 		std::vector<double> Egas(nx);
+		std::vector<double> vgas(nx);
 
 		for (int i = 0; i < nx; ++i) {
 			const double x = position[i];
@@ -261,6 +262,8 @@ auto problem_main() -> int
 			const double Egas_t = (Etot_t - Ekin);
 			Egas.at(i) = Egas_t;
 			Tgas.at(i) = quokka::EOS<SuOlsonProblem>::ComputeTgasFromEint(rho, Egas_t);
+
+			vgas.at(i) = x1GasMom / rho;
 		}
 
 		// read in exact solution
@@ -315,6 +318,18 @@ auto problem_main() -> int
 		amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
 
 		if ((rel_error > error_tol) || std::isnan(rel_error)) {
+			status = 1;
+		}
+
+		// check if velocity is strictly zero
+		const double error_v_tol = 1.0e-10;
+		double error_v = 0.0;
+		const double cs = std::sqrt(5. / 3. * T_initial); // sound speed
+		for (size_t i = 0; i < xs.size(); ++i) {
+			error_v += std::abs(vgas[i])/ cs;
+		}
+		amrex::Print() << "Sum of abs(v) / cs = " << error_v << std::endl;
+		if ((error_v > error_v_tol) || std::isnan(error_v)) {
 			status = 1;
 		}
 

--- a/src/RadMarshak/test_radiation_marshak.cpp
+++ b/src/RadMarshak/test_radiation_marshak.cpp
@@ -326,7 +326,7 @@ auto problem_main() -> int
 		double error_v = 0.0;
 		const double cs = std::sqrt(5. / 3. * T_initial); // sound speed
 		for (size_t i = 0; i < xs.size(); ++i) {
-			error_v += std::abs(vgas[i])/ cs;
+			error_v += std::abs(vgas[i]) / cs;
 		}
 		amrex::Print() << "Sum of abs(v) / cs = " << error_v << std::endl;
 		if ((error_v > error_v_tol) || std::isnan(error_v)) {

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1608,7 +1608,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		auto x1GasMom1 = consPrev(i, j, k, x1GasMomentum_index);
 		auto x2GasMom1 = consPrev(i, j, k, x2GasMomentum_index);
 		auto x3GasMom1 = consPrev(i, j, k, x3GasMomentum_index);
-		if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
+		if (Physics_Traits<problem_t>::is_hydro_enabled) {
 			x1GasMom1 += dMomentum[0] * gas_update_factor;
 			x2GasMom1 += dMomentum[1] * gas_update_factor;
 			x3GasMom1 += dMomentum[2] * gas_update_factor;

--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1604,12 +1604,18 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		// 4b. Store new radiation energy, gas energy
 		// In the first stage of the IMEX scheme, the hydro quantities are updated by a fraction (defined by
 		// gas_update_factor) of the time step.
-		const auto x1GasMom1 = consPrev(i, j, k, x1GasMomentum_index) + dMomentum[0] * gas_update_factor;
-		const auto x2GasMom1 = consPrev(i, j, k, x2GasMomentum_index) + dMomentum[1] * gas_update_factor;
-		const auto x3GasMom1 = consPrev(i, j, k, x3GasMomentum_index) + dMomentum[2] * gas_update_factor;
-		consNew(i, j, k, x1GasMomentum_index) = x1GasMom1;
-		consNew(i, j, k, x2GasMomentum_index) = x2GasMom1;
-		consNew(i, j, k, x3GasMomentum_index) = x3GasMom1;
+		// if is_hydro_enabled
+		auto x1GasMom1 = consPrev(i, j, k, x1GasMomentum_index);
+		auto x2GasMom1 = consPrev(i, j, k, x2GasMomentum_index);
+		auto x3GasMom1 = consPrev(i, j, k, x3GasMomentum_index);
+		if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
+			x1GasMom1 += dMomentum[0] * gas_update_factor;
+			x2GasMom1 += dMomentum[1] * gas_update_factor;
+			x3GasMom1 += dMomentum[2] * gas_update_factor;
+			consNew(i, j, k, x1GasMomentum_index) = x1GasMom1;
+			consNew(i, j, k, x2GasMomentum_index) = x2GasMom1;
+			consNew(i, j, k, x3GasMomentum_index) = x3GasMom1;
+		}
 		if constexpr (gamma_ != 1.0) {
 			Egas_guess = Egas0 + (Egas_guess - Egas0) * gas_update_factor;
 			consNew(i, j, k, gasInternalEnergy_index) = Egas_guess;


### PR DESCRIPTION
### Description
Due to a mistake at the end of `AddSourceTerms`, the gas momentum is updated to balance with radiation flux update even when hydro is turned off. This is unexpected behaviour. I fixed it and tested it with an extra velocity check in the RadMarshak test. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
