### PR TITLE
remove old debugging code from ODE integrator

### DIFF
--- a/src/ODEIntegrate.hpp
+++ b/src/ODEIntegrate.hpp
@@ -135,8 +135,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 	quokka::valarray<Real, N> ydot0{};
 	rhs(t0, y0, ydot0, user_data);
 	const Real dt_guess = 0.1 * min(abs(y0 / ydot0));
-
-	AMREX_ALWAYS_ASSERT(dt_guess > 0.);
+	AMREX_ASSERT(dt_guess > 0.0);
 
 	// adaptive timestep controller
 	const int maxRetries = 7;
@@ -208,9 +207,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 
 		if (!step_success) {
 			success = false;
-			printf("ODE integrator failed to reach accuracy tolerance after "
-			       "maximum step-size re-tries reached! dt = %g\n",
-			       dt);
 			break;
 		}
 
@@ -224,7 +220,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 
 	if (!success) {
 		steps_taken = maxStepsODEIntegrate;
-		printf("ODE integration exceeded maxStepsODEIntegrate! steps_taken = %d\n", steps_taken);
 	}
 }
 


### PR DESCRIPTION
### Description
This removes old debugging `printf`s from the ODE integrator. They are not necessary anymore, and each `printf` has a performance penalty on GPU.

Error handling has already been fully integrated into hydro retries mechanism for some time already.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
