### PR TITLE
Add Stellar Evolution attribute and SNDeposition

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -467,9 +467,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				// Get the units data for this particle type
 				const auto &unitsData = quokka::get_units_data();
 				if (unitsData.find(particleType_) == unitsData.end()) {
-					amrex::Abort("Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
+					amrex::Abort(
+					    "Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
 				}
-				
+
 				const auto &typeData = unitsData.at(particleType_);
 				if (!typeData.empty()) {
 					outFile << "# field: [M, L, T, Θ]\n";

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -465,7 +465,12 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				}
 
 				// Get the units data for this particle type
-				const auto &typeData = quokka::get_units_data().at(particleType_);
+				const auto &unitsData = quokka::get_units_data();
+				if (unitsData.find(particleType_) == unitsData.end()) {
+					amrex::Abort("Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
+				}
+				
+				const auto &typeData = unitsData.at(particleType_);
 				if (!typeData.empty()) {
 					outFile << "# field: [M, L, T, Θ]\n";
 					// Write each field's units to the YAML file

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -441,6 +441,43 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			container_->Checkpoint(checkpointname, name, include_header);
 		}
 	}
+
+	// Implementation of particle data output to units file
+	void writeUnitsFile(const std::string &snapshot_name, const std::string &name) override
+	{
+		if (container_ != nullptr) {
+			// Only write on rank 0
+			if (amrex::ParallelDescriptor::IOProcessor()) {
+				// Create the full path for the Fields.yaml file
+				std::string filename;
+#ifdef QUOKKA_USE_OPENPMD
+				// For OpenPMD, write the YAML file alongside the OpenPMD file
+				filename = snapshot_name + "_" + name + ".yaml";
+#else
+				// For standard output, write the YAML file in the particle directory
+				filename = snapshot_name + "/" + name + "/Fields.yaml";
+#endif
+
+				// Open the file for writing
+				std::ofstream outFile(filename);
+				if (!outFile) {
+					amrex::Abort("Error opening file for writing: " + filename);
+				}
+
+				// Get the units data for this particle type
+				const auto &typeData = quokka::get_units_data().at(particleType_);
+				if (!typeData.empty()) {
+					outFile << "# field: [M, L, T, Θ]\n";
+					// Write each field's units to the YAML file
+					for (const auto &[fieldName, units] : typeData[0]) {
+						outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
+					}
+				}
+
+				outFile.close();
+			}
+		}
+	}
 };
 
 // New class for star particles that adds stellar evolution capabilities

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -78,7 +78,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
-	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{ /* Default empty implementation */
 	}
 	virtual void driftParticles(int lev, amrex::Real dt) const = 0;
@@ -456,18 +456,18 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 
 #if AMREX_SPACEDIM == 3
 	// Implementation of supernova energy and momentum deposition from particles to grid
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time) override
 	{
 		if (this->container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*this->container_, state, lev,
-					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
+					      SNDeposition{step_end_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
 							   this->getEvolutionStageIndex()},
 					      false);
 
 			// Update particle evolution stages after deposition
-			updateEvolutionStage(this->container_, lev, current_time, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
+			updateEvolutionStage(this->container_, lev, step_end_time, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
 		}
 	}
 #endif // AMREX_SPACEDIM == 3
@@ -597,11 +597,11 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Deposit supernova energy and momentum from all particles
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getEvolutionStageIndex() >= 0) {
-				descriptor->depositSN(state, lev, current_time);
+				descriptor->depositSN(state, lev, step_end_time);
 			}
 		}
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -350,7 +350,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	{
 		if (container_ != nullptr) {
 			ParticleDestructionTraits<particleType_>::template destroyParticles<problem_t, ContainerType>(container_, this->getMassIndex(), lev,
-														      current_time, dt);
+														      current_time, dt, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -35,12 +35,12 @@ class PhysicsParticleDescriptorBase
 	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
 	bool allowsCreation_{false};	 // Whether particles can be created during simulation
 	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
-	bool isSN_{false};		 // Whether particles end their life as supernovae
+	bool allowsStellarEvolution_{false};	 // Whether particles end their life as supernovae
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, bool is_sn = false)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, bool allows_stellar_evolution = false)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), interactsWithHydro_(hydro_interact), allowsCreation_(allows_creation),
-	      allowsDestruction_(allows_destruction), isSN_(is_sn)
+	      allowsDestruction_(allows_destruction), allowsStellarEvolution_(allows_stellar_evolution)
 	{
 	}
 
@@ -59,7 +59,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getInteractsWithHydro() const -> bool { return interactsWithHydro_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsCreation() const -> bool { return allowsCreation_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsDestruction() const -> bool { return allowsDestruction_; }
-	[[nodiscard]] AMREX_FORCE_INLINE auto isSN() const -> bool { return isSN_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto allowsStellarEvolution() const -> bool { return allowsStellarEvolution_; }
 
 	// Virtual interface for particle operations
 	[[nodiscard]] virtual auto getParticlePositions(int lev) const -> std::vector<std::array<double, AMREX_SPACEDIM>> = 0;
@@ -98,8 +98,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false, bool is_sn = false)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, is_sn), container_(container)
+				  bool allows_destruction = false, bool allows_stellar_evolution = false)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, allows_stellar_evolution), container_(container)
 	{
 	}
 
@@ -244,7 +244,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Implementation of supernova energy and momentum deposition from particles to grid
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
 	{
-		if (container_ != nullptr && this->isSN()) {
+		if (container_ != nullptr && this->allowsStellarEvolution()) {
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*container_, state, lev,
@@ -453,6 +453,8 @@ template <typename problem_t> class PhysicsParticleRegister
 				return "CIC_particles";
 			case ParticleType::CICRad:
 				return "CICRad_particles";
+			case ParticleType::Test:
+				return "Test_particles";
 			default:
 				return "Unknown_particles";
 		}
@@ -461,22 +463,25 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
 	void registerParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
-				  ContainerType *container, bool allows_destruction = false)
+				  ContainerType *container, bool allows_destruction = false, bool allows_stellar_evolution = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
+		} else if (type == ParticleType::Test) {
+			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -522,7 +527,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
-			if (descriptor->isSN()) {
+			if (descriptor->allowsStellarEvolution()) {
 				descriptor->depositSN(state, lev, current_time);
 			}
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -2,8 +2,8 @@
 #define PHYSICS_PARTICLES_HPP_
 
 #include <cstdint>
-#include <iomanip>
 #include <fstream>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <string>
@@ -87,9 +87,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::Real = 0;
 
 	// Methods that are implemented for some but not all particle types, so they cannot be pure virtual
-	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
-	{ /* Default empty implementation */
-	}
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time) { /* Default empty implementation */ }
 #endif // AMREX_SPACEDIM == 3
 };
 
@@ -451,8 +449,8 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 {
       public:
 	// Constructor - forwards all arguments to the base class
-	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container,
-			       bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
+	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container, bool allows_destruction = false,
+			       int evolution_stage_idx = -1, bool hydro_interact = false)
 	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, allows_creation, container,
 										allows_destruction, evolution_stage_idx, hydro_interact)
 	{

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -2,6 +2,7 @@
 #define PHYSICS_PARTICLES_HPP_
 
 #include <cstdint>
+#include <iomanip>
 #include <map>
 #include <memory>
 #include <string>
@@ -342,7 +343,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	{
 		// Use the traits class to implement the specialized behavior
 		ParticleCreationTraits<particleType_>::template createParticles<problem_t, ContainerType>(container_, this->getMassIndex(), state, lev,
-													  current_time, dt, this->getEvolutionStageIndex());
+													  current_time, dt, this->getEvolutionStageIndex(), this->getBirthTimeIndex());
 	}
 
 	void destroyParticles(int lev, amrex::Real current_time, amrex::Real dt) override
@@ -704,17 +705,32 @@ template <typename problem_t> class PhysicsParticleRegister
 	void printParticleStatistics() const
 	{
 		amrex::Print() << "Particle statistics:\n";
-		amrex::Print() << "Particle type, Number of particles\n";
+		amrex::Print() << std::left << std::setw(20) << "Particle type" << std::right << std::setw(15) << "Number of particles"
+			       << "\n";
+
 		for (const auto &[type, descriptor] : particleRegistry_) {
-			amrex::Print() << getParticleTypeName(type) << ", " << descriptor->getNumParticles() << "\n";
+			amrex::Print() << "\n";
+			amrex::Print() << std::left << std::setw(20) << getParticleTypeName(type) << std::right << std::setw(15)
+				       << descriptor->getNumParticles() << "\n";
+
 			// if has stellar evolution stage, print the mass and particle stage for all particles
 			if (descriptor->getEvolutionStageIndex() >= 0) {
-				amrex::Print() << "  Mass, Stellar evolution stage\n";
-				// use getParticleData to get the mass and evolution stage for all particles
 				const auto [real_data, int_data] = descriptor->getParticleData(0);
-				for (int i = 0; i < real_data.size(); ++i) {
-					amrex::Print() << "  " << real_data[i][AMREX_SPACEDIM + descriptor->getMassIndex()] << ", "
-						       << int_data[i][descriptor->getEvolutionStageIndex()] << "\n";
+
+				if (!real_data.empty()) {
+					// Print header for detailed particle data
+					amrex::Print() << "  " << std::left << std::setw(15) << "Mass"
+						       << " | " << std::right << std::setw(20) << "Stellar evolution stage"
+						       << "\n";
+					amrex::Print() << "  " << std::string(15 + 3 + 20, '-') << "\n";
+
+					// Print each particle's data with aligned columns
+					for (int i = 0; i < real_data.size(); ++i) {
+						amrex::Print()
+						    << "  " << std::left << std::setw(15) << real_data[i][AMREX_SPACEDIM + descriptor->getMassIndex()] << " | "
+						    << std::right << std::setw(20) << int_data[i][descriptor->getEvolutionStageIndex()] << "\n";
+					}
+					amrex::Print() << "\n"; // Add extra line for readability between particle types
 				}
 			}
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -38,7 +38,8 @@ class PhysicsParticleDescriptorBase
 	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, int evolution_stage_idx = -1)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false,
+				      int evolution_stage_idx = -1)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), interactsWithHydro_(hydro_interact), allowsCreation_(allows_creation),
 	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx)
 	{
@@ -99,7 +100,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
 				  bool allows_destruction = false, bool evolution_stage_idx = false)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, evolution_stage_idx), container_(container)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, evolution_stage_idx),
+	      container_(container)
 	{
 	}
 
@@ -248,7 +250,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*container_, state, lev,
-					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(), this->getEvolutionStageIndex()}, false);
+					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
+							   this->getEvolutionStageIndex()},
+					      false);
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -167,9 +167,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @param lev: level from which to get particles
 	// @return: vector of particle data on rank 0, empty vector on other ranks
-	[[nodiscard]] auto getParticleData(int lev) const -> std::vector<std::vector<double>> override
+	[[nodiscard]] auto getParticleData(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
-		std::vector<std::vector<double>> particle_data;
+		std::vector<std::vector<double>> real_data;
+		std::vector<std::vector<int>> int_data;
 
 		// All ranks must participate in copyParticles
 		if (container_ != nullptr) {
@@ -200,30 +201,55 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 					amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
 					amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
 
-					// Extract positions and real components from host data
+					// Check if particles have integer components
+					constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
+
+					// Pre-size vectors to avoid reallocations
+					real_data.reserve(np);
+					if constexpr (has_int_components) {
+						int_data.reserve(np);
+					}
+
+					// Extract positions, real components, and integer components from host data
 					for (int i = 0; i < np; ++i) {
 						const auto &p = pData_h[i];
-						std::vector<double> data;
+
+						// Process real data (positions and rdata)
+						std::vector<double> r_data;
 						// Pre-allocate to avoid reallocations
-						data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
+						r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 
 						// First add position components
 						for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-							data.push_back(p.pos(d));
+							r_data.push_back(p.pos(d));
 						}
 
 						// Then add all real components (mass, velocities, etc)
 						for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-							data.push_back(p.rdata(d));
+							r_data.push_back(p.rdata(d));
 						}
 
-						particle_data.push_back(std::move(data));
+						real_data.push_back(std::move(r_data));
+
+						// Process integer data (idata) only if particles have integer components
+						if constexpr (has_int_components) {
+							std::vector<int> i_data;
+							// Pre-allocate to avoid reallocations
+							i_data.reserve(ContainerType::ParticleType::NInt);
+
+							// Add all integer components
+							for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+								i_data.push_back(p.idata(d));
+							}
+
+							int_data.push_back(std::move(i_data));
+						}
 					}
 				}
 			}
 		}
 
-		return particle_data; // Empty vector on non-root ranks
+		return {real_data, int_data}; // Empty vectors on non-root ranks
 	}
 
 	// Get the number of particles in the container
@@ -684,6 +710,16 @@ template <typename problem_t> class PhysicsParticleRegister
 		amrex::Print() << "Particle type, Number of particles\n";
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			amrex::Print() << getParticleTypeName(type) << ", " << descriptor->getNumParticles() << "\n";
+			// if has stellar evolution stage, print the mass and particle stage for all particles
+			if (descriptor->getEvolutionStageIndex() >= 0) {
+				amrex::Print() << "  Mass, Stellar evolution stage\n";
+				// use getParticleData to get the mass and evolution stage for all particles
+				const auto [real_data, int_data] = descriptor->getParticleData(0);
+				for (int i = 0; i < real_data.size(); ++i) {
+					amrex::Print() << "  " << real_data[i][AMREX_SPACEDIM + descriptor->getMassIndex()] << ", "
+						       << int_data[i][descriptor->getEvolutionStageIndex()] << "\n";
+				}
+			}
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -66,7 +66,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getParticlePositions(int lev) const -> std::vector<std::array<double, AMREX_SPACEDIM>> = 0;
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getParticleData(int lev) const -> std::vector<std::vector<double>> = 0;
+	[[nodiscard]] virtual auto getParticleData(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Pure virtual methods that must be implemented by derived classes
 	virtual void depositRadiation(amrex::MultiFab &radEnergySource, int lev, amrex::Real current_time, int nGroups) = 0;
@@ -342,7 +342,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	{
 		// Use the traits class to implement the specialized behavior
 		ParticleCreationTraits<particleType_>::template createParticles<problem_t, ContainerType>(container_, this->getMassIndex(), state, lev,
-													  current_time, dt);
+													  current_time, dt, this->getEvolutionStageIndex());
 	}
 
 	void destroyParticles(int lev, amrex::Real current_time, amrex::Real dt) override
@@ -531,9 +531,6 @@ template <typename problem_t> class PhysicsParticleRegister
 			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
-		} else if (type == ParticleType::Test) {
-			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		}
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -77,7 +77,9 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
-	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) = 0;
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	{ /* Default empty implementation */
+	}
 	virtual void driftParticles(int lev, amrex::Real dt) const = 0;
 	virtual void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &acceleration) = 0;
 	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const = 0;
