### PR TITLE
add safety check in ComputeEddingtonTensor to avoid FPE error

### DIFF
--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -912,16 +912,29 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
-	auto f = std::sqrt(fx * fx + fy * fy + fz * fz);
-	std::array<amrex::Real, 3> fvec = {fx, fy, fz};
+	const double f = std::sqrt((fx * fx) + (fy * fy) + (fz * fz));
+	const std::array<amrex::Real, 3> fvec = {fx, fy, fz};
+	const double f_floor = 1e-10;
 
 	// angle between interface and radiation flux \hat{n}
-	// If direction is undefined, just drop direction-dependent
-	// terms.
+	// If direction is undefined, just drop direction-dependent terms.
 	std::array<amrex::Real, 3> n{};
 
+	// if fvec has a inf component, set n to zero
+	bool has_inf = false;
 	for (int ii = 0; ii < 3; ++ii) {
-		n[ii] = (f > 0.) ? (fvec[ii] / f) : 0.;
+		if (fvec[ii] > 1.1) {
+			has_inf = true;
+			break;
+		}
+	}
+
+	if (has_inf || (f <= f_floor)) {
+		n = {0.0, 0.0, 0.0};
+	} else {
+		for (int ii = 0; ii < 3; ++ii) {
+			n[ii] = fvec[ii] / f;
+		}
 	}
 
 	// compute radiation pressure tensors

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -920,16 +920,17 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// If direction is undefined, just drop direction-dependent terms.
 	std::array<amrex::Real, 3> n{};
 
-	// if fvec has a inf component, set n to zero
-	bool has_inf = false;
+	// if fvec has a component with a large flux limiting violation, set n to zero
+	bool has_flux_limiting_violation = false;
+	const double large_flux_limiting_violation_threshold = 1.1;
 	for (int ii = 0; ii < 3; ++ii) {
-		if (fvec[ii] > 1.1) {
-			has_inf = true;
+		if (fvec[ii] > large_flux_limiting_violation_threshold) {
+			has_flux_limiting_violation = true;
 			break;
 		}
 	}
 
-	if (has_inf || (f <= f_floor)) {
+	if (has_flux_limiting_violation || (f <= f_floor)) {
 		n = {0.0, 0.0, 0.0};
 	} else {
 		for (int ii = 0; ii < 3; ++ii) {


### PR DESCRIPTION
### Description
Add safety check in ComputeEddingtonTensor to avoid FPE error:
1. Check for large flux limiting violation: `if (fvec[ii] > 2.0) { # set n = 0.0 }`
2. set `f_floor = 1e-10` and `if (f <= f_floor) { # set n = 0.0 }`

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
