### PR TITLE
Reduce walltime for RandomBlast regression test

### DIFF
--- a/tests/RandomBlast_regression.in
+++ b/tests/RandomBlast_regression.in
@@ -28,14 +28,12 @@ cfl = 0.2
 hydro.reconstruction_order = 3
 derived_vars = temperature
 
-plotfile_interval = 40000
+plotfile_interval = 10000
 checkpoint_interval = -1
-max_timesteps = 40000
+max_timesteps = 10000
+stop_time = 3.154e12       # 1e5 yr
 
-dt_initial = 3.154e10       # 1000 yr
-stop_time = 3.154e13       # 1e6 yr
-
-SN_rate_per_volume = 0.03   # yr^-1 kpc^-1
+SN_rate_per_volume = 0.03  # yr^-1 kpc^-1
 
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1


### PR DESCRIPTION
### Description
It takes about 1 hour to run, which is too long. This changes the max simulation time to 1e5 yr (instead of 1e6 yr), so the regression test should complete about 10x faster.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