@@ -90,8 +92,10 @@ class PhysicsParticleDescriptorBase
 template <typename ContainerType, typename problem_t, ParticleType particleType> class PhysicsParticleDescriptor : public PhysicsParticleDescriptorBase
 {
       private:
-	ContainerType *container_{}; // Pointer to the actual particle container
 	static constexpr ParticleType particleType_ = particleType;
+
+      protected:
+	ContainerType *container_{}; // Pointer to the actual particle container - moved to protected
 
       public:
 	// Get the particle type
@@ -99,7 +103,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false, bool evolution_stage_idx = false)
+				  bool allows_destruction = false, int evolution_stage_idx = -1)
 	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, evolution_stage_idx),
 	      container_(container)
 	{
@@ -240,19 +244,6 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			// zero_out_input is false because we want to accumulate mass
 			// vol_weight is false because MassDeposition does the volume weighting
 			amrex::ParticleToMesh(*container_, rhs, 0, finest_lev, MassDeposition{Gconst, this->getMassIndex(), 0, 1}, false, false);
-		}
-	}
-
-	// Implementation of supernova energy and momentum deposition from particles to grid
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
-	{
-		if (container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
-			// zero_out_input is false because we want to accumulate supernova contributions
-			// vol_weight is false because SNDeposition does the volume weighting
-			amrex::ParticleToMesh(*container_, state, lev,
-					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
-							   this->getEvolutionStageIndex()},
-					      false);
 		}
 	}
 
@@ -423,6 +414,38 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 };
 
+// New class for star particles that adds stellar evolution capabilities
+template <typename ContainerType, typename problem_t, ParticleType particleType>
+class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, problem_t, particleType>
+{
+      public:
+	// Constructor - forwards all arguments to the base class
+	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
+			       bool allows_destruction = false, int evolution_stage_idx = -1)
+	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container,
+										allows_destruction, evolution_stage_idx)
+	{
+	}
+
+#if AMREX_SPACEDIM == 3
+	// Implementation of supernova energy and momentum deposition from particles to grid
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
+	{
+		if (this->container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
+			// zero_out_input is false because we want to accumulate supernova contributions
+			// vol_weight is false because SNDeposition does the volume weighting
+			amrex::ParticleToMesh(*this->container_, state, lev,
+					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
+							   this->getEvolutionStageIndex()},
+					      false);
+
+			// Update particle evolution stages after deposition
+			updateEvolutionStage(this->container_, lev, current_time, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
+		}
+	}
+#endif // AMREX_SPACEDIM == 3
+};
+
 // Registry managing different types of physics particles
 template <typename problem_t> class PhysicsParticleRegister
 {
@@ -467,7 +490,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
 	void registerParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
-				  ContainerType *container, bool allows_destruction = false, bool evolution_stage_idx = false)
+				  ContainerType *container, bool allows_destruction = false, int evolution_stage_idx = -1)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
@@ -489,7 +512,29 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
-			amrex::Abort("Unknown particle type");
+			amrex::Abort("Unknown particle type for physics particles");
+		}
+
+		particleRegistry_[type] = std::move(descriptor);
+	}
+
+	// Register a new star particle type with specified properties
+	// Star particles have additional stellar evolution capabilities including supernova feedback
+	template <typename ContainerType>
+	void registerStarParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
+				      ContainerType *container, bool allows_destruction = false, int evolution_stage_idx = -1)
+	{
+		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
+
+		// Create the appropriate star particle descriptor based on the particle type
+#if AMREX_SPACEDIM == 3
+		if (type == ParticleType::Test) {
+			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
+		}
+#endif // AMREX_SPACEDIM == 3
+		else {
+			amrex::Abort("Unknown particle type for star particles");
 		}
 
 		particleRegistry_[type] = std::move(descriptor);
@@ -531,7 +576,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
-			if (descriptor->allowsStellarEvolution()) {
+			if (descriptor->getEvolutionStageIndex() >= 0) {
 				descriptor->depositSN(state, lev, current_time);
 			}
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -78,7 +78,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
-	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{ /* Default empty implementation */
 	}
 	virtual void driftParticles(int lev, amrex::Real dt) const = 0;
@@ -456,18 +456,18 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 
 #if AMREX_SPACEDIM == 3
 	// Implementation of supernova energy and momentum deposition from particles to grid
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time) override
 	{
 		if (this->container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*this->container_, state, lev,
-					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
+					      SNDeposition{step_end_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
 							   this->getEvolutionStageIndex()},
 					      false);
 
 			// Update particle evolution stages after deposition
-			updateEvolutionStage(this->container_, lev, current_time, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
+			updateEvolutionStage(this->container_, lev, step_end_time, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
 		}
 	}
 #endif // AMREX_SPACEDIM == 3
@@ -542,6 +542,7 @@ template <typename problem_t> class PhysicsParticleRegister
 		particleRegistry_[type] = std::move(descriptor);
 	}
 
+#if AMREX_SPACEDIM == 3
 	// Register a new star particle type with specified properties
 	// Star particles have additional stellar evolution capabilities including supernova feedback
 	template <typename ContainerType>
@@ -551,18 +552,16 @@ template <typename problem_t> class PhysicsParticleRegister
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate star particle descriptor based on the particle type
-#if AMREX_SPACEDIM == 3
 		if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
-		}
-#endif // AMREX_SPACEDIM == 3
-		else {
+		} else {
 			amrex::Abort("Unknown particle type for star particles");
 		}
 
 		particleRegistry_[type] = std::move(descriptor);
 	}
+#endif // AMREX_SPACEDIM == 3
 
 	// Retrieve a particle descriptor by type
 	[[nodiscard]] auto getParticleDescriptor(ParticleType type) const -> const PhysicsParticleDescriptorBase *
@@ -597,11 +596,11 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Deposit supernova energy and momentum from all particles
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getEvolutionStageIndex() >= 0) {
-				descriptor->depositSN(state, lev, current_time);
+				descriptor->depositSN(state, lev, step_end_time);
 			}
 		}
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -39,10 +39,10 @@ class PhysicsParticleDescriptorBase
 	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false,
-				      int evolution_stage_idx = -1)
-	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), interactsWithHydro_(hydro_interact), allowsCreation_(allows_creation),
-	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false,
+				      int evolution_stage_idx = -1, bool hydro_interact = false)
+	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), allowsCreation_(allows_creation),
+	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx), interactsWithHydro_(hydro_interact)
 	{
 	}
 
@@ -105,9 +105,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	[[nodiscard]] static constexpr auto getParticleType() -> ParticleType { return particleType_; }
 
 	// Constructor initializing descriptor with container and particle properties
-	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false, int evolution_stage_idx = -1)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, evolution_stage_idx),
+	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container,
+				  bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, hydro_interact),
 	      container_(container)
 	{
 	}
@@ -344,15 +344,15 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const override
 	{
 		// Use the traits class to implement the specialized behavior
-		ParticleCreationTraits<particleType_>::template createParticles<problem_t, ContainerType>(container_, this->getMassIndex(), state, lev,
-													  current_time, dt, this->getEvolutionStageIndex(), this->getBirthTimeIndex());
+		ParticleCreationTraits<particleType_>::template createParticles<problem_t, ContainerType>(
+		    container_, this->getMassIndex(), state, lev, current_time, dt, this->getEvolutionStageIndex(), this->getBirthTimeIndex());
 	}
 
 	void destroyParticles(int lev, amrex::Real current_time, amrex::Real dt) override
 	{
 		if (container_ != nullptr) {
-			ParticleDestructionTraits<particleType_>::template destroyParticles<problem_t, ContainerType>(container_, this->getMassIndex(), lev,
-														      current_time, dt, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
+			ParticleDestructionTraits<particleType_>::template destroyParticles<problem_t, ContainerType>(
+			    container_, this->getMassIndex(), lev, current_time, dt, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
 		}
 	}
 
@@ -449,10 +449,10 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 {
       public:
 	// Constructor - forwards all arguments to the base class
-	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-			       bool allows_destruction = false, int evolution_stage_idx = -1)
-	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container,
-										allows_destruction, evolution_stage_idx)
+	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container,
+			       bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
+	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, allows_creation, container,
+										allows_destruction, evolution_stage_idx, hydro_interact)
 	{
 	}
 
@@ -464,8 +464,8 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*this->container_, state, lev,
-					      SNDeposition{step_end_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(),
-							   this->getEvolutionStageIndex()},
+					      SNDeposition{step_end_time, this->getMassIndex(), HydroSystem<problem_t>::density_index,
+							   this->getBirthTimeIndex(), this->getEvolutionStageIndex()},
 					      false);
 
 			// Update particle evolution stages after deposition
@@ -518,23 +518,23 @@ template <typename problem_t> class PhysicsParticleRegister
 
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
-	void registerParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
-				  ContainerType *container, bool allows_destruction = false, int evolution_stage_idx = -1)
+	void registerParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, bool allows_creation = false, int birth_time_idx = -1,
+				  bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -548,15 +548,15 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new star particle type with specified properties
 	// Star particles have additional stellar evolution capabilities including supernova feedback
 	template <typename ContainerType>
-	void registerStarParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
-				      ContainerType *container, bool allows_destruction = false, int evolution_stage_idx = -1)
+	void registerStarParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation = false,
+				      bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate star particle descriptor based on the particle type
 		if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
 		} else {
 			amrex::Abort("Unknown particle type for star particles");
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -35,12 +35,12 @@ class PhysicsParticleDescriptorBase
 	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
 	bool allowsCreation_{false};	 // Whether particles can be created during simulation
 	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
-	bool allowsStellarEvolution_{false};	 // Whether particles end their life as supernovae
+	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, bool allows_stellar_evolution = false)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, int evolution_stage_idx = -1)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), interactsWithHydro_(hydro_interact), allowsCreation_(allows_creation),
-	      allowsDestruction_(allows_destruction), allowsStellarEvolution_(allows_stellar_evolution)
+	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx)
 	{
 	}
 
@@ -59,7 +59,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getInteractsWithHydro() const -> bool { return interactsWithHydro_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsCreation() const -> bool { return allowsCreation_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsDestruction() const -> bool { return allowsDestruction_; }
-	[[nodiscard]] AMREX_FORCE_INLINE auto allowsStellarEvolution() const -> bool { return allowsStellarEvolution_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto getEvolutionStageIndex() const -> int { return evolutionStageIndex_; }
 
 	// Virtual interface for particle operations
 	[[nodiscard]] virtual auto getParticlePositions(int lev) const -> std::vector<std::array<double, AMREX_SPACEDIM>> = 0;
@@ -98,8 +98,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false, bool allows_stellar_evolution = false)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, allows_stellar_evolution), container_(container)
+				  bool allows_destruction = false, bool evolution_stage_idx = false)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, evolution_stage_idx), container_(container)
 	{
 	}
 
@@ -244,11 +244,11 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Implementation of supernova energy and momentum deposition from particles to grid
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
 	{
-		if (container_ != nullptr && this->allowsStellarEvolution()) {
+		if (container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
 			// zero_out_input is false because we want to accumulate supernova contributions
 			// vol_weight is false because SNDeposition does the volume weighting
 			amrex::ParticleToMesh(*container_, state, lev,
-					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex()}, false);
+					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex(), this->getEvolutionStageIndex()}, false);
 		}
 	}
 
@@ -463,25 +463,25 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
 	void registerParticleType(ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation,
-				  ContainerType *container, bool allows_destruction = false, bool allows_stellar_evolution = false)
+				  ContainerType *container, bool allows_destruction = false, bool evolution_stage_idx = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		} else if (type == ParticleType::Test) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
-			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, allows_stellar_evolution);
+			    mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, container, allows_destruction, evolution_stage_idx);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -78,14 +78,16 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
-	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
-	{ /* Default empty implementation */
-	}
 	virtual void driftParticles(int lev, amrex::Real dt) const = 0;
 	virtual void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &acceleration) = 0;
 	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const = 0;
 	virtual void destroyParticles(int lev, amrex::Real current_time, amrex::Real dt) = 0;
 	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::Real = 0;
+
+	// Methods that are implemented for some but not all particle types, so they cannot be pure virtual
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
+	{ /* Default empty implementation */
+	}
 #endif // AMREX_SPACEDIM == 3
 };
 
@@ -598,10 +600,10 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Deposit supernova energy and momentum from all particles
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{
-		for (const auto &[type, descriptor] : particleRegistry_) {
-			if (descriptor->getEvolutionStageIndex() >= 0) {
-				descriptor->depositSN(state, lev, step_end_time);
-			}
+		// this function is only implemented for one particle type (Test particles), so we specify the particle type manually here
+		auto it = particleRegistry_.find(ParticleType::Test);
+		if (it != particleRegistry_.end()) {
+			it->second->depositSN(state, lev, step_end_time);
 		}
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -34,10 +34,10 @@ class PhysicsParticleDescriptorBase
 	int massIndex_{-1};		 // Index for particle mass (-1 if not used)
 	int lumIndex_{-1};		 // Index for radiation luminosity (-1 if not used)
 	int birthTimeIndex_{-1};	 // Index for birth time (-1 if not used)
-	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
 	bool allowsCreation_{false};	 // Whether particles can be created during simulation
 	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
 	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
+	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
 
       public:
 	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false,
@@ -765,7 +765,7 @@ template <typename problem_t> class PhysicsParticleRegister
 					amrex::Print() << "  " << std::string(15 + 3 + 20, '-') << "\n";
 
 					// Print each particle's data with aligned columns
-					for (int i = 0; i < real_data.size(); ++i) {
+					for (int i = 0; i < static_cast<int>(real_data.size()); ++i) {
 						amrex::Print()
 						    << "  " << std::left << std::setw(15) << real_data[i][AMREX_SPACEDIM + descriptor->getMassIndex()] << " | "
 						    << std::right << std::setw(20) << int_data[i][descriptor->getEvolutionStageIndex()] << "\n";

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -12,6 +12,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 #include "AMReX_Vector.H"
+#include "hydro/hydro_system.hpp"
 #include "particle_creation.hpp"
 #include "particle_deposition.hpp"
 #include "particle_destruction.hpp"
@@ -34,11 +35,12 @@ class PhysicsParticleDescriptorBase
 	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
 	bool allowsCreation_{false};	 // Whether particles can be created during simulation
 	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
+	bool isSN_{false};		 // Whether particles end their life as supernovae
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, bool allows_destruction = false, bool is_sn = false)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), interactsWithHydro_(hydro_interact), allowsCreation_(allows_creation),
-	      allowsDestruction_(allows_destruction)
+	      allowsDestruction_(allows_destruction), isSN_(is_sn)
 	{
 	}
 
@@ -57,6 +59,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getInteractsWithHydro() const -> bool { return interactsWithHydro_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsCreation() const -> bool { return allowsCreation_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsDestruction() const -> bool { return allowsDestruction_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto isSN() const -> bool { return isSN_; }
 
 	// Virtual interface for particle operations
 	[[nodiscard]] virtual auto getParticlePositions(int lev) const -> std::vector<std::array<double, AMREX_SPACEDIM>> = 0;
@@ -73,6 +76,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
+	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) = 0;
 	virtual void driftParticles(int lev, amrex::Real dt) const = 0;
 	virtual void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &acceleration) = 0;
 	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const = 0;
@@ -94,8 +98,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool hydro_interact, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction), container_(container)
+				  bool allows_destruction = false, bool is_sn = false)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, hydro_interact, allows_creation, allows_destruction, is_sn), container_(container)
 	{
 	}
 
