### PR TITLE
Reduce regression testing disk space usage

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -20,7 +20,7 @@ jobs:
     pool: avatar
     timeoutInMinutes: 300
     steps:
-    - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
+    - script: ./extern/regression_testing/regtest.py --clean_testdir --delete_exe regression/quokka-tests.ini
       displayName: 'Run regression testing'
     - publish: /home/bwibking/regression-tests/web
       condition: succeededOrFailed()


### PR DESCRIPTION
### Description
This enables the option in the nightly regression tests that deletes the compiled binary for each test after it runs.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
