### PR TITLE
Line cooling and cosmic ray heating

### DIFF
--- a/src/math/interpolate.cpp
+++ b/src/math/interpolate.cpp
@@ -108,6 +108,9 @@ void interpolate_arrays(double *x, double *y, int len, double *arr_x, double *ar
 	/* Note: arr_x must be sorted in ascending order,
 		and arr_len must be >= 3. */
 
+	// check if x is within the range of arr_x
+	assert(x[0] >= arr_x[0] && x[len - 1] <= arr_x[arr_len - 1]);
+
 	int64_t j = 0;
 	for (int i = 0; i < len; i++) {
 		j = binary_search_with_guess(x[i], arr_x, arr_len, j);

--- a/src/math/interpolate.cpp
+++ b/src/math/interpolate.cpp
@@ -1,8 +1,8 @@
 #include <cassert>
 #include <cmath>
 
-#include "math/interpolate.hpp"
 #include "AMReX_BLassert.H"
+#include "math/interpolate.hpp"
 
 #define LIKELY_IN_CACHE_SIZE 8
 

--- a/src/math/interpolate.cpp
+++ b/src/math/interpolate.cpp
@@ -2,6 +2,7 @@
 #include <cmath>
 
 #include "math/interpolate.hpp"
+#include "AMReX_BLassert.H"
 
 #define LIKELY_IN_CACHE_SIZE 8
 
@@ -109,7 +110,7 @@ void interpolate_arrays(double *x, double *y, int len, double *arr_x, double *ar
 		and arr_len must be >= 3. */
 
 	// check if x is within the range of arr_x
-	assert(x[0] >= arr_x[0] && x[len - 1] <= arr_x[arr_len - 1]);
+	AMREX_ASSERT(x[0] >= arr_x[0] && x[len - 1] <= arr_x[arr_len - 1]);
 
 	int64_t j = 0;
 	for (int i = 0; i < len; i++) {
@@ -127,7 +128,7 @@ void interpolate_arrays(double *x, double *y, int len, double *arr_x, double *ar
 			const double slope = (arr_y[j + 1] - arr_y[j]) / (arr_x[j + 1] - arr_x[j]);
 			y[i] = slope * (x[i] - arr_x[j]) + arr_y[j];
 		}
-		assert(!std::isnan(y[i]));
+		AMREX_ASSERT(!std::isnan(y[i]));
 	}
 }
 
@@ -153,6 +154,6 @@ double interpolate_value(double x, double const *arr_x, double const *arr_y, int
 		const double slope = (arr_y[j + 1] - arr_y[j]) / (arr_x[j + 1] - arr_x[j]);
 		y = slope * (x - arr_x[j]) + arr_y[j];
 	}
-	assert(!std::isnan(y));
+	AMREX_ASSERT(!std::isnan(y));
 	return y;
 }

--- a/src/problems/CMakeLists.txt
+++ b/src/problems/CMakeLists.txt
@@ -38,6 +38,7 @@ add_subdirectory(RadDustMG)
 add_subdirectory(RadMarshakDust)
 add_subdirectory(RadMarshakDustPE)
 add_subdirectory(RadLineCooling)
+add_subdirectory(RadLineCoolingMG)
 
 add_subdirectory(RadhydroShell)
 add_subdirectory(RadhydroShock)

--- a/src/problems/CMakeLists.txt
+++ b/src/problems/CMakeLists.txt
@@ -37,6 +37,7 @@ add_subdirectory(RadDust)
 add_subdirectory(RadDustMG)
 add_subdirectory(RadMarshakDust)
 add_subdirectory(RadMarshakDustPE)
+add_subdirectory(RadLineCooling)
 
 add_subdirectory(RadhydroShell)
 add_subdirectory(RadhydroShock)

--- a/src/problems/RadLineCooling/CMakeLists.txt
+++ b/src/problems/RadLineCooling/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test_rad_line_cooling test_rad_line_cooling.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+    setup_target_for_cuda_compilation(test_rad_line_cooling)
+endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+
+add_test(NAME RadLineCooling COMMAND test_rad_line_cooling RadLineCooling.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -32,7 +32,6 @@ constexpr double C_V = 1.0;
 constexpr double k_B = 1.0;
 
 constexpr double nu_unit = 1.0;
-constexpr double Erad_bar = a_rad * T0 * T0 * T0 * T0;
 constexpr double erad_floor = a_rad * 1e-20;
 
 const double max_time = 10.0;
@@ -152,7 +151,7 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 
 template <> void QuokkaSimulation<PulseProblem>::computeAfterTimestep()
 {
-	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
+	auto [_, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		userData_.t_vec_.push_back(tNew_[0]);
@@ -217,7 +216,7 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// read output variables
-	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
+	auto [_, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 
 	std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
 	std::vector<double> &Erad = sim.userData_.Erad_vec_;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -84,7 +84,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const temperature, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -1,0 +1,266 @@
+/// \file test_rad_line_cooling.cpp
+/// \brief Defines a test problem for line cooling and cosmic-ray heating in a uniform medium.
+///
+
+#include <cmath>
+#include <unordered_map>
+
+#include "AMReX_Array.H"
+#include "AMReX_BC_TYPES.H"
+#include "AMReX_BLassert.H"
+#include "radiation/radiation_system.hpp"
+#include "util/fextract.hpp"
+#include "AMReX_Print.H"
+#include "physics_info.hpp"
+#include "test_rad_line_cooling.hpp"
+
+static constexpr bool export_csv = true;
+
+struct PulseProblem {
+}; // dummy type to allow compile-type polymorphism via template specialization
+
+constexpr int n_groups_ = 4;
+constexpr int line_index = 3; // last group
+constexpr double CR_heating_rate = 1.0;
+constexpr double line_cooling_rate = CR_heating_rate;
+constexpr amrex::GpuArray<double, 5> rad_boundaries_ = {1.00000000e-03, 1.77827941e-02, 3.16227766e-01, 5.62341325e+00, 1.00000000e+02};
+
+constexpr double c = 1.0e8;
+constexpr double chat = c;
+constexpr double v0 = 0.0;
+constexpr double kappa0 = 0.0;
+
+constexpr double T0 = 1.0;   // temperature
+constexpr double rho0 = 1.0; // matter density
+constexpr double a_rad = 1.0;
+constexpr double mu = 1.0;
+constexpr double k_B = 1.0;
+
+constexpr double nu_unit = 1.0;
+constexpr double T_equilibrium = 0.768032502191;
+constexpr double Erad_bar = a_rad * T0 * T0 * T0 * T0;
+constexpr double erad_floor = a_rad * 1e-20;
+
+constexpr double max_time = 10.0 / (1e-2 * c);
+
+template <> struct quokka::EOS_Traits<PulseProblem> {
+	static constexpr double mean_molecular_weight = mu;
+	static constexpr double boltzmann_constant = k_B;
+	static constexpr double gamma = 5. / 3.;
+};
+
+template <> struct Physics_Traits<PulseProblem> {
+	// cell-centred
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = true;
+	// face-centred
+	static constexpr bool is_mhd_enabled = false;
+	static constexpr int nGroups = n_groups_;
+};
+
+template <> struct RadSystem_Traits<PulseProblem> {
+	static constexpr double c_light = c;
+	static constexpr double c_hat = chat;
+	static constexpr double radiation_constant = a_rad;
+	static constexpr double Erad_floor = erad_floor;
+	static constexpr int beta_order = 0;
+	static constexpr double energy_unit = nu_unit;
+	static constexpr amrex::GpuArray<double, n_groups_ + 1> radBoundaries = rad_boundaries_;
+	static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
+	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
+};
+
+template <>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
+RadSystem<PulseProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double /*rho*/,
+							      const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
+{
+	amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> exponents_and_values{};
+	for (int i = 0; i < nGroups_ + 1; ++i) {
+		exponents_and_values[0][i] = 0.0;
+	}
+	for (int i = 0; i < nGroups_ + 1; ++i) {
+		exponents_and_values[1][i] = kappa0;
+	}
+	return exponents_and_values;
+}
+
+template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract variables required from the geom object
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho0, T0);
+
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int g = 0; g < n_groups_; ++g) {
+			state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index + Physics_NumVars::numRadVars * g) = erad_floor;
+			state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index + Physics_NumVars::numRadVars * g) = 0.;
+			state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index + Physics_NumVars::numRadVars * g) = 0.;
+			state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index + Physics_NumVars::numRadVars * g) = 0.;
+		}
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho0 * v0 * v0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho0;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
+		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
+	});
+}
+
+auto problem_main() -> int
+{
+	// This problem is a *linear* radiation diffusion problem, i.e.
+	// parameters are chosen such that the radiation and gas temperatures
+	// should be near equilibrium, and the opacity is chosen to go as
+	// T^3, such that the radiation diffusion equation becomes linear in T.
+
+	// This makes this problem a stringent test of the asymptotic-
+	// preserving property of the computational method, since the
+	// optical depth per cell at the peak of the temperature profile is
+	// of order 10^5.
+
+	// Problem parameters
+	const int max_timesteps = 1e6;
+	const double CFL_number_gas = 0.8;
+	const double CFL_number_rad = 8.0;
+
+	const double max_dt = 1.0;
+
+	// Boundary conditions
+	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
+	for (int n = 0; n < nvars; ++n) {
+		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+		}
+	}
+
+	// Problem initialization
+	QuokkaSimulation<PulseProblem> sim(BCs_cc);
+
+	sim.radiationReconstructionOrder_ = 3; // PPM
+	sim.stopTime_ = max_time;
+	sim.radiationCflNumber_ = CFL_number_rad;
+	sim.cflNumber_ = CFL_number_gas;
+	sim.maxDt_ = max_dt;
+	sim.maxTimesteps_ = max_timesteps;
+	sim.plotfileInterval_ = -1;
+
+	// initialize
+	sim.setInitialConditions();
+
+	// evolve
+	sim.evolve();
+
+	// read output variables
+	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
+	const int nx = static_cast<int>(position.size());
+
+	std::vector<double> xs(nx);
+	std::vector<double> Tgas(nx);
+	std::vector<double> Tgas_exact{};
+	std::vector<double> Erad_line{};
+	std::vector<double> Erad_line_exact{};
+	double Erad_other_groups_error = 0.0;
+
+	// compute exact solution and error norm
+	for (int i = 0; i < nx; ++i) {
+		amrex::Real const x = position[i];
+		xs.at(i) = x;
+		double Erad_t = 0.0;
+		for (int g = 0; g < n_groups_; ++g) {
+			Erad_t = values.at(RadSystem<PulseProblem>::radEnergy_index + Physics_NumVars::numRadVars * g)[i];
+			if (g == line_index) {
+				Erad_line.push_back(Erad_t);
+				Erad_line_exact.push_back(erad_floor); // TODO
+			} else {
+				Erad_other_groups_error += std::abs(Erad_t - erad_floor);
+			}
+		}
+		const auto rho_t = values.at(RadSystem<PulseProblem>::gasDensity_index)[i];
+		const auto Egas = values.at(RadSystem<PulseProblem>::gasInternalEnergy_index)[i];
+		Tgas.at(i) = quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho_t, Egas);
+		Tgas_exact.push_back(T0);
+	}
+	// compare temperature with Tgas_exact
+	double err_norm_T = 0.;
+	double sol_norm_T = 0.;
+	for (int i = 0; i < nx; ++i) {
+		err_norm_T += std::abs(Tgas[i] - Tgas_exact[i]);
+		sol_norm_T += std::abs(Tgas_exact[i]);
+	}
+	const double rel_error_T = err_norm_T / sol_norm_T;
+	// compute error norm for Erad_line 
+	double err_norm_Erad = 0.;
+	for (int i = 0; i < nx; ++i) {
+		err_norm_Erad += std::abs(Erad_line[i] - Erad_line_exact[i]);
+	}
+	const double rel_error_Erad = (err_norm_Erad + Erad_other_groups_error) / Erad_bar;
+	const double rel_error = std::max(rel_error_T, rel_error_Erad);
+
+	const double error_tol = 0.01;
+	amrex::Print() << "Relative L1 error norm for T_gas = " << rel_error << std::endl;
+	int status = 0;
+	if ((rel_error > error_tol) || std::isnan(rel_error)) {
+		status = 1;
+	}
+
+#ifdef HAVE_PYTHON
+	// plot temperature
+	matplotlibcpp::clf();
+	std::map<std::string, std::string> Tgas_args;
+	Tgas_args["label"] = "T_gas (numerical)";
+	Tgas_args["linestyle"] = "-";
+	matplotlibcpp::plot(xs, Tgas, Tgas_args);
+	matplotlibcpp::xlabel("x (dimensionless)");
+	matplotlibcpp::ylabel("temperature (dimensionless)");
+	matplotlibcpp::legend();
+	matplotlibcpp::ylim(0.0, 2.0);
+	matplotlibcpp::title(fmt::format("time ct = {:.4g}", sim.tNew_[0] * c));
+	matplotlibcpp::tight_layout();
+	matplotlibcpp::save("./rad_line_cooling_temperature.pdf");
+
+	// plot Erad_line
+	matplotlibcpp::clf();
+	std::map<std::string, std::string> Erad_args;
+	std::map<std::string, std::string> Erad_exact_args;
+	Erad_args["label"] = "E_rad (numerical)";
+	Erad_args["linestyle"] = "-";
+	Erad_exact_args["label"] = "E_rad (exact)";
+	Erad_exact_args["linestyle"] = "--";
+	matplotlibcpp::plot(xs, Erad_line, Erad_args);
+	matplotlibcpp::plot(xs, Erad_line_exact, Erad_exact_args);
+	matplotlibcpp::xlabel("x (dimensionless)");
+	matplotlibcpp::ylabel("radiation energy density (dimensionless)");
+	matplotlibcpp::legend();
+	matplotlibcpp::title(fmt::format("time ct = {:.4g}", sim.tNew_[0] * c));
+	matplotlibcpp::tight_layout();
+	matplotlibcpp::save("./rad_line_cooling_radiation_energy_density.pdf");
+#endif
+
+	if (export_csv) {
+		std::ofstream file;
+		file.open("rad_line_cooling_temp.csv");
+		file << "xs,Tgas,Tgas_exact\n";
+		for (size_t i = 0; i < xs.size(); ++i) {
+			file << std::scientific << std::setprecision(12) << xs[i] << "," << Tgas[i] << "," << Tgas_exact[i] << "\n";
+		}
+		file.close();
+
+		file.open("rad_line_cooling_rad_energy_density.csv");
+		file << "xs,Erad_line,Erad_line_exact\n";
+		for (size_t i = 0; i < xs.size(); ++i) {
+			file << std::scientific << std::setprecision(12) << xs[i] << "," << Erad_line[i] << "," << Erad_line_exact[i] << "\n";
+		}
+		file.close();
+	}
+
+	// exit
+	return status;
+}

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -223,8 +223,6 @@ auto problem_main() -> int
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 	const int nx = static_cast<int>(position.size());
 
-	double Erad_other_groups_error = 0.0;
-
 	std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
 	std::vector<double> &Erad = sim.userData_.Erad_vec_;
 	std::vector<double> &t_sim = sim.userData_.t_vec_;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -16,9 +16,6 @@ static constexpr bool export_csv = true;
 struct PulseProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-constexpr int n_groups_ = 1;
-constexpr amrex::GpuArray<double, 5> rad_boundaries_ = {1.00000000e-03, 1.77827941e-02, 3.16227766e-01, 5.62341325e+00, 1.00000000e+02};
-
 const double cooling_rate = 0.1;
 const double CR_heating_rate = 0.03;
 
@@ -35,7 +32,6 @@ constexpr double C_V = 1.0;
 constexpr double k_B = 1.0;
 
 constexpr double nu_unit = 1.0;
-constexpr double T_equilibrium = 0.768032502191;
 constexpr double Erad_bar = a_rad * T0 * T0 * T0 * T0;
 constexpr double erad_floor = a_rad * 1e-20;
 
