### PR TITLE
add scripts to run on Frontier

### DIFF
--- a/scripts/frontier-1node.submit
+++ b/scripts/frontier-1node.submit
@@ -1,0 +1,30 @@
+#!/usr/bin/env zsh
+
+#SBATCH -A ast146
+#SBATCH -J amrex_quokka
+#SBATCH -o 1node_%x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=7
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 1
+
+# load cray modules (must be done manually before submitting the job)
+# module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
+
+# note (5-16-22, OLCFHELP-6888)
+# this environment setting is currently needed on Crusher to work-around a
+# known issue with Libfabric
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+
+# always run with GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# use correct NIC-to-GPU binding
+# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
+export MPICH_OFI_NIC_POLICY=NUMA
+
+srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in
+

--- a/scripts/frontier-1node.submit
+++ b/scripts/frontier-1node.submit
@@ -11,20 +11,11 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 1
 
-# load cray modules (must be done manually before submitting the job)
-# module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
+# note (5-16-22, OLCFHELP-6888): libfabric workaround
+export FI_MR_CACHE_MAX_COUNT=0
 
-# note (5-16-22, OLCFHELP-6888)
-# this environment setting is currently needed on Crusher to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
-
-# always run with GPU-aware MPI
+# GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# use correct NIC-to-GPU binding
-# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
-export MPICH_OFI_NIC_POLICY=NUMA
-
-srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_512.in
 

--- a/scripts/frontier-4096node.submit
+++ b/scripts/frontier-4096node.submit
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+
+#SBATCH -A ast146
+#SBATCH -J amrex_quokka
+#SBATCH -o 4096node_%x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=7
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 4096
+
+# note (5-16-22, OLCFHELP-6888): libfabric workaround
+export FI_MR_CACHE_MAX_COUNT=0
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_8192.in

--- a/scripts/frontier-512node.submit
+++ b/scripts/frontier-512node.submit
@@ -1,0 +1,20 @@
+#!/usr/bin/env zsh
+
+#SBATCH -A ast146
+#SBATCH -J amrex_quokka
+#SBATCH -o 512node_%x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=7
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 512
+
+# note (5-16-22, OLCFHELP-6888): libfabric workaround
+export FI_MR_CACHE_MAX_COUNT=0
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_4096.in

--- a/scripts/frontier-64node.submit
+++ b/scripts/frontier-64node.submit
@@ -1,0 +1,29 @@
+#!/usr/bin/env zsh
+
+#SBATCH -A ast146
+#SBATCH -J amrex_quokka
+#SBATCH -o 64node-%x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 64
+
+# note (5-16-22, OLCFHELP-6888)
+# this environment setting is currently needed on Crusher to work-around a
+# known issue with Libfabric
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+
+# load cray modules
+module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
+
+# always run with GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# use correct NIC-to-GPU binding
+# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
+export MPICH_OFI_NIC_POLICY=NUMA
+
+srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in

--- a/scripts/frontier-64node.submit
+++ b/scripts/frontier-64node.submit
@@ -2,28 +2,19 @@
 
 #SBATCH -A ast146
 #SBATCH -J amrex_quokka
-#SBATCH -o 64node-%x-%j.out
+#SBATCH -o 64node_%x-%j.out
 #SBATCH -t 00:10:00
 #SBATCH -p batch
 #SBATCH --ntasks-per-node=8
-#SBATCH --cpus-per-task=8
+#SBATCH --cpus-per-task=7
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=closest
 #SBATCH -N 64
 
-# note (5-16-22, OLCFHELP-6888)
-# this environment setting is currently needed on Crusher to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# note (5-16-22, OLCFHELP-6888): libfabric workaround
+export FI_MR_CACHE_MAX_COUNT=0
 
-# load cray modules
-module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
-
-# always run with GPU-aware MPI
+# GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# use correct NIC-to-GPU binding
-# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
-export MPICH_OFI_NIC_POLICY=NUMA
-
-srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_2048.in

--- a/scripts/frontier-8node.submit
+++ b/scripts/frontier-8node.submit
@@ -2,28 +2,19 @@
 
 #SBATCH -A ast146
 #SBATCH -J amrex_quokka
-#SBATCH -o 8node-%x-%j.out
+#SBATCH -o 8node_%x-%j.out
 #SBATCH -t 00:10:00
 #SBATCH -p batch
 #SBATCH --ntasks-per-node=8
-#SBATCH --cpus-per-task=8
+#SBATCH --cpus-per-task=7
 #SBATCH --gpus-per-task=1
 #SBATCH --gpu-bind=closest
 #SBATCH -N 8
 
-# note (5-16-22, OLCFHELP-6888)
-# this environment setting is currently needed on Crusher to work-around a
-# known issue with Libfabric
-export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+# note (5-16-22, OLCFHELP-6888): libfabric workaround
+export FI_MR_CACHE_MAX_COUNT=0
 
-# load cray modules
-module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
-
-# always run with GPU-aware MPI
+# GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# use correct NIC-to-GPU binding
-# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
-export MPICH_OFI_NIC_POLICY=NUMA
-
-srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in
+srun build/src/problems/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in

