### PR TITLE
Rename RadhydroSimulation class to QuokkaSimulation

### DIFF
--- a/src/QuokkaSimulation.cpp
+++ b/src/QuokkaSimulation.cpp
@@ -1,0 +1,1 @@
+#include "QuokkaSimulation.hpp"

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -543,8 +543,7 @@ auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiF
 	return (burn_success && cool_success);
 }
 
-template <typename problem_t>
-void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
+template <typename problem_t> void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
 {
 	// compute derived variables and save in 'mf' -- user should implement
 }
@@ -570,7 +569,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::ErrorEst(int lev
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	// user should implement
 }
@@ -771,8 +770,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::FixupState(int l
 // NOTE: This has to be implemented here because PreInterpState and PostInterpState
 // are implemented in this class (and must be *static* functions).
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen,
-					      quokka::direction dir, FillPatchType fptype)
+void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
+					    FillPatchType fptype)
 {
 	BL_PROFILE("AMRSimulation::FillPatch()");
 
@@ -881,7 +880,7 @@ auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F co
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
-								   amrex::YAFluxRegister *fr_as_fine)
+								 amrex::YAFluxRegister *fr_as_fine)
 {
 	BL_PROFILE_REGION("HydroSolver");
 	// timestep retries
@@ -1028,7 +1027,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-							int lev, amrex::Real time, amrex::Real dt_lev) -> bool
+						      int lev, amrex::Real time, amrex::Real dt_lev) -> bool
 {
 	BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
@@ -1320,7 +1319,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
-						  amrex::iMultiFab &redoFlag)
+						amrex::iMultiFab &redoFlag)
 {
 	BL_PROFILE("QuokkaSimulation::replaceFluxes()");
 
@@ -1365,8 +1364,8 @@ void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMRE
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes,
-						  std::array<amrex::MultiFab, AMREX_SPACEDIM> &srcfluxes, const int srccomp, const int dstcomp)
+void QuokkaSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &srcfluxes,
+						const int srccomp, const int dstcomp)
 {
 	BL_PROFILE("QuokkaSimulation::addFluxArrays()");
 
@@ -1379,7 +1378,7 @@ void QuokkaSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMRE
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, const int nstartNew,
-						     const int ncompNew) -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>
+						   const int ncompNew) -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>
 {
 	BL_PROFILE("QuokkaSimulation::expandFluxArrays()");
 
@@ -1489,8 +1488,8 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 template <typename problem_t>
 template <FluxDir DIR>
 void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab const &x1Flat,
-						      amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
+						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab const &x1Flat,
+						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
 	if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
@@ -1556,7 +1555,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 template <typename problem_t>
 template <FluxDir DIR>
 void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-							amrex::MultiFab &flux, amrex::MultiFab &faceVel, const int ng_reconstruct, const int nvars)