@@ -222,7 +218,6 @@ auto problem_main() -> int
 
 	// read output variables
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
-	const int nx = static_cast<int>(position.size());
 
 	std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
 	std::vector<double> &Erad = sim.userData_.Erad_vec_;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -3,12 +3,9 @@
 ///
 
 #include <cmath>
-#include <unordered_map>
 
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
-#include "AMReX_BLassert.H"
-#include "radiation/radiation_system.hpp"
 #include "util/fextract.hpp"
 #include "AMReX_Print.H"
 #include "physics_info.hpp"

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -13,7 +13,7 @@
 
 static constexpr bool export_csv = true;
 
-struct PulseProblem {
+struct CoolingProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
 const double cooling_rate = 0.1;
@@ -36,19 +36,19 @@ constexpr double erad_floor = a_rad * 1e-20;
 
 const double max_time = 10.0;
 
-template <> struct SimulationData<PulseProblem> {
+template <> struct SimulationData<CoolingProblem> {
 	std::vector<double> t_vec_;
 	std::vector<double> Tgas_vec_;
 	std::vector<double> Erad_vec_;
 };
 
-template <> struct quokka::EOS_Traits<PulseProblem> {
+template <> struct quokka::EOS_Traits<CoolingProblem> {
 	static constexpr double mean_molecular_weight = mu;
 	static constexpr double boltzmann_constant = k_B;
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<CoolingProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -59,7 +59,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr int nGroups = 1;
 };
 
-template <> struct RadSystem_Traits<PulseProblem> {
+template <> struct RadSystem_Traits<CoolingProblem> {
 	static constexpr double c_light = c;
 	static constexpr double c_hat = chat;
 	static constexpr double radiation_constant = a_rad;
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr double energy_unit = nu_unit;
 };
 
-template <> struct ISM_Traits<PulseProblem> {
+template <> struct ISM_Traits<CoolingProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
 	static constexpr bool enable_photoelectric_heating = false;
@@ -76,7 +76,7 @@ template <> struct ISM_Traits<PulseProblem> {
 };
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/)
+AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/)
     -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
@@ -86,7 +86,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
     -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
@@ -95,25 +95,25 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDeri
 	return cooling;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
 {
 	return CR_heating_rate;
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<PulseProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<CoolingProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
 {
 	return kappa0;
 }
 
-template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::ComputeFluxMeanOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblem>::ComputeFluxMeanOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
 {
 	return kappa0;
 }
 
 template <>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
-RadSystem<PulseProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double /*rho*/,
+RadSystem<CoolingProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double /*rho*/,
 							      const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
 {
 	amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> exponents_and_values{};
@@ -126,59 +126,52 @@ RadSystem<PulseProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<do
 	return exponents_and_values;
 }
 
-template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<CoolingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	const double Egas = quokka::EOS<PulseProblem>::ComputeEintFromTgas(rho0, T0);
+	const double Egas = quokka::EOS<CoolingProblem>::ComputeEintFromTgas(rho0, T0);
 
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		state_cc(i, j, k, RadSystem<PulseProblem>::radEnergy_index) = erad_floor;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1RadFlux_index) = 0.;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x2RadFlux_index) = 0.;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x3RadFlux_index) = 0.;
-		state_cc(i, j, k, RadSystem<PulseProblem>::gasEnergy_index) = Egas + 0.5 * rho0 * v0 * v0;
-		state_cc(i, j, k, RadSystem<PulseProblem>::gasDensity_index) = rho0;
-		state_cc(i, j, k, RadSystem<PulseProblem>::gasInternalEnergy_index) = Egas;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x1GasMomentum_index) = v0 * rho0;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
-		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::radEnergy_index) = erad_floor;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x1RadFlux_index) = 0.;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x2RadFlux_index) = 0.;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x3RadFlux_index) = 0.;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::gasEnergy_index) = Egas + 0.5 * rho0 * v0 * v0;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::gasDensity_index) = rho0;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::gasInternalEnergy_index) = Egas;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x1GasMomentum_index) = v0 * rho0;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x2GasMomentum_index) = 0.;
+		state_cc(i, j, k, RadSystem<CoolingProblem>::x3GasMomentum_index) = 0.;
 	});
 }
 
-template <> void QuokkaSimulation<PulseProblem>::computeAfterTimestep()
+template <> void QuokkaSimulation<CoolingProblem>::computeAfterTimestep()
 {
-	auto [_, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
+	auto values = std::get<1>(fextract(state_new_cc_[0], Geom(0), 0, 0.5)); // NOLINT
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		userData_.t_vec_.push_back(tNew_[0]);
 
-		const amrex::Real Etot_i = values.at(RadSystem<PulseProblem>::gasEnergy_index)[0];
-		const amrex::Real x1GasMom = values.at(RadSystem<PulseProblem>::x1GasMomentum_index)[0];
-		const amrex::Real x2GasMom = values.at(RadSystem<PulseProblem>::x2GasMomentum_index)[0];
-		const amrex::Real x3GasMom = values.at(RadSystem<PulseProblem>::x3GasMomentum_index)[0];
-		const amrex::Real rho = values.at(RadSystem<PulseProblem>::gasDensity_index)[0];
-		const amrex::Real Egas_i = RadSystem<PulseProblem>::ComputeEintFromEgas(rho, x1GasMom, x2GasMom, x3GasMom, Etot_i);
-		userData_.Tgas_vec_.push_back(quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho, Egas_i));
-		const double Erad_i = values.at(RadSystem<PulseProblem>::radEnergy_index)[0];
+		const amrex::Real Etot_i = values.at(RadSystem<CoolingProblem>::gasEnergy_index)[0];
+		const amrex::Real x1GasMom = values.at(RadSystem<CoolingProblem>::x1GasMomentum_index)[0];
+		const amrex::Real x2GasMom = values.at(RadSystem<CoolingProblem>::x2GasMomentum_index)[0];
+		const amrex::Real x3GasMom = values.at(RadSystem<CoolingProblem>::x3GasMomentum_index)[0];
+		const amrex::Real rho = values.at(RadSystem<CoolingProblem>::gasDensity_index)[0];
+		const amrex::Real Egas_i = RadSystem<CoolingProblem>::ComputeEintFromEgas(rho, x1GasMom, x2GasMom, x3GasMom, Etot_i);
+		userData_.Tgas_vec_.push_back(quokka::EOS<CoolingProblem>::ComputeTgasFromEint(rho, Egas_i));
+		const double Erad_i = values.at(RadSystem<CoolingProblem>::radEnergy_index)[0];
 		userData_.Erad_vec_.push_back(Erad_i);
 	}
 }
 
 auto problem_main() -> int
 {
-	// This problem is a *linear* radiation diffusion problem, i.e.
-	// parameters are chosen such that the radiation and gas temperatures
-	// should be near equilibrium, and the opacity is chosen to go as
-	// T^3, such that the radiation diffusion equation becomes linear in T.
-
-	// This makes this problem a stringent test of the asymptotic-
-	// preserving property of the computational method, since the
-	// optical depth per cell at the peak of the temperature profile is
-	// of order 10^5.
+	// This problem is a test of line cooling and cosmic-ray heating in a uniform medium. The gas/dust opacity is set to zero, so that the radiation does not interact with matter. The initial conditions are set to a constant temperature and zero radiation energy density. The gas cools at a rate of 0.1 per unit time, and is heated by cosmic rays at a rate of 0.03 per unit time. The exact solution is given by the following system of equations:
+	// dTgas/dt = -0.1 * Tgas + 0.03, 
 
 	// Problem parameters
 	const int max_timesteps = 1e6;
@@ -188,7 +181,7 @@ auto problem_main() -> int
 	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
+	constexpr int nvars = RadSystem<CoolingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
@@ -198,7 +191,7 @@ auto problem_main() -> int
 	}
 
 	// Problem initialization
-	QuokkaSimulation<PulseProblem> sim(BCs_cc);
+	QuokkaSimulation<CoolingProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;
@@ -214,9 +207,6 @@ auto problem_main() -> int
 
 	// evolve
 	sim.evolve();
-
-	// read output variables
-	auto [_, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 
 	std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
 	std::vector<double> &Erad = sim.userData_.Erad_vec_;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -6,10 +6,10 @@
 
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
-#include "util/fextract.hpp"
 #include "AMReX_Print.H"
 #include "physics_info.hpp"
 #include "test_rad_line_cooling.hpp"
+#include "util/fextract.hpp"
 
 static constexpr bool export_csv = true;
 
@@ -81,7 +81,8 @@ template <> struct ISM_Traits<PulseProblem> {
 };
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
@@ -90,7 +91,8 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
@@ -98,13 +100,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDeri
 	return cooling;
 }
 
-template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
 {
 	return CR_heating_rate;
 }
 
