### PR TITLE
[WIP] set Newton iteration maxIter to 50

### DIFF
--- a/src/radiation_system.hpp
+++ b/src/radiation_system.hpp
@@ -1257,7 +1257,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 				quokka::valarray<double, nGroups_> F_D{};
 
 				const double resid_tol = 1.0e-11; // 1.0e-15;
-				const int maxIter = 400;
+				const int maxIter = 50;
 				int n = 0;
 				for (; n < maxIter; ++n) {
 					// compute material temperature


### PR DESCRIPTION
### Description

We don't need a high value for maxIter since the Newton-Raphson iteration converges fast under the new base variables. We should also minimizing the average/maximal iterations for good performance. 


### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