+						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, const int ng_reconstruct, const int nvars)
 {
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
@@ -1572,7 +1571,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationSta
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
-							     amrex::YAFluxRegister *fr_as_fine)
+							   amrex::YAFluxRegister *fr_as_fine)
 {
 	// compute radiation timestep
 	int nsubSteps = 0;
@@ -1656,8 +1655,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int const iter_count,
-								   int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse,
-								   amrex::YAFluxRegister *fr_as_fine)
+								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	if (Verbose()) {
 		amrex::Print() << "\tsubstep " << iter_count << " t = " << time << '\n';
@@ -1723,7 +1721,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+							       int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
@@ -1756,7 +1754,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-								int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+							      int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
 
@@ -1792,9 +1790,9 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, const amrex::Real time,
-							     const double dt, const int stage, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
+							   const double dt, const int stage, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
 {
 	amrex::FArrayBox radEnergySource(indexRange, Physics_Traits<problem_t>::nGroups,
 					 amrex::The_Async_Arena()); // cell-centered scalar
@@ -1810,7 +1808,7 @@ void QuokkaSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex::
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, const int nvars,
-							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
+							 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
     -> std::tuple<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>
 {
 	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, 0);
@@ -1841,7 +1839,7 @@ auto QuokkaSimulation<problem_t>::computeRadiationFluxes(amrex::Array4<const amr
 template <typename problem_t>
 template <FluxDir DIR>
 void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
-						 const amrex::Box &indexRange, const int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
+					       const amrex::Box &indexRange, const int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
 	int dir = 0;
 	if constexpr (DIR == FluxDir::X1) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -5,7 +5,7 @@
 // Copyright 2020 Benjamin Wibking.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
-/// \file RadhydroSimulation.hpp
+/// \file QuokkaSimulation.hpp
 /// \brief Implements classes and functions to organise the overall setup,
 /// timestepping, solving, and I/O of a simulation for radiation moments.
 
@@ -61,7 +61,7 @@
 #include "simulation.hpp"
 
 // Simulation class should be initialized only once per program (i.e., is a singleton)
-template <typename problem_t> class RadhydroSimulation : public AMRSimulation<problem_t>
+template <typename problem_t> class QuokkaSimulation : public AMRSimulation<problem_t>
 {
       public:
 	using AMRSimulation<problem_t>::state_old_cc_;
@@ -142,12 +142,12 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
 	// member functions
-	explicit RadhydroSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : AMRSimulation<problem_t>(BCs_cc, BCs_fc)
+	explicit QuokkaSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : AMRSimulation<problem_t>(BCs_cc, BCs_fc)
 	{
 		initialize();
 	}
 
-	explicit RadhydroSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { initialize(); }
+	explicit QuokkaSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { initialize(); }
 
 	inline void initialize()
 	{
@@ -279,7 +279,7 @@ template <typename problem_t> class RadhydroSimulation : public AMRSimulation<pr
 			   amrex::iMultiFab &redoFlag);
 };
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::defineComponentNames()
+template <typename problem_t> void QuokkaSimulation<problem_t>::defineComponentNames()
 {
 
 	// cell-centred
@@ -319,7 +319,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::defineComponen
 	}
 }
 
-template <typename problem_t> auto RadhydroSimulation<problem_t>::getScalarVariableNames() -> std::vector<std::string>
+template <typename problem_t> auto QuokkaSimulation<problem_t>::getScalarVariableNames() -> std::vector<std::string>
 {
 	// return vector of names for the passive scalars
 	// this can be specialized by the user to provide more descriptive names
@@ -335,7 +335,7 @@ template <typename problem_t> auto RadhydroSimulation<problem_t>::getScalarVaria
 	return names;
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::readParmParse()
+template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 {
 	// set hydro runtime parameters
 	{
@@ -390,7 +390,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::readParmParse(
 	}
 }
 
-template <typename problem_t> auto RadhydroSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int
 {
 	// compute radiation timestep
 	auto const &dx = geom[lev].CellSizeArray();
@@ -401,9 +401,9 @@ template <typename problem_t> auto RadhydroSimulation<problem_t>::computeNumberO
 	return nsubSteps;
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::computeMaxSignalLocal(int const level)
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignalLocal(int const level)
 {
-	BL_PROFILE("RadhydroSimulation::computeMaxSignalLocal()");
+	BL_PROFILE("QuokkaSimulation::computeMaxSignalLocal()");
 
 	// hydro: loop over local grids, compute CFL timestep
 	for (amrex::MFIter iter(state_new_cc_[level]); iter.isValid(); ++iter) {
@@ -436,9 +436,9 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::computeMaxSign
 	}
 }
 
-template <typename problem_t> auto RadhydroSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::Real
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::Real
 {
-	BL_PROFILE("RadhydroSimulation::computeExtraPhysicsTimestep()");
+	BL_PROFILE("QuokkaSimulation::computeExtraPhysicsTimestep()");
 	// users can override this to enforce additional timestep constraints
 	return std::numeric_limits<amrex::Real>::max();
 }
@@ -449,9 +449,9 @@ template <typename problem_t> auto RadhydroSimulation<problem_t>::computeExtraPh
 #define CHECK_HYDRO_STATES(mf)
 #endif
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::checkHydroStates(amrex::MultiFab &mf, char const *file, int line)
+template <typename problem_t> void QuokkaSimulation<problem_t>::checkHydroStates(amrex::MultiFab &mf, char const *file, int line)
 {
-	BL_PROFILE("RadhydroSimulation::checkHydroStates()");
+	BL_PROFILE("QuokkaSimulation::checkHydroStates()");
 
 	bool validStates = HydroSystem<problem_t>::CheckStatesValid(mf);
 	amrex::ParallelDescriptor::ReduceBoolAnd(validStates);
@@ -465,55 +465,55 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::checkHydroStat
 	}
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::preCalculateInitialConditions()
+template <typename problem_t> void QuokkaSimulation<problem_t>::preCalculateInitialConditions()
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
+template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 	// note: an implementation is only required if face-centered vars are used
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::createInitialParticles()
+template <typename problem_t> void QuokkaSimulation<problem_t>::createInitialParticles()
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 	// note: an implementation is only required if particles are used
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::computeBeforeTimestep()
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeBeforeTimestep()
 {
 	// do nothing -- user should implement if desired
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterTimestep()
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterTimestep()
 {
 	// do nothing -- user should implement if desired
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterLevelAdvance(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterLevelAdvance(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
 {
 	// user should implement if desired
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt)
+template <typename problem_t> void QuokkaSimulation<problem_t>::addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt)
 {
 	// user should implement
 	// (when Strang splitting is enabled, dt is actually 0.5*dt_lev)
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt) -> bool
+auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt) -> bool
 {
 	// start by assuming cooling integrator is successful.
 	bool cool_success = true;
@@ -544,38 +544,38 @@ auto RadhydroSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::Mult
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
+void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
 {
 	// compute derived variables and save in 'mf' -- user should implement
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::ComputeProjections(int /*dir*/) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
+auto QuokkaSimulation<problem_t>::ComputeProjections(int /*dir*/) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
 {
 	// compute projections and return as unordered_map -- user should implement
 	return std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>{};
 }
 
-template <typename problem_t> auto RadhydroSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real>
+template <typename problem_t> auto QuokkaSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real>
 {
 	// compute statistics and return a std::map<std::string, amrex::Real> -- user should implement
 	// IMPORTANT: the user is responsible for performing any necessary MPI reductions before returning
 	return std::map<std::string, amrex::Real>{};
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <typename problem_t> void QuokkaSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement -- user should implement
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	// user should implement
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
@@ -647,9 +647,9 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::computeAfterEv
 	amrex::Print() << '\n';
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
+template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
 {
-	BL_PROFILE("RadhydroSimulation::advanceSingleTimestepAtLevel()");
+	BL_PROFILE("QuokkaSimulation::advanceSingleTimestepAtLevel()");
 
 	// get flux registers
 	amrex::YAFluxRegister *fr_as_crse = nullptr;
@@ -703,7 +703,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::advanceSingleT
 	AMREX_ASSERT(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()));
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs_mf, const int lev)
+template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs_mf, const int lev)
 {
 	// add hydro density to Poisson rhs
 	auto const &state = state_new_cc_[lev].const_arrays();
@@ -718,7 +718,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::fillPoissonRhs
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const amrex::Real dt)
+template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const amrex::Real dt)
 {
 	if constexpr (AMREX_SPACEDIM == 3) {
 		// apply Poisson gravity operator on level 'lev'
@@ -755,9 +755,9 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::applyPoissonGr
 
 // fix-up any unphysical states created by AMR operations
 // (e.g., caused by the flux register or from interpolation)
-template <typename problem_t> void RadhydroSimulation<problem_t>::FixupState(int lev)
+template <typename problem_t> void QuokkaSimulation<problem_t>::FixupState(int lev)
 {
-	BL_PROFILE("RadhydroSimulation::FixupState()");
+	BL_PROFILE("QuokkaSimulation::FixupState()");
 
 	// fix hydro state
 	HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, state_new_cc_[lev]);
@@ -771,7 +771,7 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::FixupState(int
 // NOTE: This has to be implemented here because PreInterpState and PostInterpState
 // are implemented in this class (and must be *static* functions).
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen,
+void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen,
 					      quokka::direction dir, FillPatchType fptype)
 {
 	BL_PROFILE("AMRSimulation::FillPatch()");
@@ -798,9 +798,9 @@ void RadhydroSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::
 	}
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::PreInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
+template <typename problem_t> void QuokkaSimulation<problem_t>::PreInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
 {
-	BL_PROFILE("RadhydroSimulation::PreInterpState()");
+	BL_PROFILE("QuokkaSimulation::PreInterpState()");
 
 	auto const &cons = mf.arrays();
 	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
@@ -817,9 +817,9 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::PreInterpState
 	});
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::PostInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
+template <typename problem_t> void QuokkaSimulation<problem_t>::PostInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
 {
-	BL_PROFILE("RadhydroSimulation::PostInterpState()");
+	BL_PROFILE("QuokkaSimulation::PostInterpState()");
 
 	auto const &cons = mf.arrays();
 	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
@@ -839,10 +839,10 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::PostInterpStat
 
 template <typename problem_t>
 template <typename F>
-auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F const &user_f) -> amrex::Gpu::HostVector<amrex::Real>
+auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F const &user_f) -> amrex::Gpu::HostVector<amrex::Real>
 {
 	// compute a 1D profile of user_f(i, j, k, state) along the given axis.
-	BL_PROFILE("RadhydroSimulation::computeAxisAlignedProfile()");
+	BL_PROFILE("QuokkaSimulation::computeAxisAlignedProfile()");
 
 	// allocate temporary multifabs
 	amrex::Vector<amrex::MultiFab> q;
@@ -880,7 +880,7 @@ auto RadhydroSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F 
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
+void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 								   amrex::YAFluxRegister *fr_as_fine)
 {
 	BL_PROFILE_REGION("HydroSolver");
@@ -986,7 +986,7 @@ void RadhydroSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amre
 	}
 }
 
-template <typename problem_t> auto RadhydroSimulation<problem_t>::isCflViolated(int lev, amrex::Real /*time*/, amrex::Real dt_actual) -> bool
+template <typename problem_t> auto QuokkaSimulation<problem_t>::isCflViolated(int lev, amrex::Real /*time*/, amrex::Real dt_actual) -> bool
 {
 	// check whether dt_actual would violate CFL condition using the post-update hydro state
 
@@ -1009,7 +1009,7 @@ template <typename problem_t> auto RadhydroSimulation<problem_t>::isCflViolated(
 	return cflViolation;
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::printCoordinates(int lev, const amrex::IntVect &cell_idx)
+template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates(int lev, const amrex::IntVect &cell_idx)
 {
 
 	amrex::Real x_coord = geom[lev].ProbLo(0) + (cell_idx[0] + 0.5) * geom[lev].CellSize(0);
@@ -1027,10 +1027,10 @@ template <typename problem_t> void RadhydroSimulation<problem_t>::printCoordinat
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
+auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 							int lev, amrex::Real time, amrex::Real dt_lev) -> bool
 {
-	BL_PROFILE("RadhydroSimulation::advanceHydroAtLevel()");
+	BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
 	amrex::Real fluxScaleFactor = NAN;
 	if (integratorOrder_ == 2) {
@@ -1319,10 +1319,10 @@ auto RadhydroSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_o
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
+void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
 						  amrex::iMultiFab &redoFlag)
 {
-	BL_PROFILE("RadhydroSimulation::replaceFluxes()");
+	BL_PROFILE("QuokkaSimulation::replaceFluxes()");
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) { // loop over dimension
 		// ensure that flux arrays have the same number of components
@@ -1365,10 +1365,10 @@ void RadhydroSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AM
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes,
+void QuokkaSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes,
 						  std::array<amrex::MultiFab, AMREX_SPACEDIM> &srcfluxes, const int srccomp, const int dstcomp)
 {
-	BL_PROFILE("RadhydroSimulation::addFluxArrays()");
+	BL_PROFILE("QuokkaSimulation::addFluxArrays()");
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto const &srcflux = srcfluxes[idim];
@@ -1378,10 +1378,10 @@ void RadhydroSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AM
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, const int nstartNew,
+auto QuokkaSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, const int nstartNew,
 						     const int ncompNew) -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>
 {
-	BL_PROFILE("RadhydroSimulation::expandFluxArrays()");
+	BL_PROFILE("QuokkaSimulation::expandFluxArrays()");
 
 	// This is needed because reflux arrays must have the same number of components as
 	// state_new_cc_[lev]
@@ -1398,10 +1398,10 @@ auto RadhydroSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
+auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
     -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
-	BL_PROFILE("RadhydroSimulation::computeHydroFluxes()");
+	BL_PROFILE("QuokkaSimulation::computeHydroFluxes()");
 
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
@@ -1488,7 +1488,7 @@ auto RadhydroSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &co
 
 template <typename problem_t>
 template <FluxDir DIR>
-void RadhydroSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab const &x1Flat,
 						      amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
@@ -1514,10 +1514,10 @@ void RadhydroSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &pri
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
+auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
     -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
-	BL_PROFILE("RadhydroSimulation::computeFOHydroFluxes()");
+	BL_PROFILE("QuokkaSimulation::computeFOHydroFluxes()");
 
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
@@ -1555,7 +1555,7 @@ auto RadhydroSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &
 
 template <typename problem_t>
 template <FluxDir DIR>
-void RadhydroSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 							amrex::MultiFab &flux, amrex::MultiFab &faceVel, const int ng_reconstruct, const int nvars)
 {
 	// donor-cell reconstruction
@@ -1564,14 +1564,14 @@ void RadhydroSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &p
 	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
 }
 
-template <typename problem_t> void RadhydroSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)
+template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)
 {
 	// copy radiation state variables from stateNew to stateOld
 	amrex::MultiFab::Copy(stateOld, stateNew, nstartHyperbolic_, nstartHyperbolic_, ncompHyperbolic_, 0);
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
+void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
 							     amrex::YAFluxRegister *fr_as_fine)
 {
 	// compute radiation timestep
@@ -1655,7 +1655,7 @@ void RadhydroSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Rea
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int const iter_count,
+void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int const iter_count,
 								   int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse,
 								   amrex::YAFluxRegister *fr_as_fine)
 {
@@ -1722,7 +1722,7 @@ void RadhydroSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amre
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
+void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
 								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	// get cell sizes
@@ -1755,7 +1755,7 @@ void RadhydroSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex:
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
+void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
 								int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
@@ -1791,7 +1791,7 @@ void RadhydroSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::
 }
 
 template <typename problem_t>
-void RadhydroSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, const amrex::Real time,
+void QuokkaSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, const amrex::Real time,
 							     const double dt, const int stage, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
@@ -1809,7 +1809,7 @@ void RadhydroSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex
 }
 
 template <typename problem_t>
-auto RadhydroSimulation<problem_t>::computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, const int nvars,
+auto QuokkaSimulation<problem_t>::computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, const int nvars,
 							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
     -> std::tuple<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>
 {
@@ -1840,7 +1840,7 @@ auto RadhydroSimulation<problem_t>::computeRadiationFluxes(amrex::Array4<const a
 
 template <typename problem_t>
 template <FluxDir DIR>
-void RadhydroSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
+void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 						 const amrex::Box &indexRange, const int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
 	int dir = 0;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -471,13 +471,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::preCalculateInit
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
+template <typename problem_t> void QuokkaSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -173,8 +173,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeMaxSignalLocal(int level) override;
 	auto computeExtraPhysicsTimestep(int lev) -> amrex::Real override;
 	void preCalculateInitialConditions() override;
-	void setInitialConditionsOnGrid(quokka::grid grid_elem) override;
-	void setInitialConditionsOnGridFaceVars(quokka::grid grid_elem) override;
+	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
+	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
 	void createInitialParticles() override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) override;
 	void computeBeforeTimestep() override;

--- a/src/RadhydroSimulation.cpp
+++ b/src/RadhydroSimulation.cpp
@@ -1,1 +1,0 @@
-#include "RadhydroSimulation.hpp"

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -63,8 +63,8 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void computeMaxSignalLocal(int level) override;
 	auto computeExtraPhysicsTimestep(int level) -> amrex::Real override;
 	void preCalculateInitialConditions() override;
-	void setInitialConditionsOnGrid(quokka::grid grid_elem) override;
-	void setInitialConditionsOnGridFaceVars(quokka::grid grid_elem) override;
+	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
+	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
 	void createInitialParticles() override;
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int /*ncycle*/) override;
 	void computeBeforeTimestep() override;
@@ -137,13 +137,13 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::preCalculateI
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <typename problem_t> void AdvectionSimulation<problem_t>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
+template <typename problem_t> void AdvectionSimulation<problem_t>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// default empty implementation
 	// user should implement using problem-specific template specialization

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -47,7 +47,7 @@ AMREX_GPU_DEVICE void ComputeExactSolution(int i, int j, int k, int n, amrex::Ar
 	exact_arr(i, j, k, n) = value;
 }
 
-template <> void AdvectionSimulation<SawtoothProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void AdvectionSimulation<SawtoothProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -57,7 +57,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto exactSolutionAtIndex(int i, int j, amre
 	return rho;
 }
 
-template <> void AdvectionSimulation<SquareProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void AdvectionSimulation<SquareProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -46,7 +46,7 @@ AMREX_GPU_DEVICE void ComputeExactSolution(int i, int j, int k, int n, amrex::Ar
 	exact_arr(i, j, k, n) = dens;
 }
 
-template <> void AdvectionSimulation<SemiellipseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void AdvectionSimulation<SemiellipseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -23,7 +23,7 @@
 
 #include "AMReX_REAL.H"
 #include "AMReX_ccse-mpi.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "binary_orbit.hpp"
 #include "hydro/hydro_system.hpp"
 #include <algorithm>
@@ -56,7 +56,7 @@ template <> struct SimulationData<BinaryOrbit> {
 	std::vector<amrex::ParticleReal> dist{};
 };
 
-template <> void RadhydroSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -72,7 +72,7 @@ template <> void RadhydroSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quo
 	});
 }
 
-template <> void RadhydroSimulation<BinaryOrbit>::createInitialParticles()
+template <> void QuokkaSimulation<BinaryOrbit>::createInitialParticles()
 {
 	// read particles from ASCII file
 	const int nreal_extra = 4; // mass vx vy vz
@@ -80,7 +80,7 @@ template <> void RadhydroSimulation<BinaryOrbit>::createInitialParticles()
 	CICParticles->InitFromAsciiFile("BinaryOrbit_particles.txt", nreal_extra, nullptr);
 }
 
-template <> void RadhydroSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <> void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {
@@ -91,7 +91,7 @@ template <> void RadhydroSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std
 	}
 }
 
-template <> void RadhydroSimulation<BinaryOrbit>::computeAfterTimestep()
+template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 {
 	// every N cycles, save particle statistics
 	static int cycle = 1;
@@ -167,7 +167,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BinaryOrbit> sim(BCs_cc);
+	QuokkaSimulation<BinaryOrbit> sim(BCs_cc);
 	sim.doPoissonSolve_ = 1; // enable self-gravity
 	sim.initDt_ = 1.0e3;	 // s
 

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -56,7 +56,7 @@ template <> struct SimulationData<BinaryOrbit> {
 	std::vector<amrex::ParticleReal> dist{};
 };
 
-template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -13,7 +13,7 @@
 #include "AMReX_GpuDevice.H"
 #include "AMReX_TableData.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 
 using amrex::Real;
@@ -53,7 +53,7 @@ const int kmin = 0;
 const int kmax = 16;
 Real const A = 0.05 / kmax;
 
-template <> void RadhydroSimulation<CoolingTest>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<CoolingTest>::preCalculateInitialConditions()
 {
 	// generate random phases
 	amrex::Array<int, 3> tlo{kmin, kmin, kmin}; // lower bounds
@@ -81,7 +81,7 @@ template <> void RadhydroSimulation<CoolingTest>::preCalculateInitialConditions(
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void RadhydroSimulation<CoolingTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CoolingTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -195,7 +195,7 @@ auto problem_main() -> int
 #endif
 	}
 
-	RadhydroSimulation<CoolingTest> sim(BCs_cc);
+	QuokkaSimulation<CoolingTest> sim(BCs_cc);
 
 	// Standard PPM gives unphysically enormous temperatures when used for
 	// this problem (e.g., ~1e14 K or higher), but can be fixed by

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -81,7 +81,7 @@ template <> void QuokkaSimulation<CoolingTest>::preCalculateInitialConditions()
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void QuokkaSimulation<CoolingTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CoolingTest>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -16,7 +16,7 @@
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
 #include "test_fc_quantities.hpp"
@@ -71,7 +71,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	state(i, j, k, HydroSystem<FCQuantities>::internalEnergy_index) = Eint;
 }
 
-template <> void RadhydroSimulation<FCQuantities>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract grid information
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -89,7 +89,7 @@ template <> void RadhydroSimulation<FCQuantities>::setInitialConditionsOnGrid(qu
 	});
 }
 
-template <> void RadhydroSimulation<FCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
+template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
 {
 	// extract grid information
 	const amrex::Array4<double> &state = grid_elem.array_;
@@ -155,12 +155,12 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<FCQuantities> sim_write(BCs_cc, BCs_fc);
+	QuokkaSimulation<FCQuantities> sim_write(BCs_cc, BCs_fc);
 	sim_write.setInitialConditions();
 	amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const &state_new_fc_write = sim_write.getNewMF_fc();
 	amrex::Print() << "\n";
 
-	RadhydroSimulation<FCQuantities> sim_restart(BCs_cc, BCs_fc);
+	QuokkaSimulation<FCQuantities> sim_restart(BCs_cc, BCs_fc);
 	sim_restart.setChkFile("chk00000");
 	sim_restart.setInitialConditions();
 	amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const &state_new_fc_restart = sim_restart.getNewMF_fc();

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -71,7 +71,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	state(i, j, k, HydroSystem<FCQuantities>::internalEnergy_index) = Eint;
 }
 
-template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -89,7 +89,7 @@ template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quok
 	});
 }
 
