### PR TITLE
Avoid running out of disk space for regression testing

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -19,7 +19,7 @@ jobs:
     pool: avatar
     timeoutInMinutes: 300
     steps:
-    - script: ./extern/regression_testing/regtest.py regression/quokka-tests.ini
+    - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
     - publish: /home/bwibking/regression-tests/web
       condition: succeededOrFailed()


### PR DESCRIPTION
### Description
This runs the regression testing Python script with the `--clean_testdir` option, which deletes the test output directory after a given test passes.

### Related issues
https://github.com/quokka-astro/quokka/issues/764

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
