### PR TITLE
Redefine PRIMORDIAL_CHEM preprocessor as CHEMISTRY

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -374,10 +374,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		}
 	}
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	// set chemistry runtime parameters
 	{
-		amrex::ParmParse hpp("primordial_chem");
+		amrex::ParmParse hpp("chemistry");
 		hpp.query("enabled", enableChemistry_);
 		hpp.query("max_density_allowed", max_density_allowed); // chemistry is not accurate for densities > 3e-6
 		hpp.query("min_density_allowed", min_density_allowed); // don't do chemistry in cells with densities below the minimum density specified
@@ -533,7 +533,7 @@ auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiF
 
 	// start by assuming chemistry burn is successful.
 	bool burn_success = true; // NOLINT
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	if (enableChemistry_ == 1) {
 		// compute chemistry
 		burn_success = quokka::chemistry::computeChemistry<problem_t>(state, dt, max_density_allowed, min_density_allowed);

--- a/src/chemistry/Chemistry.hpp
+++ b/src/chemistry/Chemistry.hpp
@@ -17,7 +17,7 @@
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 #include "actual_eos_data.H"
 #include "burn_type.H"
 #include "eos.H"

--- a/src/hydro/EOS.hpp
+++ b/src/hydro/EOS.hpp
@@ -20,7 +20,7 @@
 
 #include "eos.H"
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 #include "actual_eos_data.H"
 #endif
 
@@ -79,7 +79,7 @@ EOS<problem_t>::ComputeTgasFromEint(amrex::Real rho, amrex::Real Eint,
 	// return temperature for an ideal gas given density and internal energy
 	amrex::Real Tgas = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
@@ -121,7 +121,7 @@ EOS<problem_t>::ComputeEintFromTgas(amrex::Real rho, amrex::Real Tgas,
 	// return internal energy density given density and temperature
 	amrex::Real Eint = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	// Define and initialize Tgas here
@@ -164,7 +164,7 @@ EOS<problem_t>::ComputeEintFromPres(amrex::Real rho, amrex::Real Pressure,
 	// return internal energy density given density and pressure
 	amrex::Real Eint = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	chemstate.p = Pressure;
@@ -205,7 +205,7 @@ EOS<problem_t>::ComputeEintTempDerivative(const amrex::Real rho, const amrex::Re
 	// compute derivative of internal energy w/r/t temperature, given density and temperature
 	amrex::Real dEint_dT = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
@@ -254,7 +254,7 @@ EOS<problem_t>::ComputeOtherDerivatives(const amrex::Real rho, const amrex::Real
 	// fundamental derivative
 	amrex::Real G = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	chemstate.p = P;
@@ -302,7 +302,7 @@ EOS<problem_t>::ComputePressure(amrex::Real rho, amrex::Real Eint, std::optional
 {
 	// return pressure for an ideal gas
 	amrex::Real P = NAN;
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
@@ -348,7 +348,7 @@ EOS<problem_t>::ComputeSoundSpeed(amrex::Real rho, amrex::Real Pressure,
 	// return sound speed for an ideal gas
 	amrex::Real cs = NAN;
 
-#ifdef PRIMORDIAL_CHEM
+#ifdef CHEMISTRY
 	eos_t chemstate;
 	chemstate.rho = rho;
 	chemstate.p = Pressure;

--- a/src/problems/PopIII/CMakeLists.txt
+++ b/src/problems/PopIII/CMakeLists.txt
@@ -10,7 +10,7 @@ if (AMReX_SPACEDIM EQUAL 3)
     include_directories(BEFORE ${primordial_chem_dirs} "${CMAKE_CURRENT_BINARY_DIR}/" "includes/extern_parameters.H" "includes/network_properties.H")
 
     add_executable(popiii popiii.cpp "${QuokkaSourcesNoEOS}" ../../turbulence/TurbDataReader.cpp ../../chemistry/Chemistry.cpp ${primordial_chem_sources})
-    target_compile_definitions(popiii PUBLIC PRIMORDIAL_CHEM) #this will add #define PRIMORDIAL_CHEM
+    target_compile_definitions(popiii PUBLIC CHEMISTRY) #this will add #define CHEMISTRY
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(popiii)

--- a/src/problems/PrimordialChem/CMakeLists.txt
+++ b/src/problems/PrimordialChem/CMakeLists.txt
@@ -7,8 +7,8 @@ include_directories(BEFORE ${primordial_chem_dirs} "${CMAKE_CURRENT_BINARY_DIR}/
 
 add_executable(test_primordial_chem test_primordial_chem.cpp "${QuokkaSourcesNoEOS}" ../../chemistry/Chemistry.cpp ${primordial_chem_sources})
 
-# this will add #define PRIMORDIAL_CHEM
-target_compile_definitions(test_primordial_chem PUBLIC PRIMORDIAL_CHEM) 
+# this will add #define CHEMISTRY
+target_compile_definitions(test_primordial_chem PUBLIC CHEMISTRY) 
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_primordial_chem)

--- a/tests/PopIII.in
+++ b/tests/PopIII.in
@@ -53,13 +53,14 @@ derived_vars = temperature velx pressure sound_speed
 amrex.throw_exception = 0
 amrex.signal_handling = 1
 
-primordial_chem.enabled = 1
+chemistry.enabled = 1
+chemistry.max_density_allowed = 3e-6
+chemistry.min_density_allowed = 5e-21
+
 primordial_chem.temperature = 0.26415744E+003
 
 primordial_chem.small_temp = 1.e1
 primordial_chem.small_dens = 1.e-60
-primordial_chem.max_density_allowed = 3e-6
-primordial_chem.min_density_allowed = 5e-21
 #format in krome fort22_wD.dat file: E H- D- H HE H2 HD D H+ HE+ H2+ D+ HD+ HE++
 #format in quokka: E H+ H H- D+ D H2+ D- H2 HD+ HD HE++ HE+ HE
 primordial_chem.primary_species_1 = 0.88499253E-006

--- a/tests/primordial_chem.in
+++ b/tests/primordial_chem.in
@@ -22,12 +22,13 @@ amr.max_grid_size   = 1
 do_reflux = 0
 do_subcycle = 0
 
-primordial_chem.enabled = 1
+chemistry.enabled = 1
+chemistry.max_density_allowed = 3e-6
+
 primordial_chem.temperature = 1e2
 
 primordial_chem.small_temp = 1.e1
 primordial_chem.small_dens = 1.e-60
-primordial_chem.max_density_allowed = 3e-6
 
 primordial_chem.primary_species_1 = 1e-4
 primordial_chem.primary_species_2 = 1e-4


### PR DESCRIPTION
### Description
Now that we are going to have metal+dust chemistry, redefine the ifdef to CHEMISTRY

### Related issues
Will be useful for #723 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [] I have requested a reviewer for this PR.