-template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid grid_elem)
+template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::Array4<double> &state = grid_elem.array_;

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<BlastProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<BlastProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BlastProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -18,7 +18,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_TagBox.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "test_hydro2d_blast.hpp"
 
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<BlastProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<BlastProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BlastProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -94,7 +94,7 @@ template <> void RadhydroSimulation<BlastProblem>::setInitialConditionsOnGrid(qu
 	});
 }
 
-template <> void RadhydroSimulation<BlastProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<BlastProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -143,7 +143,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = RadhydroSimulation<BlastProblem>::nvarTotal_cc_;
+	const int ncomp_cc = QuokkaSimulation<BlastProblem>::nvarTotal_cc_;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
@@ -164,7 +164,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BlastProblem> sim(BCs_cc);
+	QuokkaSimulation<BlastProblem> sim(BCs_cc);
 
 	sim.stopTime_ = 0.1; // 1.5;
 	sim.cflNumber_ = 0.3;

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -15,7 +15,7 @@
 #include "AMReX_Print.H"
 #include "AMReX_SPACE.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 
@@ -52,14 +52,14 @@ template <> struct Physics_Traits<SedovProblem> {
 const double rho = 1.0;	   // g cm^-3
 double E_blast = 0.851072; // ergs
 
-template <> void RadhydroSimulation<SedovProblem>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<SedovProblem>::preCalculateInitialConditions()
 {
 	if constexpr (!simulate_full_box) {
 		E_blast /= 8.0; // only one octant, so 1/8 of the total energy
 	}
 }
 
-template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SedovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// initialize a Sedov test problem using parameters from
 	// Richard Klein and J. Bolstad
@@ -115,7 +115,7 @@ template <> void RadhydroSimulation<SedovProblem>::setInitialConditionsOnGrid(qu
 	});
 }
 
-template <> void RadhydroSimulation<SedovProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<SedovProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -150,7 +150,7 @@ template <> void RadhydroSimulation<SedovProblem>::ErrorEst(int lev, amrex::TagB
 	}
 }
 
-template <> void RadhydroSimulation<SedovProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
+template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
@@ -254,7 +254,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SedovProblem> sim(BCs_cc);
+	QuokkaSimulation<SedovProblem> sim(BCs_cc);
 
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.stopTime_ = 1.0;	      // seconds

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -59,7 +59,7 @@ template <> void QuokkaSimulation<SedovProblem>::preCalculateInitialConditions()
 	}
 }
 
-template <> void QuokkaSimulation<SedovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SedovProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// initialize a Sedov test problem using parameters from
 	// Richard Klein and J. Bolstad

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_contact.hpp"
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<ContactProblem> {
 
 constexpr double v_contact = 0.0; // contact wave velocity
 
-template <> void RadhydroSimulation<ContactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ContactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -83,7 +83,7 @@ template <> void RadhydroSimulation<ContactProblem>::setInitialConditionsOnGrid(
 }
 
 template <>
-void RadhydroSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
@@ -195,7 +195,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ContactProblem> sim(BCs_cc);
+	QuokkaSimulation<ContactProblem> sim(BCs_cc);
 
 	sim.stopTime_ = 2.0;
 	sim.cflNumber_ = 0.8;

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -84,7 +84,7 @@ template <> void QuokkaSimulation<ContactProblem>::setInitialConditionsOnGrid(qu
 
 template <>
 void QuokkaSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<ContactProblem> {
 
 constexpr double v_contact = 0.0; // contact wave velocity
 
-template <> void QuokkaSimulation<ContactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ContactProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "util/fextract.hpp"
 #ifdef HAVE_PYTHON
@@ -45,7 +45,7 @@ template <> struct Physics_Traits<HighMachProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<HighMachProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -81,7 +81,7 @@ template <> void RadhydroSimulation<HighMachProblem>::setInitialConditionsOnGrid
 }
 
 template <>
-void RadhydroSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
 								   amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -258,7 +258,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<HighMachProblem> sim(BCs_cc);
+	QuokkaSimulation<HighMachProblem> sim(BCs_cc);
 
 	sim.computeReferenceSolution_ = true;
 

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -82,7 +82,7 @@ template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(q
 
 template <>
 void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-								   amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
+								 amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	// extract solution

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -45,7 +45,7 @@ template <> struct Physics_Traits<HighMachProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -15,7 +15,7 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "test_hydro2d_kh.hpp"
 
@@ -43,7 +43,7 @@ template <> struct Physics_Traits<KelvinHelmholzProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<KelvinHelmholzProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<KelvinHelmholzProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -87,7 +87,7 @@ template <> void RadhydroSimulation<KelvinHelmholzProblem>::setInitialConditions
 	});
 }
 
