### PR TITLE
add metadata.yaml to slice outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ docs/doxygen/
 tests/last_chk
 tests/plt*
 tests/chk*
+tests/slice*
 tests/*.csv
 tests/plt*
 sims/

--- a/src/io/DiagBase.H
+++ b/src/io/DiagBase.H
@@ -4,6 +4,7 @@
 #include "AMReX_MultiFab.H"
 #include "DiagFilter.H"
 #include "Factory.H"
+#include "yaml-cpp/yaml.h"
 
 class DiagBase : public quokka::Factory<DiagBase>
 {
@@ -24,7 +25,7 @@ class DiagBase : public quokka::Factory<DiagBase>
 			     const amrex::Vector<amrex::DistributionMapping> &a_dmap, const amrex::Vector<std::string> &a_varNames);
 
 	virtual void processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-				 const amrex::Vector<std::string> &a_varNames) = 0;
+				 const amrex::Vector<std::string> &a_varNames, const YAML::Node &simulationMetadata) = 0;
 
 	virtual void addVars(amrex::Vector<std::string> &a_varList);
 

--- a/src/io/DiagFramePlane.H
+++ b/src/io/DiagFramePlane.H
@@ -3,6 +3,7 @@
 
 #include "AMReX_VisMF.H"
 #include "DiagBase.H"
+#include "yaml-cpp/yaml.h"
 
 class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 {
@@ -17,7 +18,7 @@ class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 		     const amrex::Vector<amrex::DistributionMapping> &a_dmap, const amrex::Vector<std::string> &a_varNames) override;
 
 	void processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-			 const amrex::Vector<std::string> &a_varNames) override;
+			 const amrex::Vector<std::string> &a_varNames, const YAML::Node &simulationMetadata) override;
 
 	void addVars(amrex::Vector<std::string> &a_varList) override;
 

--- a/src/io/DiagFramePlane.H
+++ b/src/io/DiagFramePlane.H
@@ -24,7 +24,7 @@ class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 
 	void Write2DMultiLevelPlotfile(const std::string &a_pltfile, int a_nlevels, const amrex::Vector<const amrex::MultiFab *> &a_slice,
 				       const amrex::Vector<std::string> &a_varnames, const amrex::Vector<amrex::Geometry> &a_geoms, const amrex::Real &a_time,
-				       const amrex::Vector<int> &a_steps, const amrex::Vector<amrex::IntVect> &a_rref);
+				       const amrex::Vector<int> &a_steps, const amrex::Vector<amrex::IntVect> &a_rref, const YAML::Node &simulationMetadata);
 
 	static void VisMF2D(const amrex::MultiFab &a_mf, const std::string &a_mf_name);
 

--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -259,29 +259,15 @@ void DiagFramePlane::processDiag(int a_nstep, const amrex::Real &a_time, const a
 			diagfile = m_diagfile + std::to_string(a_time);
 		}
 		amrex::Vector<int> const step_array(nlevs, a_nstep);
-		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio);
-
-		// Write metadata file
-		if (amrex::ParallelDescriptor::IOProcessor()) {
-			std::string const MetadataFileName(diagfile + "/metadata.yaml");
-			amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::IO_Buffer_Size);
-			std::ofstream MetadataFile;
-			MetadataFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
-			MetadataFile.open(MetadataFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
-			if (!MetadataFile.good()) {
-				amrex::FileOpenFailed(MetadataFileName);
-			}
-
-			// write YAML to MetadataFile
-			MetadataFile << simulationMetadata << '\n';
-			MetadataFile.close();
-		}
+		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio,
+					  simulationMetadata);
 	}
 }
 
 void DiagFramePlane::Write2DMultiLevelPlotfile(const std::string &a_pltfile, int a_nlevels, const amrex::Vector<const amrex::MultiFab *> &a_slice,
 					       const amrex::Vector<std::string> &a_varnames, const amrex::Vector<amrex::Geometry> &a_geoms,
-					       const amrex::Real &a_time, const amrex::Vector<int> &a_steps, const amrex::Vector<amrex::IntVect> &a_rref)
+					       const amrex::Real &a_time, const amrex::Vector<int> &a_steps, const amrex::Vector<amrex::IntVect> &a_rref,
+					       const YAML::Node &simulationMetadata)
 {
 	const std::string levelPrefix = "Level_";
 	const std::string mfPrefix = "Cell";
@@ -327,6 +313,19 @@ void DiagFramePlane::Write2DMultiLevelPlotfile(const std::string &a_pltfile, int
 
 		PlaneFile.flush();
 		PlaneFile.close();
+
+		// Write metadata file
+		std::string const MetadataFileName(a_pltfile + "/metadata.yaml");
+		std::ofstream MetadataFile;
+		MetadataFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
+		MetadataFile.open(MetadataFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+		if (!MetadataFile.good()) {
+			amrex::FileOpenFailed(MetadataFileName);
+		}
+
+		// write YAML to MetadataFile
+		MetadataFile << simulationMetadata << '\n';
+		MetadataFile.close();
 	}
 
 	// Write a 2D version of the MF at each level

--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -315,11 +315,8 @@ void DiagFramePlane::Write2DMultiLevelPlotfile(const std::string &a_pltfile, int
 		PlaneFile.close();
 
 		// Write metadata file
-#ifdef QUOKKA_USE_OPENPMD
-		std::string const MetadataFileName(a_pltfile + ".metadata.yaml");
-#else
+		// The slices are always in AMReX plotfile format, so we can always use /metadata.yaml.
 		std::string const MetadataFileName(a_pltfile + "/metadata.yaml");
-#endif
 		std::ofstream MetadataFile;
 		MetadataFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
 		MetadataFile.open(MetadataFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);

--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -315,7 +315,11 @@ void DiagFramePlane::Write2DMultiLevelPlotfile(const std::string &a_pltfile, int
 		PlaneFile.close();
 
 		// Write metadata file
+#ifdef QUOKKA_USE_OPENPMD
+		std::string const MetadataFileName(a_pltfile + ".metadata.yaml");
+#else
 		std::string const MetadataFileName(a_pltfile + "/metadata.yaml");
+#endif
 		std::ofstream MetadataFile;
 		MetadataFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
 		MetadataFile.open(MetadataFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);

--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -3,6 +3,7 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_PlotFileUtil.H"
 #include "AMReX_VisMF.H"
+#include "yaml-cpp/yaml.h"
 
 void printLowerDimIntVect(std::ostream &a_File, const amrex::IntVect &a_IntVect, int skipDim)
 {
@@ -191,7 +192,7 @@ void DiagFramePlane::prepare(int a_nlevels, const amrex::Vector<amrex::Geometry>
 }
 
 void DiagFramePlane::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-				 const amrex::Vector<std::string> & /*a_stateVar*/)
