### PR TITLE
add nightly regression testing infrastructure

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -1,0 +1,19 @@
+# YAML file in the main branch
+
+schedules:
+- cron: '0 0 * * *'
+  displayName: Daily midnight build
+  branches:
+    include:
+    - development
+
+jobs:
+  - job: GPU_Regression
+    pool: avatar
+    timeoutInMinutes: 300
+    steps:
+    - script: ./extern/regression_testing/regtest.py regression/quokka-tests.ini
+      displayName: 'Run regression testing'
+    - publish: /home/bwibking/regression-tests/web
+      artifact: regressionHTMLOutput
+      displayName: 'Upload results'

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "extern/openPMD-api"]
 	path = extern/openPMD-api
 	url = https://github.com/openPMD/openPMD-api.git
+[submodule "extern/regression_testing"]
+	path = extern/regression_testing
+	url = https://github.com/AMReX-Codes/regression_testing.git

--- a/regression/quokka-cuda-tests.ini
+++ b/regression/quokka-cuda-tests.ini
@@ -1,0 +1,55 @@
+[main]
+testTopDir = /home/bwibking/quokka/regression
+webTopDir  = /home/bwibking/quokka/regression/web
+
+MAKE = cmake --source . --build build --config Release --parallel 8
+sourceTree = quokka
+
+COMP = g++
+
+purge_output = 1
+
+# suiteName is the name prepended to all output directories
+suiteName = quokka-GPU
+
+reportActiveTestsOnly = 1
+
+# Add "GO UP" link at the top of the web page?
+goUpLink = 1
+
+# email
+sendEmailWhenFail = 1
+emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com
+emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/AMReX/ for more details.
+
+# MPIcommand should use the placeholders:
+#   @host@ to indicate where to put the hostname to run on
+#   @nprocs@ to indicate where to put the number of processors
+#   @command@ to indicate where to put the command to run
+#
+# only tests with useMPI = 1 will run in parallel
+# nprocs is problem dependent and specified in the individual problem
+# sections.
+
+MPIcommand = mpirun -n @nprocs@ @command@
+MPIhost =
+
+[quokka]
+dir = /home/bwibking/quokka
+# PLEASE DO NOT CHANGE THIS.  IF YOU CHANGE THIS PLEASE REMEMBER TO
+# CHANGE IT BACK TO DEVELOPMENT.
+branch = "development"
+
+# individual problems follow
+
+[Sedov]
+addToCompileString = -DAMReX_GPU_BACKEND=CUDA
+buildDir = .
+inputFile = tests/blast_unigrid_128.in
+dim = 3
+restartTest = 0
+useMPI = 0
+numprocs = 1
+compileTest = 0
+doVis = 0
+testSrcTree = .

--- a/regression/quokka-cuda-tests.ini
+++ b/regression/quokka-cuda-tests.ini
@@ -3,7 +3,7 @@ testTopDir = /home/bwibking/quokka/regression
 webTopDir  = /home/bwibking/quokka/regression/web
 
 MAKE = cmake --source . --build build --config Release --parallel 8
-sourceTree = quokka
+sourceTree = ../../
 
 COMP = g++
 

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -9,7 +9,7 @@ numMakeJobs = 16
 
 plot_file_name = plotfile_prefix
 check_file_name = checkpoint_prefix
-purge_output = 0
+purge_output = 1
 
 # suiteName is the name prepended to all output directories
 suiteName = quokka
@@ -49,24 +49,27 @@ branch = BenWibking/add-regression-testing
 
 # individual problems follow
 
-[Sedov-CPU]
-buildDir = .
-target = test_hydro3d_blast
-inputFile = tests/blast_unigrid_128_cpu.in
-dim = 3
-restartTest = 0
-useMPI = 1
-numprocs = 16
-compileTest = 0
-doVis = 1
-visVar = gasDensity
-testSrcTree = .
-ignore_return_code = 1
+# this is commented out because it takes 2 hours to run
+# but is useful as an example CPU test problem
+#
+#[Sedov-CPU]
+#buildDir = .
+#target = test_hydro3d_blast
+#inputFile = tests/blast_unigrid_128_cpu.in
+#dim = 3
+#restartTest = 0
+#useMPI = 1
+#numprocs = 16
+#compileTest = 0
+#doVis = 1
+#visVar = gasDensity
+#testSrcTree = .
+#ignore_return_code = 1
 
 [Sedov-GPU]
 buildDir = .
 target = test_hydro3d_blast
