### PR TITLE
update docs re Intel GPUs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -143,13 +143,12 @@ issues that affect the correctness of simulation results (see
 https://github.com/quokka-astro/quokka/issues/394 and
 https://github.com/quokka-astro/quokka/issues/447).
 
-Intel GPUs *(experimental, use at your own risk)*
+Intel GPUs *(does not compile)*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Not tested. You can attempt this by compiling with
-``-DAMReX_GPU_BACKEND=SYCL``. Please start a Discussion if you encounter
-issues on Intel GPUs. Your MPI library **must** support GPU-aware MPI
-for Intel GPUs.
+Due to limitations in the Intel GPU programming model, Quokka currently
+cannot be compiled for Intel GPUs. (See https://github.com/quokka-astro/quokka/issues/619
+for the technical details.)
 
 Building a specific test problem
 --------------------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -93,7 +93,7 @@ Running on GPUs
 ---------------
 
 By default, Quokka compiles itself to run only on CPUs. Quokka can run
-on either NVIDIA, AMD, or Intel GPUs. Consult the sub-sections below for
+on either NVIDIA or AMD GPUs. Consult the sub-sections below for
 the build instructions for a given GPU vendor.
 
 NVIDIA GPUs


### PR DESCRIPTION
### Description
Updates the documentation to note that Quokka cannot currently be compiled for Intel GPUs due to design limitations in Intel's GPU programming model.

### Related issues
https://github.com/quokka-astro/quokka/issues/619

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
