### PR TITLE
update Setonix job scripts

### DIFF
--- a/scripts/setonix-1node.submit
+++ b/scripts/setonix-1node.submit
@@ -11,12 +11,8 @@
 ##SBATCH --core-spec=8
 #SBATCH -N 1
 
-# load modules
-module load craype-accel-amd-gfx90a
-module load rocm/5.2.3
-
-# workaround no longer needed for AMReX 23.07+
-#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# multi-node MPI communication will hang without this (memhooks does NOT work)
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/setonix-64nodes.submit
+++ b/scripts/setonix-64nodes.submit
@@ -11,12 +11,22 @@
 ##SBATCH --core-spec=8
 #SBATCH -N 64
 
-# load modules
-module load craype-accel-amd-gfx90a
-module load rocm/5.2.3
+# WARNING: jobs with 64 nodes hang after "AMReX initialized" (July 2024)
+# (It's probably a network issue.)
+#
+# Example output:
+#
+#  Initializing AMReX (24.06-26-g7418556773c7)...
+#  MPI initialized with 512 MPI processes
+#  MPI initialized with thread support level 0
+#  Initializing HIP...
+#  HIP initialized with 512 devices.
+#  AMReX (24.06-26-g7418556773c7) initialized
+#
+# [job hangs here]
 
-# workaround no longer needed for AMReX 23.07+
-#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# multi-node MPI communication will hang without this (memhooks does NOT work)
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/setonix-8nodes.submit
+++ b/scripts/setonix-8nodes.submit
@@ -11,12 +11,8 @@
 ##SBATCH --core-spec=8
 #SBATCH -N 8
 
-# load modules
-module load craype-accel-amd-gfx90a
-module load rocm/5.2.3
-
-# workaround no longer needed for AMReX 23.07+
-#export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# multi-node MPI communication will hang without this (memhooks does NOT work)
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
### Description
This updates the Setonix job scripts so that they work again after the June 2024 software update.

However, 64 node jobs do not work. They either hang or fail with an error in Cray MPI.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
