### PR TITLE
Enforce minimum ROCm version >= 6.3

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -22,7 +22,7 @@ sudo mkdir --parents --mode=0755 /etc/apt/keyrings
 wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
     gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
-for ver in 5.7.1 6.3; do
+for ver in 5.7.1 6.3.1; do
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver focal main" \
     | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
@@ -43,12 +43,12 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev5.7.1        \
-    roctracer-dev5.7.1   \
-    rocprofiler-dev5.7.1 \
-    rocrand-dev5.7.1     \
-    rocprim-dev5.7.1     \
-    rocsparse-dev5.7.1
+    rocm-dev6.3.1        \
+    roctracer-dev6.3.1   \
+    rocprofiler-dev6.3.1 \
+    rocrand-dev6.3.1     \
+    rocprim-dev6.3.1     \
+    rocsparse-dev6.3.1
 
 # activate
 #

--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -47,6 +47,7 @@ sudo apt-get install -y --no-install-recommends \
     roctracer-dev6.3.1   \
     rocprofiler-dev6.3.1 \
     rocrand-dev6.3.1     \
+    hiprand-dev6.3.1     \
     rocprim-dev6.3.1     \
     rocsparse-dev6.3.1
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(AMReX_GPU_BACKEND MATCHES "HIP")
   string(REPLACE "HIP version: " "" hipcc_version ${hipcc_version})
   message(STATUS "HIP compiler version: ${hipcc_version}")
 
-  if(hipcc_version VERSION_LESS 6.4)
+  if(hipcc_version VERSION_LESS 6.3)
     message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that may cause Quokka to produce incorrect results.")
   endif()
 endif(AMReX_GPU_BACKEND MATCHES "HIP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(AMReX_GPU_BACKEND MATCHES "HIP")
   endif()
 
   if(hipcc_version VERSION_LESS 6.3)
-    message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that cause Quokka to produce incorrect results.")
+    message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that may cause Quokka to produce incorrect results.")
   endif()
 endif(AMReX_GPU_BACKEND MATCHES "HIP")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(AMReX_GPU_BACKEND MATCHES "HIP")
   string(REPLACE "HIP version: " "" hipcc_version ${hipcc_version})
   message(STATUS "HIP compiler version: ${hipcc_version}")
 
-  if(hipcc_version VERSION_LESS 6.3)
+  if(hipcc_version VERSION_LESS 6.4)
     message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that may cause Quokka to produce incorrect results.")
   endif()
 endif(AMReX_GPU_BACKEND MATCHES "HIP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,9 +59,10 @@ if(AMReX_GPU_BACKEND MATCHES "HIP")
   )
   if(NOT hipcc_result EQUAL 0)
       message(FATAL_ERROR "Failed to detect HIP compiler version: ${hipcc_error}")
-  else()
-      message(STATUS "HIP compiler version: ${hipcc_version}")
   endif()
+
+  string(REPLACE "HIP version: " "" hipcc_version ${hipcc_version})
+  message(STATUS "HIP compiler version: ${hipcc_version}")
 
   if(hipcc_version VERSION_LESS 6.3)
     message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that may cause Quokka to produce incorrect results.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,25 @@ if(AMReX_GPU_BACKEND MATCHES "CUDA")
   endif(CMAKE_VERSION VERSION_LESS 3.20)
 endif(AMReX_GPU_BACKEND MATCHES "CUDA")
 
+if(AMReX_GPU_BACKEND MATCHES "HIP")
+  execute_process(
+      COMMAND hipcc --version
+      RESULT_VARIABLE hipcc_result
+      OUTPUT_VARIABLE hipcc_version
+      ERROR_VARIABLE hipcc_error
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT hipcc_result EQUAL 0)
+      message(FATAL_ERROR "Failed to detect HIP compiler version: ${hipcc_error}")
+  else()
+      message(STATUS "HIP compiler version: ${hipcc_version}")
+  endif()
+
+  if(hipcc_version VERSION_LESS 6.3)
+    message(FATAL_ERROR "You must use ROCm version >= 6.3 to compile Quokka. All previous ROCm versions have compiler bugs that cause Quokka to produce incorrect results.")
+  endif()
+endif(AMReX_GPU_BACKEND MATCHES "HIP")
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
   # abort! Intel Compiler Classic cannot compile Quokka!
   message(FATAL_ERROR "You have configured CMake to use the 'classic' Intel compilers (icc/icpc), which are the old Intel compilers. They cannot compile Quokka correctly! You must use the new LLVM-based Intel compilers (icx/icpx) instead by adding the following CMake command-line options: -DCMAKE_C_COMPILER=icx -DCMAKE_CXX_COMPILER=icpx")


### PR DESCRIPTION
### Description
Require ROCm 6.3 or newer to compile Quokka for AMD GPUs.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/394.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