-template <> 
+template <>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto RadSystem<PulseProblem>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
 {
 	return kappa0;
@@ -161,7 +162,7 @@ template <> void QuokkaSimulation<PulseProblem>::computeAfterTimestep()
 		userData_.t_vec_.push_back(tNew_[0]);
 
 		const amrex::Real Etot_i = values.at(RadSystem<PulseProblem>::gasEnergy_index)[0];
-		const amrex::Real x1GasMom = values.at(RadSystem<PulseProblem>::x1GasMomentum_index)[0];	
+		const amrex::Real x1GasMom = values.at(RadSystem<PulseProblem>::x1GasMomentum_index)[0];
 		const amrex::Real x2GasMom = values.at(RadSystem<PulseProblem>::x2GasMomentum_index)[0];
 		const amrex::Real x3GasMom = values.at(RadSystem<PulseProblem>::x3GasMomentum_index)[0];
 		const amrex::Real rho = values.at(RadSystem<PulseProblem>::gasDensity_index)[0];
@@ -229,11 +230,12 @@ auto problem_main() -> int
 
 	std::vector<double> Tgas_exact_vec{};
 	std::vector<double> Erad_exact_vec{};
-	for (const auto& t_exact : t_sim) {
-		const double Egas_exact_solution = std::exp(-cooling_rate * t_exact) * (cooling_rate * T0 - CR_heating_rate + CR_heating_rate * std::exp(cooling_rate * t_exact)) / cooling_rate;
+	for (const auto &t_exact : t_sim) {
+		const double Egas_exact_solution = std::exp(-cooling_rate * t_exact) *
+						   (cooling_rate * T0 - CR_heating_rate + CR_heating_rate * std::exp(cooling_rate * t_exact)) / cooling_rate;
 		const double T_exact_solution = Egas_exact_solution / C_V;
 		Tgas_exact_vec.push_back(T_exact_solution);
-		const double Erad_exact_solution = - (Egas_exact_solution - C_V * T0 - CR_heating_rate * t_exact) * (chat / c);
+		const double Erad_exact_solution = -(Egas_exact_solution - C_V * T0 - CR_heating_rate * t_exact) * (chat / c);
 		Erad_exact_vec.push_back(Erad_exact_solution);
 	}
 

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -114,7 +114,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblem>::ComputeFluxMea
 template <>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 RadSystem<CoolingProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double /*rho*/,
-							      const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
+								const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
 {
 	amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> exponents_and_values{};
 	for (int i = 0; i < nGroups_ + 1; ++i) {
@@ -170,8 +170,10 @@ template <> void QuokkaSimulation<CoolingProblem>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
-	// This problem is a test of line cooling and cosmic-ray heating in a uniform medium. The gas/dust opacity is set to zero, so that the radiation does not interact with matter. The initial conditions are set to a constant temperature and zero radiation energy density. The gas cools at a rate of 0.1 per unit time, and is heated by cosmic rays at a rate of 0.03 per unit time. The exact solution is given by the following system of equations:
-	// dTgas/dt = -0.1 * Tgas + 0.03, 
+	// This problem is a test of line cooling and cosmic-ray heating in a uniform medium. The gas/dust opacity is set to zero, so that the radiation does
+	// not interact with matter. The initial conditions are set to a constant temperature and zero radiation energy density. The gas cools at a rate of 0.1
+	// per unit time, and is heated by cosmic rays at a rate of 0.03 per unit time. The exact solution is given by the following system of equations:
+	// dTgas/dt = -0.1 * Tgas + 0.03,
 
 	// Problem parameters
 	const int max_timesteps = 1e6;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.hpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.hpp
@@ -21,7 +21,7 @@
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
-#include "radiation/radiation_system.hpp"
+#include "radiation/radiation_dust_system.hpp"
 
 // function definitions
 auto problem_main() -> int;

--- a/src/problems/RadLineCooling/test_rad_line_cooling.hpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.hpp
@@ -1,0 +1,29 @@
+#ifndef TEST_RAD_LINE_COOLING_HPP_ // NOLINT
+#define TEST_RAD_LINE_COOLING_HPP_
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_rad_line_cooling.hpp
+/// \brief Defines a test problem for line cooling and cosmic-ray heating in a uniform medium.
+///
+
+// external headers
+#ifdef HAVE_PYTHON
+#include "util/matplotlibcpp.h"
+#endif
+#include <fmt/format.h>
+#include <fstream>
+
+// internal headers
+
+#include "QuokkaSimulation.hpp"
+#include "hydro/hydro_system.hpp"
+#include "math/interpolate.hpp"
+#include "radiation/radiation_system.hpp"
+
+// function definitions
+auto problem_main() -> int;
+
+#endif // TEST_RAD_LINE_COOLING_HPP_

--- a/src/problems/RadLineCoolingMG/CMakeLists.txt
+++ b/src/problems/RadLineCoolingMG/CMakeLists.txt
@@ -5,3 +5,4 @@ if(AMReX_GPU_BACKEND MATCHES "CUDA")
 endif(AMReX_GPU_BACKEND MATCHES "CUDA")
 
 add_test(NAME RadLineCoolingMG COMMAND test_rad_line_cooling_MG RadLineCooling.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+add_test(NAME RadLineCoolingMG_coupled COMMAND test_rad_line_cooling_MG RadLineCoolingCoupled.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/problems/RadLineCoolingMG/CMakeLists.txt
+++ b/src/problems/RadLineCoolingMG/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(test_rad_line_cooling_MG test_rad_line_cooling_MG.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+    setup_target_for_cuda_compilation(test_rad_line_cooling_MG)
+endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+
+add_test(NAME RadLineCoolingMG COMMAND test_rad_line_cooling_MG RadLineCooling.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -74,7 +74,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 template <> struct ISM_Traits<PulseProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_photoelectric_heating = false;
+	static constexpr bool enable_photoelectric_heating = true;
 	static constexpr bool enable_linear_cooling_heating = true;
 };
 

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -73,10 +73,10 @@ template <> struct RadSystem_Traits<PulseProblem> {
 };
 
 template <> struct ISM_Traits<PulseProblem> {
-	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
+	static constexpr bool enable_dust_gas_thermal_coupling_model = 1;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_photoelectric_heating = false;
-	static constexpr bool enable_linear_cooling_heating = true;
+	static constexpr bool enable_photoelectric_heating = 1;
+	static constexpr bool enable_linear_cooling_heating = 1;
 };
 
 template <>

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -22,7 +22,8 @@ constexpr double CR_heating_rate = 1.0;
 constexpr double line_cooling_rate = CR_heating_rate;
 constexpr amrex::GpuArray<double, 5> rad_boundaries_ = {1.00000000e-03, 1.77827941e-02, 3.16227766e-01, 5.62341325e+00, 1.00000000e+02};
 
-const double cooling_rate = 1.0e-1;
+// const double cooling_rate = 1.0e-1;
+const double cooling_rate = 0.0;
 
 constexpr double c = 1.0;
 constexpr double chat = c;

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -22,8 +22,8 @@ constexpr double CR_heating_rate = 1.0;
 constexpr double line_cooling_rate = CR_heating_rate;
 constexpr amrex::GpuArray<double, 5> rad_boundaries_ = {1.00000000e-03, 1.77827941e-02, 3.16227766e-01, 5.62341325e+00, 1.00000000e+02};
 
-// const double cooling_rate = 1.0e-1;
-const double cooling_rate = 0.0;
+const double cooling_rate = 1.0e-1;
+// const double cooling_rate = 0.0;
 
 constexpr double c = 1.0;
 constexpr double chat = c;

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -43,6 +43,12 @@ const int line_index = 0; // last group
 const double cooling_rate = 0.1;
 const double PE_rate = 0.02;
 
+template <> struct SimulationData<PulseProblem> {
+	std::vector<double> t_vec_;
+	std::vector<double> Tgas_vec_;
+	std::vector<double> Erad_line_vec_;
+};
+
 template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double mean_molecular_weight = mu;
 	static constexpr double boltzmann_constant = k_B;
@@ -145,6 +151,25 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 	});
 }
 
+template <> void QuokkaSimulation<PulseProblem>::computeAfterTimestep()
+{
+	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
+
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		userData_.t_vec_.push_back(tNew_[0]);
+
+		const amrex::Real Etot_i = values.at(RadSystem<PulseProblem>::gasEnergy_index)[0];
+		const amrex::Real x1GasMom = values.at(RadSystem<PulseProblem>::x1GasMomentum_index)[0];
+		const amrex::Real x2GasMom = values.at(RadSystem<PulseProblem>::x2GasMomentum_index)[0];
+		const amrex::Real x3GasMom = values.at(RadSystem<PulseProblem>::x3GasMomentum_index)[0];
+		const amrex::Real rho = values.at(RadSystem<PulseProblem>::gasDensity_index)[0];
+		const amrex::Real Egas_i = RadSystem<PulseProblem>::ComputeEintFromEgas(rho, x1GasMom, x2GasMom, x3GasMom, Etot_i);
+		userData_.Tgas_vec_.push_back(quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho, Egas_i));
+		const double Erad_line_i = values.at(RadSystem<PulseProblem>::radEnergy_index + Physics_NumVars::numRadVars * line_index)[0];
+		userData_.Erad_line_vec_.push_back(Erad_line_i);
+	}
+}
+
 auto problem_main() -> int
 {
 	// This problem is a *linear* radiation diffusion problem, i.e.
@@ -196,65 +221,32 @@ auto problem_main() -> int
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 	const int nx = static_cast<int>(position.size());
 
-	std::vector<double> xs(nx);
-	std::vector<double> Tgas(nx);
-	std::vector<double> Tgas_exact{};
-	std::vector<double> Erad_line{};
-	std::vector<double> Erad_line_exact{};
-	double Erad_other_groups_error = 0.0;
-
 	const auto t_end = sim.tNew_[0];
 
-	// compute exact solution and error norm
-	for (int i = 0; i < nx; ++i) {
-		amrex::Real const x = position[i];
-		xs.at(i) = x;
-		const auto rho_t = values.at(RadSystem<PulseProblem>::gasDensity_index)[i];
-		const auto Egas = values.at(RadSystem<PulseProblem>::gasInternalEnergy_index)[i];
-		Tgas.at(i) = quokka::EOS<PulseProblem>::ComputeTgasFromEint(rho_t, Egas);
-		// OLD: cooling only; no PE heating
-		// const double T_exact_solution = std::exp(-cooling_rate * t_end) * T0;
-		// NEW: cooling and PE heating
-		// sol = exp(-a t) * (a * T0 - b + b * exp(a t)) / a, where a = cooling_rate, b = PE_rate
-		const double PE_rate_ = ISM_Traits<PulseProblem>::enable_photoelectric_heating ? PE_rate : 0.0;
-		const double Egas_exact_solution = std::exp(-cooling_rate * t_end) * (cooling_rate * T0 - PE_rate_ + PE_rate_ * std::exp(cooling_rate * t_end)) / cooling_rate;
+	const double PE_rate_ = ISM_Traits<PulseProblem>::enable_photoelectric_heating ? PE_rate : 0.0;
+
+	// compute exact solution from t = 0 to t = t_end	
+	const double N_dt = 1000.;
+	double t_exact = 0.0;
+	std::vector<double> t_exact_vec{};
+	std::vector<double> Tgas_exact_vec{};
+	std::vector<double> Erad_line_exact_vec{};
+	while (true) {
+		const double Egas_exact_solution = std::exp(-cooling_rate * t_exact) * (cooling_rate * T0 - PE_rate_ + PE_rate_ * std::exp(cooling_rate * t_exact)) / cooling_rate;
 		const double T_exact_solution = Egas_exact_solution / C_V;
-		Tgas_exact.push_back(T_exact_solution);
-		const double Erad_line_exact_solution = - (Egas_exact_solution - C_V * T0 - PE_rate_ * t_end) * (chat / c);
-		for (int g = 0; g < n_groups_; ++g) {
-			const auto Erad_t = values.at(RadSystem<PulseProblem>::radEnergy_index + Physics_NumVars::numRadVars * g)[i];
-			if (g == line_index) {
-				Erad_line.push_back(Erad_t);
-				Erad_line_exact.push_back(Erad_line_exact_solution);
-			} else if (g == n_groups_ - 1) {
-				Erad_other_groups_error += std::abs(Erad_t - Erad_FUV);
-			} else {
-				Erad_other_groups_error += std::abs(Erad_t - Erad_floor_);
-			}
+		Tgas_exact_vec.push_back(T_exact_solution);
+		const double Erad_line_exact_solution = - (Egas_exact_solution - C_V * T0 - PE_rate_ * t_exact) * (chat / c);
+		Erad_line_exact_vec.push_back(Erad_line_exact_solution);
+		t_exact_vec.push_back(t_exact);
+		t_exact += t_end / N_dt;
+		if (t_exact > 1.01 * t_end) {
+			break; // note that we need the last time to be greater than t_end
 		}
 	}
-	// compare temperature with Tgas_exact
-	double err_norm_T = 0.;
-	double sol_norm_T = 0.;
-	for (int i = 0; i < nx; ++i) {
-		err_norm_T += std::abs(Tgas[i] - Tgas_exact[i]);
-		sol_norm_T += std::abs(Tgas_exact[i]);
-	}
-	const double rel_error_T = err_norm_T / sol_norm_T;
-	// compute error norm for Erad_line 
-	double err_norm_Erad = 0.;
-	for (int i = 0; i < nx; ++i) {
-		err_norm_Erad += std::abs(Erad_line[i] - Erad_line_exact[i]);
-	}
-	const double rel_error_Erad = (err_norm_Erad + Erad_other_groups_error) / Erad_bar;
-	const double rel_error = std::max(rel_error_T, rel_error_Erad);
 
-	const double error_tol = 0.005;
-	amrex::Print() << "Relative L1 error norm for T_gas = " << rel_error << std::endl;
-	int status = 0;
-	if ((rel_error > error_tol) || std::isnan(rel_error)) {
-		status = 1;
-	}
+	std::vector<double> &Tgas = sim.userData_.Tgas_vec_;
+	std::vector<double> &Erad_line = sim.userData_.Erad_line_vec_;
+	std::vector<double> &t = sim.userData_.t_vec_;
 
 #ifdef HAVE_PYTHON
 	// plot temperature
@@ -262,15 +254,14 @@ auto problem_main() -> int
 	std::map<std::string, std::string> Tgas_args;
 	Tgas_args["label"] = "T_gas (numerical)";
 	Tgas_args["linestyle"] = "-";
-	matplotlibcpp::plot(xs, Tgas, Tgas_args);
+	matplotlibcpp::plot(t, Tgas, Tgas_args);
 	Tgas_args["label"] = "T_gas (exact)";
 	Tgas_args["linestyle"] = "--";
-	matplotlibcpp::plot(xs, Tgas_exact, Tgas_args);
-	matplotlibcpp::xlabel("x (dimensionless)");
+	matplotlibcpp::plot(t_exact_vec, Tgas_exact_vec, Tgas_args);
+	matplotlibcpp::xlabel("t (dimensionless)");
 	matplotlibcpp::ylabel("temperature (dimensionless)");
 	matplotlibcpp::legend();
 	matplotlibcpp::ylim(-0.05, 2.05);
-	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./rad_line_cooling_MG_temperature.pdf");
 
@@ -282,34 +273,54 @@ auto problem_main() -> int
 	Erad_args["linestyle"] = "-";
 	Erad_exact_args["label"] = "E_rad (exact)";
 	Erad_exact_args["linestyle"] = "--";
-	matplotlibcpp::plot(xs, Erad_line, Erad_args);
-	matplotlibcpp::plot(xs, Erad_line_exact, Erad_exact_args);
-	matplotlibcpp::xlabel("x (dimensionless)");
+	matplotlibcpp::plot(t, Erad_line, Erad_args);
+	matplotlibcpp::plot(t_exact_vec, Erad_line_exact_vec, Erad_exact_args);
+	matplotlibcpp::xlabel("t (dimensionless)");
 	matplotlibcpp::ylabel("radiation energy density (dimensionless)");
 	matplotlibcpp::ylim(-0.05, 1.05);
 	matplotlibcpp::legend();
-	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./rad_line_cooling_MG_radiation_energy_density.pdf");
 #endif
 
+	std::vector<double> Tgas_interp(t.size());
+	std::vector<double> Erad_line_interp(t.size());
+	interpolate_arrays(t.data(), Tgas_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Tgas_exact_vec.data(), static_cast<int>(t_exact_vec.size()));
+	interpolate_arrays(t.data(), Erad_line_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Erad_line_exact_vec.data(), static_cast<int>(t_exact_vec.size()));
+
+	// compute error norm
+	double err_norm = 0.;
+	double sol_norm = 0.;
+	for (size_t i = 0; i < t.size(); ++i) {
+		err_norm += std::abs(Tgas[i] - Tgas_interp[i]);
+		err_norm += std::abs(Erad_line[i] - Erad_line_interp[i]);
+		sol_norm += std::abs(Tgas_interp[i]) + std::abs(Erad_line_interp[i]);
+	}
+	const double rel_error = err_norm / sol_norm;
+	amrex::Print() << "Relative L1 error norm = " << rel_error << std::endl;
+
 	if (export_csv) {
 		std::ofstream file;
 		file.open("rad_line_cooling_temp.csv");
-		file << "xs,Tgas,Tgas_exact\n";
-		for (size_t i = 0; i < xs.size(); ++i) {
-			file << std::scientific << std::setprecision(12) << xs[i] << "," << Tgas[i] << "," << Tgas_exact[i] << "\n";
+		file << "t,Tgas,Tgas_exact\n";
+		for (size_t i = 0; i < t.size(); ++i) {
+			file << std::scientific << std::setprecision(12) << t[i] << "," << Tgas[i] << "," << Tgas_exact_vec[i] << "\n";
 		}
 		file.close();
 
 		file.open("rad_line_cooling_rad_energy_density.csv");
-		file << "xs,Erad_line,Erad_line_exact\n";
-		for (size_t i = 0; i < xs.size(); ++i) {
-			file << std::scientific << std::setprecision(12) << xs[i] << "," << Erad_line[i] << "," << Erad_line_exact[i] << "\n";
+		file << "t,Erad_line,Erad_line_exact\n";
+		for (size_t i = 0; i < t.size(); ++i) {
+			file << std::scientific << std::setprecision(12) << t[i] << "," << Erad_line[i] << "," << Erad_line_exact_vec[i] << "\n";
 		}
 		file.close();
 	}
 
 	// exit
+	int status = 0;
+	const double error_tol = 0.0005;
+	if (rel_error > error_tol) {
+		status = 1;
+	}
 	return status;
 }

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -109,7 +109,6 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDeri
 	return cooling;
 }
 
-// CR heating
 template <>
 AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
 {

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -6,10 +6,10 @@
 
 #include "AMReX_Array.H"
 #include "AMReX_BC_TYPES.H"
-#include "util/fextract.hpp"
 #include "AMReX_Print.H"
 #include "physics_info.hpp"
 #include "test_rad_line_cooling_MG.hpp"
+#include "util/fextract.hpp"
 
 static constexpr bool export_csv = true;
 
@@ -85,14 +85,15 @@ template <> struct ISM_Traits<PulseProblem> {
 };
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/,
-											     amrex::Real const /*num_density*/) -> amrex::Real
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+    -> amrex::Real
 {
 	return PE_rate / Erad_FUV;
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::Real const temperature, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
@@ -101,7 +102,8 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRate(amrex::
 }
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
@@ -109,8 +111,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineNetCoolingRateTempDeri
 	return cooling;
 }
 
-template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<PulseProblem>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
 {
 	return CR_heating_rate;
 }
@@ -232,17 +233,18 @@ auto problem_main() -> int
 
 	const double heating_rate_ = ISM_Traits<PulseProblem>::enable_photoelectric_heating ? PE_rate + CR_heating_rate : CR_heating_rate;
 
-	// compute exact solution from t = 0 to t = t_end	
+	// compute exact solution from t = 0 to t = t_end
 	const double N_dt = 1000.;
 	double t_exact = 0.0;
 	std::vector<double> t_exact_vec{};
 	std::vector<double> Tgas_exact_vec{};
 	std::vector<double> Erad_line_exact_vec{};
 	while (true) {
-		const double Egas_exact_solution = std::exp(-cooling_rate * t_exact) * (cooling_rate * T0 - heating_rate_ + heating_rate_ * std::exp(cooling_rate * t_exact)) / cooling_rate;
+		const double Egas_exact_solution =
+		    std::exp(-cooling_rate * t_exact) * (cooling_rate * T0 - heating_rate_ + heating_rate_ * std::exp(cooling_rate * t_exact)) / cooling_rate;
 		const double T_exact_solution = Egas_exact_solution / C_V;
 		Tgas_exact_vec.push_back(T_exact_solution);
-		const double Erad_line_exact_solution = - (Egas_exact_solution - C_V * T0 - heating_rate_ * t_exact) * (chat / c);
+		const double Erad_line_exact_solution = -(Egas_exact_solution - C_V * T0 - heating_rate_ * t_exact) * (chat / c);
 		Erad_line_exact_vec.push_back(Erad_line_exact_solution);
 		t_exact_vec.push_back(t_exact);
 		t_exact += t_end / N_dt;
@@ -300,8 +302,10 @@ auto problem_main() -> int
 
 	std::vector<double> Tgas_interp(t.size());
 	std::vector<double> Erad_line_interp(t.size());
-	interpolate_arrays(t.data(), Tgas_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Tgas_exact_vec.data(), static_cast<int>(t_exact_vec.size()));
-	interpolate_arrays(t.data(), Erad_line_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Erad_line_exact_vec.data(), static_cast<int>(t_exact_vec.size()));
+	interpolate_arrays(t.data(), Tgas_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Tgas_exact_vec.data(),
+			   static_cast<int>(t_exact_vec.size()));
+	interpolate_arrays(t.data(), Erad_line_interp.data(), static_cast<int>(t.size()), t_exact_vec.data(), Erad_line_exact_vec.data(),
+			   static_cast<int>(t_exact_vec.size()));
 
 	// compute error norm
 	double err_norm = 0.;

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -40,7 +40,7 @@ constexpr double Erad_FUV = Erad_bar; // = 1.0
 const double max_time = 10.0;
 const double CR_heating_rate = 1.0;
 const int line_index = 0; // last group
-const double cooling_rate = 1.0e-1;
+const double cooling_rate = 0.1;
 const double PE_rate = 0.05;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {
@@ -75,7 +75,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 template <> struct ISM_Traits<PulseProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = 1;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_photoelectric_heating = 1;
+	static constexpr bool enable_photoelectric_heating = 0;
 	static constexpr bool enable_linear_cooling_heating = 1;
 };
 
@@ -269,7 +269,7 @@ auto problem_main() -> int
 	matplotlibcpp::xlabel("x (dimensionless)");
 	matplotlibcpp::ylabel("temperature (dimensionless)");
 	matplotlibcpp::legend();
-	matplotlibcpp::ylim(0.0, 2.0);
+	matplotlibcpp::ylim(-0.05, 2.05);
 	matplotlibcpp::title(fmt::format("time t = {:.4g}", sim.tNew_[0]));
 	matplotlibcpp::tight_layout();
 	matplotlibcpp::save("./rad_line_cooling_MG_temperature.pdf");

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -41,7 +41,7 @@ const double max_time = 10.0;
 const double CR_heating_rate = 1.0;
 const int line_index = 0; // last group
 const double cooling_rate = 0.1;
-const double PE_rate = 0.05;
+const double PE_rate = 0.02;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double mean_molecular_weight = mu;
@@ -75,7 +75,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 template <> struct ISM_Traits<PulseProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = 1;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_photoelectric_heating = 0;
+	static constexpr bool enable_photoelectric_heating = 1;
 	static constexpr bool enable_linear_cooling_heating = 1;
 };
 

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -32,7 +32,6 @@ constexpr double C_V = 1.0;
 constexpr double k_B = 1.0;
 
 constexpr double nu_unit = 1.0;
-constexpr double T_equilibrium = 0.768032502191;
 constexpr double Erad_bar = a_rad * T0 * T0 * T0 * T0;
 constexpr double Erad_floor_ = a_rad * 1e-20;
 constexpr double Erad_FUV = Erad_bar; // = 1.0
@@ -227,7 +226,6 @@ auto problem_main() -> int
 
 	// read output variables
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
-	const int nx = static_cast<int>(position.size());
 
 	const auto t_end = sim.tNew_[0];
 

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -39,7 +39,7 @@ constexpr double Erad_bar = a_rad * T0 * T0 * T0 * T0;
 constexpr double Erad_floor_ = a_rad * 1e-20;
 constexpr double Erad_FUV = Erad_bar; // = 1.0
 
-const double max_time = 30.0;
+const double max_time = 10.0;
 const double cooling_rate = 1.0e-1;
 const double PE_rate = 0.05;
 
@@ -75,7 +75,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 template <> struct ISM_Traits<PulseProblem> {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = true;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_photoelectric_heating = true;
+	static constexpr bool enable_photoelectric_heating = false;
 	static constexpr bool enable_linear_cooling_heating = true;
 };
 
@@ -162,7 +162,7 @@ auto problem_main() -> int
 	const double CFL_number_gas = 0.8;
 	const double CFL_number_rad = 0.8;
 
-	const double the_dt = 1.0e-1;
+	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
 	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
@@ -228,7 +228,8 @@ auto problem_main() -> int
 		// const double T_exact_solution = std::exp(-cooling_rate * t_end) * T0;
 		// NEW: cooling and PE heating
 		// sol = exp(-a t) * (a * T0 - b + b * exp(a t)) / a, where a = cooling_rate, b = PE_rate
-		const double T_exact_solution = std::exp(-cooling_rate * t_end) * (cooling_rate * T0 - PE_rate + PE_rate * std::exp(cooling_rate * t_end)) / cooling_rate;
+		const double PE_rate_ = ISM_Traits<PulseProblem>::enable_photoelectric_heating ? PE_rate : 0.0;
+		const double T_exact_solution = std::exp(-cooling_rate * t_end) * (cooling_rate * T0 - PE_rate_ + PE_rate_ * std::exp(cooling_rate * t_end)) / cooling_rate;
 		Tgas_exact.push_back(T_exact_solution);
 	}
 	// compare temperature with Tgas_exact
@@ -247,7 +248,7 @@ auto problem_main() -> int
 	const double rel_error_Erad = (err_norm_Erad + Erad_other_groups_error) / Erad_bar;
 	const double rel_error = std::max(rel_error_T, rel_error_Erad);
 
-	const double error_tol = 1.0e-3;
+	const double error_tol = 0.005;
 	amrex::Print() << "Relative L1 error norm for T_gas = " << rel_error << std::endl;
 	int status = 0;
 	if ((rel_error > error_tol) || std::isnan(rel_error)) {

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -158,7 +158,7 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 
 template <> void QuokkaSimulation<PulseProblem>::computeAfterTimestep()
 {
-	auto [position, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
+	auto [_, values] = fextract(state_new_cc_[0], Geom(0), 0, 0.5); // NOLINT
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		userData_.t_vec_.push_back(tNew_[0]);
@@ -225,7 +225,7 @@ auto problem_main() -> int
 	const bool is_coupled = sim.dustGasInteractionCoeff_ > 1.0;
 
 	// read output variables
-	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
+	auto [_, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0);
 
 	const auto t_end = sim.tNew_[0];
 

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -84,8 +84,8 @@ template <> struct ISM_Traits<CoolingProblemMG> {
 };
 
 template <>
-AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblemMG>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
-    -> amrex::Real
+AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblemMG>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/,
+											       amrex::Real const /*num_density*/) -> amrex::Real
 {
 	return PE_rate / Erad_FUV;
 }
@@ -118,7 +118,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<CoolingProblemMG>::DefineCosmic
 template <>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 RadSystem<CoolingProblemMG>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double /*rho*/,
-							      const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
+								  const double /*Tgas*/) -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
 {
 	amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> exponents_and_values{};
 	for (int i = 0; i < nGroups_ + 1; ++i) {
@@ -177,9 +177,11 @@ template <> void QuokkaSimulation<CoolingProblemMG>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
-	// This problem is a test of photoelectric heating, line cooling, and cosmic-ray heating in a uniform medium with multigroup radiation. The gas/dust opacity is set to zero, so that the radiation does not interact with matter. The initial conditions are set to a constant temperature and radiation energy density Erad_FUV = 1. The gas cools at a rate of 0.1 per unit time, and is heated by cosmic rays at a rate of 0.03 per unit time. The photoelectric heating rate is 0.02 * Erad_FUV per unit time. The exact solution is given by the following system of equations:
-	// dTgas/dt = -0.1 * Tgas + 0.03 + 0.02 * Erad_FUV
-	// where Erad_FUV = 1.0 is constant over time.
+	// This problem is a test of photoelectric heating, line cooling, and cosmic-ray heating in a uniform medium with multigroup radiation. The gas/dust
+	// opacity is set to zero, so that the radiation does not interact with matter. The initial conditions are set to a constant temperature and radiation
+	// energy density Erad_FUV = 1. The gas cools at a rate of 0.1 per unit time, and is heated by cosmic rays at a rate of 0.03 per unit time. The
+	// photoelectric heating rate is 0.02 * Erad_FUV per unit time. The exact solution is given by the following system of equations: dTgas/dt = -0.1 * Tgas
+	// + 0.03 + 0.02 * Erad_FUV where Erad_FUV = 1.0 is constant over time.
 
 	// Problem parameters
 	const int max_timesteps = 1e6;

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.hpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.hpp
@@ -1,0 +1,29 @@
+#ifndef TEST_RAD_LINE_COOLING_MG_HPP_ // NOLINT
+#define TEST_RAD_LINE_COOLING_MG_HPP_
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_rad_line_cooling_MG.hpp
+/// \brief Defines a test problem for line cooling and cosmic-ray heating in a uniform medium.
+///
+
+// external headers
+#ifdef HAVE_PYTHON
+#include "util/matplotlibcpp.h"
+#endif
+#include <fmt/format.h>
+#include <fstream>
+
+// internal headers
+
+#include "QuokkaSimulation.hpp"
+#include "hydro/hydro_system.hpp"
+#include "math/interpolate.hpp"
+#include "radiation/radiation_dust_system.hpp"
+
+// function definitions
+auto problem_main() -> int;
+
+#endif // TEST_RAD_LINE_COOLING_MG_HPP_

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -19,8 +19,6 @@ struct MarshakProblem {
 AMREX_GPU_MANAGED double kappa1 = NAN; // dust opacity at IR
 AMREX_GPU_MANAGED double kappa2 = NAN; // dust opacity at FUV
 
-constexpr bool dust_on = true;
-
 constexpr double c = 1.0;    // speed of light
 constexpr double chat = 1.0; // reduced speed of light
 constexpr double rho0 = 1.0;

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -95,8 +95,6 @@ constexpr double T_equilibrium = 0.768032502191;
 // constexpr double max_time = 1000.0 / (c * rho0 * kappa0); // dt >> 1 / (c * chi)
 constexpr double max_time = 10.0 / (1e-2 * c);
 
-constexpr double Erad0 = a_rad * T0 * T0 * T0 * T0;
-constexpr double Erad_beta2 = (1. + 4. / 3. * (v0 * v0) / (c * c)) * Erad0;
 constexpr double erad_floor = a_rad * 1e-30;
 
 template <> struct quokka::EOS_Traits<PulseProblem> {

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -9,18 +9,11 @@
 #include "AMReX_BC_TYPES.H"
 
 #include "AMReX_BLassert.H"
-#include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/ArrayUtil.hpp"
 #include "util/fextract.hpp"
 
-// #include "AMReX_BC_TYPES.H"
-#include "AMReX_IntVect.H"
 #include "AMReX_Print.H"
-// #include "QuokkaSimulation.hpp"
-// #include "util/fextract.hpp"
 #include "physics_info.hpp"
-// #include "radiation/radiation_system.hpp"
 #include "test_radhydro_bb.hpp"
 
 static constexpr bool export_csv = true;

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -17,7 +17,6 @@ struct SGProblem {
 struct MGproblem {
 };
 
-constexpr int isconst = 0;
 // constexpr int n_groups_ = 1;
 // constexpr amrex::GpuArray<double, n_groups_ + 1> rad_boundaries_{0., inf};
 // constexpr int n_groups_ = 2;
@@ -67,10 +66,6 @@ constexpr int64_t max_timesteps = 1e2; // for fast testing
 // constexpr double kappa0 = 1000.; // cm^2 g^-1
 // constexpr double v0 = 1.0e8;    // advecting pulse
 // constexpr double max_time = 1.2e-4; // max_time = 2.0 * width / v1;
-
-constexpr double T_ref = T0;
-constexpr double nu_ref = 1.0e18; // Hz
-constexpr double coeff_ = h_planck * nu_ref / (k_B * T_ref);
 
 AMREX_GPU_HOST_DEVICE
 auto compute_initial_Tgas(const double x) -> double

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -4,7 +4,7 @@
 
 #define LARGE 1.e100
 
-#include "radiation/radiation_system.hpp" // IWYU pragma: keep
+#include "radiation/radiation_system.hpp"
 
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const num_density)

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -511,33 +511,33 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 		// }
 	} // END NEWTON-RAPHSON LOOP
 
-	const auto cooling = DefineNetCoolingRate(T_gas, num_den) * dt;
+	const auto cooling_t0 = DefineNetCoolingRate(T_gas, num_den) * dt;
 	if (dust_model == 2) {
 		// compute cooling/heating terms
 
-		const double compare = Egas_guess + sum(abs(cooling));
+		const double compare = Egas_guess + cscale * lambda_gd_times_dt + sum(abs(cooling_t0));
 
 		// RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling)
-		auto rhs = [=](double Egas) -> double {
-			const double T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas, massScalars);
-			const auto cooling = DefineNetCoolingRate(T_gas, num_den) * dt;
-			return Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling);
+		auto rhs = [=](double Egas_) -> double {
+			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
+			const auto cooling_ = DefineNetCoolingRate(T_gas_, num_den) * dt;
+			return Egas_ - Egas0 + cscale * lambda_gd_times_dt + sum(cooling_);
 		};
 
 		// Jacobian of the RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling)
-		auto jac = [=](double Egas) -> double {
-			const double T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas, massScalars);
-			const auto d_cooling_d_Tgas = DefineNetCoolingRateTempDerivative(T_gas, num_den) * dt;
-			return 1.0 + sum(d_cooling_d_Tgas);
+		auto jac = [=](double Egas_) -> double {
+			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
+			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, num_den) * dt;
+			return 1.0 + sum(d_cooling_d_Tgas_);
 		};
 
 		Egas_guess = BackwardEulerOneVariable(rhs, jac, Egas0, compare);
 	}
 
 	if constexpr (!add_line_cooling_to_radiation) {
-		AMREX_ASSERT_WITH_MESSAGE(min(cooling) >= 0., "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
+		AMREX_ASSERT_WITH_MESSAGE(min(cooling_t0) >= 0., "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
 		// TODO(CCH): potential GPU-related issue here.
-		EradVec_guess += (1/cscale) * cooling;
+		EradVec_guess += (1/cscale) * cooling_t0;
 	}
 
 	AMREX_ASSERT(Egas_guess > 0.0);
@@ -861,16 +861,29 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		// }
 	} // END NEWTON-RAPHSON LOOP
 
-	const auto cooling = DefineNetCoolingRate(T_gas, num_den) * dt;
+	const auto cooling_t0 = DefineNetCoolingRate(T_gas, num_den) * dt;
 	if (dust_model == 2) {
-		// compute cooling/heating terms
-		// const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, NAN) * dt;
+		const double compare = Egas_guess + cscale * lambda_gd_times_dt + sum(abs(cooling_t0));
 
-		Egas_guess = Egas0 - cscale * lambda_gd_times_dt - sum(cooling) + PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1];
+		// RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling) - PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1];
+		auto rhs = [=](double Egas_) -> double {
+			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
+			const auto cooling_ = DefineNetCoolingRate(T_gas_, num_den) * dt;
+			return Egas_ - Egas0 + cscale * lambda_gd_times_dt + sum(cooling_) - PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1];
+		};
+
+		// Jacobian of the RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling) + PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1];
+		auto jac = [=](double Egas_) -> double {
+			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
+			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, num_den) * dt;
+			return 1.0 + sum(d_cooling_d_Tgas_);
+		};
+
+		Egas_guess = BackwardEulerOneVariable(rhs, jac, Egas0, compare);
 	}
 
 	if constexpr (!add_line_cooling_to_radiation) {
-		EradVec_guess += (1/cscale) * cooling;
+		EradVec_guess += (1/cscale) * cooling_t0;
 	}
 
 	AMREX_ASSERT(Egas_guess > 0.0);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -103,12 +103,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustDecouple
 {
 	JacobianResult<problem_t> result;
 
-	result.F0 = -lambda_gd_time_dt;
+	result.F0 = -lambda_gd_time_dt + sum(Rvec);
 	result.Fg = Erad_diff - (Rvec + Src);
 	result.Fg_abs_sum = 0.0;
 	for (int g = 0; g < nGroups_; ++g) {
 		if (tau[g] > 0.0) {
-			result.F0 += Rvec[g];
 			result.Fg_abs_sum += std::abs(result.Fg[g]);
 		}
 	}
@@ -152,13 +151,12 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
 
 	const double cscale = c_light_ / c_hat_;
 
-	result.F0 = Egas_diff;
+	result.F0 = Egas_diff + cscale * sum(Rvec);
 	result.Fg = Erad - Erad0 - (Rvec + Src);
 	result.Fg_abs_sum = 0.0;
 	for (int g = 0; g < nGroups_; ++g) {
 		if (tau[g] > 0.0) {
 			result.Fg_abs_sum += std::abs(result.Fg[g]);
-			result.F0 += cscale * Rvec[g];
 		}
 	}
 	result.F0 -= PE_heating_energy_derivative * Erad[nGroups_ - 1];

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -286,7 +286,6 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 	double T_d = NAN;
 	double delta_x = NAN;
 	quokka::valarray<double, nGroups_> delta_R{};
-	quokka::valarray<double, nGroups_> F_D{};
 	quokka::valarray<double, nGroups_> Rvec{};
 	quokka::valarray<double, nGroups_> tau0{};	 // optical depth across c * dt at old state
 	quokka::valarray<double, nGroups_> tau{};	 // optical depth across c * dt at new state
@@ -636,7 +635,6 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 	double T_d = NAN;
 	double delta_x = NAN;
 	quokka::valarray<double, nGroups_> delta_R{};
-	quokka::valarray<double, nGroups_> F_D{};
 	quokka::valarray<double, nGroups_> Rvec{};
 	quokka::valarray<double, nGroups_> tau0{};	 // optical depth across c * dt at old state
 	quokka::valarray<double, nGroups_> tau{};	 // optical depth across c * dt at new state

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -328,7 +328,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 	double Egas_guess = Egas0;
 	auto EradVec_guess = Erad0Vec;
 
-	const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
+	const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 
 	T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 	AMREX_ASSERT(T_gas >= 0.);
@@ -437,7 +437,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 
 		if (dust_model == 1) {
 			jacobian = ComputeJacobianForGasAndDust(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
-								opacity_terms.kappaPoverE, d_fourpiboverc_d_t, atomic_H_num_den, dt);
+								opacity_terms.kappaPoverE, d_fourpiboverc_d_t, H_num_den, dt);
 		} else {
 			jacobian = ComputeJacobianForGasAndDustDecoupled(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
 									 opacity_terms.kappaPoverE, d_fourpiboverc_d_t);
@@ -512,25 +512,25 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 		// }
 	} // END NEWTON-RAPHSON LOOP
 
-	const auto cooling_tend = DefineNetCoolingRate(T_gas, atomic_H_num_den) * dt;
+	const auto cooling_tend = DefineNetCoolingRate(T_gas, H_num_den) * dt;
 	if (dust_model == 2) {
 		// include line cooling/heating, cosmic ray heating terms; implicitly update Egas_guess
 
-		const double CR_heating = DefineCosmicRayHeatingRate(atomic_H_num_den) * dt;
+		const double CR_heating = DefineCosmicRayHeatingRate(H_num_den) * dt;
 
 		const double compare = Egas_guess + cscale * lambda_gd_times_dt + sum(abs(cooling_tend)) + CR_heating;
 
 		// RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling)
 		auto rhs = [=](double Egas_) -> double {
 			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
-			const auto cooling_ = DefineNetCoolingRate(T_gas_, atomic_H_num_den) * dt;
+			const auto cooling_ = DefineNetCoolingRate(T_gas_, H_num_den) * dt;
 			return Egas_ - Egas0 + cscale * lambda_gd_times_dt + sum(cooling_) - CR_heating;
 		};
 
 		// Jacobian of the RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling)
 		auto jac = [=](double Egas_) -> double {
 			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
-			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, atomic_H_num_den) * dt;
+			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, H_num_den) * dt;
 			return 1.0 + sum(d_cooling_d_Tgas_);
 		};
 
@@ -681,8 +681,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 	AMREX_ASSERT(T_gas >= 0.);
 
 	// phtoelectric heating
-	const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
-	const double PE_heating_energy_derivative = dt * DefinePhotoelectricHeatingE1Derivative(T_gas, atomic_H_num_den);
+	const double H_num_den = ComputeNumberDensityH(rho, massScalars);
+	const double PE_heating_energy_derivative = dt * DefinePhotoelectricHeatingE1Derivative(T_gas, H_num_den);
 
 	const double resid_tol = 1.0e-11; // 1.0e-15;
 	const int maxIter = 100;
@@ -789,7 +789,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		if (dust_model == 1) {
 			jacobian = ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src,
 								      coeff_n, tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t,
-								      atomic_H_num_den, dt);
+								      H_num_den, dt);
 		} else {
 			jacobian = ComputeJacobianForGasAndDustDecoupled(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
 									 opacity_terms.kappaPoverE, d_fourpiboverc_d_t);
@@ -864,18 +864,18 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		// }
 	} // END NEWTON-RAPHSON LOOP
 
-	const auto cooling_tend = DefineNetCoolingRate(T_gas, atomic_H_num_den) * dt;
+	const auto cooling_tend = DefineNetCoolingRate(T_gas, H_num_den) * dt;
 	if (dust_model == 2) {
 		// compute cooling/heating terms; implicitly update Egas_guess
 
-		const double CR_heating = DefineCosmicRayHeatingRate(atomic_H_num_den) * dt;
+		const double CR_heating = DefineCosmicRayHeatingRate(H_num_den) * dt;
 		const double compare = Egas_guess + cscale * lambda_gd_times_dt + sum(abs(cooling_tend)) + CR_heating;
 
 		// RHS of the equation 0 = Egas - Egas0 + cscale * lambda_gd_times_dt + sum(cooling) - PE_heating_energy_derivative * EradVec_guess[nGroups_ -
 		// 1];
 		auto rhs = [=](double Egas_) -> double {
 			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
-			const auto cooling_ = DefineNetCoolingRate(T_gas_, atomic_H_num_den) * dt;
+			const auto cooling_ = DefineNetCoolingRate(T_gas_, H_num_den) * dt;
 			return Egas_ - Egas0 + cscale * lambda_gd_times_dt + sum(cooling_) - PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1] -
 			       CR_heating;
 		};
@@ -884,7 +884,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		// EradVec_guess[nGroups_ - 1];
 		auto jac = [=](double Egas_) -> double {
 			const double T_gas_ = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_, massScalars);
-			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, atomic_H_num_den) * dt;
+			const auto d_cooling_d_Tgas_ = DefineNetCoolingRateTempDerivative(T_gas_, H_num_den) * dt;
 			return 1.0 + sum(d_cooling_d_Tgas_);
 		};
 

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -141,7 +141,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
 	const auto cooling = DefineNetCoolingRate(T_gas, NAN);
 	const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, NAN);
 
