### PR TITLE
Make assertion work in the exchange step and dust temperature solution step 

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -251,8 +251,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void operatorSplitSourceTerms(amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, amrex::Real time, double dt, int stage,
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, int *num_failed_coupling, int *num_failed_dust, 
-							int *p_num_failed_outer_ite);
+				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, int *num_failed_coupling, int *num_failed_dust,
+				      int *p_num_failed_outer_ite);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
@@ -1638,7 +1638,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				// Note that only a fraction (IMEX_a32) of the matter-radiation exchange source terms are added to hydro. This ensures that the
 				// hydro properties get to t + IMEX_a32 dt in terms of matter-radiation exchange.
 				operatorSplitSourceTerms(stateNew, indexRange, time_subcycle, dt_radiation, 1, dx, prob_lo, prob_hi, p_num_failed_coupling,
-								p_num_failed_dust, p_num_failed_outer);
+							 p_num_failed_dust, p_num_failed_outer);
 			}
 
 			nf_coupling = *(num_failed_coupling.copyToHost());
@@ -1672,7 +1672,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			auto const &prob_hi = geom[lev].ProbHiArray();
 			// update state_new_cc_[lev] in place (updates both radiation and hydro vars)
 			operatorSplitSourceTerms(stateNew, indexRange, time_subcycle, dt_radiation, 2, dx, prob_lo, prob_hi, p_num_failed_coupling,
-							p_num_failed_dust, p_num_failed_outer);
+						 p_num_failed_dust, p_num_failed_outer);
 		}
 
 		nf_coupling = *(num_failed_coupling.copyToHost());
@@ -1837,7 +1837,8 @@ template <typename problem_t>
 void QuokkaSimulation<problem_t>::operatorSplitSourceTerms(amrex::Array4<amrex::Real> const &stateNew, const amrex::Box &indexRange, const amrex::Real time,
 							   const double dt, const int stage, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, int *p_num_failed_coupling, int *p_num_failed_dust, int *p_num_failed_outer_ite)
+							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, int *p_num_failed_coupling,
+							   int *p_num_failed_dust, int *p_num_failed_outer_ite)
 {
 	amrex::FArrayBox radEnergySource(indexRange, Physics_Traits<problem_t>::nGroups,
 					 amrex::The_Async_Arena()); // cell-centered scalar

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1659,8 +1659,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		const int nf_coupling = *(num_failed_coupling.copyToHost());
 		const int nf_dust = *(num_failed_dust.copyToHost());
 		const int nf_outer = *(num_failed_outer.copyToHost());
-		// Note that the nf_dust has to abort BEFORE nf_coupling, because the dust temperature is used in the matter-radiation coupling and if dust temperature
-		// is negative, the matter-radiation coupling will fail to converge.
+		// Note that the nf_dust has to abort BEFORE nf_coupling, because the dust temperature is used in the matter-radiation coupling and if dust
+		// temperature is negative, the matter-radiation coupling will fail to converge.
 		if (nf_dust > 0) {
 			amrex::Abort("Newton-Raphson iteration for dust temperature failed to converge or dust temperature is negative!");
 		}

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1468,7 +1468,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 							const auto Lambda_gd = sum(Rvec) / (dt * chat / c);
 							T_d = T_gas - Lambda_gd / (dustGasCoeff_local * num_den * num_den * std::sqrt(T_gas));
 						}
-						AMREX_ASSERT(T_d >= 0.);
+						AMREX_ALWAYS_ASSERT_WITH_MESSAGE(T_d >= 0., "Newton-Raphson iteration for dust temperature failed to converge or dust temperature is negative!");
 						if (T_d < 0.0) {
 							amrex::Gpu::Atomic::Add(p_num_failed_dust_local, 1);
 						}
@@ -1988,7 +1988,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 		amrex::Abort("Newton-Raphson iteration failed to converge on GPU!");
 	}
 	if (nf_dust > 0) {
-		amrex::Abort("Newton-Raphson iteration for dust temperature failed to converge on GPU!");
+		amrex::Abort("Newton-Raphson iteration for dust temperature failed to converge or dust temperature is negative on GPU!");
 	}
 }
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1277,8 +1277,8 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 	amrex::Gpu::Buffer<int> num_failed_coupling({0});
 	amrex::Gpu::Buffer<int> num_failed_dust({0});
-	int* p_num_failed_coupling = num_failed_coupling.data();
-	int* p_num_failed_dust = num_failed_dust.data();
+	int *p_num_failed_coupling = num_failed_coupling.data();
+	int *p_num_failed_dust = num_failed_dust.data();
 
 	// Add source terms
 
@@ -1287,7 +1287,7 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		// make a local reference of p_num_failed 
+		// make a local reference of p_num_failed
 		auto p_num_failed_coupling_local = p_num_failed_coupling;
 		auto p_num_failed_dust_local = p_num_failed_dust;
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1468,7 +1468,9 @@ void RadSystem<problem_t>::AddSourceTerms(array_t &consVar, arrayconst_t &radEne
 							const auto Lambda_gd = sum(Rvec) / (dt * chat / c);
 							T_d = T_gas - Lambda_gd / (dustGasCoeff_local * num_den * num_den * std::sqrt(T_gas));
 						}
-						AMREX_ALWAYS_ASSERT_WITH_MESSAGE(T_d >= 0., "Newton-Raphson iteration for dust temperature failed to converge or dust temperature is negative!");
+						AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+						    T_d >= 0.,
+						    "Newton-Raphson iteration for dust temperature failed to converge or dust temperature is negative!");
 						if (T_d < 0.0) {
 							amrex::Gpu::Atomic::Add(p_num_failed_dust_local, 1);
 						}


### PR DESCRIPTION
### Description

A fix to #543 : make the Newton-Raphson iteration return a flag and check it on host. 

More changes:
- Change `maxIter` from 400 to 50. 50 iterations should be more than enough. If it doesn't converge in less than 50 steps, it probably never will. 

### Related issues
Fixes #543 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
