### PR TITLE
add ROCm dev container

### DIFF
--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -3,7 +3,7 @@ FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0
 
 # Set environment variables for ROCm
 ENV hip_DIR=/opt/rocm/lib/cmake/hip
-ENV AMREX_AMD_ARCH=gfx90a
+ENV AMREX_AMD_ARCH=gfx908
 
 # Update package lists and install necessary dependencies
 RUN apt-get update -qq && apt-get upgrade -y -qq && \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -1,13 +1,15 @@
 # Use the AMD ROCm image as the base image
 FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0031116f56b04ada7d5
 
-# Set environment variables for ROCm
+# Set environment variables for CMake
 ENV hip_DIR=/opt/rocm/lib/cmake/hip
 ENV rocrand_DIR=/opt/rocm-6.3.4/lib/cmake/rocrand
 ENV hiprand_DIR=/opt/rocm-6.3.4/lib/cmake/hiprand
 ENV rocprim_DIR=/opt/rocm-6.3.4/lib/cmake/rocprim
 ENV rocsparse_DIR=/opt/rocm-6.3.4/lib/cmake/rocsparse
 ENV AMREX_AMD_ARCH=gfx908
+ENV CC=hipcc
+ENV CXX=hipcc
 
 # Update package lists and install necessary dependencies
 RUN apt-get update -qq && apt-get upgrade -y -qq && \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -8,6 +8,7 @@ ENV AMREX_AMD_ARCH=gfx908
 # Update package lists and install necessary dependencies
 RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \
+    rocrand-dev hiprand-dev rocprim-dev rocsparse-dev \
     build-essential wget curl git ninja-build gcc g++ \
     python3-dev python3-numpy python3-matplotlib python3-pip \
     libhdf5-dev libopenmpi-dev && \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -1,6 +1,10 @@
 # Use the AMD ROCm image as the base image
 FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0031116f56b04ada7d5
 
+# Set environment variables for ROCm
+ENV hip_DIR=/opt/rocm/lib/cmake/hip
+ENV AMREX_AMD_ARCH=gfx90a
+
 # Update package lists and install necessary dependencies
 RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -3,6 +3,10 @@ FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0
 
 # Set environment variables for ROCm
 ENV hip_DIR=/opt/rocm/lib/cmake/hip
+ENV rocrand_DIR=/opt/rocm-6.3.4/lib/cmake/rocrand
+ENV hiprand_DIR=/opt/rocm-6.3.4/lib/cmake/hiprand
+ENV rocprim_DIR=/opt/rocm-6.3.4/lib/cmake/rocprim
+ENV rocsparse_DIR=/opt/rocm-6.3.4/lib/cmake/rocsparse
 ENV AMREX_AMD_ARCH=gfx908
 
 # Update package lists and install necessary dependencies

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -1,0 +1,51 @@
+# Use the AMD ROCm image as the base image
+FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0031116f56b04ada7d5
+
+# Update package lists and install necessary dependencies
+RUN apt-get update -qq && apt-get upgrade -y -qq && \
+    apt-get install -y -qq --no-install-recommends \
+    build-essential wget curl git ninja-build gcc g++ \
+    python3-dev python3-numpy python3-matplotlib python3-pip \
+    libhdf5-dev && \
+    apt-get --yes -qq clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Clang 19.x
+RUN mkdir -m 0755 -p /etc/apt/keyrings/ && \
+ curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && \
+ echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
+
+RUN apt-get clean && apt-get update -y && \
+ apt-get install -y --no-install-recommends clang-19 llvm-19 libomp-19-dev libclang-rt-19-dev clangd-19 && \
+ rm -rf /var/lib/apt/lists/*
+
+# Create symlink for clangd
+RUN ln -s /usr/bin/clangd-19 /usr/bin/clangd
+
+# Install the latest version of CMake
+RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \
+    echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null
+
+RUN apt-get clean && apt-get update -y && \
+    apt-get install -y --no-install-recommends cmake && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install blosc2 (needed for ADIOS2)
+RUN pip3 install blosc2 --break-system-packages
+
+# Install ADIOS2 (needed for OpenPMD)
+RUN mkdir -p /tmp/build-adios2 && cd /tmp/build-adios2 && \
+    wget -q https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.10.1.tar.gz && \
+    tar xzf v2.10.1.tar.gz && \
+    mkdir adios2-build && cd adios2-build && \
+    cmake ../ADIOS2-2.10.1 -DADIOS2_USE_Blosc2=ON -DADIOS2_USE_Fortran=OFF && \
+    make -j$(nproc) && make install && \
+    cd / && \
+    rm -rf /tmp/build-adios2
+
+# Set the working directory and user
+WORKDIR /home/ubuntu
+USER ubuntu
+
+# Set the default command to bash
+CMD [ "/bin/bash" ]

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \
     build-essential wget curl git ninja-build gcc g++ \
     python3-dev python3-numpy python3-matplotlib python3-pip \
-    libhdf5-dev && \
+    libhdf5-dev libopenmpi-dev && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/rocm-container/devcontainer.json
+++ b/.devcontainer/rocm-container/devcontainer.json
@@ -1,0 +1,31 @@
+// devcontainer.json
+    {
+      "name": "Quokka ROCm Dev Container",
+      // (NOTE: using the cloud image is temporarily disabled, since it doesn't exist yet)
+      // "image": "ghcr.io/quokka-astro/quokka:development",
+      "build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
+      },
+      "hostRequirements": {
+        "cpus": 4
+      },
+      "customizations": {
+        "vscode": {
+          "settings": {},
+          "extensions": [
+            // disabled, since it interferes with clangd
+            "-ms-vscode.cpptools",
+            "llvm-vs-code-extensions.vscode-clangd",
+            "github.vscode-pull-request-github",
+            "ms-vscode.live-server",
+            "ms-azuretools.vscode-docker"
+          ]
+        }
+      },
+      "remoteUser": "ubuntu",
+      // we need to manually checkout the submodules,
+      // but VSCode may try to configure CMake before they are fully checked-out.
+      // workaround TBD
+      "postCreateCommand": "git submodule update --init"
+    }


### PR DESCRIPTION
### Description
Adds a Docker container to build Quokka with the AMD ROCm software stack for AMD GPUs. Note that using this on a recent Mac will be slow, since it runs under emulation (AMD only supports its software stack on x86_64 host CPUs).

In the near future, I am planning to run the CI tests on moth inside this container.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/768.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