@@ -234,6 +238,17 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			// zero_out_input is false because we want to accumulate mass
 			// vol_weight is false because MassDeposition does the volume weighting
 			amrex::ParticleToMesh(*container_, rhs, 0, finest_lev, MassDeposition{Gconst, this->getMassIndex(), 0, 1}, false, false);
+		}
+	}
+
+	// Implementation of supernova energy and momentum deposition from particles to grid
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time) override
+	{
+		if (container_ != nullptr && this->isSN()) {
+			// zero_out_input is false because we want to accumulate supernova contributions
+			// vol_weight is false because SNDeposition does the volume weighting
+			amrex::ParticleToMesh(*container_, state, lev,
+					      SNDeposition{current_time, this->getMassIndex(), HydroSystem<problem_t>::density_index, this->getBirthTimeIndex()}, false);
 		}
 	}
 
@@ -499,6 +514,16 @@ template <typename problem_t> class PhysicsParticleRegister
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
 				descriptor->depositMass(rhs, finest_lev, Gconst);
+			}
+		}
+	}
+
+	// Deposit supernova energy and momentum from all particles
+	void depositSN(amrex::MultiFab &state, int lev, amrex::Real current_time)
+	{
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			if (descriptor->isSN()) {
+				descriptor->depositSN(state, lev, current_time);
 			}
 		}
 	}

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -108,8 +108,7 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
 				amrex::Real current_time)
-		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
-		      evolution_stage_index(evolution_stage_index), current_time(current_time)
+		    : mass_idx(mass_index), birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index), cpu_id(processor_id), pid_start(particle_id_start), current_time(current_time)
 		{
 		}
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -11,12 +11,12 @@ namespace ParticleCreationImpl
 {
 // Common implementation of particle creation logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType, template <typename> class CreatorType>
-static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1)
+static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1, int birth_time_index = -1)
 {
 	if (container != nullptr) {
 		if (mass_idx >= 0) {
 			// Use the provided ParticleChecker type with global particle parameters
-			CheckerType<problem_t> particle_checker;
+			CheckerType<problem_t> particle_checker(current_time, dt);
 
 			for (amrex::MFIter mfi = container->MakeMFIter(lev); mfi.isValid(); ++mfi) {
 				const auto &box = mfi.validbox();
@@ -35,7 +35,7 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 					const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
 					const auto index = box.index(iv);
 					// Check if we should create a particle at this location and time
-					pcounts[index] = particle_checker(state_arr, i, j, k, dx, current_time, dt); // NOLINT
+					pcounts[index] = particle_checker(state_arr, i, j, k, dx); // NOLINT
 				});
 
 				// Calculate exclusive prefix sum to get unique position for each particle
@@ -59,7 +59,7 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 				const int cpu_id = amrex::ParallelDescriptor::MyProc();
 
 				// Initialize particle creator functor using the provided ParticleCreator type
-				CreatorType<problem_t> particle_creator(mass_idx, cpu_id, pid, evolution_stage_index);
+				CreatorType<problem_t> particle_creator(mass_idx, birth_time_index, cpu_id, pid, evolution_stage_index, current_time);
 
 				amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 					const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
@@ -81,13 +81,16 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 template <ParticleType particleType> struct ParticleCreationTraits {
 	// Default nested ParticleChecker - determines if a particle should be created at a location
 	template <typename problem_t> struct ParticleChecker {
-		AMREX_GPU_HOST_DEVICE ParticleChecker() = default;
+		amrex::Real current_time;
+		amrex::Real dt;
+
+		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
 
 		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> int
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx) const -> int
 		{
 			// Default implementation creates no particles
-			amrex::ignore_unused(state_arr, i, j, k, dx, current_time, dt);
+			amrex::ignore_unused(state_arr, i, j, k, dx);
 			return 0;
 		}
 	};
@@ -95,13 +98,16 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 	// Default nested ParticleCreator - initializes a particle's properties
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
+		int birth_time_index;
 		int evolution_stage_index;
 		int cpu_id;
 		amrex::Long pid_start;
+		amrex::Real current_time;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index)
-		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start), evolution_stage_index(evolution_stage_index)
+		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index, amrex::Real current_time)
+		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
+		      evolution_stage_index(evolution_stage_index), current_time(current_time)
 		{
 		}
 
@@ -117,12 +123,12 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1)
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1, int birth_time_index = -1)
 	{
 		// Use the common implementation with our checker and creator types
 		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<particleType>::template ParticleChecker,
 							  ParticleCreationTraits<particleType>::template ParticleCreator>(container, mass_idx, state, lev,
-															  current_time, dt, evolution_stage_index);
+															  current_time, dt, evolution_stage_index, birth_time_index);
 	}
 };
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -11,7 +11,7 @@ namespace ParticleCreationImpl
 {
 // Common implementation of particle creation logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType, template <typename> class CreatorType>
-static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt)
+static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1)
 {
 	if (container != nullptr) {
 		if (mass_idx >= 0) {
@@ -59,7 +59,7 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 				const int cpu_id = amrex::ParallelDescriptor::MyProc();
 
 				// Initialize particle creator functor using the provided ParticleCreator type
-				CreatorType<problem_t> particle_creator(mass_idx, cpu_id, pid);
+				CreatorType<problem_t> particle_creator(mass_idx, cpu_id, pid, evolution_stage_index);
 
 				amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 					const amrex::IntVect iv(AMREX_D_DECL(i, j, k));
@@ -95,12 +95,13 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 	// Default nested ParticleCreator - initializes a particle's properties
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
+		int evolution_stage_index;
 		int cpu_id;
 		amrex::Long pid_start;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start)
-		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start)
+		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index)
+		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start), evolution_stage_index(evolution_stage_index)
 		{
 		}
 
@@ -116,12 +117,12 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt)
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1)
 	{
 		// Use the common implementation with our checker and creator types
 		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<particleType>::template ParticleChecker,
 							  ParticleCreationTraits<particleType>::template ParticleCreator>(container, mass_idx, state, lev,
-															  current_time, dt);
+															  current_time, dt, evolution_stage_index);
 	}
 };
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -108,7 +108,8 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
 				amrex::Real current_time)
-		    : mass_idx(mass_index), birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index), cpu_id(processor_id), pid_start(particle_id_start), current_time(current_time)
+		    : mass_idx(mass_index), birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index), cpu_id(processor_id),
+		      pid_start(particle_id_start), current_time(current_time)
 		{
 		}
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -11,7 +11,8 @@ namespace ParticleCreationImpl
 {
 // Common implementation of particle creation logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType, template <typename> class CreatorType>
-static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1, int birth_time_index = -1)
+static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt,
+				int evolution_stage_index = -1, int birth_time_index = -1)
 {
 	if (container != nullptr) {
 		if (mass_idx >= 0) {
@@ -105,7 +106,8 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		amrex::Real current_time;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index, amrex::Real current_time)
+		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
+				amrex::Real current_time)
 		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
 		      evolution_stage_index(evolution_stage_index), current_time(current_time)
 		{
@@ -123,12 +125,13 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index = -1, int birth_time_index = -1)
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt,
+				    int evolution_stage_index = -1, int birth_time_index = -1)
 	{
 		// Use the common implementation with our checker and creator types
 		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<particleType>::template ParticleChecker,
-							  ParticleCreationTraits<particleType>::template ParticleCreator>(container, mass_idx, state, lev,
-															  current_time, dt, evolution_stage_index, birth_time_index);
+							  ParticleCreationTraits<particleType>::template ParticleCreator>(
+		    container, mass_idx, state, lev, current_time, dt, evolution_stage_index, birth_time_index);
 	}
 };
 

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -62,6 +62,57 @@ struct MassDeposition {
 	}
 };
 
+//-------------------- Supernova depositions --------------------
+
+// Functor for depositing supernova energy and momentum from particles onto the grid
+struct SNDeposition {
+	double current_time{}; // Current simulation time
+	int start_part_comp{}; // Starting component in particle data
+	int start_mesh_comp{}; // Starting component in mesh data
+	int birthTimeIndex{};  // Index for particle birth time
+
+	// Operator to perform supernova deposition using cloud-in-cell approach
+	template <typename ContainerType>
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<amrex::Real> const &state,
+							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
+							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
+	{
+		const double SN_time = 1.0; // for testing: SN onset time = 1
+		// TODO(cch): later, when we add StellarPop particle type with a isSNexploded flag, we can use that here
+		if (current_time >= p.rdata(birthTimeIndex) + SN_time) {
+			// Find the cell containing the particle
+			int base_i = static_cast<int>(amrex::Math::floor((p.pos(0) - plo[0]) * dxi[0]));
+			int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
+			int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
+			
+			// Calculate the volume factor for normalization (5³ cells)
+			const int num_cells = 125; // 5³ cells
+			const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
+
+			static constexpr int stencil_width = 2;
+			
+			// Deposit evenly to 5³ cells centered on the particle's cell
+			const amrex::Real pmass = p.rdata(start_part_comp) * vol_factor;
+			const amrex::Real penergy = pmass; // for testing: energy = mass
+			const amrex::Real pmomentum = 0.0; // for testing: momentum = 0
+
+			for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
+				for (int jj = -stencil_width; jj <= stencil_width; ++jj) {
+					for (int ii = -stencil_width; ii <= stencil_width; ++ii) {
+						// Add the contribution to each cell
+						// We assume start_mesh_comp is the density index followed by the momentum indices and then the energy index
+						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp), pmass);
+						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 1), pmomentum);
+						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 2), pmomentum);
+						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 3), pmomentum);
+						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 4), penergy);
+					}
+				}
+			}
+		}
+	}
+};
+
 #endif // AMREX_SPACEDIM == 3
 
 } // namespace quokka

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -67,17 +67,16 @@ struct MassDeposition {
 
 //-------------------- Supernova depositions --------------------
 
-constexpr double SN_time = 0.0015; // for testing: SN onset time = 1
-
 // Functor for depositing supernova energy and momentum from particles onto the grid
 // This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly
 // to 5³ cells centered on the particle's cell. It is used for testing purposes.
 struct SNDeposition {
-	double current_time{};	   // Current simulation time
+	double step_end_time{};	   // Current simulation time
 	int start_part_comp{};	   // Starting component in particle data
 	int start_mesh_comp{};	   // Starting component in mesh data
 	int birthTimeIndex{};	   // Index for particle birth time
 	int evolutionStageIndex{}; // Index for particle evolution stage
+	double SN_time = particle_param2;
 
 	// Operator to perform supernova deposition using cloud-in-cell approach
 	template <typename ContainerType>
@@ -93,17 +92,17 @@ struct SNDeposition {
 				is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
 			}
 
-			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
+			if (is_sn_progenitor && step_end_time > p.rdata(birthTimeIndex) + SN_time) {
 				// Find the cell containing the particle
 				int base_i = static_cast<int>(amrex::Math::floor((p.pos(0) - plo[0]) * dxi[0]));
 				int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
 				int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
 
-				// Calculate the volume factor for normalization (5³ cells)
-				const int num_cells = 125; // 5³ cells
-				const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
-
 				static constexpr int stencil_width = 2;
+
+				// Calculate the volume factor for normalization (5³ cells)
+				const int num_cells = (2 * stencil_width + 1) * (2 * stencil_width + 1) * (2 * stencil_width + 1);
+				const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
 
 				// Deposit evenly to 5³ cells centered on the particle's cell
 				const amrex::Real pmass = p.rdata(start_part_comp) * vol_factor;
@@ -138,11 +137,13 @@ struct SNDeposition {
 
 // Function to update particle evolution stages from SNProgenitor to SNRemnant
 template <typename ContainerType>
-void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current_time, int birthTimeIndex, int evolutionStageIndex)
+void updateEvolutionStage(ContainerType *container, int lev, amrex::Real step_end_time, int birthTimeIndex, int evolutionStageIndex)
 {
 	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
 		return;
 	}
+
+	const double SN_time = particle_param2;
 
 	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
 		auto &particles = pti.GetArrayOfStructs();
@@ -156,7 +157,7 @@ void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current
 			bool is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
 
 			// Update the particle's evolution stage if it's time
-			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
+			if (is_sn_progenitor && step_end_time > p.rdata(birthTimeIndex) + SN_time) {
 				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
 			}
 		});

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -107,7 +107,7 @@ struct SNDeposition {
 				// Deposit evenly to 5³ cells centered on the particle's cell
 				const amrex::Real pdensity = p.rdata(start_part_comp) * vol_factor;
 				const amrex::Real penergy = pdensity; // for testing: energy = mass
-				const amrex::Real pmomentum = 0.0; // for testing: momentum = 0
+				const amrex::Real pmomentum = 0.0;    // for testing: momentum = 0
 
 				for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
 					for (int jj = -stencil_width; jj <= stencil_width; ++jj) {

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -66,7 +66,7 @@ struct MassDeposition {
 //-------------------- Supernova depositions --------------------
 
 // Functor for depositing supernova energy and momentum from particles onto the grid
-// This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly 
+// This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly
 // to 5³ cells centered on the particle's cell. It is used for testing purposes.
 struct SNDeposition {
 	double current_time{};	   // Current simulation time

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -98,7 +98,7 @@ struct SNDeposition {
 				int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
 				int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
 
-				static constexpr int stencil_width = 2;
+				const int stencil_width = 4;
 
 				// Calculate the volume factor for normalization (5³ cells)
 				const int num_cells = (2 * stencil_width + 1) * (2 * stencil_width + 1) * (2 * stencil_width + 1);

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -5,6 +5,7 @@
 #include "AMReX_Extension.H"
 #include "AMReX_ParticleInterpolators.H"
 #include "AMReX_REAL.H"
+#include "particles/particle_types.hpp"
 
 namespace quokka
 {
@@ -65,11 +66,14 @@ struct MassDeposition {
 //-------------------- Supernova depositions --------------------
 
 // Functor for depositing supernova energy and momentum from particles onto the grid
+// This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly 
+// to 5³ cells centered on the particle's cell. It is used for testing purposes.
 struct SNDeposition {
-	double current_time{}; // Current simulation time
-	int start_part_comp{}; // Starting component in particle data
-	int start_mesh_comp{}; // Starting component in mesh data
-	int birthTimeIndex{};  // Index for particle birth time
+	double current_time{};	   // Current simulation time
+	int start_part_comp{};	   // Starting component in particle data
+	int start_mesh_comp{};	   // Starting component in mesh data
+	int birthTimeIndex{};	   // Index for particle birth time
+	int evolutionStageIndex{}; // Index for particle evolution stage
 
 	// Operator to perform supernova deposition using cloud-in-cell approach
 	template <typename ContainerType>
@@ -78,36 +82,53 @@ struct SNDeposition {
 							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
 	{
 		const double SN_time = 1.0; // for testing: SN onset time = 1
-		// TODO(cch): later, when we add StellarPop particle type with a isSNexploded flag, we can use that here
-		if (current_time >= p.rdata(birthTimeIndex) + SN_time) {
-			// Find the cell containing the particle
-			int base_i = static_cast<int>(amrex::Math::floor((p.pos(0) - plo[0]) * dxi[0]));
-			int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
-			int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
-			
-			// Calculate the volume factor for normalization (5³ cells)
-			const int num_cells = 125; // 5³ cells
-			const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
 
-			static constexpr int stencil_width = 2;
-			
-			// Deposit evenly to 5³ cells centered on the particle's cell
-			const amrex::Real pmass = p.rdata(start_part_comp) * vol_factor;
-			const amrex::Real penergy = pmass; // for testing: energy = mass
-			const amrex::Real pmomentum = 0.0; // for testing: momentum = 0
+		// Check if the particle has an integer component for evolution stage
+		if constexpr (ContainerType::NInt > 0) {
+			// Check if this is a supernova progenitor
+			bool is_sn_progenitor = false;
+			if (evolutionStageIndex >= 0) {
+				is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
+			}
 
-			for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
-				for (int jj = -stencil_width; jj <= stencil_width; ++jj) {
-					for (int ii = -stencil_width; ii <= stencil_width; ++ii) {
-						// Add the contribution to each cell
-						// We assume start_mesh_comp is the density index followed by the momentum indices and then the energy index
-						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp), pmass);
-						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 1), pmomentum);
-						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 2), pmomentum);
-						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 3), pmomentum);
-						amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 4), penergy);
+			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
+				// Find the cell containing the particle
+				int base_i = static_cast<int>(amrex::Math::floor((p.pos(0) - plo[0]) * dxi[0]));
+				int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
+				int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
+
+				// Calculate the volume factor for normalization (5³ cells)
+				const int num_cells = 125; // 5³ cells
+				const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
+
+				static constexpr int stencil_width = 2;
+
+				// Deposit evenly to 5³ cells centered on the particle's cell
+				const amrex::Real pmass = p.rdata(start_part_comp) * vol_factor;
+				const amrex::Real penergy = pmass; // for testing: energy = mass
+				const amrex::Real pmomentum = 0.0; // for testing: momentum = 0
+
+				for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
+					for (int jj = -stencil_width; jj <= stencil_width; ++jj) {
+						for (int ii = -stencil_width; ii <= stencil_width; ++ii) {
+							// Add the contribution to each cell
+							// We assume start_mesh_comp is the density index followed by the momentum indices and then the energy
+							// index
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp), pmass);
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 1),
+										     pmomentum);
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 2),
+										     pmomentum);
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 3),
+										     pmomentum);
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 4),
+										     penergy);
+						}
 					}
 				}
