### PR TITLE
Add script to make a movie from simulation images

### DIFF
--- a/scripts/make_movie.sh
+++ b/scripts/make_movie.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+CONVERT_EXE=/sw/andes/spack-envs/base/opt/linux-rhel8-x86_64/gcc-8.3.1/imagemagick-7.0.8-7-srnwz5bn26ielesvto2lrctsw4qby573/bin/convert
+RENAME_EXE=/gpfs/alpine2/ast196/proj-shared/wibking/spack/opt/spack/linux-rhel8-zen2/gcc-9.3.0/rename-1.600-jzccmpqqd2tu2muki2fd3o2aehxkdvr4/bin/rename
+FFMPEG_EXE=/gpfs/alpine2/ast196/proj-shared/wibking/spack/opt/spack/linux-rhel8-zen2/gcc-9.3.0/ffmpeg-7.0.2-ywl5f5ldeogjs3jtgitdufzpksnswgit/bin/ffmpeg
+
+set -x
+
+## rename *.png files
+
+$RENAME_EXE 's/\d+/sprintf("%07d",$&)/e' -- *.png
+
+## resize frames
+
+for file in *.png;
+do
+    $CONVERT_EXE $file -resize 2048x2048 $(basename -s .png $file).resize_large.png
+done
+
+## make movie
+FPS=10
+FILTERS="pad=ceil(iw/2)*2:ceil(ih/2)*2:color=white, drawtext=fontfile=/usr/share/fonts/google-droid/DroidSans.ttf:text='QED-QUOKKA Simulation':fontcolor=white:fontsize=48:box=1:boxcolor=black@0.6:boxborderw=5:x=0.9*(w-text_w):y=0.9*(h-text_h)"
+
+$FFMPEG_EXE -framerate $FPS -pattern_type glob -i "slices_*.resize_large.png" -r $FPS -vcodec libx264 -vf "$FILTERS" -pix_fmt yuv420p -preset slow -tune animation -crf 18 slice_movie_large.mov

--- a/scripts/make_movie.sh
+++ b/scripts/make_movie.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-CONVERT_EXE=/sw/andes/spack-envs/base/opt/linux-rhel8-x86_64/gcc-8.3.1/imagemagick-7.0.8-7-srnwz5bn26ielesvto2lrctsw4qby573/bin/convert
-RENAME_EXE=/gpfs/alpine2/ast196/proj-shared/wibking/spack/opt/spack/linux-rhel8-zen2/gcc-9.3.0/rename-1.600-jzccmpqqd2tu2muki2fd3o2aehxkdvr4/bin/rename
-FFMPEG_EXE=/gpfs/alpine2/ast196/proj-shared/wibking/spack/opt/spack/linux-rhel8-zen2/gcc-9.3.0/ffmpeg-7.0.2-ywl5f5ldeogjs3jtgitdufzpksnswgit/bin/ffmpeg
+CONVERT_EXE=$(which convert)  # install with: "spack install imagemagick"
+RENAME_EXE=$(which rename)    # install with: "spack install rename"
+FFMPEG_EXE=$(which ffmpeg)    # install with: "spack install ffmpeg+libx264+drawtext"
 
 set -x
 
@@ -19,6 +19,6 @@ done
 
 ## make movie
 FPS=10
-FILTERS="pad=ceil(iw/2)*2:ceil(ih/2)*2:color=white, drawtext=fontfile=/usr/share/fonts/google-droid/DroidSans.ttf:text='QED-QUOKKA Simulation':fontcolor=white:fontsize=48:box=1:boxcolor=black@0.6:boxborderw=5:x=0.9*(w-text_w):y=0.9*(h-text_h)"
+FILTERS="pad=ceil(iw/2)*2:ceil(ih/2)*2:color=white, drawtext=fontfile=/usr/share/fonts/google-droid/DroidSans.ttf:text='QUOKKA Simulation':fontcolor=white:fontsize=48:box=1:boxcolor=black@0.6:boxborderw=5:x=0.9*(w-text_w):y=0.9*(h-text_h)"
 
-$FFMPEG_EXE -framerate $FPS -pattern_type glob -i "slices_*.resize_large.png" -r $FPS -vcodec libx264 -vf "$FILTERS" -pix_fmt yuv420p -preset slow -tune animation -crf 18 slice_movie_large.mov
+$FFMPEG_EXE -framerate $FPS -pattern_type glob -i "*.resize_large.png" -r $FPS -vcodec libx264 -vf "$FILTERS" -pix_fmt yuv420p -preset slow -tune animation -crf 18 movie_large.mov


### PR DESCRIPTION
### Description
This adds a Bash script to process a sequence of image files (`*.png`) in the current working directory into a H.264-encoded `*.mov` movie, with a text annotation for consistent branding of Quokka simulation movies.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues see (see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [x] I have requested a reviewer for this PR.
