### PR TITLE
Upload results even if regression tests fail

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -22,7 +22,9 @@ jobs:
     - script: ./extern/regression_testing/regtest.py regression/quokka-tests.ini
       displayName: 'Run regression testing'
     - publish: /home/bwibking/regression-tests/web
+      condition: succeededOrFailed()
       artifact: regressionHTMLOutput
       displayName: 'Upload results to Azure Pipelines'
     - script: cd /home/bwibking/regression-tests/web && git add . && git commit -m 'updated results' && git push
+      condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'


### PR DESCRIPTION
### Description
Upload the test results even if a test fails. Currently, the pipeline is canceled if any of the tests fail, and the results aren't available on the website (https://quokka-astro.github.io/regression-testing-results/).

Documentation: https://learn.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