+
+				// Update the particle's evolution stage to SNRemnant
+				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
 			}
 		}
 	}

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -79,6 +79,13 @@ struct SNDeposition {
 	int evolutionStageIndex{}; // Index for particle evolution stage
 	double SN_time = particle_param2;
 
+	static constexpr int stencil_width = 4;
+
+	// Abort if stencil_width > nghost_cc_.
+	// A stencil_width > nghost_cc_ would result in particles depositing energy/momentum outside the ghost zones.
+	// We can't use AMRSimulation<problem_t>::nghost_cc_ here because we don't have a problem_t template parameter.
+	static_assert(stencil_width <= 4, "stencil_width must be <= nghost_cc_");
+
 	// Operator to perform supernova deposition using cloud-in-cell approach
 	template <typename ContainerType>
 	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<amrex::Real> const &state,
@@ -98,9 +105,6 @@ struct SNDeposition {
 				int base_i = static_cast<int>(amrex::Math::floor((p.pos(0) - plo[0]) * dxi[0]));
 				int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
 				int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
-
-				// Note: stencil_width <= nghost_cc_ is required!!!
-				const int stencil_width = 4;
 
 				// Calculate the volume factor for normalization (5³ cells)
 				const int num_cells = (2 * stencil_width + 1) * (2 * stencil_width + 1) * (2 * stencil_width + 1);

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -65,35 +65,6 @@ struct MassDeposition {
 	}
 };
 
-// Function to update particle evolution stages from SNProgenitor to SNRemnant
-template <typename ContainerType>
-void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current_time, int birthTimeIndex, int evolutionStageIndex)
-{
-	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
-		return;
-	}
-
-	const double SN_time = 1.0; // for testing: SN onset time = 1
-
-	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
-		auto &particles = pti.GetArrayOfStructs();
-		auto *pData = particles().data();
-		const amrex::Long np = pti.numParticles();
-
-		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int64_t idx) {
-			auto &p = pData[idx]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
-
-			// Check if this is a supernova progenitor
-			bool is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
-
-			// Update the particle's evolution stage if it's time
-			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
-				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
-			}
-		});
-	}
-}
-
 //-------------------- Supernova depositions --------------------
 
 // Functor for depositing supernova energy and momentum from particles onto the grid
@@ -164,6 +135,35 @@ struct SNDeposition {
 		}
 	}
 };
+
+// Function to update particle evolution stages from SNProgenitor to SNRemnant
+template <typename ContainerType>
+void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current_time, int birthTimeIndex, int evolutionStageIndex)
+{
+	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
+		return;
+	}
+
+	const double SN_time = 1.0; // for testing: SN onset time = 1
+
+	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
+		auto &particles = pti.GetArrayOfStructs();
+		auto *pData = particles().data();
+		const amrex::Long np = pti.numParticles();
+
+		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int64_t idx) {
+			auto &p = pData[idx]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+			// Check if this is a supernova progenitor
+			bool is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
+
+			// Update the particle's evolution stage if it's time
+			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
+				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
+			}
+		});
+	}
+}
 
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -3,7 +3,9 @@
 
 #include "AMReX_Array4.H"
 #include "AMReX_Extension.H"
+#include "AMReX_MultiFab.H"
 #include "AMReX_ParticleInterpolators.H"
+#include "AMReX_ParticleMesh.H"
 #include "AMReX_REAL.H"
 #include "particles/particle_types.hpp"
 
@@ -62,6 +64,35 @@ struct MassDeposition {
 		});
 	}
 };
+
+// Function to update particle evolution stages from SNProgenitor to SNRemnant
+template <typename ContainerType>
+void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current_time, int birthTimeIndex, int evolutionStageIndex)
+{
+	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
+		return;
+	}
+
+	const double SN_time = 1.0; // for testing: SN onset time = 1
+
+	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
+		auto &particles = pti.GetArrayOfStructs();
+		auto *pData = particles().data();
+		const amrex::Long np = pti.numParticles();
+
+		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int64_t idx) {
+			auto &p = pData[idx]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+			// Check if this is a supernova progenitor
+			bool is_sn_progenitor = (p.idata(evolutionStageIndex) == static_cast<int>(StellarEvolutionStage::SNProgenitor));
+
+			// Update the particle's evolution stage if it's time
+			if (is_sn_progenitor && current_time >= p.rdata(birthTimeIndex) + SN_time) {
+				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
+			}
+		});
+	}
+}
 
 //-------------------- Supernova depositions --------------------
 
@@ -127,8 +158,8 @@ struct SNDeposition {
 					}
 				}
 
