### PR TITLE
add chongchonghe to CODEOWNERS for particles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,8 +19,8 @@ src/hydro/ @BenWibking @markkrumholz
 # optically-thin radiative cooling (assuming ionization equilibrium)
 src/cooling/ @BenWibking @markkrumholz
 
-# particles -- CICParticles only
-src/particles/CICParticles.hpp @BenWibking @markkrumholz
+# particles
+src/particles/ @chongchonghe @BenWibking @markkrumholz
 
 # chemistry (including chemical heating/cooling)
 src/chemistry/ @psharda @BenWibking @markkrumholz


### PR DESCRIPTION
### Description

@chongchonghe claims ownership to src/particles/

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
