### PR TITLE
update yt: replace AMReXDataset with yt.load

### DIFF
--- a/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
+++ b/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
@@ -1,6 +1,5 @@
-# note: the AMReX frontend is broken in yt 4.3.0
+# note: requires yt>=4.3.0
 import yt
-from yt.frontends.boxlib.data_structures import AMReXDataset
 
 def particle_dist(plotfiles):
     t_arr = []
@@ -8,7 +7,7 @@ def particle_dist(plotfiles):
     d0 = 2.0 * 3.125e12
 
     for pltfile in plotfiles:
-        ds = AMReXDataset(pltfile)
+        ds = yt.load(pltfile)
         Lx = ds.domain_right_edge[0] - ds.domain_left_edge[0]
         Nx = ds.domain_dimensions[0]
         cell_dx = Lx/Nx


### PR DESCRIPTION
### Description
Since yt version 4.4.0 (or perhaps 4.3.0), you can read Quokka outputs with `yt.load`. It returns a `QuokkaDataset`, which inherits from `AMReXDataset`. This PR modifies `particle_orbit_plot.py` to reflect this update. I have tested running ``particle_orbit_plot.py` on my own computer and it works. 

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