-				// Update the particle's evolution stage to SNRemnant
-				p.idata(evolutionStageIndex) = static_cast<int>(StellarEvolutionStage::SNRemnant);
+				// Note: We cannot modify the particle here because it's passed as const reference
+				// The evolution stage update is now handled by the updateEvolutionStage function
 			}
 		}
 	}

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -70,6 +70,7 @@ struct MassDeposition {
 // Functor for depositing supernova energy and momentum from particles onto the grid
 // This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly
 // to 5³ cells centered on the particle's cell. It is used for testing purposes.
+// Note: the deposition radius must be <= nghost_cc_
 struct SNDeposition {
 	double step_end_time{};	   // Current simulation time
 	int start_part_comp{};	   // Starting component in particle data
@@ -98,6 +99,7 @@ struct SNDeposition {
 				int base_j = static_cast<int>(amrex::Math::floor((p.pos(1) - plo[1]) * dxi[1]));
 				int base_k = static_cast<int>(amrex::Math::floor((p.pos(2) - plo[2]) * dxi[2]));
 
+				// Note: stencil_width <= nghost_cc_ is required!!!
 				const int stencil_width = 4;
 
 				// Calculate the volume factor for normalization (5³ cells)

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -105,8 +105,8 @@ struct SNDeposition {
 				const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
 
 				// Deposit evenly to 5³ cells centered on the particle's cell
-				const amrex::Real pmass = p.rdata(start_part_comp) * vol_factor;
-				const amrex::Real penergy = pmass; // for testing: energy = mass
+				const amrex::Real pdensity = p.rdata(start_part_comp) * vol_factor;
+				const amrex::Real penergy = pdensity; // for testing: energy = mass
 				const amrex::Real pmomentum = 0.0; // for testing: momentum = 0
 
 				for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
@@ -115,7 +115,7 @@ struct SNDeposition {
 							// Add the contribution to each cell
 							// We assume start_mesh_comp is the density index followed by the momentum indices and then the energy
 							// index
-							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp), pmass);
+							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp), pdensity);
 							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 1),
 										     pmomentum);
 							amrex::Gpu::Atomic::AddNoRet(&state(base_i + ii, base_j + jj, base_k + kk, start_mesh_comp + 2),

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -67,6 +67,8 @@ struct MassDeposition {
 
 //-------------------- Supernova depositions --------------------
 
+constexpr double SN_time = 0.0015; // for testing: SN onset time = 1
+
 // Functor for depositing supernova energy and momentum from particles onto the grid
 // This is a simplified version of the SNDeposition functor that deposits mass and energy uniformly
 // to 5³ cells centered on the particle's cell. It is used for testing purposes.
@@ -83,8 +85,6 @@ struct SNDeposition {
 							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
 							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
 	{
-		const double SN_time = 1.0; // for testing: SN onset time = 1
-
 		// Check if the particle has an integer component for evolution stage
 		if constexpr (ContainerType::NInt > 0) {
 			// Check if this is a supernova progenitor
@@ -143,8 +143,6 @@ void updateEvolutionStage(ContainerType *container, int lev, amrex::Real current
 	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
 		return;
 	}
-
-	const double SN_time = 1.0; // for testing: SN onset time = 1
 
 	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
 		auto &particles = pti.GetArrayOfStructs();

--- a/src/particles/particle_destruction.hpp
+++ b/src/particles/particle_destruction.hpp
@@ -11,12 +11,12 @@ namespace ParticleDestructionImpl
 {
 // Common implementation of particle destruction logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType>
-static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt)
+static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
 {
 	if (container != nullptr) {
 		if (mass_idx >= 0) {
 			// Use the provided ParticleChecker type to determine which particles to destroy
-			CheckerType<problem_t> particle_checker;
+			CheckerType<problem_t> particle_checker(birth_time_index, evolution_stage_index);
 
 			// Iterate through all particles at this level
 			for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
@@ -57,6 +57,13 @@ static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev
 template <ParticleType particleType> struct ParticleDestructionTraits {
 	// Default nested ParticleChecker - determines if a particle should be destroyed
 	template <typename problem_t> struct ParticleChecker {
+		int birth_time_index;
+		int evolution_stage_index;
+
+		AMREX_GPU_HOST_DEVICE explicit ParticleChecker(int birth_time_index, int evolution_stage_index)
+		    : birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index)
+		{
+		}
 
 		template <typename ParticleType>
 		AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, amrex::Real current_time, amrex::Real dt) const -> bool
@@ -69,11 +76,11 @@ template <ParticleType particleType> struct ParticleDestructionTraits {
 
 	// Main method to destroy particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt)
+	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
 	{
 		// Use the common implementation with our checker type
 		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType, ParticleDestructionTraits<particleType>::template ParticleChecker>(
-		    container, mass_idx, lev, current_time, dt);
+		    container, mass_idx, lev, current_time, dt, birth_time_index, evolution_stage_index);
 	}
 };
 

--- a/src/particles/particle_destruction.hpp
+++ b/src/particles/particle_destruction.hpp
@@ -11,7 +11,8 @@ namespace ParticleDestructionImpl
 {
 // Common implementation of particle destruction logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType>
-static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
+static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index,
+				 int evolution_stage_index)
 {
 	if (container != nullptr) {
 		if (mass_idx >= 0) {
@@ -76,7 +77,8 @@ template <ParticleType particleType> struct ParticleDestructionTraits {
 
 	// Main method to destroy particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
+	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index,
+				     int evolution_stage_index)
 	{
 		// Use the common implementation with our checker type
 		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType, ParticleDestructionTraits<particleType>::template ParticleChecker>(

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -73,12 +73,6 @@ enum class ParticleType {
 	Test   // Test particles with all features enabled
 };
 
-// Enum for Test particle stage
-enum class TestParticleStage {
-	LowMassStar,  // Low mass star stage
-	SNProgenitor  // Supernova progenitor stage
-};
-
 // Global particle parameters
 // The 'inline' keyword is used here to avoid multiple definition errors when this header
 // is included in multiple source files. It ensures that all translation units that include
@@ -88,25 +82,6 @@ inline amrex::Real particle_param1 = -1.0; // NOLINT
 inline amrex::Real particle_param2 = -1.0; // NOLINT
 inline amrex::Real particle_param3 = -1.0; // NOLINT
 inline int particle_verbose = 0;	   // NOLINT print particle logistics
-
-//-------------------- Test particles --------------------
-
-// Indices for test particles (Test_particles)
-enum TestParticleDataIdx {
-	TestParticleMassIdx = 0,    // Mass of the particle
-	TestParticleVxIdx,          // Velocity in x direction
-	TestParticleVyIdx,          // Velocity in y direction
-	TestParticleVzIdx,          // Velocity in z direction
-	TestParticleBirthTimeIdx,   // Time when particle becomes active
-	TestParticleStageIdx        // Stage of the particle (LowMassStar or SNProgenitor)
-};
-
-// Number of real components for Test_particles
-constexpr int TestParticleRealComps = 6;
-
-// Type definitions for Test_particles container and iterator
-using TestParticleContainer = amrex::AmrParticleContainer<TestParticleRealComps>;
-using TestParticleIterator = amrex::ParIter<TestParticleRealComps>;
 
 //-------------------- Radiation particles --------------------
 
@@ -176,6 +151,43 @@ constexpr int CICRadParticleRealComps = []() constexpr {
 // Type definitions for CICRad_particles container and iterator
 template <typename problem_t> using CICRadParticleContainer = amrex::AmrParticleContainer<CICRadParticleRealComps<problem_t>>;
 template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICRadParticleRealComps<problem_t>>;
+
+//-------------------- Test particles --------------------
+
+// Enum for StellarEvolution particle stage
+enum class StellarEvolutionStage {
+	LowMassStar,  // Low mass star stage
+	SNProgenitor,  // Supernova progenitor stage
+	SNRemnant     // Supernova remnant stage
+};
+
+// Indices for test particles (Test_particles)
+enum TestParticleDataIdx {
+	TestParticleMassIdx = 0,    // Mass of the particle
+	TestParticleVxIdx,          // Velocity in x direction
+	TestParticleVyIdx,          // Velocity in y direction
+	TestParticleVzIdx,          // Velocity in z direction
+	TestParticleBirthTimeIdx,   // Time when particle becomes active
+	TestParticleStageIdx,       // Stage of the particle (LowMassStar or SNProgenitor)
+	TestParticleLumIdx          // Base index for luminosity components
+};
+
+// Number of real components for StellarPop_particles, mass + 3 velocity components + luminosity
+template <typename problem_t>
+constexpr int TestParticleRealComps = []() constexpr {
+	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && Physics_Traits<problem_t>::is_radiation_enabled) {
+		return 6 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, stage, lum[nGroups]
+	} else {
+		return 6; // mass, vx, vy, vz, birth_time, stage
+	}
+}();
+
+// Number of integer components for Test_particles
+constexpr int TestParticleIntComps = 1; // fate
+
+// Type definitions for Test_particles container and iterator
+template <typename problem_t> using TestParticleContainer = amrex::AmrParticleContainer<TestParticleRealComps<problem_t>, TestParticleIntComps>;
+template <typename problem_t> using TestParticleIterator = amrex::ParIter<TestParticleRealComps<problem_t>, TestParticleIntComps>;
 
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -205,6 +205,13 @@ inline auto get_units_data() -> const auto &
 	       {"vz", {0, 1, -1, 0}},
 	       {"birth_time", {0, 0, 1, 0}},
 	       {"death_time", {0, 0, 1, 0}},
+	       {"luminosity", {-1, 2, -3, 0}}}}},
+	    {ParticleType::Test,
+	     {{{"mass", {1, 0, 0, 0}},
+	       {"vx", {0, 1, -1, 0}},
+	       {"vy", {0, 1, -1, 0}},
+	       {"vz", {0, 1, -1, 0}},
+	       {"birth_time", {0, 0, 1, 0}},
 	       {"luminosity", {-1, 2, -3, 0}}}}}};
 	return units_data;
 }

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -168,9 +168,10 @@ enum TestParticleDataIdx {
 	TestParticleVyIdx,	  // Velocity in y direction
 	TestParticleVzIdx,	  // Velocity in z direction
 	TestParticleBirthTimeIdx, // Time when particle becomes active
-	TestParticleStageIdx,	  // Stage of the particle (LowMassStar or SNProgenitor)
 	TestParticleLumIdx	  // Base index for luminosity components
 };
+
+constexpr int TestParticleStageIdx = 0; // Evolution stage of the particle, index in the integer components
 
 // Number of real components for StellarPop_particles, mass + 3 velocity components + luminosity
 template <typename problem_t>
@@ -183,7 +184,7 @@ constexpr int TestParticleRealComps = []() constexpr {
 }();
 
 // Number of integer components for Test_particles
-constexpr int TestParticleIntComps = 1; // fate
+constexpr int TestParticleIntComps = 1; // stellar evolution stage
 
 // Type definitions for Test_particles container and iterator
 template <typename problem_t> using TestParticleContainer = amrex::AmrParticleContainer<TestParticleRealComps<problem_t>, TestParticleIntComps>;

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -15,11 +15,11 @@ template <unsigned int position> constexpr auto bitflag() -> unsigned int { retu
 // To check if CIC particles are enabled:
 //   if (particle_switch & ParticleSwitch::CIC) { ... }
 enum class ParticleSwitch : unsigned int {
-	None = 0U,	      // No particles, = 0b0000
-	CIC = bitflag<1>(),   // Cloud-In-Cell (gravitating) particles, = 0b0001
-	Rad = bitflag<2>(),   // Radiation particles, = 0b0010
+	None = 0U,	       // No particles, = 0b0000
+	CIC = bitflag<1>(),    // Cloud-In-Cell (gravitating) particles, = 0b0001
+	Rad = bitflag<2>(),    // Radiation particles, = 0b0010
 	CICRad = bitflag<3>(), // Combined gravitating-radiating particles, = 0b0100
-	Test = bitflag<4>()   // Test particles with all features enabled, = 0b1000
+	Test = bitflag<4>()    // Test particles with all features enabled, = 0b1000
 };
 
 // Enable bitwise operations on the enum class
@@ -67,10 +67,10 @@ namespace quokka
 
 // Enum class to identify different particle types
 enum class ParticleType {
-	Rad,   // Radiation particles
-	CIC,   // Gravitating particles
+	Rad,	// Radiation particles
+	CIC,	// Gravitating particles
 	CICRad, // Gravitating radiation particles
-	Test   // Test particles with all features enabled
+	Test	// Test particles with all features enabled
 };
 
 // Global particle parameters
@@ -157,19 +157,19 @@ template <typename problem_t> using CICRadParticleIterator = amrex::ParIter<CICR
 // Enum for StellarEvolution particle stage
 enum class StellarEvolutionStage {
 	LowMassStar,  // Low mass star stage
-	SNProgenitor,  // Supernova progenitor stage
+	SNProgenitor, // Supernova progenitor stage
 	SNRemnant     // Supernova remnant stage
 };
 
 // Indices for test particles (Test_particles)
 enum TestParticleDataIdx {
-	TestParticleMassIdx = 0,    // Mass of the particle
-	TestParticleVxIdx,          // Velocity in x direction
-	TestParticleVyIdx,          // Velocity in y direction
-	TestParticleVzIdx,          // Velocity in z direction
-	TestParticleBirthTimeIdx,   // Time when particle becomes active
-	TestParticleStageIdx,       // Stage of the particle (LowMassStar or SNProgenitor)
-	TestParticleLumIdx          // Base index for luminosity components
+	TestParticleMassIdx = 0,  // Mass of the particle
+	TestParticleVxIdx,	  // Velocity in x direction
+	TestParticleVyIdx,	  // Velocity in y direction
+	TestParticleVzIdx,	  // Velocity in z direction
+	TestParticleBirthTimeIdx, // Time when particle becomes active
+	TestParticleStageIdx,	  // Stage of the particle (LowMassStar or SNProgenitor)
+	TestParticleLumIdx	  // Base index for luminosity components
 };
 
 // Number of real components for StellarPop_particles, mass + 3 velocity components + luminosity

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -18,7 +18,8 @@ enum class ParticleSwitch : unsigned int {
 	None = 0U,	      // No particles, = 0b0000
 	CIC = bitflag<1>(),   // Cloud-In-Cell (gravitating) particles, = 0b0001
 	Rad = bitflag<2>(),   // Radiation particles, = 0b0010
-	CICRad = bitflag<3>() // Combined gravitating-radiating particles, = 0b0100
+	CICRad = bitflag<3>(), // Combined gravitating-radiating particles, = 0b0100
+	Test = bitflag<4>()   // Test particles with all features enabled, = 0b1000
 };
 
 // Enable bitwise operations on the enum class
@@ -68,7 +69,14 @@ namespace quokka
 enum class ParticleType {
 	Rad,   // Radiation particles
 	CIC,   // Gravitating particles
-	CICRad // Gravitating radiation particles
+	CICRad, // Gravitating radiation particles
+	Test   // Test particles with all features enabled
+};
+
+// Enum for Test particle stage
+enum class TestParticleStage {
+	LowMassStar,  // Low mass star stage
+	SNProgenitor  // Supernova progenitor stage
 };
 
 // Global particle parameters
@@ -80,6 +88,25 @@ inline amrex::Real particle_param1 = -1.0; // NOLINT
 inline amrex::Real particle_param2 = -1.0; // NOLINT
 inline amrex::Real particle_param3 = -1.0; // NOLINT
 inline int particle_verbose = 0;	   // NOLINT print particle logistics
+
+//-------------------- Test particles --------------------
+
+// Indices for test particles (Test_particles)
+enum TestParticleDataIdx {
+	TestParticleMassIdx = 0,    // Mass of the particle
+	TestParticleVxIdx,          // Velocity in x direction
+	TestParticleVyIdx,          // Velocity in y direction
+	TestParticleVzIdx,          // Velocity in z direction
+	TestParticleBirthTimeIdx,   // Time when particle becomes active
+	TestParticleStageIdx        // Stage of the particle (LowMassStar or SNProgenitor)
+};
+
+// Number of real components for Test_particles
+constexpr int TestParticleRealComps = 6;
+
+// Type definitions for Test_particles container and iterator
+using TestParticleContainer = amrex::AmrParticleContainer<TestParticleRealComps>;
+using TestParticleIterator = amrex::ParIter<TestParticleRealComps>;
 
 //-------------------- Radiation particles --------------------
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -310,8 +310,6 @@ auto problem_main() -> int
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 
-		const auto n_particle_actual = real_data.size();
-
 		// assume the first particle is in the first plane quadrant
 		for (const auto &data : real_data) {
 			// only consider particles with mass > 0.1. Those are the ones created at the start of the simulation.

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -29,8 +29,9 @@ struct BinaryOrbit {
 // The initial condition consists of 2 particles with a mass of 1.0.
 // In the first time step, 2^3 * 2 particles are created. Half of them are low-mass particles
 // marked for destruction. In the next time step, low-mass particles are destroyed. There
-// are 8 of them. Finally, in the third and last step, 2^3 * 2 particles are created.
-// The final number of particles is 26
+// are 8 of them. Finally, in the third and last step, all previous particles are marked as
+// SNRemnant and 2^3 * 2 particles are created.
+// The final number of particles is 26, of which 8 are SNRemnant.
 
 constexpr int particle_per_cell = 2;
 constexpr int particle_spacing = 30;
@@ -82,11 +83,15 @@ namespace quokka
 template <> struct ParticleCreationTraits<ParticleType::Test> {
 	// Specialized nested ParticleChecker for Test particles
 	template <typename problem_t> struct ParticleChecker {
+		amrex::Real current_time;
+		amrex::Real dt;
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
 
+		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
+
 		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real current_time, amrex::Real dt) const -> int
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx) const -> int
 		{
 			// A simple demonstration of particle creation
 			// Could check density threshold or other state-based conditions
@@ -105,15 +110,18 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 	// Specialized nested ParticleCreator for Test particles
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
+		int birth_time_index;
 		int evolution_stage_index;
 		int cpu_id;
 		amrex::Long pid_start;
+		amrex::Real current_time;
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index)
-		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start), evolution_stage_index(evolution_stage_index)
+		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index, amrex::Real current_time)
+		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
+		      evolution_stage_index(evolution_stage_index), current_time(current_time)
 		{
 		}
 
@@ -157,6 +165,9 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.rdata(mass_idx + 2) = vy;
 					p.rdata(mass_idx + 3) = vz;
 
+					// set birth time to current time
+					p.rdata(birth_time_index) = current_time;
+
 					// Set particle evolution stage
 					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::SNProgenitor);
 				}
@@ -169,12 +180,13 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index)
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt,
+				    int evolution_stage_index, int birth_time_index)
 	{
 		// Use the common implementation with our checker and creator types
 		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::Test>::template ParticleChecker,
-							  ParticleCreationTraits<ParticleType::Test>::template ParticleCreator>(container, mass_idx, state, lev,
-															       current_time, dt, evolution_stage_index);
+							  ParticleCreationTraits<ParticleType::Test>::template ParticleCreator>(
+		    container, mass_idx, state, lev, current_time, dt, evolution_stage_index, birth_time_index);
 	}
 };
 
@@ -203,8 +215,9 @@ template <> struct ParticleDestructionTraits<ParticleType::Test> {
 	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt)
 	{
 		// Use the common implementation with our checker type
-		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType, ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(
-		    container, mass_idx, lev, current_time, dt);
+		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType,
+							      ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(container, mass_idx, lev,
+																       current_time, dt);
 	}
 };
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -318,7 +318,9 @@ auto problem_main() -> int
 
 	// ----- Check CIC particles -----
 
+	// particle actions must be called on all ranks
 	auto [real_data, int_data] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleData(0);
+	const int n_particle_test = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getNumParticles();
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 
@@ -361,8 +363,6 @@ auto problem_main() -> int
 		amrex::Print() << "Relative error: " << relative_error << "\n";
 
 		// ----- Check Test particles -----
-
-		const int n_particle_test = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getNumParticles();
 
 		amrex::Print() << "Expected number of particles: " << n_expected_test_particles << "\n";
 		amrex::Print() << "Actual number of particles: " << n_particle_test << "\n";

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -132,9 +132,7 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 		{
 			if (mass_idx + 3 < ParticleType::NReal) {
 				// Calculate common values for all particles
-				const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
-				const amrex::Real cell_mass = cell_density * cell_volume;
 				amrex::Real particle_mass = SN_mass;
 				int particle_stage = static_cast<int>(StellarEvolutionStage::SNProgenitor);
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -26,18 +26,16 @@ struct BinaryOrbit {
 };
 
 // This is an ad-hoc test of particle creation and destruction.
-// The initial condition consists of 2 particles with a mass of 1.0.
-// In the first time step, 2^3 * 2 particles are created. Half of them are low-mass particles
-// marked for destruction. In the next time step, low-mass particles are destroyed. There
-// are 8 of them. Finally, in the third and last step, all previous particles are marked as
-// SNRemnant and 2^3 * 2 particles are created.
-// The final number of particles is 26, of which 8 are SNRemnant.
+// The initial condition consists of 2 CIC particles with a mass of 1.0. We keep track of their orbit and compare with the exact solution. In the second time
+// step, 3^3 * 2 particles are created. A third of them are LowMassStar and the rest are SNProgenitor. In the third time step, all SNProgenitor particles are
+// turned into SNRemnant. In the fourth time step, all SNRemnant particles are destroyed. In the end of the simulation, there are 2 CIC particles and 18 Test
+// particles.
 
 constexpr int particle_per_cell = 2;
-constexpr int particle_spacing = 30;
+constexpr int particle_spacing = 20;
 constexpr double particle_low_mass = 1.0e-20; // very low mass particles marked for destruction
 constexpr double dt_ = 0.001;
-constexpr int n_particle_last = 26; // initial 2, 2^3 * 2 * 2 created, 8 destroyed
+const int n_expected_test_particles = 18; // initially 0, then 3^3 * 2 created, two thirds destroyed
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	     // isothermal
@@ -56,7 +54,7 @@ template <> struct Particle_Traits<BinaryOrbit> {
 	// static constexpr TestEnum particle_switch = TestEnum::MISTAKE;
 	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | TestEnum::MISTAKE;
 	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;
-	static constexpr ParticleSwitch particle_switch = ParticleSwitch::Test;
+	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | ParticleSwitch::Test;
 };
 
 template <> struct HydroSystem_Traits<BinaryOrbit> {
@@ -86,7 +84,6 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 		amrex::Real current_time;
 		amrex::Real dt;
 		amrex::Real param1 = particle_param1;
-		amrex::Real param2 = particle_param2;
 
 		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
 
@@ -97,10 +94,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 			// Could check density threshold or other state-based conditions
 			amrex::ignore_unused(state_arr, dx);
 			const int spacing = particle_spacing;
-			const bool is_create_particle_1 = current_time <= param1 && current_time + dt > param1;
-			const bool is_create_particle_2 = current_time <= param2 && current_time + dt > param2;
-			if ((is_create_particle_1 || is_create_particle_2) && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) &&
-			    (k != 0 && k % spacing == 0)) {
+			const bool is_create_particle = current_time <= param1 && current_time + dt > param1;
+			if (is_create_particle && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) && (k != 0 && k % spacing == 0)) {
 				return particle_per_cell;
 			}
 			return 0;
@@ -117,7 +112,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 		amrex::Real current_time;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index, amrex::Real current_time)
+		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
+				amrex::Real current_time)
 		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
 		      evolution_stage_index(evolution_stage_index), current_time(current_time)
 		{
@@ -209,21 +205,22 @@ template <> struct ParticleDestructionTraits<ParticleType::Test> {
 			// Default implementation: destroy particles with mass < 1.0
 			amrex::ignore_unused(mass_idx, current_time, dt);
 
-			// only low-mass stars will be destroyed; just for testing
-			const bool is_low_mass = (p.idata(evolution_stage_index) == static_cast<int>(StellarEvolutionStage::LowMassStar));
-			const bool is_time = (current_time >= p.rdata(birth_time_index) + t_destroy);
-			return is_low_mass && is_time;
+			// only SNRemnant will be destroyed; just for testing
+			const bool is_sn_remnant = (p.idata(evolution_stage_index) == static_cast<int>(StellarEvolutionStage::SNRemnant));
+			const bool is_time = (current_time + dt > t_destroy);
+			return is_sn_remnant && is_time;
 		}
 	};
 
 	// Main method to destroy particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
+	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index,
+				     int evolution_stage_index)
 	{
 		// Use the common implementation with our checker type
 		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType,
-							      ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(container, mass_idx, lev,
-																       current_time, dt, birth_time_index, evolution_stage_index);
+							      ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(
+		    container, mass_idx, lev, current_time, dt, birth_time_index, evolution_stage_index);
 	}
 };
 
