### PR TITLE
Make metadata.yaml structured and add Fields.yaml in particle plotfile

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -346,25 +346,25 @@ template <typename problem_t> void AMRSimulation<problem_t>::initializeSimulatio
 		// if unit system is CONSTANTS, the units are not well defined unless all four constants, G, k_B, c, and a_rad, are defined. However, in a hydro
 		// simulation, only k_B is defined. In a radiation-hydrodynamics simulation, only k_B, c, and a_rad are defined. Besides, CONSTANTS is only used
 		// for testing purposes, so we don't care about the units in that case.
-		simulationMetadata_["unit_length"] = NAN;
-		simulationMetadata_["unit_mass"] = NAN;
-		simulationMetadata_["unit_time"] = NAN;
-		simulationMetadata_["unit_temperature"] = NAN;
+		simulationMetadata_["units"]["unit_length"] = NAN;
+		simulationMetadata_["units"]["unit_mass"] = NAN;
+		simulationMetadata_["units"]["unit_time"] = NAN;
+		simulationMetadata_["units"]["unit_temperature"] = NAN;
 
 		// constants
-		simulationMetadata_["k_B"] = Physics_Traits<problem_t>::boltzmann_constant;
-		simulationMetadata_["G"] = Physics_Traits<problem_t>::gravitational_constant;
+		simulationMetadata_["constants"]["k_B"] = Physics_Traits<problem_t>::boltzmann_constant;
+		simulationMetadata_["constants"]["G"] = Physics_Traits<problem_t>::gravitational_constant;
 		if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-			simulationMetadata_["c"] = Physics_Traits<problem_t>::c_light;
-			simulationMetadata_["c_hat"] = Physics_Traits<problem_t>::c_light * RadSystem_Traits<problem_t>::c_hat_over_c;
-			simulationMetadata_["a_rad"] = Physics_Traits<problem_t>::radiation_constant;
+			simulationMetadata_["constants"]["c"] = Physics_Traits<problem_t>::c_light;
+			simulationMetadata_["constants"]["c_hat"] = Physics_Traits<problem_t>::c_light * RadSystem_Traits<problem_t>::c_hat_over_c;
+			simulationMetadata_["constants"]["a_rad"] = Physics_Traits<problem_t>::radiation_constant;
 		}
 	} else {
 		// units
-		simulationMetadata_["unit_length"] = unit_length;
-		simulationMetadata_["unit_mass"] = unit_mass;
-		simulationMetadata_["unit_time"] = unit_time;
-		simulationMetadata_["unit_temperature"] = unit_temperature;
+		simulationMetadata_["units"]["unit_length"] = unit_length;
+		simulationMetadata_["units"]["unit_mass"] = unit_mass;
+		simulationMetadata_["units"]["unit_time"] = unit_time;
+		simulationMetadata_["units"]["unit_temperature"] = unit_temperature;
 
 		// constants
 		double k_B = NAN;
@@ -376,12 +376,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::initializeSimulatio
 			      (Physics_Traits<problem_t>::unit_length * Physics_Traits<problem_t>::unit_length * Physics_Traits<problem_t>::unit_mass /
 			       (Physics_Traits<problem_t>::unit_time * Physics_Traits<problem_t>::unit_time) / Physics_Traits<problem_t>::unit_temperature);
 		}
-		simulationMetadata_["k_B"] = k_B;
-		simulationMetadata_["G"] = Gconst_;
+		simulationMetadata_["constants"]["k_B"] = k_B;
+		simulationMetadata_["constants"]["G"] = Gconst_;
 		if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-			simulationMetadata_["c"] = RadSystem<problem_t>::c_light_;
-			simulationMetadata_["c_hat"] = RadSystem<problem_t>::c_hat_;
-			simulationMetadata_["a_rad"] = RadSystem<problem_t>::radiation_constant_;
+			simulationMetadata_["constants"]["c"] = RadSystem<problem_t>::c_light_;
+			simulationMetadata_["constants"]["c_hat"] = RadSystem<problem_t>::c_hat_;
+			simulationMetadata_["constants"]["a_rad"] = RadSystem<problem_t>::radiation_constant_;
 		}
 	}
 }

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <fstream>
 
 #include "AMReX_Array4.H"
 #include "AMReX_MultiFab.H"
