### PR TITLE
Use specific Intel compiler version in CI

### DIFF
--- a/.github/workflows/dependencies/dependencies_dpcpp.sh
+++ b/.github/workflows/dependencies/dependencies_dpcpp.sh
@@ -24,14 +24,17 @@ echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt
 
 sudo apt-get update
 
+# specify version of DPCPP/MKL (in order to workaround bugs)
+VERSION=2024.1
+
 # try apt install up to five times, to avoid connection splits
 status=1
 for itry in {1..5}
 do
     sudo apt-get install -y --no-install-recommends \
         build-essential \
-        intel-oneapi-compiler-dpcpp-cpp \
-        intel-oneapi-mkl-devel \
+        intel-oneapi-compiler-dpcpp-cpp-$VERSION \
+        intel-oneapi-mkl-devel-$VERSION \
         intel-oneapi-mpi-devel \
         python3-dev python3-numpy python3-matplotlib \
         libhdf5-mpi-dev \


### PR DESCRIPTION
### Description
This is a temporary workaround to avoid overly-aggressive floating-point optimizations in newer Intel compilers.

### Related issues
Temporary workaround for https://github.com/quokka-astro/quokka/issues/649.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