-	result.F0 = Egas_diff + cscale * sum(Rvec) + sum(cooling) - PE_heating_energy_derivative * Erad[nGroups_ - 1];
+	result.F0 = Egas_diff + cscale * sum(Rvec) + sum(cooling) * dt - PE_heating_energy_derivative * Erad[nGroups_ - 1];
 	result.Fg = Erad - Erad0 - (Rvec + Src);
 	if constexpr (add_line_cooling_to_radiation) {
 		result.Fg -= (1.0/cscale) * cooling * dt;

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -4,40 +4,11 @@
 
 #include "radiation/radiation_system.hpp"
 
-#define LARGE 1.0e100
-
-static constexpr bool add_line_cooling_to_radiation = false;
-
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
     -> amrex::Real
 {
 	return 0.0;
-}
-
-// Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
-template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
-{
-	return 0.0;
-}
-
-// Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
-template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
-{
-	quokka::valarray<double, nGroups_> cooling{};
-	cooling.fillin(0.0);
-	return cooling;
-}
-
-// Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
-template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
-{
-	quokka::valarray<double, nGroups_> cooling{};
-	cooling.fillin(0.0);
-	return cooling;
 }
 
 // Compute the Jacobian of energy update equations for the gas-dust-radiation system. The result is a struct containing the following elements:

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -89,6 +89,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustDecouple
 {
 	JacobianResult<problem_t> result;
 
+	// I will ignore the cooling radiation here, because that replies on the updated gas temperature, which is not available here.
+	// // compute cooling/heating terms
+	// const double cscale = c_light_ / c_hat_;
+	// const auto cooling = DefineNetCoolingRate(T_gas, NAN) * dt;
+
 	result.F0 = -lambda_gd_time_dt + sum(Rvec);
 	result.Fg = Erad_diff - (Rvec + Src);
 	result.Fg_abs_sum = 0.0;
@@ -510,7 +515,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 	} // END NEWTON-RAPHSON LOOP
 
 	if (dust_model == 2) {
-		Egas_guess = Egas0 - cscale * lambda_gd_times_dt; // update Egas_guess once for all
+		// compute cooling/heating terms
+		const auto cooling = DefineNetCoolingRate(T_gas, NAN) * dt;
+		// const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, NAN) * dt;
+
+		Egas_guess = Egas0 - cscale * lambda_gd_times_dt - sum(cooling); // update Egas_guess once for all
 	}
 
 	AMREX_ASSERT(Egas_guess > 0.0);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -2,13 +2,34 @@
 #ifndef RADIATION_DUST_SYSTEM_HPP_
 #define RADIATION_DUST_SYSTEM_HPP_
 
-#define LARGE 1.e100
+#define LARGE 1.0e100
 
 #include "radiation/radiation_system.hpp"
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const num_density)
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefinePhotoelectricHeatingE1Derivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
     -> amrex::Real
