### PR TITLE
add QUOKKA_VERSION in metadata.yaml

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -100,6 +100,9 @@ using namespace conduit;
 using namespace ascent;
 #endif
 
+// Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
+constexpr auto QUOKKA_VERSION = "25.03";
+
 enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
 
 using variant_t = std::variant<amrex::Real, std::string>;
@@ -559,6 +562,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 			amrex::Abort("Grids not properly nested!");
 		}
 	}
+
+	// add Quokka version to metadata
+	simulationMetadata_["quokka_version"] = QUOKKA_VERSION;
 
 	// add git commit to metadata
 	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -101,7 +101,7 @@ using namespace ascent;
 #endif
 
 // Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
-constexpr auto QUOKKA_VERSION = "25.03";
+static constexpr auto QUOKKA_VERSION = "25.03";
 
 enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
 


### PR DESCRIPTION
### Description

Add `QUOKKA_VERSION` variable into metadata.yaml. `QUOKKA_VERSION` will be used in YT to perform version checks and determine the corresponding data structure. 

I recommend we update `QUOKKA_VERSION` under the following circumstances:
(1) before a release,
(2) when modifying the structure of the simulation outputs, especially if such changes require elaborate scripting in post-processing tools like YT.

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
