### PR TITLE
Fix typo in comment about particleCfl

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -652,7 +652,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default CFL number == 0.3, set to whatever is in the file
 	pp.query("cfl", cflNumber_);
 
-	// Default CFL number for particles == 0.99, set to whatever is in the file
+	// Default CFL number for particles == 0.5, set to whatever is in the file
 	pp.query("particle_cfl", particleCflNumber_);
 
 	// Default AMR interpolation method == lincc_interp


### PR DESCRIPTION
### Description
Fixes typo in comment about the default value of the particle CFL. The actual default value is 0.5 (line 161).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
