### PR TITLE
Speed up unit tests by running ctest in parallel

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -61,7 +61,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --parallel 2
+      run: cmake --build . --config $BUILD_TYPE --parallel 3
 
     - name: Create test output directory
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests
@@ -71,7 +71,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -C $BUILD_TYPE -j2
+      run: ctest --output-on-failure -C $BUILD_TYPE -j3
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -71,7 +71,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -C $BUILD_TYPE
+      run: ctest --output-on-failure -C $BUILD_TYPE -j2
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -59,7 +59,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/tests/leak_suppress.txt ctest --output-on-failure -C $BUILD_TYPE
+      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/tests/leak_suppress.txt ctest --output-on-failure -C $BUILD_TYPE -j4
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -62,7 +62,7 @@ jobs:
       
     - name: Run tests
       working-directory: ${{runner.workspace}}/quokka/build
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure -j4
       
     - name: Upload test output
       if: always()


### PR DESCRIPTION
### Description
Speed up CPU unit tests by running ctest on parallel, e.g. `ctest -j4`. 

### Related issues
#783 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues see (see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] I have tested this PR on my local computer and all tests pass.
- [ ] I have manually triggered the GPU tests with the magic comment `/azp run`.
- [ ] I have requested a reviewer for this PR.
