### PR TITLE
fix openPMD plotfile output

### DIFF
--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -1,5 +1,5 @@
 # Use the NVIDIA CUDA image as the base image
-FROM nvcr.io/nvidia/nvhpc:24.9-devel-cuda12.6-ubuntu24.04
+FROM nvcr.io/nvidia/nvhpc:24.11-devel-cuda12.6-ubuntu24.04
 
 # Set environment variables for NVIDIA
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -9,7 +9,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \
     build-essential wget curl git ninja-build gcc g++ \
-    python3-dev python3-numpy python3-matplotlib python3-pip \
+    python3-dev python3-numpy python3-matplotlib python3-venv python3-pip \
     libhdf5-dev && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -1,5 +1,5 @@
 # Use the NVIDIA CUDA image as the base image
-FROM nvcr.io/nvidia/nvhpc:24.11-devel-cuda12.6-ubuntu24.04
+FROM nvcr.io/nvidia/nvhpc:24.9-devel-cuda12.6-ubuntu24.04
 
 # Set environment variables for NVIDIA
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -9,7 +9,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \
     build-essential wget curl git ninja-build gcc g++ \
-    python3-dev python3-numpy python3-matplotlib python3-venv python3-pip \
+    python3-dev python3-numpy python3-matplotlib python3-pip \
     libhdf5-dev && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2230,7 +2230,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 	if (computeVars) {
 		for (int lev{0}; lev <= finestLevel(); ++lev) {
 			diagMFVec[lev] = std::make_unique<amrex::MultiFab>(grids[lev], dmap[lev], m_diagVars.size(), 1);
-			amrex::MultiFab const mf = PlotFileMFAtLevel(lev, nghost_cc_);
+			amrex::MultiFab const mf = PlotFileMFAtLevel(lev, std::min(nghost_cc_, nghost_fc_));
 			auto const varnames = GetPlotfileVarNames();
 
 			for (int v{0}; v < m_diagVars.size(); ++v) {
@@ -2291,7 +2291,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 	BL_PROFILE("AMRSimulation::RenderAscent()");
 
 	// combine multifabs
-	amrex::Vector<amrex::MultiFab> mf = PlotFileMF(nghost_cc_);
+	const int included_ghosts = std::min(nghost_cc_, nghost_fc_);
+	amrex::Vector<amrex::MultiFab> mf = PlotFileMF(included_ghosts);
 	amrex::Vector<const amrex::MultiFab *> mf_ptr = amrex::GetVecOfConstPtrs(mf);
 	amrex::Vector<std::string> varnames;
 	varnames.insert(varnames.end(), componentNames_cc_.begin(), componentNames_cc_.end());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -586,11 +586,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 	}
 
 #ifdef QUOKKA_USE_OPENPMD
-	// warning about face-centered variables and OpenPMD outputs
-	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
-		amrex::Print() << "\n[Warning] [I/O] Plotfiles will ONLY contain cell-centered averages of face-centered variables!"
-			       << " Support for outputting face-centered variables for openPMD is not yet implemented.\n";
-	}
+	// warning about particles and OpenPMD outputs
+	amrex::Print() << "\n[Warning] [I/O] OpenPMD outputs currently do NOT include particles!"
+		       	   << " Support for outputting particles for openPMD is not yet implemented.\n";
 #endif
 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -588,7 +588,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 #ifdef QUOKKA_USE_OPENPMD
 	// warning about particles and OpenPMD outputs
 	amrex::Print() << "\n[Warning] [I/O] OpenPMD outputs currently do NOT include particles!"
-		       	   << " Support for outputting particles for openPMD is not yet implemented.\n";
+		       << " Support for outputting particles for openPMD is not yet implemented.\n";
 #endif
 }
 


### PR DESCRIPTION
### Description
Fixes a segmentation fault during openPMD plotfile output when face-centered variables are enabled.

There was an implicit assumption in `AMRSimulation<problem_t>::AverageFCToCC()` that the number of face-centered ghost zones was the same as the number of cell-centered ghost zones. This PR allows the number of ghosts to differ.

I manually tested that this works inside the CUDA dev container by compiling Quokka with `-DQUOKKA_OPENPMD=ON`,  running the HydroBlast3D problem, and then examining the output files with [openPMD-viewer](https://github.com/openPMD/openPMD-viewer).

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/742.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
