### PR TITLE
Update ROCm version in dependencies_hip.sh

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -22,7 +22,7 @@ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-for ver in 5.3.3 5.4.3 5.5.1; do
+for ver in 5.7.1 6.3.0; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
     | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
@@ -43,11 +43,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev5.4.3        \
-    roctracer-dev5.4.3   \
-    rocprofiler-dev5.4.3 \
-    rocrand-dev5.4.3     \
-    rocprim-dev5.4.3
+    rocm-dev6.3.0        \
+    roctracer-dev6.3.0   \
+    rocprofiler-dev6.3.0 \
+    rocrand-dev6.3.0     \
+    rocprim-dev6.3.0
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -22,7 +22,7 @@ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-for ver in 5.7.1 6.3.0; do
+for ver in 5.7.1 6.3; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
     | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -43,11 +43,11 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev6.3.0        \
-    roctracer-dev6.3.0   \
-    rocprofiler-dev6.3.0 \
-    rocrand-dev6.3.0     \
-    rocprim-dev6.3.0
+    rocm-dev5.7.1        \
+    roctracer-dev5.7.1   \
+    rocprofiler-dev5.7.1 \
+    rocrand-dev5.7.1     \
+    rocprim-dev5.7.1
 
 # activate
 #


### PR DESCRIPTION
### Description
For GitHub actions CI tests, compile the code using ROCm 5.7.1 (the latest version available on Setonix).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