+{
+	return 0.0;
+}
+
+// Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
+{
+	return 0.0;
+}
+
+// Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*num_density*/) -> amrex::Real
+{
+	return 0.0;
+}
+
+// Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*num_density*/) -> amrex::Real
 {
 	return 0.0;
 }

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -24,15 +24,15 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDust(
     double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
     quokka::valarray<double, nGroups_> const &Src, double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v, double /*lambda_gd_time_dt*/,
     quokka::valarray<double, nGroups_> const &kappaPoverE, quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t,
-		const double n, const double dt) -> JacobianResult<problem_t>
+		const double num_den, const double dt) -> JacobianResult<problem_t>
 {
 	JacobianResult<problem_t> result;
 
 	const double cscale = c_light_ / c_hat_;
 
 	// compute cooling/heating terms
-	const auto cooling = DefineNetCoolingRate(T_gas, n) * dt;
-	const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, n) * dt;
+	const auto cooling = DefineNetCoolingRate(T_gas, num_den) * dt;
+	const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, num_den) * dt;
 
 	result.F0 = Egas_diff + cscale * sum(Rvec) + sum(cooling);
 	result.Fg = Erad_diff - (Rvec + Src);
@@ -131,15 +131,15 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
     double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
     double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
     quokka::valarray<double, nGroups_> const &tau, double c_v, double /*lambda_gd_time_dt*/, quokka::valarray<double, nGroups_> const &kappaPoverE,
-    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double const n, double const dt) -> JacobianResult<problem_t>
+    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double const num_den, double const dt) -> JacobianResult<problem_t>
 {
 	JacobianResult<problem_t> result;
 
 	const double cscale = c_light_ / c_hat_;
 
 	// compute cooling/heating terms
-	const auto cooling = DefineNetCoolingRate(T_gas, n) * dt;
-	const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, n) * dt;
+	const auto cooling = DefineNetCoolingRate(T_gas, num_den) * dt;
+	const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, num_den) * dt;
 
 	result.F0 = Egas_diff + cscale * sum(Rvec) + sum(cooling) - PE_heating_energy_derivative * Erad[nGroups_ - 1];
 	result.Fg = Erad - Erad0 - (Rvec + Src);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -182,7 +182,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
 	// Note that Fg is modified here, but it does not change Fg_abs_sum, which is used to check the convergence.
 	result.Fg = result.Fg - 1.0 / cscale * rg * result.F0;
 	result.Jgg = d_Eg_d_Rg + (-1.0);
-	result.Jgg[nGroups_ - 1] += rg[nGroups_ - 1] / cscale * PE_heating_energy_derivative * d_Eg_d_Rg[nGroups_ - 1];
+	result.Jgg[nGroups_ - 1] += rg[nGroups_ - 1] - (rg[nGroups_ - 1] / cscale) * PE_heating_energy_derivative * d_Eg_d_Rg[nGroups_ - 1];
 	result.Jg1 = rg - 1.0 / cscale * rg * result.J0g[nGroups_ - 1]; // note that this is the (nGroups_ - 1)th column, except for the (nGroups_ - 1)th row
 
 	return result;

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -131,7 +131,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
     double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
     double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
     quokka::valarray<double, nGroups_> const &tau, double c_v, double /*lambda_gd_time_dt*/, quokka::valarray<double, nGroups_> const &kappaPoverE,
-    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>
+    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double const dt) -> JacobianResult<problem_t>
 {
 	JacobianResult<problem_t> result;
 
@@ -758,7 +758,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 
 		if (dust_model == 1) {
 			jacobian = ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src,
-								      coeff_n, tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t);
+								      coeff_n, tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, dt);
 		} else {
 			jacobian = ComputeJacobianForGasAndDustDecoupled(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
 									 opacity_terms.kappaPoverE, d_fourpiboverc_d_t);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -787,9 +787,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		JacobianResult<problem_t> jacobian;
 
 		if (dust_model == 1) {
-			jacobian = ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src,
-								      coeff_n, tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t,
-								      H_num_den, dt);
+			jacobian =
+			    ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src, coeff_n,
+							       tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, H_num_den, dt);
 		} else {
 			jacobian = ComputeJacobianForGasAndDustDecoupled(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
 									 opacity_terms.kappaPoverE, d_fourpiboverc_d_t);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -787,9 +787,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		JacobianResult<problem_t> jacobian;
 
 		if (dust_model == 1) {
-			jacobian =
-			    ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src, coeff_n,
-							       tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, atomic_H_num_den, dt);
+			jacobian = ComputeJacobianForGasAndDustWithPE(T_gas, T_d, Egas_diff, EradVec_guess, Erad0Vec, PE_heating_energy_derivative, Rvec, Src,
+								      coeff_n, tau, c_v, lambda_gd_times_dt, opacity_terms.kappaPoverE, d_fourpiboverc_d_t,
+								      atomic_H_num_den, dt);
 		} else {
 			jacobian = ComputeJacobianForGasAndDustDecoupled(T_gas, T_d, Egas_diff, Erad_diff, Rvec, Src, coeff_n, tau, c_v, lambda_gd_times_dt,
 									 opacity_terms.kappaPoverE, d_fourpiboverc_d_t);

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -33,7 +33,9 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Rea
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
 {
-	return 0.0;
+	quokka::valarray<double, nGroups_> cooling{};
+	cooling.fillin(0.0);
+	return cooling;
 }
 
 // Compute the Jacobian of energy update equations for the gas-dust-radiation system. The result is a struct containing the following elements:

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -515,13 +515,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 		// const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, NAN) * dt;
 
 		Egas_guess = Egas0 - cscale * lambda_gd_times_dt - sum(cooling); // update Egas_guess once for all
-		if constexpr (!add_line_cooling_to_radiation) {
-			EradVec_guess += (1/cscale) * cooling;
-		}
-	} else {
-		if constexpr (!add_line_cooling_to_radiation) {
-			EradVec_guess += (1/cscale) * cooling;
-		}
+	}
+
+	if constexpr (!add_line_cooling_to_radiation) {
+		EradVec_guess += (1/cscale) * cooling;
 	}
 
 	AMREX_ASSERT(Egas_guess > 0.0);
@@ -851,13 +848,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 		// const auto cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, NAN) * dt;
 
 		Egas_guess = Egas0 - cscale * lambda_gd_times_dt - sum(cooling) + PE_heating_energy_derivative * EradVec_guess[nGroups_ - 1];
-		if constexpr (!add_line_cooling_to_radiation) {
-			EradVec_guess += (1/cscale) * cooling;
-		}
-	} else {
-		if constexpr (!add_line_cooling_to_radiation) {
-			EradVec_guess += (1/cscale) * cooling;
-		}
+	}
+
+	if constexpr (!add_line_cooling_to_radiation) {
+		EradVec_guess += (1/cscale) * cooling;
 	}
 
 	AMREX_ASSERT(Egas_guess > 0.0);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -270,6 +270,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto ComputeEddingtonFactor(double f) -> double;
 
+	AMREX_GPU_HOST_DEVICE static auto ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const &massScalars) -> double;
+
 	// Used for single-group RHD only. Not used for multi-group RHD.
 	AMREX_GPU_HOST_DEVICE static auto ComputePlanckOpacity(double rho, double Tgas) -> Real;
 	AMREX_GPU_HOST_DEVICE static auto ComputeFluxMeanOpacity(double rho, double Tgas) -> Real;
@@ -457,6 +459,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(am
 
 		return radEnergyFractions;
 	}
