### PR TITLE
Revert "Reduce regression testing disk space usage"

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -20,7 +20,7 @@ jobs:
     pool: avatar
     timeoutInMinutes: 300
     steps:
-    - script: ./extern/regression_testing/regtest.py --clean_testdir --delete_exe regression/quokka-tests.ini
+    - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
     - publish: /home/bwibking/regression-tests/web
       condition: succeededOrFailed()


### PR DESCRIPTION
Reverts quokka-astro/quokka#889.

This exposes a bug that I introduced into the regression testing script, and it currently causes the nightly regression tests to fail, so we go back to the prior working state.