### PR TITLE
set CMAKE_CUDA_ARCHITECTURES on avatargpu

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
     - task: CMake@1
       displayName: 'Configure CMake'
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DCMAKE_CUDA_ARCHITECTURES=70 -DQUOKKA_PYTHON=OFF'
     
     - task: CMake@1
       displayName: 'Build Quokka'


### PR DESCRIPTION
### Description
Explicitly set `CMAKE_CUDA_ARCHITECTURES=70` when compiling on avatargpu.

### Related issues
https://github.com/quokka-astro/quokka/issues/706

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
