### PR TITLE
Update cron schedule for regression tests

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -3,9 +3,10 @@ pr: none
 trigger: none
 
 # run on timed schedule, like a cron job
+# NOTE: all times are in UTC!
 schedules:
-- cron: '0 0 * * *'
-  displayName: Daily midnight build
+- cron: '0 14 * * *'
+  displayName: Daily 1am build (AEDT)
   branches:
     include:
     - development


### PR DESCRIPTION
### Description
The cron job schedule is in UTC, not local timezone. This changes the nightly regression tests to run at 14:00 UTC (1am Australian Eastern Daylight Time).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