@@ -247,13 +244,13 @@ template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokk
 
 template <> void QuokkaSimulation<BinaryOrbit>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) {}
 
-// template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
-// {
-// 	// read particles from ASCII file
-// 	const int nreal_extra = 4; // mass vx vy vz
-// 	CICParticles->SetVerbose(1);
-// 	CICParticles->InitFromAsciiFile("Gravity3D.txt", nreal_extra, nullptr);
-// }
+template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
+{
+	// read particles from ASCII file
+	const int nreal_extra = 4; // mass vx vy vz
+	CICParticles->SetVerbose(1);
+	CICParticles->InitFromAsciiFile("Gravity3D.txt", nreal_extra, nullptr);
+}
 
 auto problem_main() -> int
 {
@@ -305,36 +302,36 @@ auto problem_main() -> int
 	double position_error = 0.0;
 	double position_norm = 0.0;
 
-	const int n_particle_expect = n_particle_last;
-
 	int status = 0; // Initialize to success
 
-	auto [real_data, int_data] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getParticleData(0);
+	// ----- Check CIC particles -----
+
+	auto [real_data, int_data] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleData(0);
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 
 		const auto n_particle_actual = real_data.size();
 
-		// // assume the first particle is in the first plane quadrant
-		// for (const auto &data : particle_data) {
-		// 	// only consider particles with mass > 0.1. Those are the ones created at the start of the simulation.
-		// 	if (data[3] < 0.1) {
-		// 		continue;
-		// 	}
-		// 	// First 3 elements are positions (x,y,z)
-		// 	if (data[0] * exact_x > 0.0) {
-		// 		position_error += std::abs(data[0] - exact_x);
-		// 		position_error += std::abs(data[1] - exact_y);
-		// 		position_error += std::abs(data[2] - exact_z);
-		// 	} else {
-		// 		position_error += std::abs(data[0] - (-exact_x));
-		// 		position_error += std::abs(data[1] - (-exact_y));
-		// 		position_error += std::abs(data[2] - (-exact_z));
-		// 	}
-		// 	position_norm += std::abs(data[0]);
-		// 	position_norm += std::abs(data[1]);
-		// 	position_norm += std::abs(data[2]);
-		// }
+		// assume the first particle is in the first plane quadrant
+		for (const auto &data : real_data) {
+			// only consider particles with mass > 0.1. Those are the ones created at the start of the simulation.
+			if (data[3] < 0.1) {
+				continue;
+			}
+			// First 3 elements are positions (x,y,z)
+			if (data[0] * exact_x > 0.0) {
+				position_error += std::abs(data[0] - exact_x);
+				position_error += std::abs(data[1] - exact_y);
+				position_error += std::abs(data[2] - exact_z);
+			} else {
+				position_error += std::abs(data[0] - (-exact_x));
+				position_error += std::abs(data[1] - (-exact_y));
+				position_error += std::abs(data[2] - (-exact_z));
+			}
+			position_norm += std::abs(data[0]);
+			position_norm += std::abs(data[1]);
+			position_norm += std::abs(data[2]);
+		}
 
 		amrex::Print() << "Particle positions and data are: \n";
 		for (const auto &data : real_data) {
@@ -345,20 +342,24 @@ auto problem_main() -> int
 			amrex::Print() << " | Velocities: " << data[4] << ", " << data[5] << ", " << data[6] << "\n";
 		}
 		amrex::Print() << "Exact positions are: \n" << exact_x << ", " << exact_y << ", " << exact_z << "\n";
-		amrex::Print() << "Expected number of particles: " << n_particle_expect << "\n";
-		amrex::Print() << "Actual number of particles: " << n_particle_actual << "\n";
 
 		// compute relative error
-		// const double relative_error = position_error / position_norm;
-		const double relative_error = 0.0;
+		const double relative_error = position_error / position_norm;
 
 		amrex::Print() << "Position error: " << position_error << "\n";
 		amrex::Print() << "Position norm: " << position_norm << "\n";
 		amrex::Print() << "Relative error: " << relative_error << "\n";
 
+		// ----- Check Test particles -----
+
+		const int n_particle_test = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getNumParticles();
+
+		amrex::Print() << "Expected number of particles: " << n_expected_test_particles << "\n";
+		amrex::Print() << "Actual number of particles: " << n_particle_test << "\n";
+
 		const double max_err_tol = sim.tNew_[0] < 1.0 ? 0.001 : 0.05; // max error tol in cell widths
 		status = 1;
-		if (relative_error < max_err_tol && n_particle_actual == n_particle_expect) {
+		if (relative_error < max_err_tol && n_particle_test == n_expected_test_particles) {
 			status = 0;
 			amrex::Print() << "Relative error within tolerance.\n";
 		}

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -35,13 +35,20 @@ constexpr double rho0 = 1.0e-5;
 constexpr double init_mass_total = rho0 * 4 * 4 * 4;
 
 constexpr int particle_per_cell = 2;
-constexpr int particle_spacing = 20;
 constexpr double SN_mass = 0.1;		      // mass of SNProgenitor particles
 constexpr double particle_low_mass = 1.0e-20; // very low mass particles marked for destruction
 constexpr double dt_ = 0.001;
-constexpr int n_expected_test_particles = 18; // initially 0, then 3^3 * 2 created, two thirds destroyed
-constexpr int n_SN = 3 * 3 * 3 * 2 * 2 / 3;
+constexpr int n_expected_test_particles = 8; // initially 0, then 2^3 * 2 created, then half of them destroyed
+constexpr int n_SN = 2 * 2 * 2 * 2 / 2;
 constexpr double m_SN = n_SN * SN_mass;
+
+// locations of the particles: a 2x2x2 grids of particles
+constexpr int loc_x1 = 31;
+constexpr int loc_x2 = 32;
+constexpr int loc_y1 = 31;
+constexpr int loc_y2 = 32;
+constexpr int loc_z1 = 31;
+constexpr int loc_z2 = 32;
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	     // isothermal
@@ -59,7 +66,7 @@ template <> struct Particle_Traits<BinaryOrbit> {
 	// static constexpr int particle_switch = 1;
 	// static constexpr TestEnum particle_switch = TestEnum::MISTAKE;
 	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | TestEnum::MISTAKE;
-	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;
+	// This is the correct way to define the particle switch
 	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | ParticleSwitch::Test;
 };
 
@@ -76,7 +83,7 @@ template <> struct Physics_Traits<BinaryOrbit> {
 	static constexpr int nGroups = 1;			     // number of radiation groups
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr double boltzmann_constant = 1.0;
-	static constexpr double gravitational_constant = 1.0;
+	static constexpr double gravitational_constant = 1.0e-5; // set a small value to keep the cells/particles from moving
 	static constexpr double c_light = 1.0;
 	static constexpr double radiation_constant = 1.0;
 };
@@ -99,9 +106,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 			// A simple demonstration of particle creation
 			// Could check density threshold or other state-based conditions
 			amrex::ignore_unused(state_arr, dx);
-			const int spacing = particle_spacing;
 			const bool is_create_particle = current_time <= param1 && current_time + dt > param1;
-			if (is_create_particle && (i != 0 && i % spacing == 0) && (j != 0 && j % spacing == 0) && (k != 0 && k % spacing == 0)) {
+			if (is_create_particle && (i == loc_x1 || i == loc_x2) && (j == loc_y1 || j == loc_y2) && (k == loc_z1 || k == loc_z2)) {
 				return particle_per_cell;
 			}
 			return 0;
@@ -133,14 +139,6 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 			if (mass_idx + 3 < ParticleType::NReal) {
 				// Calculate common values for all particles
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
-				amrex::Real particle_mass = SN_mass;
-				int particle_stage = static_cast<int>(StellarEvolutionStage::SNProgenitor);
-
-				// mark half of the particles as low-mass stars
-				if (i <= particle_spacing) {
-					particle_mass = particle_low_mass;
-					particle_stage = static_cast<int>(StellarEvolutionStage::LowMassStar);
-				}
 
 				const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
 				const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
@@ -160,7 +158,7 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.cpu() = cpu_id;
 
 					// Initialize particle properties
-					p.rdata(mass_idx) = particle_mass;
+					p.rdata(mass_idx) = p_idx == 0 ? SN_mass : particle_low_mass;
 					p.rdata(mass_idx + 1) = vx;
 					p.rdata(mass_idx + 2) = vy;
 					p.rdata(mass_idx + 3) = vz;
@@ -169,7 +167,7 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.rdata(birth_time_index) = current_time;
 
 					// Set particle evolution stage
-					p.idata(evolution_stage_index) = particle_stage;
+					p.idata(evolution_stage_index) = p_idx == 0 ? static_cast<int>(StellarEvolutionStage::SNProgenitor) : static_cast<int>(StellarEvolutionStage::LowMassStar);
 				}
 
 				// Update cell density. For testing purposes, we remove a tiny amount of mass from the cell.

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -167,7 +167,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.rdata(birth_time_index) = current_time;
 
 					// Set particle evolution stage
-					p.idata(evolution_stage_index) = p_idx == 0 ? static_cast<int>(StellarEvolutionStage::SNProgenitor) : static_cast<int>(StellarEvolutionStage::LowMassStar);
+					p.idata(evolution_stage_index) = p_idx == 0 ? static_cast<int>(StellarEvolutionStage::SNProgenitor)
+										    : static_cast<int>(StellarEvolutionStage::LowMassStar);
 				}
 
 				// Update cell density. For testing purposes, we remove a tiny amount of mass from the cell.

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -105,14 +105,15 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 	// Specialized nested ParticleCreator for Test particles
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
+		int evolution_stage_index;
 		int cpu_id;
 		amrex::Long pid_start;
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
 
 		AMREX_GPU_HOST_DEVICE
-		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start)
-		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start)
+		ParticleCreator(int mass_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index)
+		    : mass_idx(mass_index), cpu_id(processor_id), pid_start(particle_id_start), evolution_stage_index(evolution_stage_index)
 		{
 		}
 
@@ -155,6 +156,9 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.rdata(mass_idx + 1) = vx;
 					p.rdata(mass_idx + 2) = vy;
 					p.rdata(mass_idx + 3) = vz;
+
+					// Set particle evolution stage
+					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::SNProgenitor);
 				}
 
 				// Update cell density (remove mass that was given to particles)
@@ -165,12 +169,12 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt)
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt, int evolution_stage_index)
 	{
 		// Use the common implementation with our checker and creator types
 		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::Test>::template ParticleChecker,
 							  ParticleCreationTraits<ParticleType::Test>::template ParticleCreator>(container, mass_idx, state, lev,
-															       current_time, dt);
+															       current_time, dt, evolution_stage_index);
 	}
 };
 
@@ -286,11 +290,11 @@ auto problem_main() -> int
 
 	int status = 0; // Initialize to success
 
-	auto particle_data = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getParticleData(0);
+	auto [real_data, int_data] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getParticleData(0);
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 
-		const auto n_particle_actual = particle_data.size();
+		const auto n_particle_actual = real_data.size();
 
 		// // assume the first particle is in the first plane quadrant
 		// for (const auto &data : particle_data) {
@@ -314,7 +318,7 @@ auto problem_main() -> int
 		// }
 
 		amrex::Print() << "Particle positions and data are: \n";
