### PR TITLE
Restructure: put radiation flux update into a function

### DIFF
--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -121,8 +121,8 @@ template <typename problem_t> struct JacobianResult {
 // A struct to hold the results of UpdateFlux(), containing the following elements:
 // Erad, gasMomentum, Frad
 template <typename problem_t> struct FluxUpdateResult {
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Erad; // radiation energy density
-	amrex::GpuArray<double, 3> gasMomentum; // gas momentum
+	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Erad;			   // radiation energy density
+	amrex::GpuArray<double, 3> gasMomentum;							   // gas momentum
 	amrex::GpuArray<amrex::GpuArray<amrex::Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
 };
 
@@ -239,8 +239,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
 				       amrex::Real time);
 
-	static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, 
-							 double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
+	static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, double gas_update_factor,
+			       double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
 					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -239,8 +239,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
 				       amrex::Real time);
 
-	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, double gas_update_factor,
-			       double Ekin0) -> FluxUpdateResult<problem_t>;
+	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
+						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
 					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -239,7 +239,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
 				       amrex::Real time);
 
-	static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, double gas_update_factor,
+	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, double gas_update_factor,
 			       double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -13,15 +13,15 @@
 
 #include <array>
 #include <cmath>
-#include <functional>
+// #include <functional>
 
 // library headers
 #include "AMReX.H" // IWYU pragma: keep
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuQualifiers.H"
-#include "AMReX_IParser_Y.H"
-#include "AMReX_IntVect.H"
+// #include "AMReX_IParser_Y.H"
+// #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
 // internal headers

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -13,15 +13,12 @@
 
 #include <array>
 #include <cmath>
-// #include <functional>
 
 // library headers
 #include "AMReX.H" // IWYU pragma: keep
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuQualifiers.H"
-// #include "AMReX_IParser_Y.H"
-// #include "AMReX_IntVect.H"
 #include "AMReX_REAL.H"
 
 // internal headers

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -242,9 +242,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
 				       amrex::Real time);
 
-	static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, 
-							NewtonIterationResult<problem_t> &energy, // quokka::valarray<double, nGroups_> &EradVec_guess,
-							double dt, double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
+	static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt, 
+							 double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
 					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -118,7 +118,7 @@ template <typename problem_t> struct JacobianResult {
 	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Fg;  // (g) components of the residual, g = 1, 2, ..., nGroups
 };
 
-// A struct to hold the results of the UpdateFlux function, containing the following elements:
+// A struct to hold the results of UpdateFlux(), containing the following elements:
 // Erad, gasMomentum, Frad
 template <typename problem_t> struct FluxUpdateResult {
 	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Erad; // radiation energy density

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -516,7 +516,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 	amrex::GpuArray<amrex::Real, 3> dMomentum{0., 0., 0.};
 	amrex::GpuArray<amrex::GpuArray<amrex::Real, nGroups_>, 3> Frad_t1{};
 
-	// make a copy of radBoundaries_ 
+	// make a copy of radBoundaries_
 	amrex::GpuArray<amrex::Real, nGroups_ + 1> radBoundaries_g = radBoundaries_;
 
 	double const rho = consPrev(i, j, k, gasDensity_index);

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -904,13 +904,18 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 				consNew(i, j, k, x3GasMomentum_index) = updated_flux.gasMomentum[2];
 				for (int g = 0; g < nGroups_; ++g) {
 					if constexpr (include_work_term_in_source) {
+						// Erad is not changed in the UpdateFlux function
 						consNew(i, j, k, radEnergy_index + numRadVars_ * g) = updated_energy.EradVec[g];
 					} else {
+						// Erad is changed in the UpdateFlux function
 						consNew(i, j, k, radEnergy_index + numRadVars_ * g) = updated_flux.Erad[g];
 					}
 					consNew(i, j, k, x1RadFlux_index + numRadVars_ * g) = updated_flux.Frad[0][g];
 					consNew(i, j, k, x2RadFlux_index + numRadVars_ * g) = updated_flux.Frad[1][g];
 					consNew(i, j, k, x3RadFlux_index + numRadVars_ * g) = updated_flux.Frad[2][g];
+				}
+				if constexpr (gamma_ != 1.0) {
+						Egas_guess = updated_energy.Egas;
 				}
 				break;
 			}
@@ -933,6 +938,7 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		const auto x1GasMom1 = consNew(i, j, k, x1GasMomentum_index);
 		const auto x2GasMom1 = consNew(i, j, k, x2GasMomentum_index);
 		const auto x3GasMom1 = consNew(i, j, k, x3GasMomentum_index);
