### PR TITLE
add git hash to metadata output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ execute_process(COMMAND git rev-parse HEAD
 
 # Check if the working directory is dirty
 execute_process(
-    COMMAND git status --porcelain
+    COMMAND git status --porcelain -uno
     WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_STATUS_OUTPUT
     OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -111,7 +111,7 @@ else()
     set(GIT_DIRTY 0)
 endif()
 
-# add preprocessor macro for git commits
+# add preprocessor macros for git commits
 add_compile_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
 add_compile_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
 add_definitions(-DQUOKKA_GIT_DIRTY=${GIT_DIRTY})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,46 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Wno-psabi)
 endif()
 
+execute_process(COMMAND git rev-parse --abbrev-ref HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}
+    OUTPUT_VARIABLE QUOKKA_GIT_BRANCH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}
+    OUTPUT_VARIABLE QUOKKA_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/amrex
+    OUTPUT_VARIABLE AMREX_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Check if the working directory is dirty
+execute_process(
+    COMMAND git status --porcelain
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_STATUS_OUTPUT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+# Set a flag if the working directory is dirty
+if(NOT GIT_STATUS_OUTPUT STREQUAL "")
+    set(GIT_DIRTY 1)
+    message(WARNING "This Quokka repository has untracked changes not reflected in its git history! That means that the exact provenance of the simulation outputs CANNOT be inferred from the output files.\nIt is STRONGLY recommended that you commit your changes to the repo, then re-run CMake and recompile Quokka in order to obtain reproducible simulation outputs.")
+else()
+    set(GIT_DIRTY 0)
+endif()
+
+# add preprocessor macro for git commits
+add_compile_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
+add_compile_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
+add_definitions(-DQUOKKA_GIT_DIRTY=${GIT_DIRTY})
+message(STATUS "Quokka git branch: ${QUOKKA_GIT_BRANCH}")
+message(STATUS "Quokka git commit hash: ${QUOKKA_GIT_HASH}")
+message(STATUS "AMReX git commit hash: ${AMREX_GIT_HASH}")
+
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/amrex ${QuokkaCode_BINARY_DIR}/amrex)
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/fmt ${QuokkaCode_BINARY_DIR}/fmt)
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/yaml-cpp ${QuokkaCode_BINARY_DIR}/yaml-cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,8 @@ else()
 endif()
 
 # add preprocessor macros for git commits
-add_compile_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
-add_compile_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
+add_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
+add_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
 message(STATUS "Quokka git branch: ${QUOKKA_GIT_BRANCH}")
 message(STATUS "Quokka git commit hash: ${QUOKKA_GIT_HASH}")
 message(STATUS "AMReX git commit hash: ${AMREX_GIT_HASH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,9 @@ execute_process(
 # Set a flag if the working directory is dirty
 if(NOT GIT_STATUS_OUTPUT STREQUAL "")
     set(GIT_DIRTY 1)
-    message(WARNING "This Quokka repository has untracked changes not reflected in its git history! That means that the exact provenance of the simulation outputs CANNOT be inferred from the output files.\nIt is STRONGLY recommended that you commit your changes to the repo, then re-run CMake and recompile Quokka in order to obtain reproducible simulation outputs.")
+    message(WARNING "This Quokka repository has untracked changes not reflected in its git history! That means that the exact provenance of plotfiles and checkpoints CANNOT be inferred from their metadata.\nIt is STRONGLY recommended that you commit your changes to the repo, then re-run CMake and recompile Quokka in order to obtain reproducible simulation outputs.")
+    # Append "-dirty" to the commit hash
+    string(APPEND QUOKKA_GIT_HASH "-dirty")
 else()
     set(GIT_DIRTY 0)
 endif()
@@ -114,7 +116,6 @@ endif()
 # add preprocessor macros for git commits
 add_compile_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
 add_compile_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
-add_definitions(-DQUOKKA_GIT_DIRTY=${GIT_DIRTY})
 message(STATUS "Quokka git branch: ${QUOKKA_GIT_BRANCH}")
 message(STATUS "Quokka git commit hash: ${QUOKKA_GIT_HASH}")
 message(STATUS "AMReX git commit hash: ${AMREX_GIT_HASH}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ execute_process(
 # Set a flag if the working directory is dirty
 if(NOT GIT_STATUS_OUTPUT STREQUAL "")
     set(GIT_DIRTY 1)
-    message(WARNING "This Quokka repository has untracked changes not reflected in its git history! That means that the exact provenance of plotfiles and checkpoints CANNOT be inferred from their metadata.\nIt is STRONGLY recommended that you commit your changes to the repo, then re-run CMake and recompile Quokka in order to obtain reproducible simulation outputs.")
+    message(WARNING "This Quokka repository has untracked changes not reflected in its git history! That means that the exact provenance of plotfiles and checkpoints CANNOT be inferred from their metadata.\nIt is STRONGLY recommended that you commit your changes to a branch locally, then re-run CMake and recompile Quokka in order to obtain reproducible simulation outputs.")
     # Append "-dirty" to the commit hash
     string(APPEND QUOKKA_GIT_HASH "-dirty")
 else()

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -326,6 +326,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void WriteCheckpointFile() const;
 	void SetLastCheckpointSymlink(std::string const &checkpointname) const;
 	void ReadCheckpointFile();
+	auto getGitHashForQuokka() const -> std::string;
+	auto getGitHashForAmrex() const -> std::string;
 	auto getWalltime() -> amrex::Real;
 	auto getCycleWalltime() -> amrex::Real;
 	void setChkFile(std::string const &chkfile_number);
@@ -460,6 +462,18 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #endif
 };
 
+template <typename problem_t> auto AMRSimulation<problem_t>::getGitHashForQuokka() const -> std::string
+{
+	// NOTE: this is defined by a preprocessor macro in CMakeLists.txt
+	return QUOKKA_GIT_HASH;
+}
+
+template <typename problem_t> auto AMRSimulation<problem_t>::getGitHashForAmrex() const -> std::string
+{
+	// NOTE: this is defined by a preprocessor macro in CMakeLists.txt
+	return AMREX_GIT_HASH;
+}
+
 template <typename problem_t> void AMRSimulation<problem_t>::setChkFile(std::string const &chkfile_number) { restart_chkfile = chkfile_number; }
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getOldMF_fc() const -> const amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> &
@@ -528,6 +542,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 		}
 	}
 
+	// add git commit to metadata
+	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();
+	simulationMetadata_["git_hash_amrex"] = getGitHashForAmrex();
+
+	// add units and physics-specific metadata
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
 		initializeSimulationMetadata();
 	}


### PR DESCRIPTION
### Description
This adds the git commit hash to `metadata.yaml` for plotfiles and checkpoints. This allows users to track the exact provenance of simulation outputs.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/852.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
