### PR TITLE
ignore FPE in YAML I/O

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -101,6 +101,9 @@ using namespace conduit;
 using namespace ascent;
 #endif
 
+// Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
+static constexpr auto QUOKKA_VERSION = "25.03";
+
 enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
 
 using variant_t = std::variant<amrex::Real, std::string>;
@@ -560,6 +563,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 			amrex::Abort("Grids not properly nested!");
 		}
 	}
+
+	// add Quokka version to metadata
+	simulationMetadata_["quokka_version"] = QUOKKA_VERSION;
 
 	// add git commit to metadata
 	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -10,6 +10,7 @@
 /// timestepping, solving, and I/O of a simulation.
 
 // c++ headers
+#include <cfenv>
 #include <cmath>
 #include <cstdint>
 #include <cstdio>
@@ -99,9 +100,6 @@ namespace filesystem = experimental::filesystem;
 using namespace conduit;
 using namespace ascent;
 #endif
-
-// Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
-static constexpr auto QUOKKA_VERSION = "25.03";
 
 enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
 
@@ -562,9 +560,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 			amrex::Abort("Grids not properly nested!");
 		}
 	}
-
-	// add Quokka version to metadata
-	simulationMetadata_["quokka_version"] = QUOKKA_VERSION;
 
 	// add git commit to metadata
 	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();
@@ -2551,6 +2546,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
+	fenv_t orig_feenv;
+	feholdexcept(&orig_feenv); // disable FPE for YAML reading
+
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
 	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
 
@@ -2573,6 +2571,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << fmt::format("\t{} has unknown type! skipping this entry.\n", key);
 		}
 	}
+
+	fesetenv(&orig_feenv); // restore FPE
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteProjectionPlotfile() const


### PR DESCRIPTION
### Description
This turns off floating point exceptions when reading YAML files.

This should avoid stochastic CI failures due to FPEs in the yaml-cpp library. They do not appear to affect Quokka in any way.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