+
 		if constexpr (gamma_ != 1.0) {
 			Egas_guess = Egas0 + (Egas_guess - Egas0) * gas_update_factor;
 			consNew(i, j, k, gasInternalEnergy_index) = Egas_guess;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -506,17 +506,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 }
 
 template <typename problem_t>
-auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, 
-							NewtonIterationResult<problem_t> &energy, // quokka::valarray<double, nGroups_> &EradVec_guess,
-							double const dt, double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
-							//  quokka::valarray<double, nGroups_> const &kappaFVec, quokka::valarray<double, nGroups_> const &kappaPVec, 
-							//  quokka::valarray<double, nGroups_> const &kappaEVec, 
-							//  quokka::valarray<double, nGroups_> const &EradVec_guess, double const dt,
-							//  double Egas_guess, double const Ekin0,
-							//  quokka::valarray<double, nGroups_> const &fourPiBoverC,
-							//  amrex::GpuArray<double, nGroups_> const &delta_nu_kappa_B_at_edge,
-							//  amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> const &kappa_expo_and_lower_value,
-							//  double const gas_update_factor
+auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy, double const dt, double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
 {
 	amrex::GpuArray<amrex::Real, 3> Frad_t0{};
 	amrex::GpuArray<amrex::Real, 3> dMomentum{0., 0., 0.};
@@ -534,7 +524,6 @@ auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arr
 	auto const kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(radBoundaries_, rho, energy.T_d);
 
 	const double chat = c_hat_;
-
 
 	for (int g = 0; g < nGroups_; ++g) {
 		Frad_t0[0] = consPrev(i, j, k, x1RadFlux_index + numRadVars_ * g);
@@ -654,15 +643,6 @@ auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arr
 					(1.0 + kappa_expo_and_lower_value[0][g]) * energy.kappaFVec[g] * chat / (c_light_ * c_light_) * dt;
 		}
 	}
-
-	// // Check for convergence of the work term: if the relative change in the work term is less than 1e-13, then break the loop
-	// const double lag_tol = 1.0e-13;
-	// bool converged = false;
-	// if ((sum(abs(energy.work)) == 0.0) || ((c_light_ / c_hat_) * sum(abs(energy.work - work_prev)) < lag_tol * Egastot1) ||
-	// 		(sum(abs(energy.work - work_prev)) <= lag_tol * sum(Rvec)) || (sum(abs(energy.work - work_prev)) <= 1.0e-8 * sum(abs(energy.work)))) {
-	// 	converged = true;
-	// }
-	// return converged;
 
 	FluxUpdateResult<problem_t> updated_flux;
 
@@ -789,10 +769,6 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		if constexpr (enable_dust_gas_thermal_coupling_model_) {
 			coeff_n = dt * dustGasCoeff_local * num_den * num_den / cscale;
 		}
-
-		// double x1GasMom1 = NAN;
-		// double x2GasMom1 = NAN;
-		// double x3GasMom1 = NAN;
 
 		// Outer iteration loop to update the work term until it converges
 		const int max_iter = 5;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -718,6 +718,11 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 
 			// 2. Compute radiation flux update
 
+			amrex::GpuArray<amrex::GpuArray<amrex::Real, 3>, nGroups_> Frad_t0{};
+
+
+			UpdateFlux(i, j, k, consPrev, consNew, gas_update_factor, kappaFVec, kappaPVec, updated_energy.delta_nu_kappa_B_at_edge, kappa_expo_and_lower_value)
+
 			amrex::GpuArray<amrex::Real, 3> Frad_t0{};
 			dMomentum = {0., 0., 0.};
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -509,8 +509,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 
 // Update radiation flux and gas momentum. Returns FluxUpdateResult struct. The function also updates energy.Egas and energy.work.
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy, double const dt,
-				      double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy,
+						       double const dt, double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
 {
 	amrex::GpuArray<amrex::Real, 3> Frad_t0{};
 	amrex::GpuArray<amrex::Real, 3> dMomentum{0., 0., 0.};

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -698,7 +698,6 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		const double x1GasMom0 = consPrev(i, j, k, x1GasMomentum_index);
 		const double x2GasMom0 = consPrev(i, j, k, x2GasMomentum_index);
 		const double x3GasMom0 = consPrev(i, j, k, x3GasMomentum_index);
-		const std::array<double, 3> gasMtm0 = {x1GasMom0, x2GasMom0, x3GasMom0};
 		const double Egastot0 = consPrev(i, j, k, gasEnergy_index);
 		auto massScalars = RadSystem<problem_t>::ComputeMassScalars(consPrev, i, j, k);
 
@@ -724,8 +723,6 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> work{};
 		quokka::valarray<double, nGroups_> work_prev{};
-		amrex::GpuArray<amrex::Real, 3> dMomentum{};
-		amrex::GpuArray<amrex::GpuArray<amrex::Real, nGroups_>, 3> Frad_t1{};
 
 		if constexpr (gamma_ != 1.0) {
 			Egas0 = ComputeEintFromEgas(rho, x1GasMom0, x2GasMom0, x3GasMom0, Egastot0);

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -278,7 +278,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 		}
 		AMREX_ASSERT_WITH_MESSAGE(T_d >= 0., "Dust temperature is negative!");
 		if (T_d < 0.0) {
-			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[1], 1);
+			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[1], 1); // NOLINT
 		}
 
 		// 2. Compute kappaP and kappaE at dust temperature
