### PR TITLE
allow disabling energy check in Sedov problem

### DIFF
--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -172,11 +172,11 @@ template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vecto
 			auto const &ekin = Ekin_mf.array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 				// compute kinetic energy
-				Real rho = state(i, j, k, HydroSystem<SedovProblem>::density_index);
-				Real px = state(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index);
-				Real py = state(i, j, k, HydroSystem<SedovProblem>::x2Momentum_index);
-				Real pz = state(i, j, k, HydroSystem<SedovProblem>::x3Momentum_index);
-				Real psq = px * px + py * py + pz * pz;
+				Real const rho = state(i, j, k, HydroSystem<SedovProblem>::density_index);
+				Real const px = state(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index);
+				Real const py = state(i, j, k, HydroSystem<SedovProblem>::x2Momentum_index);
+				Real const pz = state(i, j, k, HydroSystem<SedovProblem>::x3Momentum_index);
+				Real const psq = px * px + py * py + pz * pz;
 				ekin(i, j, k) = psq / (2.0 * rho) * vol;
 			});
 		}

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -152,71 +152,80 @@ template <> void QuokkaSimulation<SedovProblem>::ErrorEst(int lev, amrex::TagBox
 
 template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
-	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
+	amrex::ParmParse const pp("blast_problem");
+	bool checkSolution = true;
+	pp.query("check_solution", checkSolution);
 
-	// check conservation of total energy
-	amrex::Real const Egas0 = initSumCons[RadSystem<SedovProblem>::gasEnergy_index];
-	amrex::Real const Egas = state_new_cc_[0].sum(RadSystem<SedovProblem>::gasEnergy_index) * vol;
+	if (checkSolution) {
+		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
+		amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 
-	// compute kinetic energy
-	amrex::MultiFab Ekin_mf(boxArray(0), DistributionMap(0), 1, 0);
-	for (amrex::MFIter iter(state_new_cc_[0]); iter.isValid(); ++iter) {
-		const amrex::Box &indexRange = iter.validbox();
-		auto const &state = state_new_cc_[0].const_array(iter);
-		auto const &ekin = Ekin_mf.array(iter);
-		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-			// compute kinetic energy
-			Real rho = state(i, j, k, HydroSystem<SedovProblem>::density_index);
-			Real px = state(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index);
-			Real py = state(i, j, k, HydroSystem<SedovProblem>::x2Momentum_index);
-			Real pz = state(i, j, k, HydroSystem<SedovProblem>::x3Momentum_index);
-			Real psq = px * px + py * py + pz * pz;
-			ekin(i, j, k) = psq / (2.0 * rho) * vol;
-		});
-	}
-	amrex::Real const Ekin = Ekin_mf.sum(0);
+		// check conservation of total energy
+		amrex::Real const Egas0 = initSumCons[RadSystem<SedovProblem>::gasEnergy_index];
+		amrex::Real const Egas = state_new_cc_[0].sum(RadSystem<SedovProblem>::gasEnergy_index) * vol;
 
-	amrex::Real const frac_Ekin = Ekin / Egas;
-	amrex::Real const frac_Ekin_exact = 0.218729;
+		// compute kinetic energy
+		amrex::MultiFab Ekin_mf(boxArray(0), DistributionMap(0), 1, 0);
+		for (amrex::MFIter iter(state_new_cc_[0]); iter.isValid(); ++iter) {
+			const amrex::Box &indexRange = iter.validbox();
+			auto const &state = state_new_cc_[0].const_array(iter);
+			auto const &ekin = Ekin_mf.array(iter);
+			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+				// compute kinetic energy
+				Real rho = state(i, j, k, HydroSystem<SedovProblem>::density_index);
+				Real px = state(i, j, k, HydroSystem<SedovProblem>::x1Momentum_index);
+				Real py = state(i, j, k, HydroSystem<SedovProblem>::x2Momentum_index);
+				Real pz = state(i, j, k, HydroSystem<SedovProblem>::x3Momentum_index);
+				Real psq = px * px + py * py + pz * pz;
+				ekin(i, j, k) = psq / (2.0 * rho) * vol;
+			});
+		}
+		amrex::Real const Ekin = Ekin_mf.sum(0);
 
-	amrex::Real const abs_err = (Egas - Egas0);
-	amrex::Real const rel_err = abs_err / Egas0;
+		amrex::Real const frac_Ekin = Ekin / Egas;
+		amrex::Real const frac_Ekin_exact = 0.218729;
 