-inputFile = tests/blast_unigrid_128.in
+inputFile = tests/blast_unigrid_128_regression.in
 dim = 3
 cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
 restartTest = 0

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -7,10 +7,12 @@ useCmake = 1
 isSuperbuild = 1
 numMakeJobs = 8
 
+plot_file_name = plotfile_prefix
+check_file_name = checkpoint_prefix
 purge_output = 1
 
 # suiteName is the name prepended to all output directories
-suiteName = quokka-GPU
+suiteName = quokka-CPU
 
 reportActiveTestsOnly = 1
 
@@ -47,24 +49,10 @@ branch = development
 
 # individual problems follow
 
-#[HydroShocktube]
-#buildDir = .
-#target = test_hydro_shocktube
-#inputFile = tests/shocktube.in
-#dim = 1
-#restartTest = 0
-#useMPI = 1
-#numprocs = 8
-#compileTest = 0
-#doVis = 1
-#visVar = gasDensity
-#testSrcTree = .
-
-
 [Sedov]
 buildDir = .
 target = test_hydro3d_blast
-inputFile = tests/blast_unigrid_128.in
+inputFile = tests/blast_32.in
 dim = 3
 restartTest = 0
 useMPI = 1

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -5,7 +5,7 @@ webTopDir  = /home/bwibking/regression-tests/web
 sourceTree = C_Src
 useCmake = 1
 isSuperbuild = 1
-numMakeJobs = 8
+numMakeJobs = 32
 
 plot_file_name = plotfile_prefix
 check_file_name = checkpoint_prefix
@@ -56,7 +56,7 @@ inputFile = tests/blast_unigrid_128.in
 dim = 3
 restartTest = 0
 useMPI = 1
-numprocs = 16
+numprocs = 32
 compileTest = 0
 doVis = 1
 visVar = gasDensity

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -5,7 +5,7 @@ webTopDir  = /home/bwibking/regression-tests/web
 sourceTree = C_Src
 useCmake = 1
 isSuperbuild = 1
-numMakeJobs = 32
+numMakeJobs = 16
 
 plot_file_name = plotfile_prefix
 check_file_name = checkpoint_prefix
@@ -56,7 +56,7 @@ inputFile = tests/blast_unigrid_128.in
 dim = 3
 restartTest = 0
 useMPI = 1
-numprocs = 32
+numprocs = 16
 compileTest = 0
 doVis = 1
 visVar = gasDensity

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -9,7 +9,7 @@ numMakeJobs = 8
 
 plot_file_name = plotfile_prefix
 check_file_name = checkpoint_prefix
-purge_output = 1
+purge_output = 0
 
 # suiteName is the name prepended to all output directories
 suiteName = quokka-CPU
@@ -61,3 +61,4 @@ compileTest = 0
 doVis = 1
 visVar = gasDensity
 testSrcTree = .
+ignore_return_code = 1

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -19,6 +19,8 @@ reportActiveTestsOnly = 1
 # Add "GO UP" link at the top of the web page?
 goUpLink = 1
 
+default_branch = development
+
 # email
 sendEmailWhenFail = 0
 emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -38,16 +38,14 @@ emailBody = quokka regression tests failed
 MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
-ftools =
-use_ctools = 0
-
 [AMReX]
 dir = /home/bwibking/regression-tests/amrex
 branch = development
 
 [source]
 dir = /home/bwibking/regression-tests/quokka
-branch = development
+#branch = development
+branch = BenWibking/add-regression-testing
 
 # individual problems follow
 

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -12,7 +12,7 @@ check_file_name = checkpoint_prefix
 purge_output = 0
 
 # suiteName is the name prepended to all output directories
-suiteName = quokka-CPU
+suiteName = quokka
 
 reportActiveTestsOnly = 1
 
@@ -49,14 +49,29 @@ branch = BenWibking/add-regression-testing
 
 # individual problems follow
 
-[Sedov]
+[Sedov-CPU]
 buildDir = .
 target = test_hydro3d_blast
-inputFile = tests/blast_32.in
+inputFile = tests/blast_unigrid_128.in
 dim = 3
 restartTest = 0
 useMPI = 1
 numprocs = 16
