### PR TITLE
fix 'pure virtual method called' error

### DIFF
--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -97,10 +97,10 @@ template <> void QuokkaSimulation<TubeProblem>::setInitialConditionsOnGrid(quokk
 
 	// declare global variables
 	// initial conditions read from file
-	amrex::Gpu::HostVector<double> x_arr;
-	amrex::Gpu::HostVector<double> rho_arr;
-	amrex::Gpu::HostVector<double> Pgas_arr;
-	amrex::Gpu::HostVector<double> Erad_arr;
+	std::vector<double> x_arr;
+	std::vector<double> rho_arr;
+	std::vector<double> Pgas_arr;
+	std::vector<double> Erad_arr;
 
 	for (std::string line; std::getline(fstream, line);) {
 		std::istringstream iss(line);


### PR DESCRIPTION
### Description
Move `DeviceVector` inside `setInitialConditionsOnGrid` to avoid the `pure virtual method called` error, first seen in #761 . 

This branch is based on dependabot/submodules/extern/amrex-6d9c25b . 

### Related issues
Fix issues in PR #761 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