@@ -70,6 +71,7 @@ class PhysicsParticleDescriptorBase
 	virtual void redistribute(int lev, int ngrow) = 0;
 	virtual void writePlotFile(const std::string &plotfilename, const std::string &name) = 0;
 	virtual void writeCheckpoint(const std::string &checkpointname, const std::string &name, bool include_header) = 0;
+	virtual void writeUnitsFile(const std::string &snapshot_name, const std::string &name) = 0;
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
@@ -402,6 +404,40 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			container_->Checkpoint(checkpointname, name, include_header);
 		}
 	}
+
+	// Implementation of particle data output to units file
+	void writeUnitsFile(const std::string &snapshot_name, const std::string &name) override
+	{
+		if (container_ != nullptr) {
+			// Only write on rank 0
+			if (amrex::ParallelDescriptor::IOProcessor()) {
+				// Create the full path for the Fields.yaml file
+				std::string filename = snapshot_name + "/" + name + "/Fields.yaml";
+				
+				// Open the file for writing
+				std::ofstream outFile(filename);
+				if (!outFile) {
+					amrex::Abort("Error opening file for writing: " + filename);
+				}
+
+				// Get the units data for this particle type
+				const auto &typeData = quokka::units_data[particleType_];
+				if (!typeData.empty()) {
+					outFile << "# field: [M, L, T, Θ]\n";
+					// Write each field's units to the YAML file
+					for (const auto &[fieldName, units] : typeData[0]) {
+						outFile << fieldName << ": [" 
+							<< units[0] << ", " 
+							<< units[1] << ", " 
+							<< units[2] << ", " 
+							<< units[3] << "]\n";
+					}
+				}
+				
+				outFile.close();
+			}
+		}
+	}
 };
 
 // Registry managing different types of physics particles
@@ -525,6 +561,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			descriptor->writePlotFile(plotfilename, getParticleTypeName(type));
+			descriptor->writeUnitsFile(plotfilename, getParticleTypeName(type));
 		}
 	}
 
@@ -533,6 +570,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			descriptor->writeCheckpoint(checkpointname, getParticleTypeName(type), include_header);
+			descriptor->writeUnitsFile(checkpointname, getParticleTypeName(type));
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -2,10 +2,10 @@
 #define PHYSICS_PARTICLES_HPP_
 
 #include <cstdint>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <string>
-#include <fstream>
 
 #include "AMReX_Array4.H"
 #include "AMReX_MultiFab.H"
@@ -413,7 +413,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				// Create the full path for the Fields.yaml file
 				std::string filename = snapshot_name + "/" + name + "/Fields.yaml";
-				
+
 				// Open the file for writing
 				std::ofstream outFile(filename);
 				if (!outFile) {
@@ -426,14 +426,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 					outFile << "# field: [M, L, T, Θ]\n";
 					// Write each field's units to the YAML file
 					for (const auto &[fieldName, units] : typeData[0]) {
-						outFile << fieldName << ": [" 
-							<< units[0] << ", " 
-							<< units[1] << ", " 
-							<< units[2] << ", " 
-							<< units[3] << "]\n";
+						outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
 					}
 				}
-				
+
 				outFile.close();
 			}
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -421,7 +421,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				}
 
 				// Get the units data for this particle type