-	amrex::Real const rel_err_Ekin = frac_Ekin - frac_Ekin_exact;
+		amrex::Real const abs_err = (Egas - Egas0);
+		amrex::Real const rel_err = abs_err / Egas0;
 
-	amrex::Print() << "\nInitial energy = " << Egas0 << '\n';
-	amrex::Print() << "Final energy = " << Egas << '\n';
-	amrex::Print() << "\tabsolute conservation error = " << abs_err << '\n';
-	amrex::Print() << "\trelative conservation error = " << rel_err << '\n';
-	amrex::Print() << "\tkinetic energy = " << Ekin << '\n';
-	amrex::Print() << "\trelative K.E. error = " << rel_err_Ekin << '\n';
-	amrex::Print() << '\n';
+		amrex::Real const rel_err_Ekin = frac_Ekin - frac_Ekin_exact;
 
-	bool E_test_passes = false;  // does total energy test pass?
-	bool KE_test_passes = false; // does kinetic energy test pass?
+		amrex::Print() << "\nInitial energy = " << Egas0 << '\n';
+		amrex::Print() << "Final energy = " << Egas << '\n';
+		amrex::Print() << "\tabsolute conservation error = " << abs_err << '\n';
+		amrex::Print() << "\trelative conservation error = " << rel_err << '\n';
+		amrex::Print() << "\tkinetic energy = " << Ekin << '\n';
+		amrex::Print() << "\trelative K.E. error = " << rel_err_Ekin << '\n';
+		amrex::Print() << '\n';
 
-	if ((std::abs(rel_err) > 2.0e-15) || std::isnan(rel_err)) {
-		// note that this tolerance is appropriate for a 256^3 grid
-		// it may need to be modified for coarser resolutions
-		amrex::Print() << "Energy not conserved to machine precision!\n";
-		E_test_passes = false;
+		bool E_test_passes = false;  // does total energy test pass?
+		bool KE_test_passes = false; // does kinetic energy test pass?
+
+		if ((std::abs(rel_err) > 2.0e-15) || std::isnan(rel_err)) {
+			// note that this tolerance is appropriate for a 256^3 grid
+			// it may need to be modified for coarser resolutions
+			amrex::Print() << "Energy not conserved to machine precision!\n";
+			E_test_passes = false;
+		} else {
+			amrex::Print() << "Energy conservation is OK.\n";
+			E_test_passes = true;
+		}
+
+		if ((std::abs(rel_err_Ekin) > 0.01) || std::isnan(rel_err_Ekin)) {
+			amrex::Print() << "Kinetic energy production is incorrect by more than 1 percent!\n";
+			KE_test_passes = false;
+		} else {
+			amrex::Print() << "Kinetic energy production is OK.\n";
+			KE_test_passes = true;
+		}
+
+		// if both tests pass, then overall pass
+		test_passes = E_test_passes && KE_test_passes;
+		amrex::Print() << "\n";
 	} else {
-		amrex::Print() << "Energy conservation is OK.\n";
-		E_test_passes = true;
+		// don't check, just assume it worked
+		test_passes = true;
 	}
-
-	if ((std::abs(rel_err_Ekin) > 0.01) || std::isnan(rel_err_Ekin)) {
-		amrex::Print() << "Kinetic energy production is incorrect by more than 1 percent!\n";
-		KE_test_passes = false;
-	} else {
-		amrex::Print() << "Kinetic energy production is OK.\n";
-		KE_test_passes = true;
-	}
-
-	// if both tests pass, then overall pass
-	test_passes = E_test_passes && KE_test_passes;
-	amrex::Print() << "\n";
 }
 
 auto problem_main() -> int
@@ -258,7 +267,6 @@ auto problem_main() -> int
 
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.stopTime_ = 1.0;	      // seconds
-	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 
 	// initialize
 	sim.setInitialConditions();

--- a/tests/blast_32.in
+++ b/tests/blast_32.in
@@ -24,3 +24,5 @@ do_reflux = 0
 do_subcycle = 0
 
 plotfile_interval  = 1000
+
+blast_problem.check_solution = false


### PR DESCRIPTION
### Description
Add a runtime option to disable the energy check for the Sedov problem. It is only useful for the test suite, so users running the blast problem to learn how to use the code should be able to disable it.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