-template <> void RadhydroSimulation<KelvinHelmholzProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<KelvinHelmholzProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -132,7 +132,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<KelvinHelmholzProblem> sim(BCs_cc);
+	QuokkaSimulation<KelvinHelmholzProblem> sim(BCs_cc);
 
 	sim.stopTime_ = 1.5;
 	sim.cflNumber_ = 0.4;

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -43,7 +43,7 @@ template <> struct Physics_Traits<KelvinHelmholzProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<KelvinHelmholzProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<KelvinHelmholzProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -140,7 +140,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	// read in exact solution

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -45,7 +45,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -15,7 +15,7 @@
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_leblanc.hpp"
@@ -45,7 +45,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -139,7 +139,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 }
 
 template <>
-void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -353,7 +353,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.maxDt_ = max_dt;

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -64,7 +64,7 @@ constexpr Real ur = -5.0;
 constexpr Real pr = 0.6;
 int ishock_g = 0;
 
-template <> void QuokkaSimulation<QuirkProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<QuirkProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -26,7 +26,7 @@
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 
@@ -64,7 +64,7 @@ constexpr Real ur = -5.0;
 constexpr Real pr = 0.6;
 int ishock_g = 0;
 
-template <> void RadhydroSimulation<QuirkProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<QuirkProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -129,7 +129,7 @@ auto getDeltaEntropyVector() -> std::vector<Real> &
 	return delta_s_vec;
 }
 
-template <> void RadhydroSimulation<QuirkProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<QuirkProblem>::computeAfterTimestep()
 {
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// it should be sufficient examine a single box on level 0
@@ -182,7 +182,7 @@ template <> void RadhydroSimulation<QuirkProblem>::computeAfterTimestep()
 	}
 }
 
-template <> void RadhydroSimulation<QuirkProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/)
+template <> void QuokkaSimulation<QuirkProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/)
 {
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		auto const &deltas_vec = getDeltaEntropyVector();
@@ -259,7 +259,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<QuirkProblem> sim(BCs_cc);
+	QuokkaSimulation<QuirkProblem> sim(BCs_cc);
 
 	sim.reconstructionOrder_ = 2; // PLM
 	sim.stopTime_ = 0.4;

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -13,7 +13,7 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 
 struct RichtmeyerMeshkovProblem {
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<RichtmeyerMeshkovProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::computeAfterTimestep()
 {
 	const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
 
@@ -99,7 +99,7 @@ template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::computeAfterTimes
 	}
 }
 
-template <> void RadhydroSimulation<RichtmeyerMeshkovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -173,7 +173,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<RichtmeyerMeshkovProblem> sim(BCs_cc);
+	QuokkaSimulation<RichtmeyerMeshkovProblem> sim(BCs_cc);
 
 	sim.stopTime_ = 2.5;
 	sim.cflNumber_ = 0.4;

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -99,7 +99,7 @@ template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::computeAfterTimeste
 	}
 }
 
-template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -131,7 +131,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	auto const box = geom[0].Domain();

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -9,7 +9,7 @@
 
 #include "AMReX_BC_TYPES.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "test_hydro_sms.hpp"
 #include "util/ArrayUtil.hpp"
@@ -38,7 +38,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -130,7 +130,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 }
 
 template <>
-void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -274,7 +274,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.constantDt_ = fixed_dt;

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -38,7 +38,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -49,7 +49,7 @@ constexpr amrex::Real P_L = 100.0;
 constexpr amrex::Real rho_R = 1.0;
 constexpr amrex::Real P_R = 1.0;
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -171,7 +171,7 @@ template <> void QuokkaSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::Ta
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	// read in exact solution

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -13,7 +13,7 @@
 
 #include "AMReX_BC_TYPES.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_shocktube.hpp"
@@ -49,7 +49,7 @@ constexpr amrex::Real P_L = 100.0;
 constexpr amrex::Real rho_R = 1.0;
 constexpr amrex::Real P_R = 1.0;
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -143,7 +143,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	}
 }
 
-template <> void RadhydroSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -170,7 +170,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::
 }
 
 template <>
-void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -360,7 +360,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	// sim.cflNumber_ = CFL_number;
 	// sim.maxDt_ = max_dt;

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -14,7 +14,7 @@
 
 #include "AMReX_BC_TYPES.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_shocktube_cma.hpp"
@@ -54,7 +54,7 @@ constexpr amrex::Real P_L = 1.0;
 constexpr amrex::Real rho_R = 0.125;
 constexpr amrex::Real P_R = 0.1;
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -176,7 +176,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	}
 }
 
-template <> void RadhydroSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -202,7 +202,7 @@ template <> void RadhydroSimulation<ShocktubeProblem>::ErrorEst(int lev, amrex::
 	}
 }
 
-template <> void RadhydroSimulation<ShocktubeProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<ShocktubeProblem>::computeAfterTimestep()
 {
 	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5);
 	const int nx = static_cast<int>(position.size()); // number of cells along the x direction
@@ -253,7 +253,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -54,7 +54,7 @@ constexpr amrex::Real P_L = 1.0;
 constexpr amrex::Real rho_R = 0.125;
 constexpr amrex::Real P_R = 0.1;
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "AMReX_BC_TYPES.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_shuosher.hpp"
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -131,7 +131,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 }
 
 template <>
-void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -294,7 +294,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.constantDt_ = fixed_dt;

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -132,7 +132,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	// read in exact solution

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_hydro_vacuum.hpp"
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -135,7 +135,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 }
 
 template <>
-void RadhydroSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
@@ -316,7 +316,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<ShocktubeProblem> sim(BCs_cc);
+	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.maxDt_ = max_dt;

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -136,7 +136,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 
 	auto const box = geom[0].Domain();

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<ShocktubeProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -67,7 +67,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	state(i, j, k, HydroSystem<WaveProblem>::internalEnergy_index) = Eint;
 }
 
-template <> void QuokkaSimulation<WaveProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<WaveProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -13,7 +13,7 @@
 #include "AMReX_Array4.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "test_hydro_wave.hpp"
 #include "util/fextract.hpp"
@@ -67,7 +67,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	state(i, j, k, HydroSystem<WaveProblem>::internalEnergy_index) = Eint;
 }
 
-template <> void RadhydroSimulation<WaveProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<WaveProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -106,7 +106,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<WaveProblem> sim(BCs_cc);
+	QuokkaSimulation<WaveProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
@@ -126,7 +126,7 @@ auto problem_main() -> int
 
 	// compute error norm
 	amrex::Real err_sq = 0.;
-	for (int n = 0; n < RadhydroSimulation<WaveProblem>::ncompHydro_; ++n) {
+	for (int n = 0; n < QuokkaSimulation<WaveProblem>::ncompHydro_; ++n) {
 		if (n == HydroSystem<WaveProblem>::internalEnergy_index) {
 			continue;
 		}

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -81,7 +81,7 @@ AMREX_GPU_MANAGED amrex::GpuArray<Real, Physics_Traits<Channel>::numPassiveScala
 };											 // namespace
 #endif
 
-template <> void QuokkaSimulation<Channel>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<Channel>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -27,7 +27,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "channel.hpp"
 #include "fundamental_constants.H"
 #include "hydro/EOS.hpp"
@@ -81,7 +81,7 @@ AMREX_GPU_MANAGED amrex::GpuArray<Real, Physics_Traits<Channel>::numPassiveScala
 };											 // namespace
 #endif
 
-template <> void RadhydroSimulation<Channel>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<Channel>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -144,7 +144,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<Channel> sim(BCs_cc);
+	QuokkaSimulation<Channel> sim(BCs_cc);
 
 	amrex::ParmParse const pp("channel");
 	// initial condition parameters

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -73,7 +73,7 @@ AMREX_GPU_MANAGED amrex::Real w0 = NAN;					      // NOLINT(cppcoreguidelines-av
 AMREX_GPU_MANAGED amrex::GpuArray<Real, HydroSystem<Vortex>::nscalars_> s0{}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 }; // namespace
 
-template <> void QuokkaSimulation<Vortex>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<Vortex>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -27,7 +27,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "fundamental_constants.H"
 #include "hydro/EOS.hpp"
 #include "hydro/HydroState.hpp"
@@ -73,7 +73,7 @@ AMREX_GPU_MANAGED amrex::Real w0 = NAN;					      // NOLINT(cppcoreguidelines-av
 AMREX_GPU_MANAGED amrex::GpuArray<Real, HydroSystem<Vortex>::nscalars_> s0{}; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 }; // namespace
 
-template <> void RadhydroSimulation<Vortex>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<Vortex>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -171,7 +171,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<Vortex> sim(BCs_cc);
+	QuokkaSimulation<Vortex> sim(BCs_cc);
 
 	amrex::ParmParse const pp("vortex");
 	// initial condition parameters

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -85,7 +85,7 @@ template <> void QuokkaSimulation<ScalarProblem>::setInitialConditionsOnGrid(quo
 
 template <>
 void QuokkaSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-								 amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
+							       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<ScalarProblem> {
 
 constexpr double v_contact = 2.0; // contact wave velocity
 
-template <> void QuokkaSimulation<ScalarProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ScalarProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_scalars.hpp"
@@ -42,7 +42,7 @@ template <> struct Physics_Traits<ScalarProblem> {
 
 constexpr double v_contact = 2.0; // contact wave velocity
 
-template <> void RadhydroSimulation<ScalarProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ScalarProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -84,7 +84,7 @@ template <> void RadhydroSimulation<ScalarProblem>::setInitialConditionsOnGrid(q
 }
 
 template <>
-void RadhydroSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
+void QuokkaSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
 								 amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
@@ -210,7 +210,7 @@ void RadhydroSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab
 #endif
 }
 
-template <> void RadhydroSimulation<ScalarProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ScalarProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -252,7 +252,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ScalarProblem> sim(BCs_cc);
+	QuokkaSimulation<ScalarProblem> sim(BCs_cc);
 
 	sim.computeReferenceSolution_ = true;
 

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -170,7 +170,7 @@ template <> void QuokkaSimulation<PopIII>::preCalculateInitialConditions()
 	}
 }
 