+				 const amrex::Vector<std::string> & /*a_stateVar*/, const YAML::Node &simulationMetadata)
 {
 	// Interpolate data to slice
 	amrex::Vector<amrex::MultiFab> planeData(a_state.size());
@@ -259,6 +260,22 @@ void DiagFramePlane::processDiag(int a_nstep, const amrex::Real &a_time, const a
 		}
 		amrex::Vector<int> const step_array(nlevs, a_nstep);
 		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio);
+
+		// Write metadata file
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			std::string const MetadataFileName(diagfile + "/metadata.yaml");
+			amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::IO_Buffer_Size);
+			std::ofstream MetadataFile;
+			MetadataFile.rdbuf()->pubsetbuf(io_buffer.dataPtr(), io_buffer.size());
+			MetadataFile.open(MetadataFileName.c_str(), std::ofstream::out | std::ofstream::trunc | std::ofstream::binary);
+			if (!MetadataFile.good()) {
+				amrex::FileOpenFailed(MetadataFileName);
+			}
+
+			// write YAML to MetadataFile
+			MetadataFile << simulationMetadata << '\n';
+			MetadataFile.close();
+		}
 	}
 }
 

--- a/src/io/DiagPDF.H
+++ b/src/io/DiagPDF.H
@@ -2,6 +2,7 @@
 #define DIAGPDF_H
 
 #include "DiagBase.H"
