### PR TITLE
Allow creating multiple particle from one cell. 

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -66,8 +66,9 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 					const auto index = box.index(iv);
 
 					if (pcounts[index] > 0) {						  // NOLINT
-						auto &p = pdata[poffset[index]];				  // NOLINT
-						particle_creator(p, state_arr, i, j, k, dx, plo, poffset[index]); // NOLINT
+						const int num_particles = pcounts[index];                          // NOLINT
+						auto *particles = &pdata[poffset[index]];                          // NOLINT
+						particle_creator(particles, num_particles, state_arr, i, j, k, dx, plo, poffset[index]); // NOLINT
 					}
 				});
 			}
@@ -104,12 +105,12 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		}
 
 		template <typename ParticleType, typename StateArray>
-		AMREX_GPU_DEVICE void operator()(ParticleType &p, StateArray const &state_arr, int i, int j, int k,
+		AMREX_GPU_DEVICE void operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, int i, int j, int k,
 						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo, amrex::Long particle_offset) const
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo, amrex::Long base_offset) const
 		{
 			// Default implementation does nothing
-			amrex::ignore_unused(p, state_arr, i, j, k, dx, plo, particle_offset);
+			amrex::ignore_unused(particles, num_particles, state_arr, i, j, k, dx, plo, base_offset);
 		}
 	};
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -65,9 +65,9 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 					const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
 					const auto index = box.index(iv);
 
-					if (pcounts[index] > 0) {						  // NOLINT
-						const int num_particles = pcounts[index];                          // NOLINT
-						auto *particles = &pdata[poffset[index]];                          // NOLINT
+					if (pcounts[index] > 0) {									 // NOLINT
+						const int num_particles = pcounts[index];						 // NOLINT
+						auto *particles = &pdata[poffset[index]];						 // NOLINT
 						particle_creator(particles, num_particles, state_arr, i, j, k, dx, plo, poffset[index]); // NOLINT
 					}
 				});

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -35,7 +35,7 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 					const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
 					const auto index = box.index(iv);
 					// Check if we should create a particle at this location and time
-					pcounts[index] = particle_checker(state_arr, i, j, k, dx, current_time, dt) ? 1 : 0; // NOLINT
+					pcounts[index] = particle_checker(state_arr, i, j, k, dx, current_time, dt); // NOLINT
 				});
 
 				// Calculate exclusive prefix sum to get unique position for each particle
@@ -83,11 +83,11 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		AMREX_GPU_HOST_DEVICE ParticleChecker() = default;
 
 		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> bool
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> int
 		{
 			// Default implementation creates no particles
 			amrex::ignore_unused(state_arr, i, j, k, dx, current_time, dt);
-			return false;
+			return 0;
 		}
 	};
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -72,7 +72,7 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 		amrex::Real param2 = particle_param2;
 
 		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> bool
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> int
 		{
 			// A simple demonstration of particle creation
 			// Could check density threshold or other state-based conditions
@@ -80,8 +80,8 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 			const int spacing = 16;
 			const bool is_create_particle_1 = current_time <= param1 && current_time + dt > param1;
 			const bool is_create_particle_2 = current_time <= param2 && current_time + dt > param2;
-			return (is_create_particle_1 || is_create_particle_2) && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) &&
-			       (k != 0 && k % spacing == 0);
+			return ((is_create_particle_1 || is_create_particle_2) && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) &&
+			       (k != 0 && k % spacing == 0)) ? 1 : 0;
 		}
 	};
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -121,7 +121,7 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 
 				// Create all particles
 				for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
-					auto &p = particles[p_idx];
+					auto &p = particles[p_idx]; // NOLINT
 
 					// Set particle position (all at cell center for now)
 					p.pos(0) = plo[0] + (i + 0.5) * dx[0];

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -25,6 +25,8 @@
 struct BinaryOrbit {
 };
 
+constexpr int particle_per_cell = 2;
+
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	     // isothermal
 	static constexpr double cs_isothermal = 3.0; //
@@ -81,7 +83,7 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 			const bool is_create_particle_1 = current_time <= param1 && current_time + dt > param1;
 			const bool is_create_particle_2 = current_time <= param2 && current_time + dt > param2;
 			return ((is_create_particle_1 || is_create_particle_2) && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) &&
-			       (k != 0 && k % spacing == 0)) ? 1 : 0;
+			       (k != 0 && k % spacing == 0)) ? particle_per_cell : 0;
 		}
 	};
 
@@ -100,32 +102,42 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 		}
 
 		template <typename ParticleType, typename StateArray>
