### PR TITLE
Fix fpe_trap_invalid error in ComputeEddingtonTensor

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -25,12 +25,12 @@ jobs:
     - task: CMake@1
       displayName: 'Build Quokka'
       inputs:
-        cmakeArgs: '--build . --parallel 16'
+        cmakeArgs: '--build . --target test_radiation_streaming --parallel 16'
     
     - task: CMake@1
       displayName: 'Run CTest'
       inputs:
-        cmakeArgs: '-E chdir . ctest -E "MatterEnergyExchange*" -T Test --output-on-failure'
+        cmakeArgs: '-E chdir . ctest -R "Streaming*" -T Test --output-on-failure'
     
     - task: PublishTestResults@2
       inputs:

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -25,12 +25,12 @@ jobs:
     - task: CMake@1
       displayName: 'Build Quokka'
       inputs:
-        cmakeArgs: '--build . --target test_radiation_streaming --parallel 16'
+        cmakeArgs: '--build . --target test_radiation_streaming test_radiation_streaming_y --parallel 16'
     
     - task: CMake@1
       displayName: 'Run CTest'
       inputs:
-        cmakeArgs: '-E chdir . ctest -R "Streaming*" -T Test --output-on-failure'
+        cmakeArgs: '-E chdir . ctest -R "RadiationStreaming*" -T Test --output-on-failure'
     
     - task: PublishTestResults@2
       inputs:

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -912,16 +912,43 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
-	auto f = std::sqrt(fx * fx + fy * fy + fz * fz);
+	const double f = std::sqrt(fx * fx + fy * fy + fz * fz);
 	std::array<amrex::Real, 3> fvec = {fx, fy, fz};
+
+	AMREX_ASSERT(!std::isnan(f));
+	// AMREX_ASSERT(!std::isinf(f));
+	AMREX_ASSERT(!std::isnan(fx) && !std::isnan(fy) && !std::isnan(fz));
+	// AMREX_ASSERT(!std::isinf(fx) && !std::isinf(fy) && !std::isinf(fz));
 
 	// angle between interface and radiation flux \hat{n}
 	// If direction is undefined, just drop direction-dependent
 	// terms.
 	std::array<amrex::Real, 3> n{};
+	const double f_threshold = 1e-12; // small threshold to prevent division by very small numbers
+
+	// Check if any component is NaN or Inf before division
+	// for (int ii = 0; ii < 3; ++ii) {
+	// 	if (std::isnan(fvec[ii]) || std::isinf(fvec[ii])) {
+	// 		n[ii] = 0.;
+	// 	} else if (f > f_threshold) {
+	// 		n[ii] = fvec[ii] / f;
+	// 	} else {
+	// 		n[ii] = 0.;
+	// 	}
+	// 	AMREX_ASSERT(!std::isnan(n[ii]));
+	// 	AMREX_ASSERT(!std::isinf(n[ii]));
+	// }
 
 	for (int ii = 0; ii < 3; ++ii) {
-		n[ii] = (f > 0.) ? (fvec[ii] / f) : 0.;
+		if (std::isinf(fvec[ii])) {
+			n[ii] = 1.;
+		} else if (f > 0.0) {
+			n[ii] = fvec[ii] / f;
+		} else {
+			n[ii] = 0.;
+		}
+		// AMREX_ASSERT(!std::isnan(n[ii]));
+		// AMREX_ASSERT(!std::isinf(n[ii]));
 	}
 
 	// compute radiation pressure tensors

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -918,18 +918,35 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	AMREX_ASSERT(!std::isnan(f));
 	AMREX_ASSERT(!std::isnan(fx) && !std::isnan(fy) && !std::isnan(fz));
 
-	// angle between interface and radiation flux \hat{n} If direction is undefined, just drop direction-dependent terms.
+	// angle between interface and radiation flux \hat{n}
+	// If direction is undefined, just drop direction-dependent terms.
 	std::array<amrex::Real, 3> n{};
+	int inf_count = 0;
 
 	for (int ii = 0; ii < 3; ++ii) {
 		if (std::isinf(fvec[ii])) {
-			n[ii] = 1.;
+			n[ii] = 1.0;
+			inf_count++;
 		} else if (f > 0.0) {
 			n[ii] = fvec[ii] / f;
 		} else {
-			n[ii] = 0.;
+			n[ii] = 0.0;
 		}
 	}
+
+	// If we have multiple infinite components, normalize them
+	if (inf_count > 1) {
+		const double scale = 1.0 / std::sqrt(static_cast<double>(inf_count));
+		for (int ii = 0; ii < 3; ++ii) {
+			if (std::isinf(fvec[ii])) {
+				n[ii] = scale;
+			}
+		}
+	}
+
+	// Verify n is a unit vector (within numerical precision)
+	const double n_norm = std::sqrt((n[0] * n[0]) + (n[1] * n[1]) + (n[2] * n[2]));
+	AMREX_ASSERT(std::abs(n_norm - 1.0) < 1e-10 || n_norm < 1e-10);
 
 	// compute radiation pressure tensors
 	const double chi = RadSystem<problem_t>::ComputeEddingtonFactor(f);

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -912,32 +912,14 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
-	const double f = std::sqrt(fx * fx + fy * fy + fz * fz);
+	const double f = std::sqrt((fx * fx) + (fy * fy) + (fz * fz));
 	std::array<amrex::Real, 3> fvec = {fx, fy, fz};
 
 	AMREX_ASSERT(!std::isnan(f));
-	// AMREX_ASSERT(!std::isinf(f));
 	AMREX_ASSERT(!std::isnan(fx) && !std::isnan(fy) && !std::isnan(fz));
-	// AMREX_ASSERT(!std::isinf(fx) && !std::isinf(fy) && !std::isinf(fz));
 
-	// angle between interface and radiation flux \hat{n}
-	// If direction is undefined, just drop direction-dependent
-	// terms.
+	// angle between interface and radiation flux \hat{n} If direction is undefined, just drop direction-dependent terms.
 	std::array<amrex::Real, 3> n{};
-	const double f_threshold = 1e-12; // small threshold to prevent division by very small numbers
-
-	// Check if any component is NaN or Inf before division
-	// for (int ii = 0; ii < 3; ++ii) {
-	// 	if (std::isnan(fvec[ii]) || std::isinf(fvec[ii])) {
-	// 		n[ii] = 0.;
-	// 	} else if (f > f_threshold) {
-	// 		n[ii] = fvec[ii] / f;
-	// 	} else {
-	// 		n[ii] = 0.;
-	// 	}
-	// 	AMREX_ASSERT(!std::isnan(n[ii]));
-	// 	AMREX_ASSERT(!std::isinf(n[ii]));
-	// }
 
 	for (int ii = 0; ii < 3; ++ii) {
 		if (std::isinf(fvec[ii])) {
@@ -947,8 +929,6 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 		} else {
 			n[ii] = 0.;
 		}
-		// AMREX_ASSERT(!std::isnan(n[ii]));
-		// AMREX_ASSERT(!std::isinf(n[ii]));
 	}
 
 	// compute radiation pressure tensors


### PR DESCRIPTION
### Description
Add a more robust calculation of the angle between interface and radiation flux, `n[i]`. Check for both zero and inf. 

This avoids `Erroneous arithmetic operation` on moth and will fix the `Erroneous arithmetic operation` error for ROCm test in #912 . 

### Related issues


### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
