### PR TITLE
Fix RadhydroShell failure: SetRadEnergySource should return erg.cm^-3.s^-1

### DIFF
--- a/src/problems/RadParticle/test_radparticle.cpp
+++ b/src/problems/RadParticle/test_radparticle.cpp
@@ -69,21 +69,6 @@ template <> void QuokkaSimulation<ParticleProblem>::createInitialRadParticles()
 	RadParticles->InitFromAsciiFile("RadParticles1D.txt", nreal_extra, nullptr);
 }
 
-// template <>
-// void RadSystem<StreamingProblem>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange,
-// 						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & dx,
-// 						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
-// 						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
-// {
-// 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-// 		if (i == 32) {
-// 			// src = lum / c / (dx[0] * dx[1]);
-// 			const double src = lum1 / c / (dx[0]);
-// 			radEnergySource(i, j, k, 0) += src;
-// 		}
-// 	});
-// }
-
 template <>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 RadSystem<ParticleProblem>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/, const double rho,

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -38,7 +38,7 @@ constexpr double a_rad = 1.0;
 constexpr double c = 1.0;
 constexpr double alpha_SuOlson = 4.0 * a_rad / eps_SuOlson;
 
-constexpr double Q = (1.0 / (2.0 * x0));						// do NOT change this
+constexpr double Q = (1.0 / (2.0 * x0));						    // do NOT change this
 constexpr double S = c * Q * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum)); // erg cm^{-3}
 
 template <> struct RadSystem_Traits<MarshakProblem> {

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -39,7 +39,7 @@ constexpr double c = 1.0;
 constexpr double alpha_SuOlson = 4.0 * a_rad / eps_SuOlson;
 
 constexpr double Q = (1.0 / (2.0 * x0));						// do NOT change this
-constexpr double S = Q * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum)); // erg cm^{-3}
+constexpr double S = c * Q * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum)); // erg cm^{-3}
 
 template <> struct RadSystem_Traits<MarshakProblem> {
 	static constexpr double c_hat_over_c = 1.0;

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -98,7 +98,7 @@ void RadSystem<ShellProblem>::SetRadEnergySource(array_t &radEnergy, const amrex
 		z0 = 0.;
 	}
 
-	const amrex::Real source_norm = (1.0 / c) * L_star / std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5);
+	const amrex::Real source_norm = L_star / std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5);
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		amrex::Real const x = prob_lo[0] + (i + amrex::Real(0.5)) * dx[0];


### PR DESCRIPTION
### Description
This should fix the RadhydroShell-GPU regression test failure. 

After PR #891, the radiation source term (SetRadEnergySource) should return radiation energy density rate (erg.cm^-3.s^-1). The `1/c` from the original definition is removed. 

### Related issues
#898 is no longer required. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