+}
+
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const &/*massScalars*/) -> double
+{
+	return rho / mean_molecular_mass_;
 }
 
 // define ComputeThermalRadiation for single-group, returns the thermal radiation power = a_r * T^4

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -462,7 +462,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(am
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const &/*massScalars*/) -> double
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const & /*massScalars*/) -> double
 {
 	return rho / mean_molecular_mass_;
 }

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1455,7 +1455,6 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 		double dLHS_dTd = NAN;
 
 		if constexpr (nGroups_ == 1) {
-			const auto kappaE = ComputeEnergyMeanOpacity(rho, T_d);
 			const auto kappaP = ComputePlanckOpacity(rho, T_d);
 			const auto d_fourpib_over_c_d_t = ComputeThermalRadiationTempDerivativeSingleGroup(T_d);
 			dLHS_dTd = -c_hat_ * dt * rho * (kappaP * d_fourpib_over_c_d_t) - N_d * std::sqrt(T_gas);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -330,7 +330,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	    -> quokka::valarray<amrex::Real, nGroups_>;
 
 	template <typename RHSFunction, typename JacFunction>
-	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction rhs, JacFunction jac, double x0, double compare) -> double;
+	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, double x0, double compare) -> double;
 
 	AMREX_GPU_DEVICE static auto
 	ComputeDustTemperatureBateKeto(double T_gas, double T_d_init, double rho, quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt,
@@ -1381,7 +1381,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(con
 
 template <typename problem_t>
 template <typename RHSFunction, typename JacFunction>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction rhs, JacFunction jac, const double x0, const double compare) -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const double x0, const double compare) -> double
 {
 	double x = x0;
 	const double rel_tol = 1.0e-8;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -32,7 +32,7 @@
 using Real = amrex::Real;
 
 // Hyper parameters for the radiation solver
-static constexpr bool add_line_cooling_to_radiation = false;
+static constexpr bool add_line_cooling_to_radiation_in_jac = false;
 static constexpr bool include_delta_B = true;
 static constexpr bool use_diffuse_flux_mean_opacity = true;
 static constexpr bool special_edge_bin_slopes = false;	    // Use 2 and -4 as the slopes for the first and last bins, respectively

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -87,7 +87,7 @@ template <typename problem_t> struct ISM_Traits {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 	static constexpr bool enable_photoelectric_heating = false;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_linear_cooling_heating = false;
+	static constexpr bool enable_line_cooling_and_heating = false;
 };
 
 // A struct to hold the results of the ComputeRadPressure function.
@@ -202,7 +202,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	static constexpr bool enable_dust_gas_thermal_coupling_model_ = ISM_Traits<problem_t>::enable_dust_gas_thermal_coupling_model;
 	static constexpr bool enable_photoelectric_heating_ = ISM_Traits<problem_t>::enable_photoelectric_heating;
-	static constexpr bool enable_linear_cooling_heating_ = ISM_Traits<problem_t>::enable_linear_cooling_heating;
+	static constexpr bool enable_line_cooling_heating_ = ISM_Traits<problem_t>::enable_line_cooling_and_heating;
 
 	static constexpr int nGroups_ = Physics_Traits<problem_t>::nGroups;
 	static constexpr amrex::GpuArray<double, nGroups_ + 1> radBoundaries_ = []() constexpr {

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -270,7 +270,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto ComputeEddingtonFactor(double f) -> double;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const &massScalars) -> double;
+	AMREX_GPU_HOST_DEVICE static auto ComputeNumberDensityH(double rho, amrex::GpuArray<Real, nmscalars_> const &massScalars) -> double;
 
 	// Used for single-group RHD only. Not used for multi-group RHD.
 	AMREX_GPU_HOST_DEVICE static auto ComputePlanckOpacity(double rho, double Tgas) -> Real;
@@ -462,7 +462,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(am
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityAtomicH(double rho, amrex::GpuArray<Real, nmscalars_> const & /*massScalars*/) -> double
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityH(double rho, amrex::GpuArray<Real, nmscalars_> const & /*massScalars*/) -> double
 {
 	return rho / mean_molecular_mass_;
 }

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -139,10 +139,6 @@ template <typename problem_t> struct FluxUpdateResult {
 	amrex::GpuArray<amrex::GpuArray<amrex::Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
 };
 
-// template <typename problem_t> struct SingleVariableState {
-// 	double T; // temperature
-// }
-
 [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod_func(double a, double b) -> double
 {
 	return 0.5 * (sgn(a) + sgn(b)) * std::min(std::abs(a), std::abs(b));

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -379,7 +379,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
 	    double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
 	    quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupledWithPE(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -351,6 +351,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real temperature, amrex::Real num_density) -> quokka::valarray<double, nGroups_>;
 
+	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(amrex::Real num_density) -> double;
+
 	AMREX_GPU_DEVICE static void ComputeModelDependentKappaFAndDeltaTerms(double T, double rho, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
 									      quokka::valarray<double, nGroups_> const &fourPiBoverC,
 									      OpacityTerms<problem_t> &opacity_terms);
@@ -527,6 +529,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivat
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
 	return cooling;
+}
+
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+{
+	return 0.0;
 }
 
 // Linear equation solver for matrix with non-zeros at the first row, first column, and diagonal only.

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -357,7 +357,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 								  double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v,
 								  double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double dt) -> JacobianResult<problem_t>;
+								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double n, double dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupled(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
@@ -379,7 +379,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
 	    double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
 	    quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double dt) -> JacobianResult<problem_t>;
+	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double n, double dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupledWithPE(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1381,7 +1381,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 {
 	double x = x0;
 	const double rel_tol = 1.0e-8;
-	const double rel_change_tol = 1.0e-8; // TODO: set to 1e-6
+	const double rel_change_tol = 1.0e-6;
 	const int max_iter_td = 100;
 	int iter_Td = 0;
 	for (; iter_Td < max_iter_td; ++iter_Td) {

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -353,24 +353,6 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real temperature, amrex::Real num_density) -> quokka::valarray<double, nGroups_>;
 
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGas(double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff,
-							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
-							   quokka::valarray<double, nGroups_> const &tau, double c_v,
-							   quokka::valarray<double, nGroups_> const &kappaPoverE,
-							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
-
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(double T_gas, double T_d, double Egas_diff,
-								  quokka::valarray<double, nGroups_> const &Erad_diff,
-								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
-								  double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v,
-								  double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double n, double dt) -> JacobianResult<problem_t>;
-
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupled(
-	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
-	    quokka::valarray<double, nGroups_> const &Src, double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt,
-	    quokka::valarray<double, nGroups_> const &kappaPoverE, quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
-
 	AMREX_GPU_DEVICE static void ComputeModelDependentKappaFAndDeltaTerms(double T, double rho, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
 									      quokka::valarray<double, nGroups_> const &fourPiBoverC,
 									      OpacityTerms<problem_t> &opacity_terms);
@@ -382,16 +364,29 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 									  amrex::GpuArray<double, nGroups_> const &alpha_E = {},
 									  amrex::GpuArray<double, nGroups_> const &alpha_P = {}) -> OpacityTerms<problem_t>;
 
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGas(double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff,
+							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
+							   quokka::valarray<double, nGroups_> const &tau, double c_v,
+							   quokka::valarray<double, nGroups_> const &kappaPoverE,
+							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(double T_gas, double T_d, double Egas_diff,
+								  quokka::valarray<double, nGroups_> const &Erad_diff,
+								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
+								  double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v,
+								  double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
+								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
+
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupled(
+	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
+	    quokka::valarray<double, nGroups_> const &Src, double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt,
+	    quokka::valarray<double, nGroups_> const &kappaPoverE, quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustWithPE(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
 	    double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
 	    quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double n, double dt) -> JacobianResult<problem_t>;
-
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupledWithPE(
-	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
-	    quokka::valarray<double, nGroups_> const &Src, double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt,
-	    quokka::valarray<double, nGroups_> const &kappaPoverE, quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto
 	SolveGasRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double dt,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -349,7 +349,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(amrex::Real temperature, amrex::Real num_density) -> quokka::valarray<double, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real temperature, amrex::Real num_density) -> quokka::valarray<double, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real temperature, amrex::Real num_density)
+	    -> quokka::valarray<double, nGroups_>;
 
 	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(amrex::Real num_density) -> double;
 
@@ -368,14 +369,16 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 							   quokka::valarray<double, nGroups_> const &tau, double c_v,
 							   quokka::valarray<double, nGroups_> const &kappaPoverE,
-							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
+							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt)
+	    -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(double T_gas, double T_d, double Egas_diff,
 								  quokka::valarray<double, nGroups_> const &Erad_diff,
 								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 								  double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v,
 								  double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
+								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt)
+	    -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupled(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
@@ -507,15 +510,15 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDeri
 }
 
 // Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
-template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
 {
 	return 0.0;
 }
 
 // Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
@@ -524,15 +527,15 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Rea
 
 // Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+    -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
 	cooling.fillin(0.0);
 	return cooling;
 }
 
-template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
 {
 	return 0.0;
 }
@@ -1440,7 +1443,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 		} else {
 			const auto fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
 			const auto opacity_terms = ComputeModelDependentKappaEAndKappaP(T_d, rho, rad_boundaries, rad_boundary_ratios, fourPiBoverC, Erad, 0);
-			LHS = c_hat_ * dt * rho * sum(opacity_terms.kappaE * Erad - opacity_terms.kappaP * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
+			LHS =
+			    c_hat_ * dt * rho * sum(opacity_terms.kappaE * Erad - opacity_terms.kappaP * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
 		}
 
 		return LHS;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -368,7 +368,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 							   quokka::valarray<double, nGroups_> const &tau, double c_v,
 							   quokka::valarray<double, nGroups_> const &kappaPoverE,
-							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(double T_gas, double T_d, double Egas_diff,
 								  quokka::valarray<double, nGroups_> const &Erad_diff,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -789,7 +789,7 @@ template <typename problem_t>
 template <typename ArrayType>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeMassScalars(ArrayType const &arr, int i, int j, int k) -> amrex::GpuArray<Real, nmscalars_>
 {
-	amrex::GpuArray<Real, nmscalars_> massScalars;
+	amrex::GpuArray<Real, nmscalars_> massScalars{};
 	for (int n = 0; n < nmscalars_; ++n) {
 		massScalars[n] = arr(i, j, k, scalar0_index + n);
 	}

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1381,7 +1381,8 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(con
 
 template <typename problem_t>
 template <typename RHSFunction, typename JacFunction>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const double x0, const double compare) -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const double x0, const double compare)
+    -> double
 {
 	double x = x0;
 	const double rel_tol = 1.0e-8;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -32,6 +32,7 @@
 using Real = amrex::Real;
 
 // Hyper parameters for the radiation solver
+static constexpr bool add_line_cooling_to_radiation = false;
 static constexpr bool include_delta_B = true;
 static constexpr bool use_diffuse_flux_mean_opacity = true;
 static constexpr bool special_edge_bin_slopes = false;	    // Use 2 and -4 as the slopes for the first and last bins, respectively
@@ -501,6 +502,31 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDeri
 	auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
 	double d_power_dt = 4. * radiation_constant_ * std::pow(temperature, 3);
 	return d_power_dt * radEnergyFractions;
+}
+
+// Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
+{
+	return 0.0;
+}
+
+// Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+{
+	quokka::valarray<double, nGroups_> cooling{};
+	cooling.fillin(0.0);
+	return cooling;
+}
+
+// Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
+template <typename problem_t>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/) -> quokka::valarray<double, nGroups_>
+{
+	quokka::valarray<double, nGroups_> cooling{};
+	cooling.fillin(0.0);
+	return cooling;
 }
 
 // Linear equation solver for matrix with non-zeros at the first row, first column, and diagonal only.

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -87,7 +87,6 @@ template <typename problem_t> struct ISM_Traits {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 	static constexpr bool enable_photoelectric_heating = false;
 	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
-	static constexpr bool enable_line_cooling_and_heating = false;
 };
 
 // A struct to hold the results of the ComputeRadPressure function.
@@ -202,7 +201,6 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	static constexpr bool enable_dust_gas_thermal_coupling_model_ = ISM_Traits<problem_t>::enable_dust_gas_thermal_coupling_model;
 	static constexpr bool enable_photoelectric_heating_ = ISM_Traits<problem_t>::enable_photoelectric_heating;
-	static constexpr bool enable_line_cooling_heating_ = ISM_Traits<problem_t>::enable_line_cooling_and_heating;
 
 	static constexpr int nGroups_ = Physics_Traits<problem_t>::nGroups;
 	static constexpr amrex::GpuArray<double, nGroups_ + 1> radBoundaries_ = []() constexpr {

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -332,10 +332,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	    -> quokka::valarray<amrex::Real, nGroups_>;
 
 	template <typename RHSFunction, typename JacFunction>
-	AMREX_GPU_DEVICE static auto IntegratorOneVariable(RHSFunction rhs, JacFunction jac, double T0, double compare) -> double;
-
-	AMREX_GPU_DEVICE static auto RHS_dust_temperature(double T_gas, double T_d, double rho, quokka::valarray<double, nGroups_> const &Erad, 
-											double N_d, double dt, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double;
+	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction rhs, JacFunction jac, double x0, double compare) -> double;
 
 	AMREX_GPU_DEVICE static auto
 	ComputeDustTemperatureBateKeto(double T_gas, double T_d_init, double rho, quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt,
@@ -382,8 +379,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 									  amrex::GpuArray<double, nGroups_> const &rad_boundary_ratios,
 									  quokka::valarray<double, nGroups_> const &fourPiBoverC,
 									  quokka::valarray<double, nGroups_> const &Erad, int n_iter,
-									  amrex::GpuArray<double, nGroups_> const &alpha_E,
-									  amrex::GpuArray<double, nGroups_> const &alpha_P) -> OpacityTerms<problem_t>;
+									  amrex::GpuArray<double, nGroups_> const &alpha_E = {},
+									  amrex::GpuArray<double, nGroups_> const &alpha_P = {}) -> OpacityTerms<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustWithPE(
 	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
@@ -1380,24 +1377,24 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(con
 
 template <typename problem_t>
 template <typename RHSFunction, typename JacFunction>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::IntegratorOneVariable(RHSFunction rhs, JacFunction jac, const double T0, const double compare) -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction rhs, JacFunction jac, const double x0, const double compare) -> double
 {
-	double T = T0;
+	double x = x0;
 	const double rel_tol = 1.0e-8;
 	const double rel_change_tol = 1.0e-8; // TODO: set to 1e-6
 	const int max_iter_td = 100;
 	int iter_Td = 0;
 	for (; iter_Td < max_iter_td; ++iter_Td) {
-		const auto the_rhs = rhs(T);
+		const auto the_rhs = rhs(x);
 		if (std::abs(the_rhs) < rel_tol * compare) {
 			break;
 		}
 
-		const double dT = -the_rhs / jac(T);
-		T += dT;
+		const double dT = -the_rhs / jac(x);
+		x += dT;
 
 		if (iter_Td > 0) {
-			if (std::abs(dT) < rel_change_tol * std::abs(T)) {
+			if (std::abs(dT) < rel_change_tol * std::abs(x)) {
 				break;
 			}
 		}
@@ -1405,17 +1402,23 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::IntegratorOneVariable(RHSFunction rh
 
 	AMREX_ASSERT_WITH_MESSAGE(iter_Td < max_iter_td, "Newton iteration in IntegratorOneVariable failed to converge.");
 	if (iter_Td >= max_iter_td) {
-		T = -1.0;
+		x = -1.0;
 	}
 
-	return T;
+	return x;
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::RHS_dust_temperature(double const T_gas, double const T_d, double const rho,
-									   quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt, 
-									   amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(double const T_gas, double const T_d_init, double const rho,
+									   quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt, double R_sum,
+									   int n_step, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double
 {
+	if (n_step > 0) {
+		const auto T_d = T_gas - R_sum / (N_d * std::sqrt(T_gas));
+		AMREX_ASSERT_WITH_MESSAGE(T_d >= 0., "Dust temperature is negative!");
+		return T_d;
+	}
+
 	amrex::GpuArray<double, nGroups_> rad_boundary_ratios{};
 
 	if constexpr (nGroups_ > 1 && opacity_model_ != OpacityModel::piecewise_constant_opacity) {
@@ -1424,229 +1427,50 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::RHS_dust_temperature(double const T_
 		}
 	}
 
-	quokka::valarray<double, nGroups_> kappaPVec{};
-	quokka::valarray<double, nGroups_> kappaEVec{};
-
-	const double Lambda_compare = N_d * std::sqrt(T_gas) * T_gas;
-
-	amrex::GpuArray<double, nGroups_> alpha_quant_minus_one{};
-	for (int g = 0; g < nGroups_; ++g) {
-		alpha_quant_minus_one[g] = -1.0;
-	}
-
-	quokka::valarray<double, nGroups_> fourPiBoverC{};
-
-	if constexpr (nGroups_ == 1) {
-		fourPiBoverC[0] = ComputeThermalRadiationSingleGroup(T_d);
-	} else {
-		fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
-	}
-
-	// TODO: replace the following with ComputeOpacity function
-	if constexpr (opacity_model_ == OpacityModel::single_group) {
-		kappaPVec[0] = ComputePlanckOpacity(rho, T_d);
-		kappaEVec[0] = ComputeEnergyMeanOpacity(rho, T_d);
-	} else {
-		const auto kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(rad_boundaries, rho, T_d);
-		if constexpr (opacity_model_ == OpacityModel::piecewise_constant_opacity) {
-			for (int g = 0; g < nGroups_; ++g) {
-				kappaPVec[g] = kappa_expo_and_lower_value[1][g];
-				kappaEVec[g] = kappa_expo_and_lower_value[1][g];
-			}
-		} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_fixed_slope_spectrum) {
-			kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_quant_minus_one);
-			kappaEVec = kappaPVec;
-		} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_full_spectrum) {
-			const auto alpha_P = ComputeRadQuantityExponents(fourPiBoverC, rad_boundaries);
-			const auto alpha_E = ComputeRadQuantityExponents(Erad, rad_boundaries);
-			kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_P);
-			kappaEVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_E);
-		}
-	}
-	AMREX_ASSERT(!kappaPVec.hasnan());
-	AMREX_ASSERT(!kappaEVec.hasnan());
-
-	const double LHS = c_hat_ * dt * rho * sum(kappaEVec * Erad - kappaPVec * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
-
-	return LHS;
-}
-
-#if 1
-template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(double const T_gas, double const T_d_init, double const rho,
-									   quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt, double R_sum,
-									   int n_step, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double
-{
-	if (n_step > 0) {
-		return T_gas - R_sum / (N_d * std::sqrt(T_gas));
-	}
-
-	const double Lambda_compare = N_d * std::sqrt(T_gas) * T_gas;
-
+	// the RHS of the equation 0 = c_hat_ dt rho (kappa_E * E_g - kappa_P * B_g) + N_d sqrt(T_gas) (T_gas - T_d)
 	auto rhs = [=](double T_d) -> double {
-		return RHS_dust_temperature(T_gas, T_d, rho, Erad, N_d, dt, rad_boundaries);
+		double LHS = NAN;
+
+		if constexpr (nGroups_ == 1) {
+			const auto fourPiBoverC = ComputeThermalRadiationSingleGroup(T_d);
+			const auto kappaE = ComputeEnergyMeanOpacity(rho, T_d);
+			const auto kappaP = ComputePlanckOpacity(rho, T_d);
+			LHS = c_hat_ * dt * rho * (kappaE * Erad[0] - kappaP * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
+		} else {
+			const auto fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
+			const auto opacity_terms = ComputeModelDependentKappaEAndKappaP(T_d, rho, rad_boundaries, rad_boundary_ratios, fourPiBoverC, Erad, 0);
+			LHS = c_hat_ * dt * rho * sum(opacity_terms.kappaE * Erad - opacity_terms.kappaP * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
+		}
+
+		return LHS;
 	};
 
+	// the Jacobian of the RHS of the equation 0 = c_hat_ dt rho (kappa_E * E_g - kappa_P * B_g) + N_d sqrt(T_gas) (T_gas - T_d)
 	auto jac = [=](double T_d) -> double {
-		quokka::valarray<double, nGroups_> fourPiBoverC{};
-		quokka::valarray<double, nGroups_> kappaPVec{};
-		quokka::valarray<double, nGroups_> kappaEVec{};
-
-		amrex::GpuArray<double, nGroups_> rad_boundary_ratios{};
-
-		if constexpr (nGroups_ > 1 && opacity_model_ != OpacityModel::piecewise_constant_opacity) {
-			for (int g = 0; g < nGroups_; ++g) {
-				rad_boundary_ratios[g] = rad_boundaries[g + 1] / rad_boundaries[g];
-			}
-		}
-
-		amrex::GpuArray<double, nGroups_> alpha_quant_minus_one{};
-		for (int g = 0; g < nGroups_; ++g) {
-			alpha_quant_minus_one[g] = -1.0;
-		}
+		double dLHS_dTd = NAN;
 
 		if constexpr (nGroups_ == 1) {
-			fourPiBoverC[0] = ComputeThermalRadiationSingleGroup(T_d);
+			const auto kappaE = ComputeEnergyMeanOpacity(rho, T_d);
+			const auto kappaP = ComputePlanckOpacity(rho, T_d);
+			const auto d_fourpib_over_c_d_t = ComputeThermalRadiationTempDerivativeSingleGroup(T_d);
+			dLHS_dTd = -c_hat_ * dt * rho * (kappaP * d_fourpib_over_c_d_t) - N_d * std::sqrt(T_gas);
 		} else {
-			fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
+			const auto fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
+			const auto opacity_terms = ComputeModelDependentKappaEAndKappaP(T_d, rho, rad_boundaries, rad_boundary_ratios, fourPiBoverC, Erad, 0);
+			const auto d_fourpib_over_c_d_t = ComputeThermalRadiationTempDerivativeMultiGroup(T_d, rad_boundaries);
+			dLHS_dTd = -c_hat_ * dt * rho * sum(opacity_terms.kappaP * d_fourpib_over_c_d_t) - N_d * std::sqrt(T_gas);
 		}
 
-		if constexpr (opacity_model_ == OpacityModel::single_group) {
-			kappaPVec[0] = ComputePlanckOpacity(rho, T_d);
-			kappaEVec[0] = ComputeEnergyMeanOpacity(rho, T_d);
-		} else {
-			const auto kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(rad_boundaries, rho, T_d);
-			if constexpr (opacity_model_ == OpacityModel::piecewise_constant_opacity) {
-				for (int g = 0; g < nGroups_; ++g) {
-					kappaPVec[g] = kappa_expo_and_lower_value[1][g];
-					kappaEVec[g] = kappa_expo_and_lower_value[1][g];
-				}
-			} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_fixed_slope_spectrum) {
-				kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_quant_minus_one);
-				kappaEVec = kappaPVec;
-			} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_full_spectrum) {
-				const auto alpha_P = ComputeRadQuantityExponents(fourPiBoverC, rad_boundaries);
-				const auto alpha_E = ComputeRadQuantityExponents(Erad, rad_boundaries);
-				kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_P);
-				kappaEVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_E);
-			}
-		}
-		AMREX_ASSERT(!kappaPVec.hasnan());
-		AMREX_ASSERT(!kappaEVec.hasnan());
-
-		const double LHS = c_hat_ * dt * rho * sum(kappaEVec * Erad - kappaPVec * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
-
-		quokka::valarray<double, nGroups_> d_fourpib_over_c_d_t{};
-		if constexpr (nGroups_ == 1) {
-			d_fourpib_over_c_d_t[0] = ComputeThermalRadiationTempDerivativeSingleGroup(T_d);
-		} else {
-			d_fourpib_over_c_d_t = ComputeThermalRadiationTempDerivativeMultiGroup(T_d, rad_boundaries);
-		}
-		const double dLHS_dTd = -c_hat_ * dt * rho * sum(kappaPVec * d_fourpib_over_c_d_t) - N_d * std::sqrt(T_gas);
 		return dLHS_dTd;
 	};
 
-	const auto T = IntegratorOneVariable(rhs, jac, T_d_init, Lambda_compare);
-
-	return T;
-}
-#endif
-
-#if 0
-template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(double const T_gas, double const T_d_init, double const rho,
-									   quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt, double R_sum,
-									   int n_step, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double
-{
-	if (n_step > 0) {
-		return T_gas - R_sum / (N_d * std::sqrt(T_gas));
-	}
-
-	amrex::GpuArray<double, nGroups_> rad_boundary_ratios{};
-
-	if constexpr (nGroups_ > 1 && opacity_model_ != OpacityModel::piecewise_constant_opacity) {
-		for (int g = 0; g < nGroups_; ++g) {
-			rad_boundary_ratios[g] = rad_boundaries[g + 1] / rad_boundaries[g];
-		}
-	}
-
-	quokka::valarray<double, nGroups_> kappaPVec{};
-	quokka::valarray<double, nGroups_> kappaEVec{};
-
 	const double Lambda_compare = N_d * std::sqrt(T_gas) * T_gas;
 
-	amrex::GpuArray<double, nGroups_> alpha_quant_minus_one{};
-	for (int g = 0; g < nGroups_; ++g) {
-		alpha_quant_minus_one[g] = -1.0;
-	}
+	const auto T_d = BackwardEulerOneVariable(rhs, jac, T_d_init, Lambda_compare);
+	AMREX_ASSERT_WITH_MESSAGE(T_d >= 0., "Dust temperature is negative!");
 
-	// solve for dust temperature T_d using Newton iteration
-	double T_d = T_d_init;
-	const double lambda_rel_tol = 1.0e-8;
-	const int max_iter_td = 100;
-	int iter_Td = 0;
-	for (; iter_Td < max_iter_td; ++iter_Td) {
-		quokka::valarray<double, nGroups_> fourPiBoverC{};
-
-		if constexpr (nGroups_ == 1) {
-			fourPiBoverC[0] = ComputeThermalRadiationSingleGroup(T_d);
-		} else {
-			fourPiBoverC = ComputeThermalRadiationMultiGroup(T_d, rad_boundaries);
-		}
-
-		if constexpr (opacity_model_ == OpacityModel::single_group) {
-			kappaPVec[0] = ComputePlanckOpacity(rho, T_d);
-			kappaEVec[0] = ComputeEnergyMeanOpacity(rho, T_d);
-		} else {
-			const auto kappa_expo_and_lower_value = DefineOpacityExponentsAndLowerValues(rad_boundaries, rho, T_d);
-			if constexpr (opacity_model_ == OpacityModel::piecewise_constant_opacity) {
-				for (int g = 0; g < nGroups_; ++g) {
-					kappaPVec[g] = kappa_expo_and_lower_value[1][g];
-					kappaEVec[g] = kappa_expo_and_lower_value[1][g];
-				}
-			} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_fixed_slope_spectrum) {
-				kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_quant_minus_one);
-				kappaEVec = kappaPVec;
-			} else if constexpr (opacity_model_ == OpacityModel::PPL_opacity_full_spectrum) {
-				const auto alpha_P = ComputeRadQuantityExponents(fourPiBoverC, rad_boundaries);
-				const auto alpha_E = ComputeRadQuantityExponents(Erad, rad_boundaries);
-				kappaPVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_P);
-				kappaEVec = ComputeGroupMeanOpacity(kappa_expo_and_lower_value, rad_boundary_ratios, alpha_E);
-			}
-		}
-		AMREX_ASSERT(!kappaPVec.hasnan());
-		AMREX_ASSERT(!kappaEVec.hasnan());
-
-		const double LHS = c_hat_ * dt * rho * sum(kappaEVec * Erad - kappaPVec * fourPiBoverC) + N_d * std::sqrt(T_gas) * (T_gas - T_d);
-
-		if (std::abs(LHS) < lambda_rel_tol * std::abs(Lambda_compare)) {
-			break;
-		}
-
-		quokka::valarray<double, nGroups_> d_fourpib_over_c_d_t{};
-		if constexpr (nGroups_ == 1) {
-			d_fourpib_over_c_d_t[0] = ComputeThermalRadiationTempDerivativeSingleGroup(T_d);
-		} else {
-			d_fourpib_over_c_d_t = ComputeThermalRadiationTempDerivativeMultiGroup(T_d, rad_boundaries);
-		}
-		const double dLHS_dTd = -c_hat_ * dt * rho * sum(kappaPVec * d_fourpib_over_c_d_t) - N_d * std::sqrt(T_gas);
-		const double delta_T_d = LHS / dLHS_dTd;
-		T_d -= delta_T_d;
-
-		if (iter_Td > 0) {
-			if (std::abs(delta_T_d) < lambda_rel_tol * std::abs(T_d)) {
-				break;
-			}
-		}
-	}
-
-	AMREX_ASSERT_WITH_MESSAGE(iter_Td < max_iter_td, "Newton iteration for dust temperature failed to converge.");
-	if (iter_Td >= max_iter_td) {
-		T_d = -1.0;
-	}
 	return T_d;
 }
-#endif
 
 #include "radiation/source_terms_multi_group.hpp"  // IWYU pragma: export
 #include "radiation/source_terms_single_group.hpp" // IWYU pragma: export

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -336,6 +336,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto DefinePhotoelectricHeatingE1Derivative(amrex::Real temperature, amrex::Real num_density) -> amrex::Real;
 
+	AMREX_GPU_HOST_DEVICE static auto DefineBackgroundHeatingRate(amrex::Real num_density) -> amrex::Real;
+
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(amrex::Real num_density) -> amrex::Real;
+
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real num_density) -> amrex::Real;
+
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGas(double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff,
 							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 							   quokka::valarray<double, nGroups_> const &tau, double c_v,

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -176,6 +176,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 	const double chat = c_hat_;
 	const double cscale = c / chat;
 
+	const double num_den = rho / mean_molecular_mass_;
+
 	// const double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
 	double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
 
@@ -309,7 +311,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 		const auto Egas_diff = Egas_guess - Egas0;
 		const auto Erad_diff = EradVec_guess - Erad0Vec;
 
-		auto jacobian = ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t);
+		auto jacobian = ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, num_den, dt);
 
 		if constexpr (use_D_as_base) {
 			jacobian.J0g = jacobian.J0g * tau0;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -176,7 +176,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 	const double chat = c_hat_;
 	const double cscale = c / chat;
 
-	const double num_den = rho / mean_molecular_mass_;
+	const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
 
 	// const double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
 	double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
@@ -311,7 +311,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 		const auto Erad_diff = EradVec_guess - Erad0Vec;
 
 		auto jacobian =
-		    ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, num_den, dt);
+		    ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, atomic_H_num_den, dt);
 
 		if constexpr (use_D_as_base) {
 			jacobian.J0g = jacobian.J0g * tau0;
@@ -666,11 +666,11 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 			gas_update_factor = IMEX_a32;
 		}
 
-		const double num_den = rho / mean_molecular_mass_;
+		const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
 		const double cscale = c / chat;
 		double coeff_n = NAN;
 		if constexpr (enable_dust_gas_thermal_coupling_model_) {
-			coeff_n = dt * dustGasCoeff_local * num_den * num_den / cscale;
+			coeff_n = dt * dustGasCoeff_local * atomic_H_num_den * atomic_H_num_den / cscale;
 		}
 
 		// Outer iteration loop to update the work term until it converges

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -176,7 +176,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 	const double chat = c_hat_;
 	const double cscale = c / chat;
 
-	const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
+	const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 
 	// const double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
 	double Etot0 = Egas0 + cscale * (sum(Erad0Vec) + sum(Src));
@@ -311,7 +311,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 		const auto Erad_diff = EradVec_guess - Erad0Vec;
 
 		auto jacobian =
-		    ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, atomic_H_num_den, dt);
+		    ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, H_num_den, dt);
 
 		if constexpr (use_D_as_base) {
 			jacobian.J0g = jacobian.J0g * tau0;
@@ -666,11 +666,11 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 			gas_update_factor = IMEX_a32;
 		}
 
