### PR TITLE
add OpenPMD CI action

### DIFF
--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -58,7 +58,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -C $BUILD_TYPE -j4 HydroBlast3D
+      run: ctest --output-on-failure -R HydroBlast3D
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -42,13 +42,13 @@ jobs:
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DQUOKKA_OPENPMD=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAMReX_SPACEDIM=3 -DQUOKKA_OPENPMD=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --parallel 4
+      run: cmake --build . --config $BUILD_TYPE --parallel 4 --target test_hydro3d_blast
 
     - name: Create test output directory
       run: cmake -E make_directory $GITHUB_WORKSPACE/tests
@@ -58,7 +58,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -C $BUILD_TYPE -j4
+      run: ctest --output-on-failure -C $BUILD_TYPE -j4 HydroBlast3D
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -50,15 +50,10 @@ jobs:
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE --parallel 4 --target test_hydro3d_blast
 
-    - name: Create test output directory
-      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
-
-    - name: Test
-      working-directory: ${{runner.workspace}}/build
+    - name: Run
+      working-directory: ${{runner.workspace}}/tests
       shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -R HydroBlast3D
+      run: mpirun ../build/src/problems/HydroBlast3D/test_hydro3d_blast blast_32.in max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=100
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -51,9 +51,9 @@ jobs:
       run: cmake --build . --config $BUILD_TYPE --parallel 4 --target test_hydro3d_blast
 
     - name: Run
-      working-directory: ${{runner.workspace}}/tests
+      working-directory: ${{github.workspace}}/tests
       shell: bash
-      run: mpirun ../build/src/problems/HydroBlast3D/test_hydro3d_blast blast_32.in max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=100
+      run: mpirun $RUNNER_WORKSPACE/build/src/problems/HydroBlast3D/test_hydro3d_blast blast_32.in max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=100
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -1,0 +1,68 @@
+name: OpenPMD
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ development ]
+  merge_group:
+    branches: [ development ]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-openpmd-linux
+  cancel-in-progress: true
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: true
+
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev libadios2-mpi-c++11-dev
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DQUOKKA_OPENPMD=ON
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE --parallel 4
+
+    - name: Create test output directory
+      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute tests defined by the CMake configuration.  
+      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+      run: ctest --output-on-failure -C $BUILD_TYPE -j4
+
+    - name: Upload test output
+      if: always()
+      uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+      with:
+        name: test-results
+        path: ${{github.workspace}}/tests


### PR DESCRIPTION
### Description
This adds a Github action to test and run with OpenPMD plotfile output for the HydroBlast3D problem. This is just to ensure that we don't inadvertently break the OpenPMD output code path.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