+#include "yaml-cpp/yaml.h"
 
 class DiagPDF : public DiagBase::Register<DiagPDF>
 {
@@ -14,7 +15,7 @@ class DiagPDF : public DiagBase::Register<DiagPDF>
 		     const amrex::Vector<amrex::DistributionMapping> &a_dmap, const amrex::Vector<std::string> &a_varNames) override;
 
 	void processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-			 const amrex::Vector<std::string> &a_stateVar) override;
+			 const amrex::Vector<std::string> &a_stateVar, const YAML::Node &simulationMetadata) override;
 
 	void addVars(amrex::Vector<std::string> &a_varList) override;
 

--- a/src/io/DiagPDF.cpp
+++ b/src/io/DiagPDF.cpp
@@ -118,7 +118,7 @@ auto DiagPDF::getIdxVec(const int linidx, std::vector<int> const &nBins) -> std:
 }
 
 void DiagPDF::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-			  const amrex::Vector<std::string> &a_stateVar)
+			  const amrex::Vector<std::string> &a_stateVar, const YAML::Node &simulationMetadata)
 {
 	// Set PDF range
 	const int nvars = static_cast<int>(m_varNames.size());

--- a/src/io/DiagPDF.cpp
+++ b/src/io/DiagPDF.cpp
@@ -118,7 +118,7 @@ auto DiagPDF::getIdxVec(const int linidx, std::vector<int> const &nBins) -> std:
 }
 
 void DiagPDF::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-			  const amrex::Vector<std::string> &a_stateVar, const YAML::Node &/*simulationMetadata*/)
+			  const amrex::Vector<std::string> &a_stateVar, const YAML::Node & /*simulationMetadata*/)
 {
 	// Set PDF range
 	const int nvars = static_cast<int>(m_varNames.size());

--- a/src/io/DiagPDF.cpp
+++ b/src/io/DiagPDF.cpp
@@ -118,7 +118,7 @@ auto DiagPDF::getIdxVec(const int linidx, std::vector<int> const &nBins) -> std:
 }
 
 void DiagPDF::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::Vector<const amrex::MultiFab *> &a_state,
-			  const amrex::Vector<std::string> &a_stateVar, const YAML::Node &simulationMetadata)
+			  const amrex::Vector<std::string> &a_stateVar, const YAML::Node &/*simulationMetadata*/)
 {
 	// Set PDF range
 	const int nvars = static_cast<int>(m_varNames.size());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2415,7 +2415,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 
 	for (const auto &diag : m_diagnostics) {
 		if (diag->doDiag(tNew_[0], istep[0])) {
-			diag->processDiag(istep[0], tNew_[0], GetVecOfConstPtrs(diagMFVec), m_diagVars);
+			diag->processDiag(istep[0], tNew_[0], GetVecOfConstPtrs(diagMFVec), m_diagVars, simulationMetadata_);
 		}
 	}
 }


### PR DESCRIPTION
### Description

This adds a metadata.yaml file to slicez_pltxxxxx folders. This is helpful because when yt loads that folder (it can, very sweet), yt will recognize it as a Quokka simulation output and do all the customization for Quokka. 

Note that this yt customization for Quokka is implemented and tested in [my yt fork](https://github.com/chongchonghe/yt) and we are in the process of publishing it before the next yt release. Demo of using the new YT frontend is here: https://github.com/Rongjun-ANU/README-of-yt-frontend-for-QUOKKA/blob/main/README.ipynb

Other changes: 
- this also adds `tests/slice*` to .gitignore

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
