### PR TITLE
Fix Intel CI

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -62,7 +62,7 @@ jobs:
       
     - name: Run tests
       working-directory: ${{runner.workspace}}/quokka/build
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest --output-on-failure
       
     - name: Upload test output
       if: always()


### PR DESCRIPTION
### Description
Removes unused CMake option whose behavior changed in version 3.30.0. Thanks to Weiqun for the fix.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/674.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
