### PR TITLE
set default max_timesteps to INT_MAX

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -156,20 +156,20 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real cflNumber_ = 0.3;	      // default
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Long cycleCount_ = 0;
-	int printCycleTiming_ = 0;		    // default: don't print
-	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max();	    // default: no limit
-	amrex::Long maxWalltime_ = 0;		    // default: no limit
-	int ascentInterval_ = -1;		    // -1 == no in-situ renders with Ascent
-	int plotfileInterval_ = -1;		    // -1 == no output
-	int projectionInterval_ = -1;		    // -1 == no output
-	int statisticsInterval_ = -1;		    // -1 == no output
-	amrex::Real plotTimeInterval_ = -1.0;	    // time interval for plt file
-	amrex::Real checkpointTimeInterval_ = -1.0; // time interval for checkpoints
-	int checkpointInterval_ = -1;		    // -1 == no output
-	int amrInterpMethod_ = 1;		    // 0 == piecewise constant, 1 == lincc_interp
-	amrex::Real reltolPoisson_ = 1.0e-5;	    // default
-	amrex::Real abstolPoisson_ = 1.0e-5;	    // default (scaled by minimum RHS value)
-	int doPoissonSolve_ = 0;		    // 1 == self-gravity enabled, 0 == disabled
+	int printCycleTiming_ = 0;				     // default: don't print
+	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit
+	amrex::Long maxWalltime_ = 0;				     // default: no limit
+	int ascentInterval_ = -1;				     // -1 == no in-situ renders with Ascent
+	int plotfileInterval_ = -1;				     // -1 == no output
+	int projectionInterval_ = -1;				     // -1 == no output
+	int statisticsInterval_ = -1;				     // -1 == no output
+	amrex::Real plotTimeInterval_ = -1.0;			     // time interval for plt file
+	amrex::Real checkpointTimeInterval_ = -1.0;		     // time interval for checkpoints
+	int checkpointInterval_ = -1;				     // -1 == no output
+	int amrInterpMethod_ = 1;				     // 0 == piecewise constant, 1 == lincc_interp
+	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
+	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
+	int doPoissonSolve_ = 0;				     // 1 == self-gravity enabled, 0 == disabled
 	amrex::Vector<amrex::MultiFab> phi;
 
 	amrex::Real densityFloor_ = 0.0; // default

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -157,7 +157,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;		    // default: don't print
-	amrex::Long maxTimesteps_ = 1e4;	    // default
+	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max();	    // default: no limit
 	amrex::Long maxWalltime_ = 0;		    // default: no limit
 	int ascentInterval_ = -1;		    // -1 == no in-situ renders with Ascent
 	int plotfileInterval_ = -1;		    // -1 == no output
@@ -600,7 +600,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// ParmParse reads inputs from the *.inputs file
 	amrex::ParmParse pp;
 
-	// Default nsteps = 1e4
+	// Default nsteps = std::numeric_limits<int>::max()
 	pp.query("max_timesteps", maxTimesteps_);
 
 	// Default CFL number == 0.3, set to whatever is in the file

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -600,7 +600,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// ParmParse reads inputs from the *.inputs file
 	amrex::ParmParse pp;
 
-	// Default nsteps = std::numeric_limits<int>::max()
+	// Default nsteps == INT_MAX
 	pp.query("max_timesteps", maxTimesteps_);
 
 	// Default CFL number == 0.3, set to whatever is in the file


### PR DESCRIPTION
### Description
Set the default maximum number of timesteps to `INT_MAX`. The previous default was rather arbitrary and confusing.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