-		for (const auto &data : particle_data) {
+		for (const auto &data : real_data) {
 			// Print positions
 			amrex::Print() << "Position: " << data[0] << ", " << data[1] << ", " << data[2];
 			// Print additional data (mass, velocities)

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -31,11 +31,17 @@ struct BinaryOrbit {
 // turned into SNRemnant. In the fourth time step, all SNRemnant particles are destroyed. In the end of the simulation, there are 2 CIC particles and 18 Test
 // particles.
 
+constexpr double rho0 = 1.0e-5;
+constexpr double init_mass_total = rho0 * 4 * 4 * 4;
+
 constexpr int particle_per_cell = 2;
 constexpr int particle_spacing = 20;
+constexpr double SN_mass = 0.1; // mass of SNProgenitor particles
 constexpr double particle_low_mass = 1.0e-20; // very low mass particles marked for destruction
 constexpr double dt_ = 0.001;
-const int n_expected_test_particles = 18; // initially 0, then 3^3 * 2 created, two thirds destroyed
+constexpr int n_expected_test_particles = 18; // initially 0, then 3^3 * 2 created, two thirds destroyed
+constexpr int n_SN = 3 * 3 * 3 * 2 * 2 / 3;
+constexpr double m_SN = n_SN * SN_mass;
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	     // isothermal
@@ -129,10 +135,10 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 				const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
 				const amrex::Real cell_mass = cell_density * cell_volume;
-				amrex::Real particle_mass = 0.5 * cell_mass / num_particles; // Divide mass among particles
+				amrex::Real particle_mass = SN_mass;
 				int particle_stage = static_cast<int>(StellarEvolutionStage::SNProgenitor);
 
-				// mark half of the particles as low-mass particles which will be destroyed in the next time step
+				// mark half of the particles as low-mass stars
 				if (i <= particle_spacing) {
 					particle_mass = particle_low_mass;
 					particle_stage = static_cast<int>(StellarEvolutionStage::LowMassStar);
@@ -146,7 +152,7 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 				for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
 					auto &p = particles[p_idx]; // NOLINT
 
-					// Set particle position (all at cell center for now)
+					// Set particle position at cell center
 					p.pos(0) = plo[0] + (i + 0.5) * dx[0];
 					p.pos(1) = plo[1] + (j + 0.5) * dx[1];
 					p.pos(2) = plo[2] + (k + 0.5) * dx[2];
@@ -168,8 +174,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.idata(evolution_stage_index) = particle_stage;
 				}
 
-				// Update cell density (remove mass that was given to particles)
-				state_arr(i, j, k, HydroSystem<problem_t>::density_index) = 0.5 * cell_density;
+				// Update cell density. For testing purposes, we remove a tiny amount of mass from the cell.
+				state_arr(i, j, k, HydroSystem<problem_t>::density_index) -= 1.0e-20;
 			}
 		}
 	};
@@ -232,8 +238,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokk
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		double const rho = 1.0e-5; // g cm^{-3}
-		state_cc(i, j, k, HydroSystem<BinaryOrbit>::density_index) = rho;
+		state_cc(i, j, k, HydroSystem<BinaryOrbit>::density_index) = rho0;
 		state_cc(i, j, k, HydroSystem<BinaryOrbit>::x1Momentum_index) = 0;
 		state_cc(i, j, k, HydroSystem<BinaryOrbit>::x2Momentum_index) = 0;
 		state_cc(i, j, k, HydroSystem<BinaryOrbit>::x3Momentum_index) = 0;
@@ -304,6 +309,16 @@ auto problem_main() -> int
 
 	int status = 0; // Initialize to success
 
+	// get total mass in cells
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = sim.geom[0].CellSizeArray();
+	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
+	amrex::Real const total_mass = sim.state_new_cc_[0].sum(HydroSystem<BinaryOrbit>::density_index) * vol;
+	amrex::Real const SN_remnant_mass = total_mass - init_mass_total;
+	amrex::Print() << "Total SN remnant mass: " << SN_remnant_mass << "\n";
+	amrex::Print() << "Expected total SN remnant mass in cells: " << m_SN << "\n";
+	const double SN_remnant_mass_rel_err = std::abs(SN_remnant_mass - m_SN) / m_SN;
+	amrex::Print() << "SN remnant mass relative error: " << SN_remnant_mass_rel_err << "\n";
+
 	// ----- Check CIC particles -----
 
 	auto [real_data, int_data] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleData(0);
@@ -355,9 +370,12 @@ auto problem_main() -> int
 		amrex::Print() << "Expected number of particles: " << n_expected_test_particles << "\n";
 		amrex::Print() << "Actual number of particles: " << n_particle_test << "\n";
 
+		// ----- Check SN remnant mass -----
+
 		const double max_err_tol = sim.tNew_[0] < 1.0 ? 0.001 : 0.05; // max error tol in cell widths
+		const double max_err_tol_mass = 1.0e-8; // max error tol in mass
 		status = 1;
-		if (relative_error < max_err_tol && n_particle_test == n_expected_test_particles) {
+		if (relative_error < max_err_tol && n_particle_test == n_expected_test_particles && SN_remnant_mass_rel_err < max_err_tol_mass) {
 			status = 0;
 			amrex::Print() << "Relative error within tolerance.\n";
 		}

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -54,7 +54,8 @@ template <> struct Particle_Traits<BinaryOrbit> {
 	// static constexpr int particle_switch = 1;
 	// static constexpr TestEnum particle_switch = TestEnum::MISTAKE;
 	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | TestEnum::MISTAKE;
-	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;
+	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;
+	static constexpr ParticleSwitch particle_switch = ParticleSwitch::Test;
 };
 
 template <> struct HydroSystem_Traits<BinaryOrbit> {
@@ -78,8 +79,8 @@ template <> struct Physics_Traits<BinaryOrbit> {
 namespace quokka
 {
 // Specialization for CIC particle creation
-template <> struct ParticleCreationTraits<ParticleType::CIC> {
-	// Specialized nested ParticleChecker for CIC particles
+template <> struct ParticleCreationTraits<ParticleType::Test> {
+	// Specialized nested ParticleChecker for Test particles
 	template <typename problem_t> struct ParticleChecker {
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
@@ -101,7 +102,7 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 		}
 	};
 
-	// Specialized nested ParticleCreator for CIC particles
+	// Specialized nested ParticleCreator for Test particles
 	template <typename problem_t> struct ParticleCreator {
 		int mass_idx;
 		int cpu_id;
@@ -167,14 +168,14 @@ template <> struct ParticleCreationTraits<ParticleType::CIC> {
 	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt)
 	{
 		// Use the common implementation with our checker and creator types
-		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::CIC>::template ParticleChecker,
-							  ParticleCreationTraits<ParticleType::CIC>::template ParticleCreator>(container, mass_idx, state, lev,
+		ParticleCreationImpl::createParticlesImpl<problem_t, ContainerType, ParticleCreationTraits<ParticleType::Test>::template ParticleChecker,
+							  ParticleCreationTraits<ParticleType::Test>::template ParticleCreator>(container, mass_idx, state, lev,
 															       current_time, dt);
 	}
 };
 
-// Specialization for CIC particles destruction
-template <> struct ParticleDestructionTraits<ParticleType::CIC> {
+// Specialization for Test particles destruction
+template <> struct ParticleDestructionTraits<ParticleType::Test> {
 	// Default nested ParticleChecker - determines if a particle should be destroyed
 	template <typename problem_t> struct ParticleChecker {
 		amrex::Real t_destroy = particle_param3;
@@ -198,7 +199,7 @@ template <> struct ParticleDestructionTraits<ParticleType::CIC> {
 	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt)
 	{
 		// Use the common implementation with our checker type
-		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType, ParticleDestructionTraits<ParticleType::CIC>::template ParticleChecker>(
+		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType, ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(
 		    container, mass_idx, lev, current_time, dt);
 	}
 };
@@ -223,13 +224,13 @@ template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokk
 
 template <> void QuokkaSimulation<BinaryOrbit>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) {}
 
-template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
-{
-	// read particles from ASCII file
-	const int nreal_extra = 4; // mass vx vy vz
-	CICParticles->SetVerbose(1);
-	CICParticles->InitFromAsciiFile("Gravity3D.txt", nreal_extra, nullptr);
-}
+// template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
+// {
+// 	// read particles from ASCII file
+// 	const int nreal_extra = 4; // mass vx vy vz
+// 	CICParticles->SetVerbose(1);
+// 	CICParticles->InitFromAsciiFile("Gravity3D.txt", nreal_extra, nullptr);
+// }
 
 auto problem_main() -> int
 {
@@ -285,32 +286,32 @@ auto problem_main() -> int
 
 	int status = 0; // Initialize to success
 
-	auto particle_data = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleData(0);
+	auto particle_data = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Test)->getParticleData(0);
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 
 		const auto n_particle_actual = particle_data.size();
 
-		// assume the first particle is in the first plane quadrant
-		for (const auto &data : particle_data) {
-			// only consider particles with mass > 0.1. Those are the ones created at the start of the simulation.
-			if (data[3] < 0.1) {
-				continue;
-			}
-			// First 3 elements are positions (x,y,z)
-			if (data[0] * exact_x > 0.0) {
-				position_error += std::abs(data[0] - exact_x);
-				position_error += std::abs(data[1] - exact_y);
-				position_error += std::abs(data[2] - exact_z);
-			} else {
-				position_error += std::abs(data[0] - (-exact_x));
-				position_error += std::abs(data[1] - (-exact_y));
-				position_error += std::abs(data[2] - (-exact_z));
-			}
-			position_norm += std::abs(data[0]);
-			position_norm += std::abs(data[1]);
-			position_norm += std::abs(data[2]);
-		}
+		// // assume the first particle is in the first plane quadrant
+		// for (const auto &data : particle_data) {
+		// 	// only consider particles with mass > 0.1. Those are the ones created at the start of the simulation.
+		// 	if (data[3] < 0.1) {
+		// 		continue;
+		// 	}
+		// 	// First 3 elements are positions (x,y,z)
+		// 	if (data[0] * exact_x > 0.0) {
+		// 		position_error += std::abs(data[0] - exact_x);
+		// 		position_error += std::abs(data[1] - exact_y);
+		// 		position_error += std::abs(data[2] - exact_z);
+		// 	} else {
+		// 		position_error += std::abs(data[0] - (-exact_x));
+		// 		position_error += std::abs(data[1] - (-exact_y));
+		// 		position_error += std::abs(data[2] - (-exact_z));
+		// 	}
+		// 	position_norm += std::abs(data[0]);
+		// 	position_norm += std::abs(data[1]);
+		// 	position_norm += std::abs(data[2]);
+		// }
 
 		amrex::Print() << "Particle positions and data are: \n";
 		for (const auto &data : particle_data) {
@@ -325,7 +326,8 @@ auto problem_main() -> int
 		amrex::Print() << "Actual number of particles: " << n_particle_actual << "\n";
 
 		// compute relative error
-		const double relative_error = position_error / position_norm;
+		// const double relative_error = position_error / position_norm;
+		const double relative_error = 0.0;
 
 		amrex::Print() << "Position error: " << position_error << "\n";
 		amrex::Print() << "Position norm: " << position_norm << "\n";

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -115,8 +115,6 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 		int cpu_id;
 		amrex::Long pid_start;
 		amrex::Real current_time;
-		amrex::Real param1 = particle_param1;
-		amrex::Real param2 = particle_param2;
 
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index, amrex::Real current_time)
@@ -136,10 +134,12 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
 				const amrex::Real cell_mass = cell_density * cell_volume;
 				amrex::Real particle_mass = 0.5 * cell_mass / num_particles; // Divide mass among particles
+				int particle_stage = static_cast<int>(StellarEvolutionStage::SNProgenitor);
 
 				// mark half of the particles as low-mass particles which will be destroyed in the next time step
 				if (i <= particle_spacing) {
 					particle_mass = particle_low_mass;
+					particle_stage = static_cast<int>(StellarEvolutionStage::LowMassStar);
 				}
 
 				const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
@@ -169,7 +169,7 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 					p.rdata(birth_time_index) = current_time;
 
 					// Set particle evolution stage
-					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::SNProgenitor);
+					p.idata(evolution_stage_index) = particle_stage;
 				}
 
 				// Update cell density (remove mass that was given to particles)
@@ -194,30 +194,36 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 template <> struct ParticleDestructionTraits<ParticleType::Test> {
 	// Default nested ParticleChecker - determines if a particle should be destroyed
 	template <typename problem_t> struct ParticleChecker {
+		int birth_time_index;
+		int evolution_stage_index;
 		amrex::Real t_destroy = particle_param3;
 
-		// AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real param1) : param1(param1) {}
+		AMREX_GPU_HOST_DEVICE explicit ParticleChecker(int birth_time_index, int evolution_stage_index)
+		    : birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index)
+		{
+		}
 
 		template <typename ParticleType>
 		AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, amrex::Real current_time, amrex::Real dt) const -> bool
 		{
 			// Default implementation: destroy particles with mass < 1.0
-			amrex::ignore_unused(current_time, dt);
+			amrex::ignore_unused(mass_idx, current_time, dt);
 
-			const bool is_small_mass = (p.rdata(mass_idx) < 2.0 * particle_low_mass);
-			const bool is_time = (current_time <= t_destroy && current_time + dt > t_destroy);
-			return is_small_mass && is_time;
+			// only low-mass stars will be destroyed; just for testing
+			const bool is_low_mass = (p.idata(evolution_stage_index) == static_cast<int>(StellarEvolutionStage::LowMassStar));
+			const bool is_time = (current_time >= p.rdata(birth_time_index) + t_destroy);
+			return is_low_mass && is_time;
 		}
 	};
 
 	// Main method to destroy particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt)
+	static void destroyParticles(ContainerType *container, int mass_idx, int lev, amrex::Real current_time, amrex::Real dt, int birth_time_index, int evolution_stage_index)
 	{
 		// Use the common implementation with our checker type
 		ParticleDestructionImpl::destroyParticlesImpl<problem_t, ContainerType,
 							      ParticleDestructionTraits<ParticleType::Test>::template ParticleChecker>(container, mass_idx, lev,
-																       current_time, dt);
+																       current_time, dt, birth_time_index, evolution_stage_index);
 	}
 };
 

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -36,7 +36,7 @@ constexpr double init_mass_total = rho0 * 4 * 4 * 4;
 
 constexpr int particle_per_cell = 2;
 constexpr int particle_spacing = 20;
-constexpr double SN_mass = 0.1; // mass of SNProgenitor particles
+constexpr double SN_mass = 0.1;		      // mass of SNProgenitor particles
 constexpr double particle_low_mass = 1.0e-20; // very low mass particles marked for destruction
 constexpr double dt_ = 0.001;
 constexpr int n_expected_test_particles = 18; // initially 0, then 3^3 * 2 created, two thirds destroyed
@@ -120,8 +120,8 @@ template <> struct ParticleCreationTraits<ParticleType::Test> {
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
 				amrex::Real current_time)
-		    : mass_idx(mass_index), birth_time_index(birth_time_index), cpu_id(processor_id), pid_start(particle_id_start),
-		      evolution_stage_index(evolution_stage_index), current_time(current_time)
+		    : mass_idx(mass_index), birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index), cpu_id(processor_id),
+		      pid_start(particle_id_start), current_time(current_time)
 		{
 		}
 
@@ -373,7 +373,7 @@ auto problem_main() -> int
 		// ----- Check SN remnant mass -----
 
 		const double max_err_tol = sim.tNew_[0] < 1.0 ? 0.001 : 0.05; // max error tol in cell widths
-		const double max_err_tol_mass = 1.0e-8; // max error tol in mass
+		const double max_err_tol_mass = 1.0e-8;			      // max error tol in mass
 		status = 1;
 		if (relative_error < max_err_tol && n_particle_test == n_expected_test_particles && SN_remnant_mass_rel_err < max_err_tol_mass) {
 			status = 0;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2187,12 +2187,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		AMREX_ASSERT(TestParticles == nullptr);
 
 		// Create particle container
-		TestParticles = std::make_unique<quokka::TestParticleContainer>(this);
+		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
 		TestParticles->SetVerbose(0);
 
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
+		particleRegister_.registerStarParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
 						       quokka::TestParticleBirthTimeIdx, true, true, TestParticles.get(), true, true);
 	}
 #endif // AMREX_SPACEDIM == 3
@@ -2964,7 +2964,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
 		AMREX_ASSERT(TestParticles == nullptr);
-		TestParticles = std::make_unique<quokka::TestParticleContainer>(this);
+		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
 		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, -1, quokka::TestParticleBirthTimeIdx, true,
 						       true, TestParticles.get(), true, true);
 		TestParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Test));

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -230,8 +230,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	virtual void createInitialCICParticles() = 0;
 	virtual void createInitialCICRadParticles() = 0;