-template <> void QuokkaSimulation<PopIII>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PopIII>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -18,7 +18,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_TableData.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"
 #include "hydro/hydro_system.hpp"
 #include "popiii.hpp"
@@ -83,7 +83,7 @@ template <> struct SimulationData<PopIII> {
 	amrex::Real primary_species_14{};
 };
 
-template <> void RadhydroSimulation<PopIII>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<PopIII>::preCalculateInitialConditions()
 {
 
 	// initialize microphysics routines
@@ -170,7 +170,7 @@ template <> void RadhydroSimulation<PopIII>::preCalculateInitialConditions()
 	}
 }
 
-template <> void RadhydroSimulation<PopIII>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PopIII>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -322,7 +322,7 @@ template <> void RadhydroSimulation<PopIII>::setInitialConditionsOnGrid(quokka::
 	});
 }
 
-template <> void RadhydroSimulation<PopIII>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<PopIII>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 
 	// read-in jeans length refinement runtime params
@@ -358,7 +358,7 @@ template <> void RadhydroSimulation<PopIII>::ErrorEst(int lev, amrex::TagBoxArra
 	}
 }
 
-template <> void RadhydroSimulation<PopIII>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <> void QuokkaSimulation<PopIII>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {
@@ -446,7 +446,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<PopIII> sim(BCs_cc);
+	QuokkaSimulation<PopIII> sim(BCs_cc);
 	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	sim.tempFloor_ = 2.73 * (30.0 + 1.0);

--- a/src/problems/PrimordialChem/test_primordial_chem.cpp
+++ b/src/problems/PrimordialChem/test_primordial_chem.cpp
@@ -121,7 +121,7 @@ template <> void QuokkaSimulation<PrimordialChemTest>::preCalculateInitialCondit
 	network_init();
 }
 
-template <> void QuokkaSimulation<PrimordialChemTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PrimordialChemTest>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/PrimordialChem/test_primordial_chem.cpp
+++ b/src/problems/PrimordialChem/test_primordial_chem.cpp
@@ -23,7 +23,7 @@
 #include "AMReX_SPACE.H"
 #include "AMReX_TableData.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
@@ -71,7 +71,7 @@ template <> struct SimulationData<PrimordialChemTest> {
 	amrex::Real primary_species_14;
 };
 
-template <> void RadhydroSimulation<PrimordialChemTest>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<PrimordialChemTest>::preCalculateInitialConditions()
 {
 	// initialize microphysics routines
 	init_extern_parameters();
@@ -121,7 +121,7 @@ template <> void RadhydroSimulation<PrimordialChemTest>::preCalculateInitialCond
 	network_init();
 }
 
-template <> void RadhydroSimulation<PrimordialChemTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PrimordialChemTest>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -261,7 +261,7 @@ auto problem_main() -> int
 #endif
 	}
 
-	RadhydroSimulation<PrimordialChemTest> sim(BCs_cc);
+	QuokkaSimulation<PrimordialChemTest> sim(BCs_cc);
 
 	// Standard PPM gives unphysically enormous temperatures when used for
 	// this problem (e.g., ~1e14 K or higher), but can be fixed by

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 
 struct BeamProblem {
@@ -207,7 +207,7 @@ AMRSimulation<BeamProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 	}
 }
 
-template <> void RadhydroSimulation<BeamProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BeamProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -232,7 +232,7 @@ template <> void RadhydroSimulation<BeamProblem>::setInitialConditionsOnGrid(quo
 	});
 }
 
-template <> void RadhydroSimulation<BeamProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<BeamProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -286,7 +286,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<BeamProblem> sim(BCs_cc);
+	QuokkaSimulation<BeamProblem> sim(BCs_cc);
 
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -207,7 +207,7 @@ AMRSimulation<BeamProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv
 	}
 }
 
-template <> void QuokkaSimulation<BeamProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<BeamProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/RadBeam/test_radiation_beam.hpp
+++ b/src/problems/RadBeam/test_radiation_beam.hpp
@@ -14,7 +14,7 @@
 #include <fstream>
 
 // internal headers
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 
 // function definitions

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -16,7 +16,7 @@
 #include "AMReX_Box.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
@@ -80,7 +80,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TubeProblem>::ComputeFluxMeanOp
 	return kappa0;
 }
 
-template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -195,7 +195,7 @@ auto problem_main() -> int
 	pp.query("max_dt", max_dt);
 
 	// Problem initialization
-	RadhydroSimulation<TubeProblem> sim(BCs_cc);
+	QuokkaSimulation<TubeProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.reconstructionOrder_ = 3;	       // PPM

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -80,7 +80,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TubeProblem>::ComputeFluxMeanOp
 	return kappa0;
 }
 
-template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "test_radiation_marshak.hpp"
 #include "util/fextract.hpp"
 
@@ -159,7 +159,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 	consVar(i, j, k, RadSystem<SuOlsonProblem>::x3GasMomentum_index) = 0.;
 }
 
-template <> void RadhydroSimulation<SuOlsonProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -213,7 +213,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SuOlsonProblem> sim(BCs_cc);
+	QuokkaSimulation<SuOlsonProblem> sim(BCs_cc);
 
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -159,7 +159,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 	consVar(i, j, k, RadSystem<SuOlsonProblem>::x3GasMomentum_index) = 0.;
 }
 
-template <> void QuokkaSimulation<SuOlsonProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -9,7 +9,7 @@
 
 #include "AMReX_BLassert.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "test_radiation_marshak_asymptotic.hpp"
 #include "util/fextract.hpp"
 
@@ -145,7 +145,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	consVar(i, j, k, RadSystem<SuOlsonProblemCgs>::x3GasMomentum_index) = 0.;
 }
 
-template <> void RadhydroSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -227,7 +227,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SuOlsonProblemCgs> sim(BCs_cc);
+	QuokkaSimulation<SuOlsonProblemCgs> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -145,7 +145,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	consVar(i, j, k, RadSystem<SuOlsonProblemCgs>::x3GasMomentum_index) = 0.;
 }
 
-template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -172,7 +172,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	consVar(i, j, k, RadSystem<SuOlsonProblemCgs>::x3GasMomentum_index) = 0.;
 }
 
-template <> void RadhydroSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -227,7 +227,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SuOlsonProblemCgs> sim(BCs_cc);
+	QuokkaSimulation<SuOlsonProblemCgs> sim(BCs_cc);
 
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -172,7 +172,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	consVar(i, j, k, RadSystem<SuOlsonProblemCgs>::x3GasMomentum_index) = 0.;
 }
 
-template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.hpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.hpp
@@ -18,7 +18,7 @@
 
 // internal headers
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
 

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -219,7 +219,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	}
 }
 
-template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -4,7 +4,7 @@
 
 #include "AMReX_BLassert.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_radiation_marshak_Vaytet.hpp"
 #include "util/fextract.hpp"
@@ -219,7 +219,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 	}
 }
 
-template <> void RadhydroSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SuOlsonProblemCgs>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -272,7 +272,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SuOlsonProblemCgs> sim(BCs_cc);
+	QuokkaSimulation<SuOlsonProblemCgs> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -102,7 +102,7 @@ constexpr double Erad0 = 1.0e12; // erg cm^-3
 constexpr double Egas0 = 1.0e2;	 // erg cm^-3
 constexpr double rho0 = 1.0e-7;	 // g cm^-3
 
-template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -11,7 +11,7 @@
 
 #include "AMReX_BC_TYPES.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "test_radiation_matter_coupling.hpp"
 #include "util/fextract.hpp"
@@ -102,7 +102,7 @@ constexpr double Erad0 = 1.0e12; // erg cm^-3
 constexpr double Egas0 = 1.0e2;	 // erg cm^-3
 constexpr double rho0 = 1.0e-7;	 // g cm^-3
 
-template <> void RadhydroSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -122,7 +122,7 @@ template <> void RadhydroSimulation<CouplingProblem>::setInitialConditionsOnGrid
 	});
 }
 
-template <> void RadhydroSimulation<CouplingProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<CouplingProblem>::computeAfterTimestep()
 {
 	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5);
 
@@ -164,7 +164,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<CouplingProblem> sim(BCs_cc);
+	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -104,7 +104,7 @@ constexpr double Erad0 = 1.0e12; // erg cm^-3
 constexpr double Egas0 = 1.0e2;	 // erg cm^-3
 constexpr double rho0 = 1.0e-7;	 // g cm^-3
 
-template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -8,7 +8,7 @@
 ///
 
 #include "test_radiation_matter_coupling_rsla.hpp"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/fextract.hpp"
 #ifdef HAVE_PYTHON
@@ -104,7 +104,7 @@ constexpr double Erad0 = 1.0e12; // erg cm^-3
 constexpr double Egas0 = 1.0e2;	 // erg cm^-3
 constexpr double rho0 = 1.0e-7;	 // g cm^-3
 
-template <> void RadhydroSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CouplingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -124,7 +124,7 @@ template <> void RadhydroSimulation<CouplingProblem>::setInitialConditionsOnGrid
 	});
 }
 
-template <> void RadhydroSimulation<CouplingProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<CouplingProblem>::computeAfterTimestep()
 {
 	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5);
 
@@ -166,7 +166,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<CouplingProblem> sim(BCs_cc);
+	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadPulse/test_radiation_pulse.cpp
+++ b/src/problems/RadPulse/test_radiation_pulse.cpp
@@ -76,7 +76,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanO
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadPulse/test_radiation_pulse.cpp
+++ b/src/problems/RadPulse/test_radiation_pulse.cpp
@@ -10,7 +10,7 @@
 #include "test_radiation_pulse.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -76,7 +76,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanO
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -139,7 +139,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
 #include "simulation.hpp"
