### PR TITLE
Update quokka-tests.ini

### DIFF
--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -6,9 +6,14 @@ sourceTree = C_Src
 useCmake = 1
 isSuperbuild = 1
 numMakeJobs = 16
+updateGitSubmodules = 1
 
 plot_file_name = plotfile_prefix
 check_file_name = checkpoint_prefix
+
+# don't compress output plotfiles (this prevents them from being deleted automatically)
+archive_output = 0
+# delete plotfiles after compare
 purge_output = 1
 
 # suiteName is the name prepended to all output directories


### PR DESCRIPTION
### Description
Updates the configuration file for the nightly regression tests. This should prevent the disk quota from being hit as quickly. This also updates git submodules when checking out new versions of Quokka before running the tests (this was not done previously).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
