### PR TITLE
update docs for runtime parameters

### DIFF
--- a/docs/parameters.rst
+++ b/docs/parameters.rst
@@ -67,12 +67,9 @@ These parameters are read in the `AMRSimulation<problem_t>::readParameters()` fu
    * - density_floor
      - Float
      - The minimum density value allowed in the simulation. Enforced through EnforceLimits.
-   * - temperature_ceiling
+   * - temperature_floor
      - Float
-     - The ceiling on temperature values in the simulation. Enforced through EnforceLimits.
-   * - speed_ceiling
-     - Float
-     - The ceiling on the absolute value of the fluid velocity in the simulation. Enforced through EnforceLimits.
+     - The minimum temperature value allowed in the simulation. Enforced through EnforceLimits.
    * - max_walltime
      - String
      - The maximum walltime for the simulation in the format DD:HH:SS (days/hours/seconds). After 90% of this walltime elapses, the simulation will automatically stop and exit.


### PR DESCRIPTION
### Description
This add `temperature_floor` to the list of runtime parameters in the documentation and removes the `*_ceiling` parameters, since those have been removed.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
