### PR TITLE
[WIP] use periodic hydro BC for PopIII

### DIFF
--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -440,8 +440,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap);
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 


### PR DESCRIPTION
### Description
Use periodic hydro boundary conditions in order to avoid numerical problems with outflow boundary conditions. Gravity is still computed using open boundary conditions.

This current fails at runtime due to an assertion in the Poisson solver:
```
Assertion `m_lobc[icomp][idim] == BCType::Periodic && m_hibc[icomp][idim] == BCType::Periodic' failed, file "/home1/02661/bwibking/quokka/extern/amrex/Src/LinearSolvers/MLMG/AMReX_MLLinOp.H", line 1199 !!!
```

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/732.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
