### PR TITLE
upload regression testing results to GitHub pages

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -7,6 +7,10 @@ schedules:
     include:
     - development
 
+# NOTE: several Python packages are needed for regression_testing to run properly:
+#   https://github.com/AMReX-Codes/regression_testing/blob/main/requirements.txt
+# ALSO NEEDED: bokeh
+
 jobs:
   - job: GPU_Regression
     pool: avatar

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -1,5 +1,8 @@
-# YAML file in the main branch
+# don't run on pull request or push
+pr: none
+trigger: none
 
+# run on timed schedule, like a cron job
 schedules:
 - cron: '0 0 * * *'
   displayName: Daily midnight build

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -16,4 +16,6 @@ jobs:
       displayName: 'Run regression testing'
     - publish: /home/bwibking/regression-tests/web
       artifact: regressionHTMLOutput
-      displayName: 'Upload results'
+      displayName: 'Upload results to Azure Pipelines'
+    - script: cd /home/bwibking/regression-tests/web && git add . && git commit -m 'updated results' && git push
+      displayName: 'Upload results to GitHub Pages'

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -86,5 +86,7 @@ numprocs = 1
 compileTest = 0
 doVis = 1
 visVar = gasDensity
+compareParticles = 1
+particleTypes = tracer_particles
 testSrcTree = .
 ignore_return_code = 1


### PR DESCRIPTION
### Description
This uploads the regression testing results to GitHub Pages, so it can be viewed here: https://quokka-astro.github.io/regression-testing-results/

Also, this turns on checks for the particle outputs, so they are checked against the reference plotfile.

### Related issues
Also fixes https://github.com/quokka-astro/quokka/issues/651.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