-				const auto &typeData = quokka::units_data[particleType_];
+				const auto &typeData = quokka::get_units_data().at(particleType_);
 				if (!typeData.empty()) {
 					outFile << "# field: [M, L, T, Θ]\n";
 					// Write each field's units to the YAML file

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -415,7 +415,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				std::string filename;
 #ifdef QUOKKA_USE_OPENPMD
 				// For OpenPMD, write the YAML file alongside the OpenPMD file
-				filename = snapshot_name + ".yaml";
+				filename = snapshot_name + "_" + name + ".yaml";
 #else
 				// For standard output, write the YAML file in the particle directory
 				filename = snapshot_name + "/" + name + "/Fields.yaml";

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -412,7 +412,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			// Only write on rank 0
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				// Create the full path for the Fields.yaml file
-				std::string filename = snapshot_name + "/" + name + "/Fields.yaml";
+				const std::string filename = snapshot_name + "/" + name + "/Fields.yaml";
 				
 				// Open the file for writing
 				std::ofstream outFile(filename);

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -412,7 +412,14 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			// Only write on rank 0
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				// Create the full path for the Fields.yaml file
-				const std::string filename = snapshot_name + "/" + name + "/Fields.yaml";
+				std::string filename;
+#ifdef QUOKKA_USE_OPENPMD
+				// For OpenPMD, write the YAML file alongside the OpenPMD file
+				filename = snapshot_name + ".yaml";
+#else
+				// For standard output, write the YAML file in the particle directory
+				filename = snapshot_name + "/" + name + "/Fields.yaml";
+#endif
 
 				// Open the file for writing
 				std::ofstream outFile(filename);

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -153,11 +153,14 @@ template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICR
 #endif // AMREX_SPACEDIM == 3
 
 // Units data for each particle type as powers of Mass, Length, Time, Temperature
-std::map<ParticleType, std::vector<std::map<std::string, std::array<int, 4>>>> units_data = {
-	{ParticleType::Rad, {{{"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
-	{ParticleType::CIC, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
-	{ParticleType::CICRad, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
-};
+inline auto get_units_data() -> const auto& {
+	static const auto units_data = std::map<ParticleType, std::vector<std::map<std::string, std::array<int, 4>>>>{
+		{ParticleType::Rad, {{{"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
+		{ParticleType::CIC, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
+		{ParticleType::CICRad, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}}
+	};
+	return units_data;
+}
 
 // Assumptions for any particle type:
 // 1. For massive particles, velocity components start after mass

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -152,6 +152,13 @@ template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICR
 
 #endif // AMREX_SPACEDIM == 3
 
+// Units data for each particle type as powers of Mass, Length, Time, Temperature
+std::map<ParticleType, std::vector<std::map<std::string, std::array<int, 4>>>> units_data = {
+	{ParticleType::Rad, {{{"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
+	{ParticleType::CIC, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
+	{ParticleType::CICRad, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
+};
+
 // Assumptions for any particle type:
 // 1. For massive particles, velocity components start after mass
 // 2. Birth time, if existing, is always followed by death time

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -154,9 +154,16 @@ template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICR
 
 // Units data for each particle type as powers of Mass, Length, Time, Temperature
 std::map<ParticleType, std::vector<std::map<std::string, std::array<int, 4>>>> units_data = {
-	{ParticleType::Rad, {{{"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
-	{ParticleType::CIC, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
-	{ParticleType::CICRad, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
+    {ParticleType::Rad, {{{"birth_time", {0, 0, 1, 0}}, {"death_time", {0, 0, 1, 0}}, {"luminosity", {-1, 2, -3, 0}}}}},
+    {ParticleType::CIC, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
+    {ParticleType::CICRad,
+     {{{"mass", {1, 0, 0, 0}},
+       {"vx", {0, 1, -1, 0}},
+       {"vy", {0, 1, -1, 0}},
+       {"vz", {0, 1, -1, 0}},
+       {"birth_time", {0, 0, 1, 0}},
+       {"death_time", {0, 0, 1, 0}},
+       {"luminosity", {-1, 2, -3, 0}}}}},
 };
 
 // Assumptions for any particle type:

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -227,8 +227,8 @@ template <> void QuokkaSimulation<ShockCloud>::computeAfterTimestep()
 		const Real vx_cm = xmom / cloud_mass;
 
 		// save cumulative position, velocity offsets in simulationMetadata_
-		const Real delta_x_prev = std::get<Real>(simulationMetadata_["delta_x"]);
-		const Real delta_vx_prev = std::get<Real>(simulationMetadata_["delta_vx"]);
+		const Real delta_x_prev = simulationMetadata_["delta_x"].as<Real>();
+		const Real delta_vx_prev = simulationMetadata_["delta_vx"].as<Real>();
 		const Real delta_x = delta_x_prev + dt_coarse * delta_vx_prev;
 		const Real delta_vx = delta_vx_prev + vx_cm;
 		simulationMetadata_["delta_x"] = delta_x;
@@ -457,13 +457,13 @@ template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<s
 	std::map<std::string, amrex::Real> stats;
 
 	// save time
-	const Real t_cc = std::get<Real>(simulationMetadata_["t_cc"]);
+	const Real t_cc = simulationMetadata_["t_cc"].as<Real>();
 	const Real time = tNew_[0];
 	stats["t_over_tcc"] = time / t_cc;
 
 	// save cloud position, velocity
-	const Real dx_cgs = std::get<Real>(simulationMetadata_["delta_x"]);
-	const Real dvx_cgs = std::get<Real>(simulationMetadata_["delta_vx"]);
+	const Real dx_cgs = simulationMetadata_["delta_x"].as<Real>();
+	const Real dvx_cgs = simulationMetadata_["delta_vx"].as<Real>();
 	const Real v_wind = ::v_wind;
 
 	stats["delta_x"] = dx_cgs / parsec_in_cm;	 // pc

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -176,7 +176,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real densityFloor_ = 0.0; // default
 	amrex::Real tempFloor_ = 0.0;	 // default
 
-	std::unordered_map<std::string, variant_t> simulationMetadata_;
+	YAML::Node simulationMetadata_;
 
 	// constructor
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }
@@ -2522,20 +2522,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 			amrex::FileOpenFailed(MetadataFileName);
 		}
 
-		// construct YAML from each (key, value) of simulationMetadata_
-		YAML::Emitter out;
-		out << YAML::BeginMap;
-		auto PrintVisitor = [&out](const auto &t) { out << YAML::Value << t; };
-		for (auto const &[key, value] : simulationMetadata_) {
-			out << YAML::Key << key;
-			std::visit(PrintVisitor, value);
-		}
-		out << YAML::EndMap;
-
 		// write YAML to MetadataFile
-		// (N.B. yaml-cpp is smart enough to emit sufficient digits for
-		//  floating-point types to represent their values to machine precision!)
-		MetadataFile << out.c_str() << '\n';
+		MetadataFile << simulationMetadata_ << '\n';
 	}
 }
 

--- a/tests/Gravity3D.in
+++ b/tests/Gravity3D.in
@@ -25,8 +25,8 @@ do_subcycle = 0
 suppress_output = 0
 
 stop_time = 5.0
-plotfile_interval = -1
-checkpoint_interval = -1
+plotfile_interval = 3
+checkpoint_interval = 3
 
 particles.param1 = 0.0005 # create particles at this time, which is step 0
 particles.param2 = 0.0025 # create particles at this time, which is step 2
@@ -34,3 +34,6 @@ particles.param3 = 0.0015 # destroy particles at this time, which is step 1
 particles.verbose = 1
 
 max_timesteps = 3
+
+#restartfile = chk00003
+#max_timesteps = 6


### PR DESCRIPTION
### Description

Changes:

1. The metadata.yaml file now has nested structure for better readability. e.g.

```yaml
git_hash_quokka: bc8f153da813c76784fac37a91002d631e5dc3c1-dirty
git_hash_amrex: 06b4a5b105f5aebe66b987194fc9b5c207fae5ff
units:
  unit_length: .nan
  unit_mass: .nan
  unit_time: .nan
  unit_temperature: .nan
constants:
  k_B: 1
  G: 1
```

2. Added a `Fields.yaml` file in each particle folder inside the checkpoint and plotfile directories. This gives the field names and their units. e.g., chk00003/CIC_particles/Fields.yaml:

```yaml
# field: [M, L, T, Θ]
mass: [1, 0, 0, 0]
vx: [0, 1, -1, 0]
vy: [0, 1, -1, 0]
vz: [0, 1, -1, 0]
```

The numbers in the bracket give the powers of the unit mass, length, time, and temperature. For instance, the unit of`vx` would be `unit_length * unit_time^-1` in the example above. This will be used by the yt Quokka frontend that Rongjun and I wrote (releasing soon).

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