@@ -110,7 +110,7 @@ AMRSimulation<ShadowProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 	}
 }
 
-template <> void RadhydroSimulation<ShadowProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShadowProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -146,7 +146,7 @@ template <> void RadhydroSimulation<ShadowProblem>::setInitialConditionsOnGrid(q
 	});
 }
 
-template <> void RadhydroSimulation<ShadowProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ShadowProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -237,7 +237,7 @@ auto problem_main() -> int
 	// const double resid_tol = 1.0e-15;
 
 	// Problem initialization
-	RadhydroSimulation<ShadowProblem> sim(BCs_cc);
+	QuokkaSimulation<ShadowProblem> sim(BCs_cc);
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number;
 	sim.maxTimesteps_ = max_timesteps;

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -110,7 +110,7 @@ AMRSimulation<ShadowProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 	}
 }
 
-template <> void QuokkaSimulation<ShadowProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShadowProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadShadow/test_radiation_shadow.hpp
+++ b/src/problems/RadShadow/test_radiation_shadow.hpp
@@ -18,7 +18,7 @@
 
 // internal headers
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 
 // function definitions

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -9,7 +9,7 @@
 
 #include "test_radiation_streaming.hpp"
 #include "AMReX.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 
@@ -58,7 +58,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 	return kappa0;
 }
 
-template <> void RadhydroSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -176,7 +176,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<StreamingProblem> sim(BCs_cc);
+	QuokkaSimulation<StreamingProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = tmax;

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -58,7 +58,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 	return kappa0;
 }
 
-template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -10,7 +10,7 @@
 #include "test_radiation_streaming_y.hpp"
 #include "AMReX.H"
 #include "AMReX_BLassert.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 
@@ -61,7 +61,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 	return kappa0;
 }
 
-template <> void RadhydroSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -186,7 +186,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<StreamingProblem> sim(BCs_cc);
+	QuokkaSimulation<StreamingProblem> sim(BCs_cc);
 
 	// read tmax from inputs file
 	amrex::ParmParse pp; // NOLINT

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -61,7 +61,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 	return kappa0;
 }
 
-template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -144,7 +144,7 @@ void RadSystem<MarshakProblem>::SetRadEnergySource(array_t &radEnergySource, amr
 	});
 }
 
-template <> void RadhydroSimulation<MarshakProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MarshakProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
@@ -217,7 +217,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<MarshakProblem> sim(BCs_cc);
+	QuokkaSimulation<MarshakProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -144,7 +144,7 @@ void RadSystem<MarshakProblem>::SetRadEnergySource(array_t &radEnergySource, amr
 	});
 }
 
-template <> void QuokkaSimulation<MarshakProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MarshakProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.hpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.hpp
@@ -18,7 +18,7 @@
 
 // internal headers
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
 

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -187,7 +187,7 @@ AMRSimulation<TophatProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 	}
 }
 
-template <> void QuokkaSimulation<TophatProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TophatProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -13,7 +13,7 @@
 #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "simulation.hpp"
 
@@ -187,7 +187,7 @@ AMRSimulation<TophatProblem>::setCustomBoundaryConditions(const amrex::IntVect &
 	}
 }
 
-template <> void RadhydroSimulation<TophatProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TophatProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -273,7 +273,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<TophatProblem> sim(BCs_cc);
+	QuokkaSimulation<TophatProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 2; // PLM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadTophat/test_radiation_tophat.hpp
+++ b/src/problems/RadTophat/test_radiation_tophat.hpp
@@ -18,7 +18,7 @@
 
 // internal headers
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
 

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -14,7 +14,7 @@
 #include "AMReX_BC_TYPES.H"
 
 #include "AMReX_ValLocPair.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
@@ -97,7 +97,7 @@ amrex::Gpu::DeviceVector<double> rho_arr_g;
 amrex::Gpu::DeviceVector<double> Pgas_arr_g;
 amrex::Gpu::DeviceVector<double> Erad_arr_g;
 
-template <> void RadhydroSimulation<TubeProblem>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<TubeProblem>::preCalculateInitialConditions()
 {
 	// map initial conditions to the global variables
 	std::string filename = "../extern/pressure_tube/initial_conditions.txt";
@@ -136,7 +136,7 @@ template <> void RadhydroSimulation<TubeProblem>::preCalculateInitialConditions(
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <> void RadhydroSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -276,7 +276,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<TubeProblem> sim(BCs_cc);
+	QuokkaSimulation<TubeProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.reconstructionOrder_ = 3;	       // PPM

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -136,7 +136,7 @@ template <> void QuokkaSimulation<TubeProblem>::preCalculateInitialConditions()
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -17,7 +17,7 @@
 // #include "AMReX_BC_TYPES.H"
 #include "AMReX_IntVect.H"
 #include "AMReX_Print.H"
-// #include "RadhydroSimulation.hpp"
+// #include "QuokkaSimulation.hpp"
 // #include "util/fextract.hpp"
 #include "physics_info.hpp"
 // #include "radiation/radiation_system.hpp"
@@ -158,7 +158,7 @@ auto compute_exact_bb(const double nu, const double T) -> double
 	return coeff * planck_integral / (std::pow(PI, 4) / 15.0) * (a_rad * std::pow(T, 4));
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -213,7 +213,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -158,7 +158,7 @@ auto compute_exact_bb(const double nu, const double T) -> double
 	return coeff * planck_integral / (std::pow(PI, 4) / 15.0) * (a_rad * std::pow(T, 4));
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/RadhydroBB/test_radhydro_bb.hpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.hpp
@@ -18,7 +18,7 @@
 
 // internal headers
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -5,7 +5,7 @@
 #include "test_radhydro_pulse.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -113,7 +113,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -144,7 +144,7 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void RadhydroSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	// Problem 1: non-advecting pulse
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	double max_time = 4.8e-5;
 	amrex::ParmParse pp; // NOLINT
@@ -267,7 +267,7 @@ auto problem_main() -> int
 	// Problem 2: advecting pulse
 
 	// Problem initialization
-	RadhydroSimulation<AdvPulseProblem> sim2(BCs_cc);
+	QuokkaSimulation<AdvPulseProblem> sim2(BCs_cc);
 
 	sim2.radiationReconstructionOrder_ = 3; // PPM
 	sim2.stopTime_ = max_time;

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -113,7 +113,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -144,7 +144,7 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -114,7 +114,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -145,7 +145,7 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -5,7 +5,7 @@
 #include "test_radhydro_pulse_dyn.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -114,7 +114,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -145,7 +145,7 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void RadhydroSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -215,7 +215,7 @@ auto problem_main() -> int
 	// Problem 1: non-advecting pulse
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	double max_time = 4.8e-6;
 	amrex::ParmParse pp; // NOLINT
@@ -268,7 +268,7 @@ auto problem_main() -> int
 	// Problem 2: advecting pulse
 
 	// Problem initialization
-	RadhydroSimulation<AdvPulseProblem> sim2(BCs_cc);
+	QuokkaSimulation<AdvPulseProblem> sim2(BCs_cc);
 
 	sim2.radiationReconstructionOrder_ = 3; // PPM
 	sim2.stopTime_ = max_time;

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -5,7 +5,7 @@
 #include "test_radhydro_pulse_grey.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -120,7 +120,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return sigma / rho;
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -151,7 +151,7 @@ template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(qu
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void RadhydroSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -211,7 +211,7 @@ auto problem_main() -> int
 	// Problem 1: non-advecting pulse
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	double max_time = 4.8e-5;
 	amrex::ParmParse pp; // NOLINT
@@ -262,7 +262,7 @@ auto problem_main() -> int
 	// Problem 2: advecting radiation
 
 	// Problem initialization
-	RadhydroSimulation<AdvPulseProblem> sim2(BCs_cc);
+	QuokkaSimulation<AdvPulseProblem> sim2(BCs_cc);
 
 	sim2.radiationReconstructionOrder_ = 3; // PPM
 	sim2.stopTime_ = max_time;

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -120,7 +120,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<AdvPulseProblem>::ComputeFluxMe
 	return sigma / rho;
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -151,7 +151,7 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<AdvPulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -6,7 +6,7 @@
 #include "test_radhydro_pulse_MG_const_kappa.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -120,7 +120,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<SGProblem>::ComputeFluxMeanOpac
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void RadhydroSimulation<SGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -198,7 +198,7 @@ RadSystem<MGproblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<doubl
 	return exponents_and_values;
 }
 
-template <> void RadhydroSimulation<MGproblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MGproblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -264,7 +264,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<SGProblem> sim(BCs_cc);
+	QuokkaSimulation<SGProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;
@@ -325,7 +325,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<MGproblem> sim2(BCs_cc2);
+	QuokkaSimulation<MGproblem> sim2(BCs_cc2);
 
 	sim2.radiationReconstructionOrder_ = 3; // PPM
 	sim2.stopTime_ = max_time;

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -120,7 +120,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<SGProblem>::ComputeFluxMeanOpac
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void QuokkaSimulation<SGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<SGProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -198,7 +198,7 @@ RadSystem<MGproblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<doubl
 	return exponents_and_values;
 }
 
-template <> void QuokkaSimulation<MGproblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MGproblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -215,7 +215,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<ExactProblem>::ComputeFluxMeanO
 	return sigma / rho;
 }
 
-template <> void QuokkaSimulation<MGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MGProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -256,7 +256,7 @@ template <> void QuokkaSimulation<MGProblem>::setInitialConditionsOnGrid(quokka:
 		state_cc(i, j, k, RadSystem<MGProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void QuokkaSimulation<ExactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ExactProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -7,7 +7,7 @@
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "radiation/planck_integral.hpp"
 #include "radiation/radiation_system.hpp"
@@ -215,7 +215,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<ExactProblem>::ComputeFluxMeanO
 	return sigma / rho;
 }
 
-template <> void RadhydroSimulation<MGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<MGProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -256,7 +256,7 @@ template <> void RadhydroSimulation<MGProblem>::setInitialConditionsOnGrid(quokk
 		state_cc(i, j, k, RadSystem<MGProblem>::x3GasMomentum_index) = 0.;
 	});
 }
