### PR TITLE
Move enable_dust_gas_thermal_coupling_model to ISM_Traits

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1682,7 +1682,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 					amrex::Print() << "The average number of Newton-Raphson solvings per IMEX stage is " << global_solving_mean
 						       << ", (mean, max) number of Newton-Raphson iterations are " << global_iteration_mean << ", "
 						       << global_iteration_max << ".\n";
-					if constexpr (RadSystem_Traits<problem_t>::enable_dust_gas_thermal_coupling_model) {
+					if constexpr (ISM_Traits<problem_t>::enable_dust_gas_thermal_coupling_model) {
 						amrex::Print() << "The fraction of gas-dust interactions that are decoupled is "
 							       << global_decoupled_iteration_mean << "\n";
 					}

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -38,7 +38,6 @@ template <> struct RadSystem_Traits<BeamProblem> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<BeamProblem> {

--- a/src/problems/RadDust/test_rad_dust.cpp
+++ b/src/problems/RadDust/test_rad_dust.cpp
@@ -50,7 +50,12 @@ template <> struct RadSystem_Traits<DustProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = beta_order_;
+};
+
+template <> struct ISM_Traits<DustProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
+	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
+	static constexpr bool enable_photoelectric_heating = false;
 };
 
 template <> struct Physics_Traits<DustProblem> {

--- a/src/problems/RadDustMG/test_rad_dust_MG.cpp
+++ b/src/problems/RadDustMG/test_rad_dust_MG.cpp
@@ -65,7 +65,12 @@ template <> struct RadSystem_Traits<DustProblem> {
 	static constexpr amrex::GpuArray<double, Physics_Traits<DustProblem>::nGroups + 1> radBoundaries{1.0e-3, 0.1, 1.0, 10.0, 1.0e3};
 	// static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
 	static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_fixed_slope_spectrum;
+};
+
+template <> struct ISM_Traits<DustProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
+	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
+	static constexpr bool enable_photoelectric_heating = false;
 };
 
 template <>

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -71,7 +71,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 	static constexpr double Erad_floor = 0.;
 	static constexpr double energy_unit = C::ev2erg;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<TubeProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real { return 0.; }

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -42,7 +42,6 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<SuOlsonProblem> {

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -39,7 +39,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = Erad_floor_;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -44,7 +44,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -73,7 +73,7 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 template <> struct ISM_Traits<MarshakProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr bool enable_photoelectric_heating = false;
-	// 1.0e-5 is the minimum value allowed for this test; smaller values will result in negative T_d. 
+	// 1.0e-5 is the minimum value allowed for this test; smaller values will result in negative T_d.
 	static constexpr double gas_dust_coupling_threshold = 1.0e-5;
 };
 

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -73,6 +73,7 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 template <> struct ISM_Traits<MarshakProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr bool enable_photoelectric_heating = false;
+	// 1.0e-5 is the minimum value allowed for this test; smaller values will result in negative T_d. 
 	static constexpr double gas_dust_coupling_threshold = 1.0e-5;
 };
 

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -65,15 +65,15 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = dust_on;
 	static constexpr double energy_unit = 1.0;
 	static constexpr amrex::GpuArray<double, n_group_ + 1> radBoundaries = radBoundaries_;
 	static constexpr OpacityModel opacity_model = opacity_model_;
 };
 
 template <> struct ISM_Traits<MarshakProblem> {
-	static constexpr double gas_dust_coupling_threshold = 1.0e-5;
+	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr bool enable_photoelectric_heating = false;
+	static constexpr double gas_dust_coupling_threshold = 1.0e-5;
 };
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<MarshakProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -62,13 +62,13 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = dust_on;
 	static constexpr double energy_unit = 1.0;
 	static constexpr amrex::GpuArray<double, n_group_ + 1> radBoundaries = radBoundaries_;
 	static constexpr OpacityModel opacity_model = opacity_model_;
 };
 
 template <> struct ISM_Traits<MarshakProblem> {
+	static constexpr bool enable_dust_gas_thermal_coupling_model = dust_on;
 	static constexpr double gas_dust_coupling_threshold = gas_dust_coupling_threshold_;
 	static constexpr bool enable_photoelectric_heating = PE_on;
 };

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -124,7 +124,6 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr double energy_unit = C::hplanck; // set boundary unit to Hz
 	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = group_edges_;
 	static constexpr OpacityModel opacity_model = opacity_model_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <>

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -42,7 +42,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<CouplingProblem> {

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -44,7 +44,6 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<CouplingProblem> {

--- a/src/problems/RadPulse/test_radiation_pulse.cpp
+++ b/src/problems/RadPulse/test_radiation_pulse.cpp
@@ -40,7 +40,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -41,7 +41,6 @@ template <> struct RadSystem_Traits<ShadowProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<ShadowProblem> {

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -46,7 +46,6 @@ template <> struct RadSystem_Traits<StreamingProblem> {
 	static constexpr double radiation_constant = 1.0;
 	static constexpr double Erad_floor = initial_Erad;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -49,7 +49,6 @@ template <> struct RadSystem_Traits<StreamingProblem> {
 	static constexpr double radiation_constant = 1.0;
 	static constexpr double Erad_floor = initial_Erad;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -50,7 +50,6 @@ template <> struct RadSystem_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct quokka::EOS_Traits<MarshakProblem> {

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -46,7 +46,6 @@ template <> struct RadSystem_Traits<TophatProblem> {
 	static constexpr double radiation_constant = radiation_constant_cgs_;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 0;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<TophatProblem> {

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -70,7 +70,6 @@ template <> struct RadSystem_Traits<TubeProblem> {
 	// static constexpr OpacityModel opacity_model = OpacityModel::single_group;
 	static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
 	// static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_fixed_slope_spectrum;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <>

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -132,7 +132,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double energy_unit = nu_unit;
 	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = rad_boundaries_;
 	static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <>

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -49,7 +49,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = beta_order_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_light = c;
@@ -57,7 +56,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = beta_order_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -50,7 +50,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = beta_order_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_light = c;
@@ -58,7 +57,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = beta_order_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -52,7 +52,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double c_light = c;
@@ -60,7 +59,6 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 2;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -111,7 +111,6 @@ template <> struct RadSystem_Traits<SGProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = erad_floor;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<SGProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real { return kappa0; }
@@ -182,7 +181,6 @@ template <> struct RadSystem_Traits<MGproblem> {
 	// static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
 	static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_fixed_slope_spectrum;
 	// static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_full_spectrum;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <>

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -132,7 +132,6 @@ template <> struct RadSystem_Traits<MGProblem> {
 	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = rad_boundaries_;
 	static constexpr int beta_order = 1;
 	static constexpr OpacityModel opacity_model = opacity_model_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 template <> struct RadSystem_Traits<ExactProblem> {
 	static constexpr double c_light = c;
@@ -142,7 +141,6 @@ template <> struct RadSystem_Traits<ExactProblem> {
 	static constexpr bool compute_v_over_c_terms = true;
 	static constexpr int beta_order = 1;
 	static constexpr OpacityModel opacity_model = OpacityModel::single_group;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 AMREX_GPU_HOST_DEVICE

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -56,7 +56,6 @@ template <> struct RadSystem_Traits<ShellProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct HydroSystem_Traits<ShellProblem> {

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -59,7 +59,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct quokka::EOS_Traits<ShockProblem> {

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -60,7 +60,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.;
 	static constexpr int beta_order = 1;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct quokka::EOS_Traits<ShockProblem> {

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -66,7 +66,6 @@ template <> struct RadSystem_Traits<ShockProblem> {
 	// static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
 	static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_fixed_slope_spectrum;
 	// static constexpr OpacityModel opacity_model = OpacityModel::PPL_opacity_full_spectrum;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct quokka::EOS_Traits<ShockProblem> {

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -62,7 +62,6 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double radiation_constant = a_rad;
 	static constexpr double Erad_floor = 0.0;
 	static constexpr int beta_order = beta_order_;
-	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 };
 
 template <> struct Physics_Traits<PulseProblem> {

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -83,8 +83,9 @@ template <typename problem_t> struct RadSystem_Traits {
 // this struct is specialized by the user application code
 //
 template <typename problem_t> struct ISM_Traits {
-	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
+	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 	static constexpr bool enable_photoelectric_heating = false;
+	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
 };
 
 // A struct to hold the results of the ComputeRadPressure function.
@@ -193,7 +194,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	static constexpr int beta_order_ = RadSystem_Traits<problem_t>::beta_order;
 
-	static constexpr bool enable_dust_gas_thermal_coupling_model_ = RadSystem_Traits<problem_t>::enable_dust_gas_thermal_coupling_model;
+	static constexpr bool enable_dust_gas_thermal_coupling_model_ = ISM_Traits<problem_t>::enable_dust_gas_thermal_coupling_model;
 	static constexpr bool enable_photoelectric_heating_ = ISM_Traits<problem_t>::enable_photoelectric_heating;
 
 	static constexpr int nGroups_ = Physics_Traits<problem_t>::nGroups;


### PR DESCRIPTION
### Description
Move the dust model switch `enable_dust_gas_thermal_coupling_model` from RadSystem_Traits to ISM_Traits so that the RadSystem_Traits is free of dust/non-LTE parameters. 

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