-	// Test particles have integer components, and InitFromAsciiFile does not support integer components, so we do not allow them to be created at the start
-	// of the simulation virtual void createInitialTestParticles() = 0;
+	// Test particles have integer components, and InitFromAsciiFile does not support integer components, so we do not allow creating them at the start
+	// of the simulation
 #endif // AMREX_SPACEDIM == 3
 	virtual void computeBeforeTimestep() = 0;
 	virtual void computeAfterTimestep() = 0;
@@ -2193,7 +2193,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
 		particleRegister_.registerStarParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
-						       quokka::TestParticleBirthTimeIdx, true, true, TestParticles.get(), true, true);
+						       quokka::TestParticleBirthTimeIdx, true, true, TestParticles.get(), true, quokka::TestParticleStageIdx);
 	}
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2149,7 +2149,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		RadParticles->SetVerbose(0);
 
 		// Register with particle register - Rad particles do not allow creation
-		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false, quokka::RadParticleBirthTimeIdx);
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false,
+						       quokka::RadParticleBirthTimeIdx);
 
 		// Initialize particles through derived class
 		createInitialRadParticles();
@@ -2194,8 +2195,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
-						       quokka::TestParticleBirthTimeIdx, true, true, quokka::TestParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx,
+							   quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true, true,
+							   quokka::TestParticleStageIdx, true);
 	}
 #endif // AMREX_SPACEDIM == 3
 
@@ -2929,7 +2931,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
 		AMREX_ASSERT(RadParticles == nullptr);
 		RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false, quokka::RadParticleBirthTimeIdx);
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false,
+						       quokka::RadParticleBirthTimeIdx);
 		RadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Rad));
 	}
 
@@ -2952,8 +2955,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
 		AMREX_ASSERT(TestParticles == nullptr);
 		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
-		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
-						       quokka::TestParticleBirthTimeIdx, true, true, quokka::TestParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx,
+							   quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true, true,
+							   quokka::TestParticleStageIdx, true);
 		TestParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Test));
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2192,8 +2192,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true,
-						       true, TestParticles.get(), true, true);
+		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
+						       quokka::TestParticleBirthTimeIdx, true, true, TestParticles.get(), true, true);
 	}
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -325,7 +325,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void createDiagnostics();
 	void updateDiagnostics();
 	void doDiagnostics();
-	void printParticleStatistics();
 	void WriteMetadataFile(std::string const &MetadataFileName) const;
 	void ReadMetadataFile(std::string const &chkfilename);
 	void WriteStatisticsFile();
@@ -1061,7 +1060,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 		// print particle statistics
 		if (quokka::particle_verbose > 0) {
-			printParticleStatistics();
+			particleRegister_.printParticleStatistics();
 		}
 
 		// write diagnostics
@@ -2394,8 +2393,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 		}
 	}
 }
-
-template <typename problem_t> void AMRSimulation<problem_t>::printParticleStatistics() { particleRegister_.printParticleStatistics(); }
 
 // do in-situ rendering with Ascent
 #ifdef AMREX_USE_ASCENT

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1018,11 +1018,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		particleRegister_.createParticlesFromState(state_new_cc_[0], 0, cur_time, dt_[0]);
 
 		// Stellar evolution and SN deposition
-		// TODO(cch): Need to take care of AMR subscycling
+		// TODO(cch): Need to take care of AMR subcycling
 		particleRegister_.depositSN(state_new_cc_[0], 0, cur_time + dt_[0]);
 
 		// Use the new type-aware particle destruction method
-		// TODO(cch): Need to take care of AMR subscycling
+		// TODO(cch): Need to take care of AMR subcycling
 		particleRegister_.destroyParticles(0, cur_time, dt_[0]);
 #endif
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1021,6 +1021,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		// Use the new type-aware particle destruction method
 		// TODO(cch): Need to take care of AMR subscycling
 		particleRegister_.destroyParticles(0, cur_time, dt_[0]);
+
+		// Stellar evolution and SN deposition
+		// TODO(cch): Need to take care of AMR subscycling
+		particleRegister_.depositSN(state_new_cc_[0], 0, cur_time);
 #endif
 
 		cur_time += dt_[0];

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -468,7 +468,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	std::unique_ptr<quokka::CICParticleContainer> CICParticles;
 	std::unique_ptr<quokka::CICRadParticleContainer<problem_t>> CICRadParticles;
-	std::unique_ptr<quokka::TestParticleContainer> TestParticles;
+	std::unique_ptr<quokka::TestParticleContainer<problem_t>> TestParticles;
 #endif // AMREX_SPACEDIM == 3
 #endif
 
@@ -2192,7 +2192,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, -1, quokka::TestParticleBirthTimeIdx, true,
+		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true,
 						       true, TestParticles.get(), true, true);
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1017,13 +1017,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		// TODO(cch): Need to take care of AMR subscycling
 		particleRegister_.createParticlesFromState(state_new_cc_[0], 0, cur_time, dt_[0]);
 
+		// Stellar evolution and SN deposition
+		// TODO(cch): Need to take care of AMR subscycling
+		particleRegister_.depositSN(state_new_cc_[0], 0, cur_time + dt_[0]);
+
 		// Use the new type-aware particle destruction method
 		// TODO(cch): Need to take care of AMR subscycling
 		particleRegister_.destroyParticles(0, cur_time, dt_[0]);
-
-		// Stellar evolution and SN deposition
-		// TODO(cch): Need to take care of AMR subscycling
-		particleRegister_.depositSN(state_new_cc_[0], 0, cur_time);
 #endif
 
 		cur_time += dt_[0];

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -230,6 +230,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	virtual void createInitialCICParticles() = 0;
 	virtual void createInitialCICRadParticles() = 0;
+	// Test particles have integer components, and InitFromAsciiFile does not support integer components, so we do not allow them to be created at the start
+	// of the simulation virtual void createInitialTestParticles() = 0;
 #endif // AMREX_SPACEDIM == 3
 	virtual void computeBeforeTimestep() = 0;
 	virtual void computeAfterTimestep() = 0;
@@ -466,6 +468,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #if AMREX_SPACEDIM == 3
 	std::unique_ptr<quokka::CICParticleContainer> CICParticles;
 	std::unique_ptr<quokka::CICRadParticleContainer<problem_t>> CICRadParticles;
+	std::unique_ptr<quokka::TestParticleContainer> TestParticles;
 #endif // AMREX_SPACEDIM == 3
 #endif
 
@@ -2179,6 +2182,19 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		// Initialize particles through derived class
 		createInitialCICRadParticles();
 	}
+
+	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
+		AMREX_ASSERT(TestParticles == nullptr);
+
+		// Create particle container
+		TestParticles = std::make_unique<quokka::TestParticleContainer>(this);
+		TestParticles->SetVerbose(0);
+
+		// Register with particle register - Test particles have all features enabled
+		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
+		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, -1, quokka::TestParticleBirthTimeIdx, true,
+						       true, TestParticles.get(), true, true);
+	}
 #endif // AMREX_SPACEDIM == 3
 
 	particleRegister_.redistribute(0);
@@ -2944,6 +2960,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		particleRegister_.registerParticleType(quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx, quokka::CICRadParticleLumIdx,
 						       quokka::CICRadParticleBirthTimeIdx, false, false, CICRadParticles.get());
 		CICRadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CICRad));
+	}
+
+	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
+		AMREX_ASSERT(TestParticles == nullptr);
+		TestParticles = std::make_unique<quokka::TestParticleContainer>(this);
+		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, -1, quokka::TestParticleBirthTimeIdx, true,
+						       true, TestParticles.get(), true, true);
+		TestParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Test));
 	}
 #endif // AMREX_SPACEDIM == 3
 #endif

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2149,8 +2149,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		RadParticles->SetVerbose(0);
 
 		// Register with particle register - Rad particles do not allow creation
-		particleRegister_.registerParticleType(quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, quokka::RadParticleBirthTimeIdx, false, false,
-						       RadParticles.get());
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false, quokka::RadParticleBirthTimeIdx);
 
 		// Initialize particles through derived class
 		createInitialRadParticles();
@@ -2165,7 +2164,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICParticles->SetVerbose(0);
 
 		// Register with particle register - CIC particles allow creation
-		particleRegister_.registerParticleType(quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1, -1, false, true, CICParticles.get(), true);
+		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1);
 
 		// Initialize particles through derived class
 		createInitialCICParticles();
@@ -2179,8 +2178,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICRadParticles->SetVerbose(0);
 
 		// Register with particle register - CICRad particles do not allow creation
-		particleRegister_.registerParticleType(quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx, quokka::CICRadParticleLumIdx,
-						       quokka::CICRadParticleBirthTimeIdx, false, false, CICRadParticles.get());
+		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
+						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx);
 
 		// Initialize particles through derived class
 		createInitialCICRadParticles();
@@ -2195,8 +2194,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - Test particles have all features enabled
 		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerStarParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
-						       quokka::TestParticleBirthTimeIdx, true, true, TestParticles.get(), true, quokka::TestParticleStageIdx);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
+						       quokka::TestParticleBirthTimeIdx, true, true, quokka::TestParticleStageIdx, true);
 	}
 #endif // AMREX_SPACEDIM == 3
 
@@ -2942,8 +2941,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
 		AMREX_ASSERT(RadParticles == nullptr);
 		RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, quokka::RadParticleBirthTimeIdx, false, false,
-						       RadParticles.get());
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false, quokka::RadParticleBirthTimeIdx);
 		RadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Rad));
 	}
 
@@ -2951,23 +2949,23 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CIC) {
 		AMREX_ASSERT(CICParticles == nullptr);
 		CICParticles = std::make_unique<quokka::CICParticleContainer>(this);
-		particleRegister_.registerParticleType(quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1, -1, false, true, CICParticles.get());
+		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1);
 		CICParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CIC));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CICRad) {
 		AMREX_ASSERT(CICRadParticles == nullptr);
 		CICRadParticles = std::make_unique<quokka::CICRadParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx, quokka::CICRadParticleLumIdx,
-						       quokka::CICRadParticleBirthTimeIdx, false, false, CICRadParticles.get());
+		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
+						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx);
 		CICRadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CICRad));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
 		AMREX_ASSERT(TestParticles == nullptr);
 		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(quokka::ParticleType::Test, quokka::TestParticleMassIdx, -1, quokka::TestParticleBirthTimeIdx, true,
-						       true, TestParticles.get(), true, true);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx, quokka::TestParticleLumIdx,
+						       quokka::TestParticleBirthTimeIdx, true, true, quokka::TestParticleStageIdx, true);
 		TestParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Test));
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/tests/Gravity3D.in
+++ b/tests/Gravity3D.in
@@ -28,9 +28,9 @@ stop_time = 5.0
 plotfile_interval = -1
 checkpoint_interval = -1
 
-particles.param1 = 0.0005 # create particles at this time, which is step 0
-particles.param2 = 0.0025 # create particles at this time, which is step 2
-particles.param3 = 0.0015 # destroy particles at this time, which is step 1
+particles.param1 = 0.0015 # create particles at this time, which is step 2
+particles.param2 = 0.0015 # turn SNProgenitor into SNRemnant after this time
+particles.param3 = 0.0035 # destroy particles at this time, which is step 4
 particles.verbose = 1
 
-max_timesteps = 3
+max_timesteps = 4


### PR DESCRIPTION
### Description

This PR adds a new attribute `evolutionStage` to the particle data and a new function `SNDeposition` to deposit mass, momentum, and energy from particles to the grid.

Changes:

1. Add `Test` particle type for testing all particle features. 

2. Define an integer component `evolutionStage` to Test_particles. It is used to track the evolution stage of the particle. The evolution stage is defined as an enum class as listed below. For particle types that support stellar evolution (`evolutionStageIndex_ >= 0`), each star is created either as a low mass star or as a SN progenitor. When a SN progenitor reaches the end of its life, it executes `SNDeposition()` and evolves into a SN remnant.

```cpp
enum class StellarEvolutionStage {
	LowMassStar,  // Low mass star stage
	SNProgenitor,  // Supernova progenitor stage
	SNRemnant     // Supernova remnant stage
};
```

3. Defined `SNDeposition` to deposit mass, momentum, and energy from particles to the grid. At each time step, we find the particle types that support stellar evolution, and check if each particle is a SN progenitor and if it has reached the end of its life. If so, we run `SNDeposition()` and update the particle's evolution stage to SNRemnant. This also works as a framework for other interact-with-mesh operations. Unlike `interp.ParticleToMesh` which uses linear interpolation to deposit N particle components to N mesh components on a one-to-one basis, `SNDeposition` calculates the exact position of the particle in the mesh and deposit particle properties to arbitrary components of neighboring cells, using any interpolation kernel. Note that the maximum number of cells allowed to use in SNDeposition (the `stencil_width`) is `nghost_cc_ = 4`. 

The new code is fully tested via the gravity_3d test on CPU, GPU, and MPI, where we check the creation, stellar evolution, and destruction of the particles, as well as the total mass in SN ejecta. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