-template <> void RadhydroSimulation<ExactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ExactProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -315,7 +315,7 @@ auto problem_main() -> int
 	// Problem 1: advecting pulse with multigroup integration
 
 	// Problem initialization
-	RadhydroSimulation<MGProblem> sim(BCs_cc);
+	QuokkaSimulation<MGProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;
@@ -385,7 +385,7 @@ auto problem_main() -> int
 	// Problem 2: exact opacity
 
 	// Problem initialization
-	RadhydroSimulation<ExactProblem> sim2(BCs_cc);
+	QuokkaSimulation<ExactProblem> sim2(BCs_cc);
 
 	sim2.radiationReconstructionOrder_ = 3; // PPM
 	sim2.stopTime_ = max_time;

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -179,7 +179,7 @@ template <> void QuokkaSimulation<ShellProblem>::preCalculateInitialConditions()
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <> void QuokkaSimulation<ShellProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShellProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -25,7 +25,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_Vector.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
@@ -145,7 +145,7 @@ amrex::Gpu::DeviceVector<double> r_arr_g;
 amrex::Gpu::DeviceVector<double> Erad_arr_g;
 amrex::Gpu::DeviceVector<double> Frad_arr_g;
 
-template <> void RadhydroSimulation<ShellProblem>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<ShellProblem>::preCalculateInitialConditions()
 {
 	std::string filename = "./initial_conditions.txt";
 	std::ifstream fstream(filename, std::ios::in);
@@ -179,7 +179,7 @@ template <> void RadhydroSimulation<ShellProblem>::preCalculateInitialConditions
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <> void RadhydroSimulation<ShellProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShellProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -264,7 +264,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto vec_dot_r(amrex::GpuArray<amrex::Real, 
 }
 
 #if 0
-template <> void RadhydroSimulation<ShellProblem>::computeAfterTimestep() {
+template <> void QuokkaSimulation<ShellProblem>::computeAfterTimestep() {
   // compute radial momentum for gas, radiation on level 0
   // (assuming octant symmetry)
 
@@ -318,7 +318,7 @@ template <> void RadhydroSimulation<ShellProblem>::computeAfterTimestep() {
 }
 #endif
 
-template <> void RadhydroSimulation<ShellProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ShellProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -406,7 +406,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ShellProblem> sim(BCs_cc);
+	QuokkaSimulation<ShellProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = 0.3;
 	sim.densityFloor_ = 1.0e-8 * rho_0;

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -11,7 +11,7 @@
 
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "test_radhydro_shock.hpp"
 #include "util/fextract.hpp"
@@ -159,7 +159,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void RadhydroSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -239,7 +239,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ShockProblem> sim(BCs_cc);
+	QuokkaSimulation<ShockProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -159,7 +159,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -156,7 +156,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void RadhydroSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -240,7 +240,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ShockProblem> sim(BCs_cc);
+	QuokkaSimulation<ShockProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -156,7 +156,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.hpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.hpp
@@ -17,7 +17,7 @@
 #include <fstream>
 
 // internal headers
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -164,7 +164,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void RadhydroSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -240,7 +240,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<ShockProblem> sim(BCs_cc);
+	QuokkaSimulation<ShockProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.reconstructionOrder_ = 3;	       // PPM

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -164,7 +164,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 	}
 }
 
-template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<ShockProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.hpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.hpp
@@ -17,7 +17,7 @@
 #include <fstream>
 
 // internal headers
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -5,7 +5,7 @@
 #include "test_radhydro_uniform_advecting.hpp"
 #include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
 
@@ -85,7 +85,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanO
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void RadhydroSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -154,7 +154,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -85,7 +85,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanO
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -22,7 +22,7 @@
 #include "AMReX_TableData.H"
 #include "AMReX_iMultiFab.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "blast.hpp"
 #include "cooling/GrackleLikeCooling.hpp"
 #include "fundamental_constants.H"
@@ -74,7 +74,7 @@ template <> struct SimulationData<RandomBlast> {
 	int use_periodic_bc = 1;     // default is periodic
 };
 
-template <> void RadhydroSimulation<RandomBlast>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RandomBlast>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;
@@ -103,7 +103,7 @@ void injectEnergy(amrex::MultiFab &mf, amrex::GpuArray<Real, AMREX_SPACEDIM> con
 		  amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx, SimulationData<RandomBlast> const &userData)
 {
 	// inject energy into cells with stochastic sampling
-	const BL_PROFILE("RadhydroSimulation::injectEnergy()");
+	const BL_PROFILE("QuokkaSimulation::injectEnergy()");
 
 	const Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]); // cm^3
 	const Real rho_eint_blast = userData.E_blast / cell_vol;   // ergs cm^-3
@@ -162,7 +162,7 @@ void injectEnergy(amrex::MultiFab &mf, amrex::GpuArray<Real, AMREX_SPACEDIM> con
 	}
 }
 
-template <> void RadhydroSimulation<RandomBlast>::computeBeforeTimestep()
+template <> void QuokkaSimulation<RandomBlast>::computeBeforeTimestep()
 {
 	// compute how many (and where) SNe will go off on the this coarse timestep
 	// sample from Poisson distribution
@@ -197,13 +197,13 @@ template <> void RadhydroSimulation<RandomBlast>::computeBeforeTimestep()
 	// TODO(ben): need to force refinement to highest level for cells near particles
 }
 
-template <> void RadhydroSimulation<RandomBlast>::computeAfterLevelAdvance(int lev, Real /*time*/, Real /*dt_lev*/, int /*ncycle*/)
+template <> void QuokkaSimulation<RandomBlast>::computeAfterLevelAdvance(int lev, Real /*time*/, Real /*dt_lev*/, int /*ncycle*/)
 {
 	// compute operator split physics
 	injectEnergy(state_new_cc_[lev], geom[lev].ProbLoArray(), geom[lev].ProbHiArray(), geom[lev].CellSizeArray(), userData_);
 }
 
-template <> void RadhydroSimulation<RandomBlast>::computeAfterTimestep()
+template <> void QuokkaSimulation<RandomBlast>::computeAfterTimestep()
 {
 	// check conservation of mass
 	static auto const &dx = geom[0].CellSizeArray();
@@ -225,7 +225,7 @@ template <> void RadhydroSimulation<RandomBlast>::computeAfterTimestep()
 	}
 }
 
-template <> void RadhydroSimulation<RandomBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <> void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {
@@ -252,7 +252,7 @@ template <> void RadhydroSimulation<RandomBlast>::ComputeDerivedVar(int lev, std
 	}
 }
 
-template <> void RadhydroSimulation<RandomBlast>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<RandomBlast>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 	const Real q_min = 1e-5 * rho0; // minimum density for refinement
@@ -338,7 +338,7 @@ auto problem_main() -> int
 		}
 	}
 
-	RadhydroSimulation<RandomBlast> sim(BCs_cc);
+	QuokkaSimulation<RandomBlast> sim(BCs_cc);
 	sim.densityFloor_ = 1.0e-5 * rho0; // density floor (to prevent vacuum)
 	sim.userData_.SN_rate_per_vol = SN_rate_per_vol;
 	sim.userData_.refine_threshold = refine_threshold;

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -74,7 +74,7 @@ template <> struct SimulationData<RandomBlast> {
 	int use_periodic_bc = 1;     // default is periodic
 };
 
-template <> void QuokkaSimulation<RandomBlast>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RandomBlast>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	const amrex::Box &indexRange = grid_elem.indexRange_;

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -12,7 +12,7 @@
 #include "AMReX_BLassert.H"
 #include "AMReX_ParmParse.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 
 struct RTProblem {
@@ -43,7 +43,7 @@ amrex::Real constexpr g_x = 0;
 amrex::Real constexpr g_y = -0.1;
 amrex::Real constexpr g_z = 0;
 
-template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -95,7 +95,7 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 }
 
 template <>