-		const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
+		const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 		const double cscale = c / chat;
 		double coeff_n = NAN;
 		if constexpr (enable_dust_gas_thermal_coupling_model_) {
-			coeff_n = dt * dustGasCoeff_local * atomic_H_num_den * atomic_H_num_den / cscale;
+			coeff_n = dt * dustGasCoeff_local * H_num_den * H_num_den / cscale;
 		}
 
 		// Outer iteration loop to update the work term until it converges

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -107,8 +107,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGas(double /*T_d*/
 								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 								  quokka::valarray<double, nGroups_> const &tau, double c_v,
 								  quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, 
-									double const num_den, double const dt) -> JacobianResult<problem_t>
+								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double const num_den,
+								  double const dt) -> JacobianResult<problem_t>
 {
 	JacobianResult<problem_t> result;
 
@@ -311,7 +311,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 		const auto Egas_diff = Egas_guess - Egas0;
 		const auto Erad_diff = EradVec_guess - Erad0Vec;
 
-		auto jacobian = ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, num_den, dt);
+		auto jacobian =
+		    ComputeJacobianForGas(T_d, Egas_diff, Erad_diff, Rvec, Src, tau, c_v, opacity_terms.kappaPoverE, d_fourpiboverc_d_t, num_den, dt);
 
 		if constexpr (use_D_as_base) {
 			jacobian.J0g = jacobian.J0g * tau0;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -113,13 +113,12 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGas(double /*T_d*/
 
 	const double cscale = c_light_ / c_hat_;
 
-	result.F0 = Egas_diff;
+	result.F0 = Egas_diff + cscale * sum(Rvec);
 	result.Fg = Erad_diff - (Rvec + Src);
 	result.Fg_abs_sum = 0.0;
 	for (int g = 0; g < nGroups_; ++g) {
 		if (tau[g] > 0.0) {
 			result.Fg_abs_sum += std::abs(result.Fg[g]);
-			result.F0 += cscale * Rvec[g];
 		}
 	}
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -107,13 +107,17 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGas(double /*T_d*/
 								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
 								  quokka::valarray<double, nGroups_> const &tau, double c_v,
 								  quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>
+								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, 
+									double const num_den, double const dt) -> JacobianResult<problem_t>
 {
 	JacobianResult<problem_t> result;
 
 	const double cscale = c_light_ / c_hat_;
 
-	result.F0 = Egas_diff + cscale * sum(Rvec);
+	// CR_heating term
+	const double CR_heating = DefineCosmicRayHeatingRate(num_den) * dt;
+
+	result.F0 = Egas_diff + cscale * sum(Rvec) - CR_heating;
 	result.Fg = Erad_diff - (Rvec + Src);
 	result.Fg_abs_sum = 0.0;
 	for (int g = 0; g < nGroups_; ++g) {

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -185,7 +185,6 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 	double T_d = NAN; // a dummy dust temperature, T_d = T_gas for gas-only model
 	double delta_x = NAN;
 	quokka::valarray<double, nGroups_> delta_R{};
-	quokka::valarray<double, nGroups_> F_D{};
 	quokka::valarray<double, nGroups_> Rvec{};
 	quokka::valarray<double, nGroups_> tau0{};	 // optical depth across c * dt at old state
 	quokka::valarray<double, nGroups_> tau{};	 // optical depth across c * dt at new state
@@ -626,7 +625,6 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		double Ekin0 = NAN;
 		double Etot0 = NAN;
 		double Egas_guess = NAN;
-		quokka::valarray<double, nGroups_> EradVec_guess{};
 		quokka::valarray<double, nGroups_> work{};
 		quokka::valarray<double, nGroups_> work_prev{};
 

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -88,12 +88,12 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		}
 
 		double coeff_n = NAN;
-		const double num_den = rho / mean_molecular_mass_;
+		const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
 		if constexpr (enable_dust_gas_thermal_coupling_model_) {
-			coeff_n = dt * dustGasCoeff_ * num_den * num_den / cscale;
+			coeff_n = dt * dustGasCoeff_ * atomic_H_num_den * atomic_H_num_den / cscale;
 		} else {
 			amrex::ignore_unused(coeff_n);
-			amrex::ignore_unused(num_den);
+			amrex::ignore_unused(atomic_H_num_den);
 			amrex::ignore_unused(dustGasCoeff_);
 		}
 
@@ -230,10 +230,10 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 					double cooling = 0.0;
 					double cooling_derivative = 0.0;
-					const double CR_heating = DefineCosmicRayHeatingRate(num_den) * dt;
+					const double CR_heating = DefineCosmicRayHeatingRate(atomic_H_num_den) * dt;
 					if constexpr (enable_dust_gas_thermal_coupling_model_) {
-						cooling = DefineNetCoolingRate(T_gas, num_den)[0];
-						cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, num_den)[0];
+						cooling = DefineNetCoolingRate(T_gas, atomic_H_num_den)[0];
+						cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, atomic_H_num_den)[0];
 					}
 
 					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt - CR_heating;
@@ -349,7 +349,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				AMREX_ASSERT(Erad_guess >= 0.0);
 
 				if constexpr (!add_line_cooling_to_radiation_in_jac) {
-					const auto cooling_tend = DefineNetCoolingRate(T_gas, num_den)[0] * dt;
+					const auto cooling_tend = DefineNetCoolingRate(T_gas, atomic_H_num_den)[0] * dt;
 					AMREX_ASSERT_WITH_MESSAGE(cooling_tend >= 0.,
 								  "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
 					// TODO(CCH): potential GPU-related issue here.

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -88,12 +88,12 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		}
 
 		double coeff_n = NAN;
-		const double atomic_H_num_den = ComputeNumberDensityAtomicH(rho, massScalars);
+		const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 		if constexpr (enable_dust_gas_thermal_coupling_model_) {
-			coeff_n = dt * dustGasCoeff_ * atomic_H_num_den * atomic_H_num_den / cscale;
+			coeff_n = dt * dustGasCoeff_ * H_num_den * H_num_den / cscale;
 		} else {
 			amrex::ignore_unused(coeff_n);
-			amrex::ignore_unused(atomic_H_num_den);
+			amrex::ignore_unused(H_num_den);
 			amrex::ignore_unused(dustGasCoeff_);
 		}
 
@@ -230,10 +230,10 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 					double cooling = 0.0;
 					double cooling_derivative = 0.0;
-					const double CR_heating = DefineCosmicRayHeatingRate(atomic_H_num_den) * dt;
+					const double CR_heating = DefineCosmicRayHeatingRate(H_num_den) * dt;
 					if constexpr (enable_dust_gas_thermal_coupling_model_) {
-						cooling = DefineNetCoolingRate(T_gas, atomic_H_num_den)[0];
-						cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, atomic_H_num_den)[0];
+						cooling = DefineNetCoolingRate(T_gas, H_num_den)[0];
+						cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, H_num_den)[0];
 					}
 
 					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt - CR_heating;
