### PR TITLE
update ROCm version on Frontier

### DIFF
--- a/scripts/frontier-1node.submit
+++ b/scripts/frontier-1node.submit
@@ -11,7 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 1
 
-source $HOME/amrex_frontier.profile
+. scripts/frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-1node.submit
+++ b/scripts/frontier-1node.submit
@@ -11,8 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 1
 
-# note (5-16-22, OLCFHELP-6888): libfabric workaround
-export FI_MR_CACHE_MAX_COUNT=0
+source $HOME/amrex_frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-4096node.submit
+++ b/scripts/frontier-4096node.submit
@@ -11,8 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 4096
 
-# note (5-16-22, OLCFHELP-6888): libfabric workaround
-export FI_MR_CACHE_MAX_COUNT=0
+source $HOME/amrex_frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-4096node.submit
+++ b/scripts/frontier-4096node.submit
@@ -11,7 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 4096
 
-source $HOME/amrex_frontier.profile
+. scripts/frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-512node.submit
+++ b/scripts/frontier-512node.submit
@@ -11,8 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 512
 
-# note (5-16-22, OLCFHELP-6888): libfabric workaround
-export FI_MR_CACHE_MAX_COUNT=0
+source $HOME/amrex_frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-512node.submit
+++ b/scripts/frontier-512node.submit
@@ -11,7 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 512
 
-source $HOME/amrex_frontier.profile
+. scripts/frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-64node.submit
+++ b/scripts/frontier-64node.submit
@@ -11,7 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 64
 
-source $HOME/amrex_frontier.profile
+. scripts/frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-64node.submit
+++ b/scripts/frontier-64node.submit
@@ -11,8 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 64
 
-# note (5-16-22, OLCFHELP-6888): libfabric workaround
-export FI_MR_CACHE_MAX_COUNT=0
+source $HOME/amrex_frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-8node.submit
+++ b/scripts/frontier-8node.submit
@@ -11,8 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 8
 
-# note (5-16-22, OLCFHELP-6888): libfabric workaround
-export FI_MR_CACHE_MAX_COUNT=0
+source $HOME/amrex_frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier-8node.submit
+++ b/scripts/frontier-8node.submit
@@ -11,7 +11,7 @@
 #SBATCH --gpu-bind=closest
 #SBATCH -N 8
 
-source $HOME/amrex_frontier.profile
+. scripts/frontier.profile
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/frontier.profile
+++ b/scripts/frontier.profile
@@ -1,44 +1,47 @@
-module purge
+#!/bin/bash
+source /opt/cray/pe/cpe/24.11/restore_lmod_system_defaults.sh
 
-# module versions of CPE, cce, and rocm *MUST* match according to this table:
-# https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#compatible-compiler-rocm-toolchain-versions
-
-module load Core/24.07
-module load cpe/24.07
+module load Core/25.03
+module load cpe/24.11
 
 module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
 
-module load rocm/6.1.3
+module load rocm/6.3.1 # MUST use this version to avoid compiler bugs
 module load cray-mpich
-module load cce/18.0.0  # must be loaded after rocm
+module load cce/18.0.1
 
 # hdf5
 module load cray-hdf5
 
+# adios2 (optional)
+module load adios2/2.10.2-mpi
+
+# python
+module load cray-python/3.11.7
+
 # cmake
-module load cmake/3.27.9
+module load cmake/3.30.5
 
 # optional
 module load emacs
 
-# optional
-module load cray-python/3.11.5
-
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# optimize GPU compilation for MI250X
+# optimize ROCm/HIP compilation for MI250X
 export AMREX_AMD_ARCH=gfx90a
 
 # compiler environment hints
-export CC=$(which cc)
-export CXX=$(which CC)
+export CC=$(which hipcc)
+export CXX=$(which hipcc)
 export FC=$(which ftn)
 
 # these flags are REQUIRED
-export CFLAGS="-I${ROCM_PATH}/include"
-export CXXFLAGS="-I${ROCM_PATH}/include -Wno-pass-failed"
-export LDFLAGS="-L${ROCM_PATH}/lib -lamdhip64"
+export CFLAGS="-I${MPICH_DIR}/include"
+export CXXFLAGS="-I${MPICH_DIR}/include"
+export LDFLAGS="-L${MPICH_DIR}/lib -lmpi \
+  ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
+  ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}"
 export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2545,6 +2545,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
+        feholdexcept(&orig_feenv); // disable FPE for YAML reading
+
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
 	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
 
@@ -2567,6 +2569,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << fmt::format("\t{} has unknown type! skipping this entry.\n", key);
 		}
 	}
+	
+	fesetenv(&orig_feenv);	   // restore FPE
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlotfile() const

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2545,6 +2545,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
+        fenv_t orig_feenv;
         feholdexcept(&orig_feenv); // disable FPE for YAML reading
 
 	// read metadata file in on all ranks (needed when restarting from checkpoint)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2545,7 +2545,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
-        fenv_t orig_feenv;
+	fenv_t orig_feenv;
 	feholdexcept(&orig_feenv); // disable FPE for YAML reading
 
 	// read metadata file in on all ranks (needed when restarting from checkpoint)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -10,6 +10,7 @@
 /// timestepping, solving, and I/O of a simulation.
 
 // c++ headers
+#include <cfenv>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2545,7 +2545,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
-        feholdexcept(&orig_feenv); // disable FPE for YAML reading
+	feholdexcept(&orig_feenv); // disable FPE for YAML reading
 
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
 	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
@@ -2569,8 +2569,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << fmt::format("\t{} has unknown type! skipping this entry.\n", key);
 		}
 	}
-	
-	fesetenv(&orig_feenv);	   // restore FPE
+
+	fesetenv(&orig_feenv); // restore FPE
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlotfile() const


### PR DESCRIPTION
### Description
Updates SLURM scripts and Bash profile for Frontier to use ROCm 6.3 (same as Setonix).

Also, we no longer need any workarounds for Slingshot network issues.

Scaling plot:
![frontier_weak_scaling_quokka](https://github.com/user-attachments/assets/2dd776cf-60b0-45b7-a9bd-e7422ed6401d)

Depends on:
* https://github.com/quokka-astro/quokka/pull/946

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
