### PR TITLE
fix Setonix compiler version

### DIFF
--- a/scripts/setonix-gpu.profile
+++ b/scripts/setonix-gpu.profile
@@ -1,11 +1,14 @@
 #!/bin/bash
 
+# NOTE: CCE and ROCm versions must match according to this table:
+#  https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#compatible-compiler-rocm-toolchain-versions
+
 #source /opt/cray/pe/cpe/23.09/restore_lmod_system_defaults.sh
 module load PrgEnv-cray
 module load craype-accel-amd-gfx90a
 module load cray-mpich
 module load cce/16.0.1
-module load rocm/5.7.3
+module load rocm/5.5.3 # matches cce/16 clang version
 
 module load cray-hdf5
 module load cray-python/3.9.13.1


### PR DESCRIPTION
### Description
This uses ROCm version 5.5.3, which is actually able to compile the metal advection problem.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