-void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int /*lev*/, const amrex::Real /*time*/, const amrex::Real dt)
+void QuokkaSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int /*lev*/, const amrex::Real /*time*/, const amrex::Real dt)
 {
 	// add gravitational source terms
 	const auto state = state_mf.arrays();
@@ -127,7 +127,7 @@ void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void RadhydroSimulation<RTProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<RTProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -193,7 +193,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<RTProblem> sim(BCs_cc);
+	QuokkaSimulation<RTProblem> sim(BCs_cc);
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -43,7 +43,7 @@ amrex::Real constexpr g_x = 0;
 amrex::Real constexpr g_y = -0.1;
 amrex::Real constexpr g_z = 0;
 
-template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -13,7 +13,7 @@
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 
 struct RTProblem {
@@ -44,7 +44,7 @@ amrex::Real constexpr g_x = 0;
 amrex::Real constexpr g_y = 0;
 amrex::Real constexpr g_z = -0.1;
 
-template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -96,7 +96,7 @@ template <> void RadhydroSimulation<RTProblem>::setInitialConditionsOnGrid(quokk
 }
 
 template <>
-void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int /*lev*/, const amrex::Real /*time*/, const amrex::Real dt)
+void QuokkaSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state_mf, const int /*lev*/, const amrex::Real /*time*/, const amrex::Real dt)
 {
 	// add gravitational source terms
 	const auto state = state_mf.arrays();
@@ -127,7 +127,7 @@ void RadhydroSimulation<RTProblem>::addStrangSplitSources(amrex::MultiFab &state
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void RadhydroSimulation<RTProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<RTProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -160,7 +160,7 @@ template <> void RadhydroSimulation<RTProblem>::ErrorEst(int lev, amrex::TagBoxA
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void RadhydroSimulation<RTProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<RTProblem>::computeAfterTimestep()
 {
 	// compute 1D mixing profile, save to text file
 	static amrex::Long cycle = 0;
@@ -224,7 +224,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<RTProblem> sim(BCs_cc);
+	QuokkaSimulation<RTProblem> sim(BCs_cc);
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -44,7 +44,7 @@ amrex::Real constexpr g_x = 0;
 amrex::Real constexpr g_y = 0;
 amrex::Real constexpr g_z = -0.1;
 
-template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -77,7 +77,7 @@ AMREX_GPU_MANAGED Real v_wind = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-
 AMREX_GPU_MANAGED Real P_wind = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED Real delta_vx = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-template <> void QuokkaSimulation<ShockCloud>::setInitialConditionsOnGrid(quokka::grid grid)
+template <> void QuokkaSimulation<ShockCloud>::setInitialConditionsOnGrid(quokka::grid const &grid)
 {
 	amrex::GpuArray<Real, AMREX_SPACEDIM> const dx = grid.dx_;
 	amrex::GpuArray<Real, AMREX_SPACEDIM> prob_lo = grid.prob_lo_;

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -22,7 +22,7 @@
 #include "AMReX_Reduce.H"
 #include "AMReX_SPACE.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "cooling/TabulatedCooling.hpp"
 #include "fundamental_constants.H"
 #include "hydro/EOS.hpp"
@@ -77,7 +77,7 @@ AMREX_GPU_MANAGED Real v_wind = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-
 AMREX_GPU_MANAGED Real P_wind = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 AMREX_GPU_MANAGED Real delta_vx = 0;		// NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-template <> void RadhydroSimulation<ShockCloud>::setInitialConditionsOnGrid(quokka::grid grid)
+template <> void QuokkaSimulation<ShockCloud>::setInitialConditionsOnGrid(quokka::grid grid)
 {
 	amrex::GpuArray<Real, AMREX_SPACEDIM> const dx = grid.dx_;
 	amrex::GpuArray<Real, AMREX_SPACEDIM> prob_lo = grid.prob_lo_;
@@ -198,7 +198,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<ShockCloud>::setCustomBou
 	}
 }
 
-template <> void RadhydroSimulation<ShockCloud>::computeAfterTimestep()
+template <> void QuokkaSimulation<ShockCloud>::computeAfterTimestep()
 {
 	const amrex::Real dt_coarse = dt_[0];
 	const amrex::Real time = tNew_[0];
@@ -266,7 +266,7 @@ template <> void RadhydroSimulation<ShockCloud>::computeAfterTimestep()
 	}
 }
 
-template <> void RadhydroSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in) const
+template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in) const
 {
 	// compute derived variables and save in 'mf'
 
@@ -450,7 +450,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto ComputeCellTemp(int i, int j, int k, am
 	return quokka::TabulatedCooling::ComputeTgasFromEgas(rho, Eint, gamma, tables);
 }
 
-template <> auto RadhydroSimulation<ShockCloud>::ComputeStatistics() -> std::map<std::string, amrex::Real>
+template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<std::string, amrex::Real>
 {
 	// compute scalar statistics
 	std::map<std::string, amrex::Real> stats;
@@ -600,7 +600,7 @@ template <> auto RadhydroSimulation<ShockCloud>::ComputeStatistics() -> std::map
 	return stats;
 }
 
-template <> auto RadhydroSimulation<ShockCloud>::ComputeProjections(const int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
+template <> auto QuokkaSimulation<ShockCloud>::ComputeProjections(const int dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>>
 {
 	std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> proj;
 
@@ -633,7 +633,7 @@ template <> auto RadhydroSimulation<ShockCloud>::ComputeProjections(const int di
 	return proj;
 }
 
-template <> void RadhydroSimulation<ShockCloud>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ShockCloud>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 	const int Ncells_per_lcool = 10;
@@ -665,7 +665,7 @@ template <> void RadhydroSimulation<ShockCloud>::ErrorEst(int lev, amrex::TagBox
 auto problem_main() -> int
 {
 	// Problem initialization
-	constexpr int nvars = RadhydroSimulation<ShockCloud>::nvarTotal_cc_;
+	constexpr int nvars = QuokkaSimulation<ShockCloud>::nvarTotal_cc_;
 	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		boundaryConditions[n].setLo(0, amrex::BCType::ext_dir); // Dirichlet
@@ -677,7 +677,7 @@ auto problem_main() -> int
 		boundaryConditions[n].setLo(2, amrex::BCType::int_dir);
 		boundaryConditions[n].setHi(2, amrex::BCType::int_dir);
 	}
-	RadhydroSimulation<ShockCloud> sim(boundaryConditions);
+	QuokkaSimulation<ShockCloud> sim(boundaryConditions);
 
 	// Read problem parameters
 	amrex::ParmParse const pp;

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -47,7 +47,7 @@ template <> struct Physics_Traits<CollapseProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void QuokkaSimulation<CollapseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CollapseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -19,7 +19,7 @@
 #include "AMReX_Print.H"
 
 #include "AMReX_SPACE.H"
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "spherical_collapse.hpp"
 
@@ -47,7 +47,7 @@ template <> struct Physics_Traits<CollapseProblem> {
 	static constexpr int nGroups = 1; // number of radiation groups
 };
 
-template <> void RadhydroSimulation<CollapseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<CollapseProblem>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -85,7 +85,7 @@ template <> void RadhydroSimulation<CollapseProblem>::setInitialConditionsOnGrid
 	});
 }
 
-template <> void RadhydroSimulation<CollapseProblem>::createInitialParticles()
+template <> void QuokkaSimulation<CollapseProblem>::createInitialParticles()
 {
 	// add particles at random positions in the box
 	const bool generate_on_root_rank = true;
@@ -98,7 +98,7 @@ template <> void RadhydroSimulation<CollapseProblem>::createInitialParticles()
 	CICParticles->InitRandom(num_particles, iseed, pdata, generate_on_root_rank);
 }
 
-template <> void RadhydroSimulation<CollapseProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<CollapseProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 	const Real q_min = 5.0; // minimum density for refinement
@@ -118,7 +118,7 @@ template <> void RadhydroSimulation<CollapseProblem>::ErrorEst(int lev, amrex::T
 	}
 }
 
-template <> void RadhydroSimulation<CollapseProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <> void QuokkaSimulation<CollapseProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {
@@ -159,7 +159,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<CollapseProblem> sim(BCs_cc);
+	QuokkaSimulation<CollapseProblem> sim(BCs_cc);
 	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	// initialize

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -23,7 +23,7 @@
 #include "AMReX_SPACE.H"
 #include "AMReX_TableData.H"
 
-#include "RadhydroSimulation.hpp"
+#include "QuokkaSimulation.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "star_cluster.hpp"
@@ -71,7 +71,7 @@ template <> struct SimulationData<StarCluster> {
 	Real alpha_vir{};
 };
 
-template <> void RadhydroSimulation<StarCluster>::preCalculateInitialConditions()
+template <> void QuokkaSimulation<StarCluster>::preCalculateInitialConditions()
 {
 	static bool isSamplingDone = false;
 	if (!isSamplingDone) {
@@ -115,7 +115,7 @@ template <> void RadhydroSimulation<StarCluster>::preCalculateInitialConditions(
 	}
 }
 
-template <> void RadhydroSimulation<StarCluster>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StarCluster>::setInitialConditionsOnGrid(quokka::grid grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -165,7 +165,7 @@ template <> void RadhydroSimulation<StarCluster>::setInitialConditionsOnGrid(quo
 	});
 }
 
-template <> void RadhydroSimulation<StarCluster>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<StarCluster>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// refine on Jeans length
 	const int N_cells = 4; // inverse of the 'Jeans number' [Truelove et al. (1997)]
@@ -186,7 +186,7 @@ template <> void RadhydroSimulation<StarCluster>::ErrorEst(int lev, amrex::TagBo
 	});
 }
 
-template <> void RadhydroSimulation<StarCluster>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <> void QuokkaSimulation<StarCluster>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "log_density") {
@@ -229,7 +229,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	RadhydroSimulation<StarCluster> sim(BCs_cc);
+	QuokkaSimulation<StarCluster> sim(BCs_cc);
 	sim.doPoissonSolve_ = 1; // enable self-gravity
 	sim.densityFloor_ = 0.01;
 

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -115,7 +115,7 @@ template <> void QuokkaSimulation<StarCluster>::preCalculateInitialConditions()
 	}
 }
 
-template <> void QuokkaSimulation<StarCluster>::setInitialConditionsOnGrid(quokka::grid grid_elem)
+template <> void QuokkaSimulation<StarCluster>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// set initial conditions
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -221,8 +221,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual auto computeExtraPhysicsTimestep(int lev) -> amrex::Real = 0;
 	virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) = 0;
 	virtual void preCalculateInitialConditions() = 0;
-	virtual void setInitialConditionsOnGrid(quokka::grid grid_elem) = 0;
-	virtual void setInitialConditionsOnGridFaceVars(quokka::grid grid_elem) = 0;
+	virtual void setInitialConditionsOnGrid(quokka::grid const &grid_elem) = 0;
+	virtual void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) = 0;
 	virtual void createInitialParticles() = 0;
 	virtual void computeBeforeTimestep() = 0;
 	virtual void computeAfterTimestep() = 0;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1576,7 +1576,7 @@ AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(const amrex::IntVec
 // Compute a new multifab 'mf' by copying in state from valid region and filling
 // ghost cells
 // NOTE: This implementation is only used by AdvectionSimulation.
-//  RadhydroSimulation provides its own implementation.
+//  QuokkaSimulation provides its own implementation.
 template <typename problem_t>
 void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)


### PR DESCRIPTION
### Description

What's changed in the PR:
- Renamed `RadhydroSimulation` class to `QuokkaSimulation` in all occurances inside src/. 
- Renamed `RadhydroSimulation.cpp/.hpp` to `QuokkaSimulation.cpp/.hpp` 

Why? This is the main simulation class that does all of the physics, including HD, gravity, radiation, MHD, etc. It should be given a more general and inclusive name to avoid the confusion caused by the name `RadhydroSimulation`. See #428 

### Related issues

Addressed issue #428 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