@@ -459,12 +459,12 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 
 	AMREX_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");
 	if (n >= maxIter) {
-		amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[0], 1);
+		amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[0], 1); // NOLINT
 	}
 
-	amrex::Gpu::Atomic::Add(&p_iteration_counter[0], 1);	 // total number of radiation updates
-	amrex::Gpu::Atomic::Add(&p_iteration_counter[1], n + 1); // total number of Newton-Raphson iterations
-	amrex::Gpu::Atomic::Max(&p_iteration_counter[2], n + 1); // maximum number of Newton-Raphson iterations
+	amrex::Gpu::Atomic::Add(&p_iteration_counter[0], 1);	 // total number of radiation updates. NOLINT
+	amrex::Gpu::Atomic::Add(&p_iteration_counter[1], n + 1); // total number of Newton-Raphson iterations. NOLINT
+	amrex::Gpu::Atomic::Max(&p_iteration_counter[2], n + 1); // maximum number of Newton-Raphson iterations. NOLINT
 
 	NewtonIterationResult<problem_t> result;
 
@@ -686,8 +686,8 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// make a local reference
-		auto p_iteration_counter_local = p_iteration_counter;
-		auto p_iteration_failure_counter_local = p_iteration_failure_counter;
+		auto p_iteration_counter_local = p_iteration_counter; // NOLINT
+		auto p_iteration_failure_counter_local = p_iteration_failure_counter; // NOLINT
 
 		const double c = c_light_;
 		const double chat = c_hat_;
@@ -791,7 +791,7 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 					T_d0 = ComputeDustTemperatureBateKeto(T_gas0, T_gas0, rho, Erad0Vec, coeff_n, dt, NAN, 0, radBoundaries_g_copy);
 					AMREX_ASSERT_WITH_MESSAGE(T_d0 >= 0., "Dust temperature is negative!");
 					if (T_d0 < 0.0) {
-						amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[1], 1);
+						amrex::Gpu::Atomic::Add(&p_iteration_failure_counter[1], 1); // NOLINT
 					}
 
 					const double max_Gamma_gd = coeff_n * std::max(std::sqrt(T_gas0) * T_gas0, std::sqrt(T_d0) * T_d0);
@@ -901,7 +901,7 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 
 		AMREX_ASSERT_WITH_MESSAGE(iter < max_iter, "AddSourceTerms iteration failed to converge!");
 		if (iter >= max_iter) {
-			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[2], 1);
+			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[2], 1); // NOLINT
 		}
 
 		// 4b. Store new radiation energy, gas energy

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -516,14 +516,17 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 	amrex::GpuArray<amrex::Real, 3> dMomentum{0., 0., 0.};
 	amrex::GpuArray<amrex::GpuArray<amrex::Real, nGroups_>, 3> Frad_t1{};
 
+	// make a copy of radBoundaries_ 
+	amrex::GpuArray<amrex::Real, nGroups_ + 1> radBoundaries_g = radBoundaries_;
+
 	double const rho = consPrev(i, j, k, gasDensity_index);
 	const double x1GasMom0 = consPrev(i, j, k, x1GasMomentum_index);
 	const double x2GasMom0 = consPrev(i, j, k, x2GasMomentum_index);
 	const double x3GasMom0 = consPrev(i, j, k, x3GasMomentum_index);
 	const std::array<double, 3> gasMtm0 = {x1GasMom0, x2GasMom0, x3GasMom0};
 
-	auto const fourPiBoverC = ComputeThermalRadiationMultiGroup(energy.T_d, radBoundaries_);
-	auto const kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(radBoundaries_, rho, energy.T_d);
+	auto const fourPiBoverC = ComputeThermalRadiationMultiGroup(energy.T_d, radBoundaries_g);
+	auto const kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(radBoundaries_g, rho, energy.T_d);
 
 	const double chat = c_hat_;
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -509,7 +509,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 
 // Update radiation flux and gas momentum. Returns FluxUpdateResult struct. The function also updates energy.Egas and energy.work.
 template <typename problem_t>
-auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy, double const dt,
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy, double const dt,
 				      double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
 {
 	amrex::GpuArray<amrex::Real, 3> Frad_t0{};

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -507,7 +507,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveMatterRadiationEnergyExchange(
 	return result;
 }
 
-// The function returns the updated radiation flux and gas momentum. It also update energy.Egas and energy.work
+// Update radiation flux and gas momentum. Returns FluxUpdateResult struct. The function also updates energy.Egas and energy.work.
 template <typename problem_t>
 auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy, double const dt, double const gas_update_factor, double const Ekin0) -> FluxUpdateResult<problem_t>
 {

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -590,6 +590,10 @@ auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arr
 
 	FluxUpdateResult<problem_t> updated_flux;
 
+	for (int g = 0; g < nGroups_; ++g) {
+		updated_flux.Erad[g] = energy.EradVec[g];
+	}
+
 	// 3. Deal with the work term.
 	if constexpr ((gamma_ != 1.0) && (beta_order_ == 1)) {
 		// compute difference in gas kinetic energy before and after momentum update
@@ -601,9 +605,6 @@ auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arr
 			// New scheme: the work term is included in the source terms. The work done by radiation went to internal energy, but it
 			// should go to the kinetic energy. Remove the work term from internal energy.
 			energy.Egas -= dEkin_work;
-			for (int g = 0; g < nGroups_; ++g) {
-				updated_flux.Erad[g] = energy.EradVec[g];
-			}
 			// The work term is included in the source term, but it is lagged. We update the work term here.
 			for (int g = 0; g < nGroups_; ++g) {
 				// compute new work term from the updated radiation flux and velocity

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -25,8 +25,8 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		auto p_iteration_counter_local = p_iteration_counter;
-		auto p_iteration_failure_counter_local = p_iteration_failure_counter;
+		auto p_iteration_counter_local = p_iteration_counter; // NOLINT
+		auto p_iteration_failure_counter_local = p_iteration_failure_counter; // NOLINT
 
 		const double c = c_light_;
 		const double chat = c_hat_;
@@ -168,7 +168,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 						T_d = ComputeDustTemperatureBateKeto(T_gas, T_gas, rho, Erad_guess_vec, coeff_n, dt, R, n);
 						AMREX_ASSERT_WITH_MESSAGE(T_d >= 0., "Dust temperature is negative!");
 						if (T_d < 0.0) {
-							amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[1], 1);
+							amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[1], 1); // NOLINT
 						}
 					}
 
@@ -323,13 +323,13 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 				AMREX_ASSERT_WITH_MESSAGE(n < maxIter, "Newton-Raphson iteration failed to converge!");
 				if (n >= maxIter) {
-					amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[0], 1);
+					amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[0], 1); // NOLINT
 				}
 
 				// update iteration counter: (+1, +ite, max(self, ite))
-				amrex::Gpu::Atomic::Add(&p_iteration_counter_local[0], 1);     // total number of radiation updates
-				amrex::Gpu::Atomic::Add(&p_iteration_counter_local[1], n + 1); // total number of Newton-Raphson iterations
-				amrex::Gpu::Atomic::Max(&p_iteration_counter_local[2], n + 1); // maximum number of Newton-Raphson iterations
+				amrex::Gpu::Atomic::Add(&p_iteration_counter_local[0], 1);     // total number of radiation updates. NOLINT
+				amrex::Gpu::Atomic::Add(&p_iteration_counter_local[1], n + 1); // total number of Newton-Raphson iterations. NOLINT
+				amrex::Gpu::Atomic::Max(&p_iteration_counter_local[2], n + 1); // maximum number of Newton-Raphson iterations. NOLINT
 
 				AMREX_ASSERT(Egas_guess > 0.0);
 				AMREX_ASSERT(Erad_guess >= 0.0);
@@ -506,7 +506,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 		AMREX_ASSERT_WITH_MESSAGE(ite < max_ite, "AddSourceTerms outer iteration failed to converge!");
 		if (ite >= max_ite) {
-			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[2], 1);
+			amrex::Gpu::Atomic::Add(&p_iteration_failure_counter_local[2], 1); // NOLINT
 		}
 
 		// 4b. Store new radiation energy, gas energy

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -25,7 +25,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		auto p_iteration_counter_local = p_iteration_counter; // NOLINT
+		auto p_iteration_counter_local = p_iteration_counter;		      // NOLINT
 		auto p_iteration_failure_counter_local = p_iteration_failure_counter; // NOLINT
 
 		const double c = c_light_;


### PR DESCRIPTION
### Description

This PR wraps the radiation flux update in source_terms_multi_group.hpp into a single function `UpdateFlux`. A new struct `FluxUpdateResult` is created to store the results from `UpdateFlux`. 

### Related issues
None. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