--- a/scripts/frontier-8node.submit
+++ b/scripts/frontier-8node.submit
@@ -1,0 +1,29 @@
+#!/usr/bin/env zsh
+
+#SBATCH -A ast146
+#SBATCH -J amrex_quokka
+#SBATCH -o 8node-%x-%j.out
+#SBATCH -t 00:10:00
+#SBATCH -p batch
+#SBATCH --ntasks-per-node=8
+#SBATCH --cpus-per-task=8
+#SBATCH --gpus-per-task=1
+#SBATCH --gpu-bind=closest
+#SBATCH -N 8
+
+# note (5-16-22, OLCFHELP-6888)
+# this environment setting is currently needed on Crusher to work-around a
+# known issue with Libfabric
+export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+
+# load cray modules
+module load cpe/22.08 craype-accel-amd-gfx90a rocm/5.2.0 cray-mpich cce/14.0.2 cray-hdf5
+
+# always run with GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# use correct NIC-to-GPU binding
+# (https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal)
+export MPICH_OFI_NIC_POLICY=NUMA
+
+srun build/src/HydroBlast3D/test_hydro3d_blast tests/benchmark_unigrid_1024.in

--- a/scripts/frontier.profile
+++ b/scripts/frontier.profile
@@ -10,7 +10,7 @@ module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
 
-module load rocm/6.2.4
+module load rocm/6.1.3
 module load cray-mpich
 module load cce/18.0.0  # must be loaded after rocm
 
@@ -33,13 +33,12 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 export AMREX_AMD_ARCH=gfx90a
 
 # compiler environment hints
-export CC=$(which hipcc)
-export CXX=$(which hipcc)
+export CC=$(which cc)
+export CXX=$(which CC)
 export FC=$(which ftn)
 
-#export CFLAGS="-I${ROCM_PATH}/include"
-#export CXXFLAGS="-I${ROCM_PATH}/include"
-#export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 ${PE_MPICH_GTL_DIR_amd_gfx90a} -lmpi_gtl_hsa"
-
-# this line is critical -- apps will crash without it
-#export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+# these flags are REQUIRED
+export CFLAGS="-I${ROCM_PATH}/include"
+export CXXFLAGS="-I${ROCM_PATH}/include -Wno-pass-failed"
+export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"
+export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/scripts/frontier.profile
+++ b/scripts/frontier.profile
@@ -1,0 +1,45 @@
+module purge
+
+# module versions of CPE, cce, and rocm *MUST* match according to this table:
+# https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#compatible-compiler-rocm-toolchain-versions
+
+module load Core/24.07
+module load cpe/24.07
+
+module load PrgEnv-cray
+module load craype-x86-trento
+module load craype-accel-amd-gfx90a
+
+module load rocm/6.2.4
+module load cray-mpich
+module load cce/18.0.0  # must be loaded after rocm
+
+# hdf5
+module load cray-hdf5
+
+# cmake
+module load cmake/3.27.9
+
+# optional
+module load emacs
+
+# optional
+module load cray-python/3.11.5
+
+# GPU-aware MPI
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+# optimize GPU compilation for MI250X
+export AMREX_AMD_ARCH=gfx90a
+
+# compiler environment hints
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
+export FC=$(which ftn)
+
+#export CFLAGS="-I${ROCM_PATH}/include"
+#export CXXFLAGS="-I${ROCM_PATH}/include"
+#export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64 ${PE_MPICH_GTL_DIR_amd_gfx90a} -lmpi_gtl_hsa"
+
+# this line is critical -- apps will crash without it
+#export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/src/hydro/HydroState.hpp
+++ b/src/hydro/HydroState.hpp
@@ -1,8 +1,6 @@
 #ifndef HYDROSTATE_HPP_ // NOLINT
 #define HYDROSTATE_HPP_
 
-#include <array>
-
 #include "AMReX_Array.H"
 
 namespace quokka
@@ -18,7 +16,7 @@ template <int Nall, int Nmass> struct HydroState {
 	double Eint;				   // internal energy density
 	double by;				   // transverse bfield component
 	double bz;				   // 2nd transverse bfield density
-	std::array<double, Nall> scalar;	   // passive scalars
+        amrex::GpuArray<double, Nall> scalar;	   // passive scalars
 	amrex::GpuArray<double, Nmass> massScalar; // mass scalars
 };
 

--- a/src/hydro/HydroState.hpp
+++ b/src/hydro/HydroState.hpp
@@ -16,7 +16,7 @@ template <int Nall, int Nmass> struct HydroState {
 	double Eint;				   // internal energy density
 	double by;				   // transverse bfield component
 	double bz;				   // 2nd transverse bfield density
-        amrex::GpuArray<double, Nall> scalar;	   // passive scalars
+	amrex::GpuArray<double, Nall> scalar;	   // passive scalars
 	amrex::GpuArray<double, Nmass> massScalar; // mass scalars
 };
 

--- a/tests/benchmark_unigrid_8192.in
+++ b/tests/benchmark_unigrid_8192.in
@@ -1,0 +1,25 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.2  1.2  1.2
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 8192 8192 8192
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.max_grid_size   = 128   # at least 128 for GPUs
+amr.blocking_factor = 128   # grid size must be divisible by this
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 0.7   # default
+
+do_reflux = 0
+do_subcycle = 0
+max_timesteps = 1000


### PR DESCRIPTION
### Description
Adds scripts to run on OLCF Frontier. Changes one instance of `std::array` to `amrex::GpuArray` to get it to compile on Frontier.

Weak scaling numbers:
![chart (1)](https://github.com/user-attachments/assets/8f6bc67f-99dc-4ff7-ad3c-a78791b032f9)

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
