### PR TITLE
update Setonix script to use ROCm 6.3

### DIFF
--- a/scripts/setonix-1node.submit
+++ b/scripts/setonix-1node.submit
@@ -11,6 +11,9 @@
 ##SBATCH --core-spec=8
 #SBATCH -N 1
 
+# *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
+. scripts/setonix-gpu.profile
+
 # multi-node MPI communication will hang without this (memhooks does NOT work)
 export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 

--- a/scripts/setonix-64nodes.submit
+++ b/scripts/setonix-64nodes.submit
@@ -25,6 +25,9 @@
 #
 # [job hangs here]
 
+# *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
+. scripts/setonix-gpu.profile
+
 # multi-node MPI communication will hang without this (memhooks does NOT work)
 export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 

--- a/scripts/setonix-8nodes.submit
+++ b/scripts/setonix-8nodes.submit
@@ -11,6 +11,9 @@
 ##SBATCH --core-spec=8
 #SBATCH -N 8
 
+# *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
+. scripts/setonix-gpu.profile
+
 # multi-node MPI communication will hang without this (memhooks does NOT work)
 export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
 

--- a/scripts/setonix-gpu.profile
+++ b/scripts/setonix-gpu.profile
@@ -1,27 +1,29 @@
 #!/bin/bash
 
-## NOTE: CCE and ROCm versions must match according to this table:
-##  https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#compatible-compiler-rocm-toolchain-versions
-## These are matching versions: cce 17.0.0 <--> cpe 23.12 <--> rocm 5.7.1
+source /opt/cray/pe/cpe/24.11/restore_lmod_system_defaults.sh
 
-source /opt/cray/pe/cpe/23.12/restore_lmod_system_defaults.sh
+module load cpe/24.11
+module load pawseyenv/2025.03
 
 module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
 
-module load rocm/5.7.1 # matches cce/17 clang version
+module load rocm/6.3.2 # MUST use this version to avoid compiler bugs
 module load cray-mpich
-module load cce/17.0.0
+module load cce/18.0.1
 
 # hdf5
 module load cray-hdf5
 
-# python
-module load cray-python/3.11.5
+# adios2 (optional)
+module load adios2/2.10.2-hdf5
 
-# cmake -- missing from cce/17.0.0 module environment!
-pip install cmake --user
+# python
+module load cray-python/3.11.7
+
+# cmake
+module load cmake/3.30.5
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
@@ -30,12 +32,14 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 export AMREX_AMD_ARCH=gfx90a
 
 # compiler environment hints
-export CC=$(which cc)
-export CXX=$(which CC)
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
 export FC=$(which ftn)
 
 # these flags are REQUIRED
-export CFLAGS="-I${ROCM_PATH}/include -Wno-#warnings -Wno-ignored-attributes"
-export CXXFLAGS="-I${ROCM_PATH}/include -Wno-pass-failed -Wno-#warnings -Wno-ignored-attributes"
-export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"
+export CFLAGS="-I${MPICH_DIR}/include"
+export CXXFLAGS="-I${MPICH_DIR}/include"
+export LDFLAGS="-L${MPICH_DIR}/lib -lmpi \
+  ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
+  ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}"
 export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH


### PR DESCRIPTION
### Description
This updates the Setonix configuration to use rocm/6.3.2, which avoids the compiler bugs that caused all the problems we saw on AMD GPUs before.

Example build:
```
source scripts/setonix-gpu.profile
mkdir build && cd build
cmake .. -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP
make -j32 my_favorite_problem
```

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