+compileTest = 0
+doVis = 1
+visVar = gasDensity
+testSrcTree = .
+ignore_return_code = 1
+
+[Sedov-GPU]
+buildDir = .
+target = test_hydro3d_blast
+inputFile = tests/blast_unigrid_128.in
+dim = 3
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+restartTest = 0
+useMPI = 1
+numprocs = 1
 compileTest = 0
 doVis = 1
 visVar = gasDensity

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,11 +1,11 @@
 [main]
-testTopDir = /home/bwibking/quokka/regression
-webTopDir  = /home/bwibking/quokka/regression/web
+testTopDir = /home/bwibking/regression-tests
+webTopDir  = /home/bwibking/regression-tests/web
 
-MAKE = cmake --source . --build build --config Release --parallel 8
-sourceTree = ../../
-
-COMP = g++
+sourceTree = C_Src
+useCmake = 1
+isSuperbuild = 1
+numMakeJobs = 8
 
 purge_output = 1
 
@@ -18,9 +18,9 @@ reportActiveTestsOnly = 1
 goUpLink = 1
 
 # email
-sendEmailWhenFail = 1
+sendEmailWhenFail = 0
 emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com
-emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/AMReX/ for more details.
+emailBody = quokka regression tests failed
 
 # MPIcommand should use the placeholders:
 #   @host@ to indicate where to put the hostname to run on
@@ -34,22 +34,42 @@ emailBody = Check https://ccse.lbl.gov/pub/GpuRegressionTesting/AMReX/ for more 
 MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
-[quokka]
-dir = /home/bwibking/quokka
-# PLEASE DO NOT CHANGE THIS.  IF YOU CHANGE THIS PLEASE REMEMBER TO
-# CHANGE IT BACK TO DEVELOPMENT.
-branch = "development"
+ftools =
+use_ctools = 0
+
+[AMReX]
+dir = /home/bwibking/regression-tests/amrex
+branch = development
+
+[source]
+dir = /home/bwibking/regression-tests/quokka
+branch = development
 
 # individual problems follow
 
+#[HydroShocktube]
+#buildDir = .
+#target = test_hydro_shocktube
+#inputFile = tests/shocktube.in
+#dim = 1
+#restartTest = 0
+#useMPI = 1
+#numprocs = 8
+#compileTest = 0
+#doVis = 1
+#visVar = gasDensity
+#testSrcTree = .
+
+
 [Sedov]
-addToCompileString = -DAMReX_GPU_BACKEND=CUDA
 buildDir = .
+target = test_hydro3d_blast
 inputFile = tests/blast_unigrid_128.in
 dim = 3
 restartTest = 0
-useMPI = 0
-numprocs = 1
+useMPI = 1
+numprocs = 16
 compileTest = 0
-doVis = 0
+doVis = 1
+visVar = gasDensity
 testSrcTree = .

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -23,6 +23,18 @@ sendEmailWhenFail = 0
 emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com
 emailBody = quokka regression tests failed
 
+# some research groups use slack for communication.  If you setup a
+# slack webhook (see the slack documentation for this), then you can
+# have the suite directly post when the test begins and ends (and # of
+# failures) to a slack channel.  You need to put the webhook URL in a
+# plaintext file somewhere that is readable by the suite (for security
+# reasons, we don't put it in this inputs file, in case this is under
+# version control).
+slack_post = 1
+slack_webhookfile = /home/bwibking/.slack.webhook
+slack_channel = "#development"
+slack_username = "buildbot"
+
 # MPIcommand should use the placeholders:
 #   @host@ to indicate where to put the hostname to run on
 #   @nprocs@ to indicate where to put the number of processors

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -21,7 +21,7 @@ default_branch = development
 # email
 sendEmailWhenFail = 0
 emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com
-emailBody = quokka regression tests failed
+emailBody = quokka regression tests completed
 
 # some research groups use slack for communication.  If you setup a
 # slack webhook (see the slack documentation for this), then you can

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -53,8 +53,7 @@ branch = development
 
 [source]
 dir = /home/bwibking/regression-tests/quokka
-#branch = development
-branch = BenWibking/add-regression-testing
+branch = development
 
 # individual problems follow
 

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -52,7 +52,7 @@ branch = BenWibking/add-regression-testing
 [Sedov-CPU]
 buildDir = .
 target = test_hydro3d_blast
-inputFile = tests/blast_unigrid_128.in
+inputFile = tests/blast_unigrid_128_cpu.in
 dim = 3
 restartTest = 0
 useMPI = 1

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -16,9 +16,6 @@ suiteName = quokka
 
 reportActiveTestsOnly = 1
 
