### PR TITLE
A clean fix of the FPE issue on moth 

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -20,7 +20,7 @@ jobs:
     - task: CMake@1
       displayName: 'Configure CMake'
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_FLAGS=-ffp-exception-behavior=strict'
     
     - task: CMake@1
       displayName: 'Build Quokka'

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -64,7 +64,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
             -DCMAKE_CXX_STANDARD=17                       \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache          \
-            -DCMAKE_CXX_FLAGS=-stdlib=libc++
+            -DCMAKE_CXX_FLAGS="-ffp-exception-behavior=strict -stdlib=libc++"
         cmake --build build -j 2
 
         ccache -s

--- a/src/problems/SphericalCollapse/CMakeLists.txt
+++ b/src/problems/SphericalCollapse/CMakeLists.txt
@@ -4,10 +4,5 @@ if (AMReX_SPACEDIM EQUAL 3)
         setup_target_for_cuda_compilation(spherical_collapse)
     endif()
 
-    if(AMReX_GPU_BACKEND MATCHES "HIP")
-        # This test failed when compiled with HIP/ROCm on the moth computer with a FPE error: Erroneous arithmetic operation. This is likely due to a bug in the compiler, so we are disabling FPE checks for this test on moth.
-        add_test(NAME SphericalCollapse COMMAND spherical_collapse SphericalCollapse.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
-    else()
-        add_test(NAME SphericalCollapse COMMAND spherical_collapse SphericalCollapse.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
-    endif()
+    add_test(NAME SphericalCollapse COMMAND spherical_collapse SphericalCollapse.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -912,30 +912,16 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// AMREX_ASSERT(f < 1.0); // there is sometimes a small (<1%) flux
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
-	const double f = std::sqrt((fx * fx) + (fy * fy) + (fz * fz));
-	const std::array<amrex::Real, 3> fvec = {fx, fy, fz};
-	const double f_floor = 1e-10;
+	auto f = std::sqrt(fx * fx + fy * fy + fz * fz);
+	std::array<amrex::Real, 3> fvec = {fx, fy, fz};
 
 	// angle between interface and radiation flux \hat{n}
-	// If direction is undefined, just drop direction-dependent terms.
+	// If direction is undefined, just drop direction-dependent
+	// terms.
 	std::array<amrex::Real, 3> n{};
 
-	// if fvec has a component with a large flux limiting violation, set n to zero
-	bool has_flux_limiting_violation = false;
-	const double large_flux_limiting_violation_threshold = 1.1;
 	for (int ii = 0; ii < 3; ++ii) {
-		if (fvec[ii] > large_flux_limiting_violation_threshold) {
-			has_flux_limiting_violation = true;
-			break;
-		}
-	}
-
-	if (has_flux_limiting_violation || (f <= f_floor)) {
-		n = {0.0, 0.0, 0.0};
-	} else {
-		for (int ii = 0; ii < 3; ++ii) {
-			n[ii] = fvec[ii] / f;
-		}
+		n[ii] = (f > 0.) ? (fvec[ii] / f) : 0.;
 	}
 
 	// compute radiation pressure tensors


### PR DESCRIPTION
### Description
Clang might have changed its FPE behaviour recently and triggers an FPE on unused vector lanes. A clean solution is applied in this PR: add `-ffp-exception-behavior=strict` to `CMAKE_CXX_FLAGS` for Clang, just like what we did on macOS. See discussions in #921 . This reverts the previous change in calculation the radiation pressure and also bring back the SphericalCollapse test with FPE checks on moth. 

### Related issues
This PR reverts #921 . 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
