### PR TITLE
add print_cycle_timing runtime option

### DIFF
--- a/tests/benchmark_unigrid_1024.in
+++ b/tests/benchmark_unigrid_1024.in
@@ -23,3 +23,4 @@ amr.grid_eff        = 0.7   # default
 do_reflux = 0
 do_subcycle = 0
 max_timesteps = 1000
+print_cycle_timing = 1

--- a/tests/benchmark_unigrid_2048.in
+++ b/tests/benchmark_unigrid_2048.in
@@ -23,3 +23,4 @@ amr.grid_eff        = 0.7   # default
 do_reflux = 0
 do_subcycle = 0
 max_timesteps = 1000
+print_cycle_timing = 1

--- a/tests/benchmark_unigrid_4096.in
+++ b/tests/benchmark_unigrid_4096.in
@@ -23,3 +23,4 @@ amr.grid_eff        = 0.7   # default
 do_reflux = 0
 do_subcycle = 0
 max_timesteps = 1000
+print_cycle_timing = 1

--- a/tests/benchmark_unigrid_512.in
+++ b/tests/benchmark_unigrid_512.in
@@ -23,3 +23,4 @@ amr.grid_eff        = 0.7   # default
 do_reflux = 0
 do_subcycle = 0
 max_timesteps = 1000
+print_cycle_timing = 1

--- a/tests/benchmark_unigrid_8192.in
+++ b/tests/benchmark_unigrid_8192.in
@@ -23,3 +23,4 @@ amr.grid_eff        = 0.7   # default
 do_reflux = 0
 do_subcycle = 0
 max_timesteps = 1000
+print_cycle_timing = 1


### PR DESCRIPTION
### Description
Adds the runtime option `print_cycle_timing = 1` to output the elapsed walltime (in seconds) of each coarse timestep.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