-# Add "GO UP" link at the top of the web page?
-goUpLink = 1
-
 default_branch = development
 
 # email

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -579,6 +579,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default checkpoint interval
 	pp.query("checkpoint_interval", checkpointInterval_);
 
+	// Default plotfile prefix
+	pp.query("plotfile_prefix", plot_file);
+
+	// Default checkpoint prefix
+	pp.query("checkpoint_prefix", chk_file);
+
 	// Default do_reflux = 1
 	pp.query("do_reflux", do_reflux);
 

--- a/tests/blast_32.in
+++ b/tests/blast_32.in
@@ -22,3 +22,5 @@ amr.grid_eff        = 0.7   # default
 
 do_reflux = 0
 do_subcycle = 0
+
+plotfile_interval  = 1000

--- a/tests/blast_unigrid_128.in
+++ b/tests/blast_unigrid_128.in
@@ -34,3 +34,5 @@ quokka.slice_z.center = 0.001                # Coordinate in the normal directio
 quokka.slice_z.int    = 10                   # Output cadence (in number of coarse steps)
 quokka.slice_z.interpolation = Linear        # (Optional, default is Linear) Interpolation type: Linear or Quadratic
 quokka.slice_z.field_names = gasDensity gasInternalEnergy      # List of variables included in output
+
+plotfile_interval  = 20000

--- a/tests/blast_unigrid_128_cpu.in
+++ b/tests/blast_unigrid_128_cpu.in
@@ -13,7 +13,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 32 32 32
+amr.n_cell          = 128 128 128
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.max_grid_size   = 64    # at least 128 for GPUs
 amr.blocking_factor = 16    # grid size must be divisible by this
@@ -22,5 +22,17 @@ amr.grid_eff        = 0.7   # default
 
 do_reflux = 0
 do_subcycle = 0
+do_tracers = 1      # turn on tracer particles
 
-plotfile_interval  = 1000
+hydro.artificial_viscosity_coefficient = 0.1
+
+quokka.diagnostics = slice_z
+quokka.slice_z.type = DiagFramePlane         # Diagnostic type
+quokka.slice_z.file = slicez_plt             # Output file prefix (must end in "plt")
+quokka.slice_z.normal = 2                    # Plane normal (0 == x, 1 == y, 2 == z)
+quokka.slice_z.center = 0.001                # Coordinate in the normal direction (cannot lie *exactly* on domain boundary)
+quokka.slice_z.int    = 10                   # Output cadence (in number of coarse steps)
+quokka.slice_z.interpolation = Linear        # (Optional, default is Linear) Interpolation type: Linear or Quadratic
+quokka.slice_z.field_names = gasDensity gasInternalEnergy      # List of variables included in output
+
+plotfile_interval  = 20000

--- a/tests/blast_unigrid_128_regression.in
+++ b/tests/blast_unigrid_128_regression.in
@@ -26,11 +26,4 @@ do_tracers = 1      # turn on tracer particles
 
 hydro.artificial_viscosity_coefficient = 0.1
 
-quokka.diagnostics = slice_z
-quokka.slice_z.type = DiagFramePlane         # Diagnostic type
-quokka.slice_z.file = slicez_plt             # Output file prefix (must end in "plt")
-quokka.slice_z.normal = 2                    # Plane normal (0 == x, 1 == y, 2 == z)
-quokka.slice_z.center = 0.001                # Coordinate in the normal direction (cannot lie *exactly* on domain boundary)
-quokka.slice_z.int    = 10                   # Output cadence (in number of coarse steps)
-quokka.slice_z.interpolation = Linear        # (Optional, default is Linear) Interpolation type: Linear or Quadratic
-quokka.slice_z.field_names = gasDensity gasInternalEnergy      # List of variables included in output
+plotfile_interval  = 20000


### PR DESCRIPTION
### Description
Adds nightly regression testing infrastructure to compare outputs for science problems with "known good" solutions.

This also adds the ability to specify the plotfile prefix and the checkpoint file prefix with ParmParse parameters `plotfile_prefix` and `checkpoint_prefix`.

If the "correct" answers (i.e., plotfile outputs) change and need to be updated, then it is necessary to run
```
./extern/regression_testing/regtest.py --make_benchmarks "<some useful comment>" regression/quokka-tests.ini
```
on avatargpue.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/346.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
