### PR TITLE
add 'cellUpdates_ > 0' check

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -692,9 +692,14 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 	amrex::Print() << '\n';
 
 	// compute average number of radiation subcycles per timestep
-	double const avg_rad_subcycles = static_cast<double>(radiationCellUpdates_) / static_cast<double>(cellUpdates_);
-	amrex::Print() << "avg. num. of radiation subcycles = " << avg_rad_subcycles << '\n';
-	amrex::Print() << '\n';
+	if (cellUpdates_ > 0) {
+		double const avg_rad_subcycles = static_cast<double>(radiationCellUpdates_) / static_cast<double>(cellUpdates_);
+		amrex::Print() << "avg. num. of radiation subcycles = " << avg_rad_subcycles << '\n';
+		amrex::Print() << '\n';
+	} else {
+		amrex::Print() << "No cell updates performed!\n";
+		amrex::Print() << '\n';
+	}
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -903,7 +903,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	getWalltime(); // initialize start_time
 
 	// Main time loop
-	for (int step = istep[0]; step < maxTimesteps_ && cur_time < stopTime_; ++step) {
+	int step = istep[0];
+	for (; step < maxTimesteps_ && cur_time < stopTime_; ++step) {
 
 		if (suppress_output == 0) {
 			amrex::Print() << "\nCoarse STEP " << step + 1 << " at t = " << cur_time << " (" << (cur_time / stopTime_) * 100. << "%) starts ..."
@@ -999,6 +1000,15 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 			// we have exceeded 90% of maxWalltime_
 			break;
 		}
+	}
+
+	if (step == 0) {
+		amrex::Print() << "No cell updates performed!\n";
+#ifdef AMREX_USE_ASCENT
+		// close Ascent
+		ascent_.close();
+#endif
+		return;
 	}
 
 	amrex::Real elapsed_sec = getWalltime();


### PR DESCRIPTION
### Description
Add checks `if (step == 0)` and `cellUpdates_ == 0` in the end of a simulation to prevent 'division by zero' error when max_time = 0.0 or max_timesteps = 0. 

### Related issues
Closes #721 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