@@ -349,7 +349,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				AMREX_ASSERT(Erad_guess >= 0.0);
 
 				if constexpr (!add_line_cooling_to_radiation_in_jac) {
-					const auto cooling_tend = DefineNetCoolingRate(T_gas, atomic_H_num_den)[0] * dt;
+					const auto cooling_tend = DefineNetCoolingRate(T_gas, H_num_den)[0] * dt;
 					AMREX_ASSERT_WITH_MESSAGE(cooling_tend >= 0.,
 								  "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
 					// TODO(CCH): potential GPU-related issue here.

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -230,12 +230,13 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 		 			double cooling = 0.0;
 		 			double cooling_derivative = 0.0;
+					const double CR_heating = DefineCosmicRayHeatingRate(num_den) * dt;
 					if constexpr (enable_dust_gas_thermal_coupling_model_) {
 						cooling = DefineNetCoolingRate(T_gas, num_den)[0];
 						cooling_derivative = DefineNetCoolingRateTempDerivative(T_gas, num_den)[0];
 					}
 
-					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt;
+					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt - CR_heating;
 					F_D = Erad_guess - Erad0 - (R + Src);
 					if constexpr (add_line_cooling_to_radiation_in_jac) {
 						F_D -= (1.0/cscale) * cooling * dt;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -228,8 +228,8 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 						}
 					}
 
-		 			double cooling = 0.0;
-		 			double cooling_derivative = 0.0;
+					double cooling = 0.0;
+					double cooling_derivative = 0.0;
 					const double CR_heating = DefineCosmicRayHeatingRate(num_den) * dt;
 					if constexpr (enable_dust_gas_thermal_coupling_model_) {
 						cooling = DefineNetCoolingRate(T_gas, num_den)[0];
@@ -239,7 +239,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt - CR_heating;
 					F_D = Erad_guess - Erad0 - (R + Src);
 					if constexpr (add_line_cooling_to_radiation_in_jac) {
-						F_D -= (1.0/cscale) * cooling * dt;
+						F_D -= (1.0 / cscale) * cooling * dt;
 					}
 					double F_D_abs = 0.0;
 					if (tau > 0.0) {
@@ -284,7 +284,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 					if constexpr (!enable_dust_gas_thermal_coupling_model_) {
 						J00 = 1.0 + cooling_derivative * dt / c_v;
 						J01 = cscale;
-						J10 = 1.0 / c_v * dEg_dT - (1/cscale) * cooling_derivative * dt;
+						J10 = 1.0 / c_v * dEg_dT - (1 / cscale) * cooling_derivative * dt;
 						if (tau <= 0.0) {
 							J11 = -std::numeric_limits<double>::infinity();
 						} else {
@@ -299,7 +299,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 						J01 = cscale;
 						J10 = 1.0 / c_v * dEg_dT;
 						if (tau <= 0.0) {
-							J11 = - LARGE;
+							J11 = -LARGE;
 						} else {
 							J11 = kappaPoverE * d_fourpiboverc_d_t * dTd_dRg - kappaPoverE / tau - 1.0;
 						}
@@ -350,9 +350,10 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 				if constexpr (!add_line_cooling_to_radiation_in_jac) {
 					const auto cooling_tend = DefineNetCoolingRate(T_gas, num_den)[0] * dt;
-					AMREX_ASSERT_WITH_MESSAGE(cooling_tend >= 0., "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
+					AMREX_ASSERT_WITH_MESSAGE(cooling_tend >= 0.,
+								  "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
 					// TODO(CCH): potential GPU-related issue here.
-					Erad_guess += (1/cscale) * cooling_tend;
+					Erad_guess += (1 / cscale) * cooling_tend;
 				}
 
 				if (n > 0) {

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -348,6 +348,13 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				AMREX_ASSERT(Egas_guess > 0.0);
 				AMREX_ASSERT(Erad_guess >= 0.0);
 
+				if constexpr (!add_line_cooling_to_radiation_in_jac) {
+					const auto cooling_tend = DefineNetCoolingRate(T_gas, num_den)[0] * dt;
+					AMREX_ASSERT_WITH_MESSAGE(cooling_tend >= 0., "add_line_cooling_to_radiation has to be enabled when there is negative cooling rate!");
+					// TODO(CCH): potential GPU-related issue here.
+					Erad_guess += (1/cscale) * cooling_tend;
+				}
+
 				if (n > 0) {
 					// calculate kappaF since the temperature has changed
 					kappaF = ComputeFluxMeanOpacity(rho, T_d);

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -237,7 +237,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 
 					F_G = Egas_guess - Egas0 + cscale * R + cooling * dt;
 					F_D = Erad_guess - Erad0 - (R + Src);
-					if constexpr (add_line_cooling_to_radiation) {
+					if constexpr (add_line_cooling_to_radiation_in_jac) {
 						F_D -= (1.0/cscale) * cooling * dt;
 					}
 					double F_D_abs = 0.0;

--- a/tests/RadLineCooling.in
+++ b/tests/RadLineCooling.in
@@ -1,0 +1,23 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  64.0  1.0  1.0
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 8 4 4
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 4     # grid size must be divisible by this
+amr.max_grid_size   = 64
+
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 1

--- a/tests/RadLineCooling.in
+++ b/tests/RadLineCooling.in
@@ -19,6 +19,7 @@ amr.blocking_factor = 4     # grid size must be divisible by this
 amr.max_grid_size   = 64
 
 radiation.print_iteration_counts = 1
+radiation.dust_gas_interaction_coeff = 1e20
 
 do_reflux = 0
 do_subcycle = 0

--- a/tests/RadLineCooling.in
+++ b/tests/RadLineCooling.in
@@ -19,7 +19,7 @@ amr.blocking_factor = 4     # grid size must be divisible by this
 amr.max_grid_size   = 64
 
 radiation.print_iteration_counts = 1
-radiation.dust_gas_interaction_coeff = 1e20
+radiation.dust_gas_interaction_coeff = 1e-20
 
 do_reflux = 0
 do_subcycle = 0

--- a/tests/RadLineCooling.in
+++ b/tests/RadLineCooling.in
@@ -18,6 +18,8 @@ amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 amr.max_grid_size   = 64
 
+radiation.print_iteration_counts = 1
+
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1

--- a/tests/RadLineCoolingCoupled.in
+++ b/tests/RadLineCoolingCoupled.in
@@ -1,0 +1,26 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  64.0  1.0  1.0
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 8 4 4
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 4     # grid size must be divisible by this
+amr.max_grid_size   = 64
+
+radiation.print_iteration_counts = 1
+radiation.dust_gas_interaction_coeff = 1e20
+
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 1


### PR DESCRIPTION
### Description
This pull request implements line cooling and cosmic ray heating. The key changes include:
- Added line cooling to the single-group and multi-group radiation solvers when `enable_dust_gas_thermal_coupling_model = true` . Line cooling is enabled by defining `DefineNetCoolingRate` and `DefineNetCoolingRateTempDerivative` in the problem file. 
- Implemented cosmic ray heating in all solvers, which is enabled by defining `DefineCosmicRayHeatingRate` in the problem file. 
- Added tests for the new line cooling and cosmic ray heating functionality.
	- RadLineCooling: test line cooling + CR heating + PE heating for single-group radiation system.
	- RadLineCoolingMG: test line cooling + CR heating + PE heating for multi-group radiation system, for both well-coupled and decoupled gas-dust systems.

This is the last feature I have finished implementing a while ago and I want to merge into the development branch before we move to Microphysics. In the next PR, I'll try to structure the code in the format of `actual_rhs()`, `actual_jac()`, and`backward_euler_integrator()` so that we can readily start to use Microphysics API. 

#### Test problems

##### RadLineCooling

Initial conditions: uniform static gas with a temperature $T_0 = 1$ and $C_V = 1$; the radiation energy density is 0. The dust opacity is 0. The line cooling rate is $\Lambda_{\rm line} = C_{\Lambda} T$, where $C_{\Lambda} = 0.1$, and the CR heating rate is $\Gamma_{\rm cr} = 0.03$. As the gas cools down, its temperature follows the following ODE:

$$
C_V \frac{d T}{d t} = - C_{\Lambda} T + \Gamma_{\rm cr}
$$

The solution is
```math
\begin{gather}
T(t) = C_{\Lambda}^{-1} e^{-\frac{C_{\Lambda
   }}{C_V} t} \left(\Gamma
   _{\text{cr}} e^{\frac{C_{\Lambda}}{C_V} t}+ T_0
   C_{\Lambda }-\Gamma_{\text{cr}}\right) \\
   E_{\rm rad}(t) = -(C_V T(t) - C_V T_0 - \Gamma_{\rm cr} t)
\end{gather}
```

In the end of the test, the numerical results of $T(t)$ and $E_{\rm rad}(t)$ are checked against the exact analytical solution.

##### RadLineCoolingMG

The initial condition is the same as that of RadLineCooling, except
1. There are four radiation bins. The first bin is the line emission and the last bin is photoelectric heating (FUV). 
2. The initial radiation energy density is 1 in the last bin and 0 in all other bins. The opacity is 0 in all bins.
3. PE heating is enabled and $\Gamma_{\rm pe} = 0.02 E_{\rm FUV} = 0.02$. 
The ODE is

$$
C_V \frac{d T}{d t} = - C_{\Lambda} T + \Gamma_{\rm cr} + \Gamma_{\rm pe}
$$

and the solution is the same as the previous one with two differences: (1) $\Gamma_{\rm cr}$ is replaced with $\Gamma_{\rm cr} + \Gamma_{\rm pe}$; (2) $E_{\rm rad}$ represents the energy density of the first bin. 

This test is run twice, one with well-coupled gas-dust model and one with decoupled gas-dust model.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] I have tested this PR on my local computer and all tests pass.
- [x] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
