### PR TITLE
no ghost cells in reference solution multifab

### DIFF
--- a/src/RadhydroSimulation.hpp
+++ b/src/RadhydroSimulation.hpp
@@ -608,14 +608,13 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterEv
 	if (computeReferenceSolution_) {
 		// compute reference solution
 		const int ncomp = state_new_cc_[0].nComp();
-		const int nghost = state_new_cc_[0].nGrow();
-		amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, nghost);
+		amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 		computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
 
 		// compute error norm
-		amrex::MultiFab residual(boxArray(0), DistributionMap(0), ncomp, nghost);
-		amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, nghost);
-		amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, nghost);
+		amrex::MultiFab residual(boxArray(0), DistributionMap(0), ncomp, 0);
+		amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
+		amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
 
 		amrex::Real sol_norm = 0.;
 		amrex::Real err_norm = 0.;


### PR DESCRIPTION
### Description
The reference solution multifab does not need to have ghost cells (they often weren't filled, and left as NaNs).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