-		AMREX_GPU_DEVICE void operator()(ParticleType &p, StateArray const &state_arr, int i, int j, int k,
+		AMREX_GPU_DEVICE void operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, int i, int j, int k,
 						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo, amrex::Long particle_offset) const
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo, amrex::Long base_offset) const
 		{
-			// A simple demonstration of particle creation
 			if (mass_idx + 3 < ParticleType::NReal) {
-				p.pos(0) = plo[0] + (i + 0.5) * dx[0];
-				p.pos(1) = plo[1] + (j + 0.5) * dx[1];
-				p.pos(2) = plo[2] + (k + 0.5) * dx[2];
-
-				// Set particle ID and CPU
-				p.id() = pid_start + particle_offset;
-				p.cpu() = cpu_id;
-
-				// Set particle mass and velocities
+				// Calculate common values for all particles
 				const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
 				const amrex::Real cell_mass = cell_density * cell_volume;
-
-				// Initialize particle properties
-				p.rdata(mass_idx) = 0.5 * cell_mass;
-				p.rdata(mass_idx + 1) = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
-				p.rdata(mass_idx + 2) = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
-				p.rdata(mass_idx + 3) = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
-
-				// Update cell density (remove mass that was given to particle)
+				const amrex::Real particle_mass = 0.5 * cell_mass / num_particles; // Divide mass among particles
+				
+				const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
+				const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
+				const amrex::Real vz = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
+				
+				// Create all particles
+				for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
+					auto &p = particles[p_idx];
+					
+					// Set particle position (all at cell center for now)
+					p.pos(0) = plo[0] + (i + 0.5) * dx[0];
+					p.pos(1) = plo[1] + (j + 0.5) * dx[1];
+					p.pos(2) = plo[2] + (k + 0.5) * dx[2];
+					
+					// Set particle ID and CPU
+					p.id() = pid_start + base_offset + p_idx;
+					p.cpu() = cpu_id;
+					
+					// Initialize particle properties
+					p.rdata(mass_idx) = particle_mass;
+					p.rdata(mass_idx + 1) = vx;
+					p.rdata(mass_idx + 2) = vy;
+					p.rdata(mass_idx + 3) = vz;
+				}
+				
+				// Update cell density (remove mass that was given to particles)
 				state_arr(i, j, k, HydroSystem<problem_t>::density_index) = 0.5 * cell_density;
 			}
 		}
@@ -218,7 +230,7 @@ auto problem_main() -> int
 	double position_error = 0.0;
 	double position_norm = 0.0;
 
-	const int n_particle_expect = 2 + (3 * 3 * 3) * 2; // 2 particles from the initial condition, (3*3*3)*2 particles from the creator
+	const int n_particle_expect = 2 + (3 * 3 * 3) * 2 * particle_per_cell; // 2 particles from the initial condition, (3*3*3)*2 particles from the creator
 
 	int status = 0; // Initialize to success
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -83,7 +83,9 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 			const bool is_create_particle_1 = current_time <= param1 && current_time + dt > param1;
 			const bool is_create_particle_2 = current_time <= param2 && current_time + dt > param2;
 			return ((is_create_particle_1 || is_create_particle_2) && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) &&
-			       (k != 0 && k % spacing == 0)) ? particle_per_cell : 0;
+				(k != 0 && k % spacing == 0))
+				   ? particle_per_cell
+				   : 0;
 		}
 	};
 
@@ -112,31 +114,31 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
 				const amrex::Real cell_mass = cell_density * cell_volume;
 				const amrex::Real particle_mass = 0.5 * cell_mass / num_particles; // Divide mass among particles
-				
+
 				const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
 				const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
 				const amrex::Real vz = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
-				
+
 				// Create all particles
 				for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
 					auto &p = particles[p_idx];
-					
+
 					// Set particle position (all at cell center for now)
 					p.pos(0) = plo[0] + (i + 0.5) * dx[0];
 					p.pos(1) = plo[1] + (j + 0.5) * dx[1];
 					p.pos(2) = plo[2] + (k + 0.5) * dx[2];
-					
+
 					// Set particle ID and CPU
 					p.id() = pid_start + base_offset + p_idx;
 					p.cpu() = cpu_id;
-					
+
 					// Initialize particle properties
 					p.rdata(mass_idx) = particle_mass;
 					p.rdata(mass_idx + 1) = vx;
 					p.rdata(mass_idx + 2) = vy;
 					p.rdata(mass_idx + 3) = vz;
 				}
-				
+
 				// Update cell density (remove mass that was given to particles)
 				state_arr(i, j, k, HydroSystem<problem_t>::density_index) = 0.5 * cell_density;
 			}


### PR DESCRIPTION
### Description

Previously, `particle_checker` returns a boolean, which means each cell creates 0 or 1 particle at a time. This PR allows creating multiple particles from a cell at a time. 

Changes:
- `particle_checker` now returns an integer instead of a bool.
- `particle_creator` now takes a pointer to particles and `num_particles`, and create `num_particles` particles at one call. 
- Updated `gravity_3d.cpp` problem to test this. Two particles are created from each cell at a timestep and the total number of particles is compared to the expect one in the end of the simulation. 

#### Alternatives

Keep the original `createParticlesImpl` (or rename it to `createSingleParticleImpl`) and add  a new `createMultiParticlesImpl` to allow creating multiple particles from a cell. Then, depending on the particle types, you use the proper implementation. For example, StellarParticle would use `createSingleParticleImpl` and StellarPopulationParticle would use `createSingleParticleImpl`. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
