### PR TITLE
[WIP] add TypeSanitizer CI action

### DIFF
--- a/.github/workflows/typesanitizer.yml
+++ b/.github/workflows/typesanitizer.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
-    - name: Install Clang/LLVM
-      run: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+    - name: Install Clang/LLVM 20.x
+      run: wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 20
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/typesanitizer.yml
+++ b/.github/workflows/typesanitizer.yml
@@ -39,7 +39,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
     - name: Install Clang/LLVM
-      run: bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+      run: sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/typesanitizer.yml
+++ b/.github/workflows/typesanitizer.yml
@@ -45,7 +45,7 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env: {CXXFLAGS: "-ffp-exception-behavior=strict -fsanitize=type -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"}
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/typesanitizer.yml
+++ b/.github/workflows/typesanitizer.yml
@@ -1,0 +1,71 @@
+name: TypeSanitizer
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ development ]
+  merge_group:
+    branches: [ development ]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-TypeSanitizer
+  cancel-in-progress: true
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: RelWithDebInfo
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: true
+        fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
+
+    - name: Install Clang/LLVM
+      run: bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      env: {CXXFLAGS: "-ffp-exception-behavior=strict -fsanitize=type -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls""}
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE --parallel 4
+
+    - name: Create test output directory
+      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: TYSAN_OPTIONS=print_stacktrace=1 ctest --output-on-failure -C $BUILD_TYPE -j4
+
+    - name: Upload test output
+      if: always()
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      with:
+        name: test-results
+        path: ${{github.workspace}}/tests

--- a/.github/workflows/typesanitizer.yml
+++ b/.github/workflows/typesanitizer.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      env: {CXXFLAGS: "-ffp-exception-behavior=strict -fsanitize=type -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls""}
+      env: {CXXFLAGS: "-ffp-exception-behavior=strict -fsanitize=type -fno-omit-frame-pointer -g -O1 -fno-optimize-sibling-calls"}
       run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
 
     - name: Build


### PR DESCRIPTION
### Description
This adds a Github Action that compiles and runs the test suite using Clang's [TypeSanitizer](https://releases.llvm.org/20.1.0/tools/clang/docs/TypeSanitizer.html).

Note that there is currently a significant [list of false positives](https://github.com/llvm/llvm-project/issues?q=is%3Aissue%20state%3Aopen%20TySan%20label%3Acompiler-rt%3Atysan).
 
**TODO:**
* add ccache support
* need to suppress false positives: https://github.com/llvm/llvm-project/issues/122470

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
