### PR TITLE
fix username for gcc devcontainer

### DIFF
--- a/.devcontainer/gcc-container/Dockerfile
+++ b/.devcontainer/gcc-container/Dockerfile
@@ -35,7 +35,7 @@ RUN mkdir /tmp/build-adios2 && cd /tmp/build-adios2 && \
  cd / && \
  rm -rf /tmp/build-adios2
 
-WORKDIR /home/ubuntu
-USER ubuntu
+WORKDIR /home/vscode
+USER vscode
 
 CMD [ "/bin/bash" ]

--- a/.devcontainer/gcc-container/devcontainer.json
+++ b/.devcontainer/gcc-container/devcontainer.json
@@ -26,7 +26,7 @@
           ]
         }
       },
-      "remoteUser": "ubuntu",
+      "remoteUser": "vscode",
       // we need to manually checkout the submodules,
       // but VSCode may try to configure CMake before they are fully checked-out.
       // workaround TBD


### PR DESCRIPTION
### Description
This changes the username used inside the Docker container from "ubuntu" to "vscode". This is required to get it working again.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
