### PR TITLE
binary orbit test on multilevel grids

### DIFF
--- a/src/problems/BinaryOrbitCIC/CMakeLists.txt
+++ b/src/problems/BinaryOrbitCIC/CMakeLists.txt
@@ -5,4 +5,5 @@ if (AMReX_SPACEDIM EQUAL 3)
     endif()
 
     add_test(NAME BinaryOrbitCIC COMMAND binary_orbit BinaryOrbit.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    add_test(NAME BinaryOrbitCICAMR COMMAND binary_orbit BinaryOrbitAMR.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -93,13 +93,10 @@ template <> void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::
 
 template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 {
-	// every N cycles, save particle statistics
+	// every N cycles, save particle statistics at the finest level
 	static int cycle = 1;
 	if (cycle % 10 == 0) {
-		// Get the finest level number
-		const int finest_level = finestLevel();
-
-		// create particle container for analysis using the same geometry as finest level
+		// create particle container for analysis
 		amrex::ParticleContainer<quokka::CICParticleRealComps> analysisPC{};
 		amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
 		amrex::Geometry const geom(box);
@@ -108,20 +105,11 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 		amrex::DistributionMapping const dmap(ranks);
 		analysisPC.Define(geom, dmap, boxArray);
 
-		// Print number of particles in source container
-		if (amrex::ParallelDescriptor::IOProcessor()) {
-			amrex::Long total_particles = 0;
-			const auto& particles = CICParticles->GetParticles(finest_level);
-			for (const auto& kv : particles) {
-				total_particles += kv.second.numParticles();
-			}
-			amrex::Print() << "Number of particles at finest level: " << total_particles << "\n";
-		}
-
-		// Create a single destination tile
+		// Create a single destination tile and copy all particles from finest level
 		auto& dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
 
 		// Copy particles from each source tile
+		const int finest_level = finestLevel();
 		const auto& particles = CICParticles->GetParticles(finest_level);
 		for (const auto& kv : particles) {
 			const auto& src_tile = kv.second;
@@ -132,60 +120,38 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 				// Resize to accommodate new particles
 				dst_tile.resize(old_size + np);
 				// Get source and destination arrays
-				auto& src_aos = src_tile.GetArrayOfStructs();
+				const auto& src_aos = src_tile.GetArrayOfStructs();
 				auto& dst_aos = dst_tile.GetArrayOfStructs();
 				// Copy particles
-				amrex::Gpu::copy(amrex::Gpu::deviceToDevice,
-							   src_aos.data(),
-							   src_aos.data() + np,
-							   dst_aos.data() + old_size);
+				amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + old_size); // NOLINT
 			}
-		}
-
-		// Print number of particles in analysis container
-		if (amrex::ParallelDescriptor::IOProcessor()) {
-			amrex::Long total_particles_analysis = 0;
-			const auto& analysis_particles = analysisPC.GetParticles(0);
-			for (const auto& kv : analysis_particles) {
-				total_particles_analysis += kv.second.numParticles();
-			}
-			amrex::Print() << "Number of particles in analysis container: " << total_particles_analysis << "\n";
 		}
 
 		if (amrex::ParallelDescriptor::IOProcessor()) {
 			quokka::CICParticleIterator const pIter(analysisPC, 0);
-			if (pIter.isValid()) {
+			if (pIter.isValid() && pIter.numParticles() >= 2) {
 				amrex::Print() << "Computing particle statistics...\n";
-				const amrex::Long np = pIter.numParticles();
-				amrex::Print() << "Number of particles in iterator: " << np << "\n";
-				
-				if (np >= 2) {  // Only proceed if we have at least 2 particles
-					auto &particles = pIter.GetArrayOfStructs();
+				auto &particles = pIter.GetArrayOfStructs();
 
-					// copy particles from device to host
-					quokka::CICParticleContainer::ParticleType *pData = particles().data();
-					amrex::Vector<quokka::CICParticleContainer::ParticleType> pData_h(np);
-					amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+				// copy particles from device to host
+				quokka::CICParticleContainer::ParticleType *pData = particles().data();
+				amrex::Vector<quokka::CICParticleContainer::ParticleType> pData_h(pIter.numParticles());
+				amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + pIter.numParticles(), pData_h.begin()); // NOLINT
 
-					// compute orbital elements
-					quokka::CICParticleContainer::ParticleType &p1 = pData_h[0];
-					quokka::CICParticleContainer::ParticleType &p2 = pData_h[1];
-					const amrex::ParticleReal dx = p1.pos(0) - p2.pos(0);
-					const amrex::ParticleReal dy = p1.pos(1) - p2.pos(1);
-					const amrex::ParticleReal dz = p1.pos(2) - p2.pos(2);
-					const amrex::ParticleReal dist = std::sqrt(dx * dx + dy * dy + dz * dz);
-					printf("dist = %e\n", dist);
-					const amrex::ParticleReal dist0 = 6.25e12; // cm
-					const amrex::Real cell_dx0 = this->geom[finest_level].CellSize(0); // Use finest level cell size
+				// compute orbital elements
+				quokka::CICParticleContainer::ParticleType &p1 = pData_h[0];
+				quokka::CICParticleContainer::ParticleType &p2 = pData_h[1];
+				const amrex::ParticleReal dx = p1.pos(0) - p2.pos(0);
+				const amrex::ParticleReal dy = p1.pos(1) - p2.pos(1);
+				const amrex::ParticleReal dz = p1.pos(2) - p2.pos(2);
+				const amrex::ParticleReal dist = std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+				const amrex::ParticleReal dist0 = 6.25e12; // cm
+				const amrex::Real cell_dx0 = this->geom[finest_level].CellSize(0);
 
-					// save statistics
-					userData_.time.push_back(tNew_[finest_level]); // Use time from finest level
-					userData_.dist.push_back((dist - dist0) / cell_dx0);
-				} else {
-					amrex::Print() << "Not enough particles for analysis (need at least 2)!\n";
-				}
-			} else {
-				amrex::Print() << "Particle iterator is not valid!\n";
+				// save statistics
+				userData_.time.push_back(tNew_[finest_level]);
+				userData_.dist.push_back((dist - dist0) / cell_dx0);
+				amrex::Print() << "Particle separation: " << dist << " cm, initial separation is " << dist0 << " cm.\n";
 			}
 		}
 	}

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -52,8 +52,8 @@ template <> struct Physics_Traits<BinaryOrbit> {
 };
 
 template <> struct SimulationData<BinaryOrbit> {
-	std::vector<amrex::ParticleReal> time{};
-	std::vector<amrex::ParticleReal> dist{};
+	std::vector<amrex::ParticleReal> time;
+	std::vector<amrex::ParticleReal> dist;
 };
 
 template <> void QuokkaSimulation<BinaryOrbit>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
@@ -162,11 +162,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::ErrorEst(int lev, amrex::TagBoxA
 {
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		const amrex::Box &box = mfi.validbox();
-		const auto prob_lo = geom[lev].ProbLoArray();
-		const auto dx = geom[lev].CellSizeArray();
-		const auto state = state_new_cc_[lev].const_array(mfi);
 		const auto tag = tags.array(mfi);
-		const int nidx = HydroSystem<BinaryOrbit>::density_index;
 
 		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { tag(i, j, k) = amrex::TagBox::SET; });
 	}

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -106,13 +106,13 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 		analysisPC.Define(geom, dmap, boxArray);
 
 		// Create a single destination tile and copy all particles from finest level
-		auto& dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
+		auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
 
 		// Copy particles from each source tile
 		const int finest_level = finestLevel();
-		const auto& particles = CICParticles->GetParticles(finest_level);
-		for (const auto& kv : particles) {
-			const auto& src_tile = kv.second;
+		const auto &particles = CICParticles->GetParticles(finest_level);
+		for (const auto &kv : particles) {
+			const auto &src_tile = kv.second;
 			const int np = src_tile.numParticles();
 			if (np > 0) {
 				// Get current size of destination tile
@@ -120,8 +120,8 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 				// Resize to accommodate new particles
 				dst_tile.resize(old_size + np);
 				// Get source and destination arrays
-				const auto& src_aos = src_tile.GetArrayOfStructs();
-				auto& dst_aos = dst_tile.GetArrayOfStructs();
+				const auto &src_aos = src_tile.GetArrayOfStructs();
+				auto &dst_aos = dst_tile.GetArrayOfStructs();
 				// Copy particles
 				amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + old_size); // NOLINT
 			}
@@ -168,9 +168,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::ErrorEst(int lev, amrex::TagBoxA
 		const auto tag = tags.array(mfi);
 		const int nidx = HydroSystem<BinaryOrbit>::density_index;
 
-		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-			tag(i, j, k) = amrex::TagBox::SET;
-		});
+		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { tag(i, j, k) = amrex::TagBox::SET; });
 	}
 }
 
@@ -219,7 +217,7 @@ auto problem_main() -> int
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		if (!sim.userData_.dist.empty()) {
 			auto result = std::max_element(sim.userData_.dist.begin(), sim.userData_.dist.end(),
-									[](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
+						       [](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
 			max_err = std::abs(*result);
 			amrex::Print() << "max particle separation = " << max_err << " cell widths.\n";
 		} else {

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -96,7 +96,10 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 	// every N cycles, save particle statistics
 	static int cycle = 1;
 	if (cycle % 10 == 0) {
-		// create single-box particle container
+		// Get the finest level number
+		const int finest_level = finestLevel();
+
+		// create particle container for analysis using the same geometry as finest level
 		amrex::ParticleContainer<quokka::CICParticleRealComps> analysisPC{};
 		amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
 		amrex::Geometry const geom(box);
@@ -104,37 +107,105 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 		amrex::Vector<int> const ranks({0}); // workaround nvcc bug
 		amrex::DistributionMapping const dmap(ranks);
 		analysisPC.Define(geom, dmap, boxArray);
-		analysisPC.copyParticles(*CICParticles);
+
+		// Print number of particles in source container
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::Long total_particles = 0;
+			const auto& particles = CICParticles->GetParticles(finest_level);
+			for (const auto& kv : particles) {
+				total_particles += kv.second.numParticles();
+			}
+			amrex::Print() << "Number of particles at finest level: " << total_particles << "\n";
+		}
+
+		// Create a single destination tile
+		auto& dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
+
+		// Copy particles from each source tile
+		const auto& particles = CICParticles->GetParticles(finest_level);
+		for (const auto& kv : particles) {
+			const auto& src_tile = kv.second;
+			const int np = src_tile.numParticles();
+			if (np > 0) {
+				// Get current size of destination tile
+				const int old_size = dst_tile.numParticles();
+				// Resize to accommodate new particles
+				dst_tile.resize(old_size + np);
+				// Get source and destination arrays
+				auto& src_aos = src_tile.GetArrayOfStructs();
+				auto& dst_aos = dst_tile.GetArrayOfStructs();
+				// Copy particles
+				amrex::Gpu::copy(amrex::Gpu::deviceToDevice,
+							   src_aos.data(),
+							   src_aos.data() + np,
+							   dst_aos.data() + old_size);
+			}
+		}
+
+		// Print number of particles in analysis container
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::Long total_particles_analysis = 0;
+			const auto& analysis_particles = analysisPC.GetParticles(0);
+			for (const auto& kv : analysis_particles) {
+				total_particles_analysis += kv.second.numParticles();
+			}
+			amrex::Print() << "Number of particles in analysis container: " << total_particles_analysis << "\n";
+		}
 
 		if (amrex::ParallelDescriptor::IOProcessor()) {
 			quokka::CICParticleIterator const pIter(analysisPC, 0);
 			if (pIter.isValid()) {
 				amrex::Print() << "Computing particle statistics...\n";
 				const amrex::Long np = pIter.numParticles();
-				auto &particles = pIter.GetArrayOfStructs();
+				amrex::Print() << "Number of particles in iterator: " << np << "\n";
+				
+				if (np >= 2) {  // Only proceed if we have at least 2 particles
+					auto &particles = pIter.GetArrayOfStructs();
 
-				// copy particles from device to host
-				quokka::CICParticleContainer::ParticleType *pData = particles().data();
-				amrex::Vector<quokka::CICParticleContainer::ParticleType> pData_h(np);
-				amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+					// copy particles from device to host
+					quokka::CICParticleContainer::ParticleType *pData = particles().data();
+					amrex::Vector<quokka::CICParticleContainer::ParticleType> pData_h(np);
+					amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
 
-				// compute orbital elements
-				quokka::CICParticleContainer::ParticleType &p1 = pData_h[0];
-				quokka::CICParticleContainer::ParticleType &p2 = pData_h[1];
-				const amrex::ParticleReal dx = p1.pos(0) - p2.pos(0);
-				const amrex::ParticleReal dy = p1.pos(1) - p2.pos(1);
-				const amrex::ParticleReal dz = p1.pos(2) - p2.pos(2);
-				const amrex::ParticleReal dist = std::sqrt(dx * dx + dy * dy + dz * dz);
-				const amrex::ParticleReal dist0 = 6.25e12; // cm
-				const amrex::Real cell_dx0 = this->geom[0].CellSize(0);
+					// compute orbital elements
+					quokka::CICParticleContainer::ParticleType &p1 = pData_h[0];
+					quokka::CICParticleContainer::ParticleType &p2 = pData_h[1];
+					const amrex::ParticleReal dx = p1.pos(0) - p2.pos(0);
+					const amrex::ParticleReal dy = p1.pos(1) - p2.pos(1);
+					const amrex::ParticleReal dz = p1.pos(2) - p2.pos(2);
+					const amrex::ParticleReal dist = std::sqrt(dx * dx + dy * dy + dz * dz);
+					printf("dist = %e\n", dist);
+					const amrex::ParticleReal dist0 = 6.25e12; // cm
+					const amrex::Real cell_dx0 = this->geom[finest_level].CellSize(0); // Use finest level cell size
 
-				// save statistics
-				userData_.time.push_back(tNew_[0]);
-				userData_.dist.push_back((dist - dist0) / cell_dx0);
+					// save statistics
+					userData_.time.push_back(tNew_[finest_level]); // Use time from finest level
+					userData_.dist.push_back((dist - dist0) / cell_dx0);
+				} else {
+					amrex::Print() << "Not enough particles for analysis (need at least 2)!\n";
+				}
+			} else {
+				amrex::Print() << "Particle iterator is not valid!\n";
 			}
 		}
 	}
 	++cycle;
+}
+
+template <> void QuokkaSimulation<BinaryOrbit>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+{
+	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
+		const amrex::Box &box = mfi.validbox();
+		const auto prob_lo = geom[lev].ProbLoArray();
+		const auto dx = geom[lev].CellSizeArray();
+		const auto state = state_new_cc_[lev].const_array(mfi);
+		const auto tag = tags.array(mfi);
+		const int nidx = HydroSystem<BinaryOrbit>::density_index;
+
+		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			tag(i, j, k) = amrex::TagBox::SET;
+		});
+	}
 }
 
 auto problem_main() -> int
@@ -178,15 +249,18 @@ auto problem_main() -> int
 	sim.evolve();
 
 	// check max abs particle distance
-	double max_err = NAN;
-	if (amrex::ParallelDescriptor::IOProcessor() && (!sim.userData_.dist.empty())) {
-		auto result = std::max_element(sim.userData_.dist.begin(), sim.userData_.dist.end(),
-					       [](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
-		max_err = std::abs(*result);
+	double max_err = 0.0;
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		if (!sim.userData_.dist.empty()) {
+			auto result = std::max_element(sim.userData_.dist.begin(), sim.userData_.dist.end(),
+									[](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
+			max_err = std::abs(*result);
+			amrex::Print() << "max particle separation = " << max_err << " cell widths.\n";
+		} else {
+			max_err = 1.0;
+			amrex::Print() << "No particles in userData_.dist.\n";
+		}
 	}
-	amrex::ParallelDescriptor::Bcast(&max_err, 1, amrex::ParallelDescriptor::Mpi_typemap<double>::type(), amrex::ParallelDescriptor::ioProcessor,
-					 amrex::ParallelDescriptor::Communicator());
-	amrex::Print() << "max particle separation = " << max_err << " cell widths.\n";
 
 	int status = 1;
 	const double max_err_tol = 0.18; // max error tol in cell widths

--- a/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
+++ b/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
@@ -33,7 +33,7 @@ def get_particle_dist(plotfiles):
         vys = ad["CIC_particles", "particle_real_comp2"]
         vzs = ad["CIC_particles", "particle_real_comp3"]
         ms = ad["CIC_particles", "particle_real_comp0"]
-        assert ms[0] == m0 and ms[1] == m0
+        assert np.isclose(ms[0], m0) and np.isclose(ms[1], m0)
         dx = x[0] - x[1]
         dy = y[0] - y[1]
         dz = z[0] - z[1]

--- a/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
+++ b/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
@@ -116,8 +116,6 @@ def plot_orbit_and_error(pltdir):
 
 
 def plot_debug_Poisson_rhs(pltdir):
-    max_idx = 300
-
     for pltfile in sorted(glob.glob(pltdir + "/debug_*")):
         # skip if not a directory
         if not os.path.isdir(pltfile):
@@ -127,8 +125,6 @@ def plot_debug_Poisson_rhs(pltdir):
         if not is_accel:
             continue
         ds = yt.load(pltfile)
-        ad = ds.all_data()
-        # field = ("boxlib", "Poisson_RHS")
         field = ("boxlib", "accel_x")
         slc = yt.SlicePlot(ds, "z", field)
         if is_accel:
@@ -140,7 +136,6 @@ def plot_debug_Poisson_rhs(pltdir):
         figfn = pltfile
         if figfn[-1] == '/':
             figfn = figfn[:-1]
-        # figfn = figfn + "_Poisson_RHS.png"
         figfn = figfn + "_accel_x.png"
         slc.save(figfn, mpl_kwargs={"dpi": 300})
 

--- a/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
+++ b/src/problems/BinaryOrbitCIC/particle_orbit_plot.py
@@ -1,13 +1,26 @@
 # note: requires yt>=4.3.0
+import os
+import sys
 import yt
+from math import sqrt
+import glob
+import numpy as np
 
-def particle_dist(plotfiles):
+yt.set_log_level(40)
+
+def get_particle_dist(plotfiles):
     t_arr = []
     err_arr = []
+    err_vel_arr = []
+    pos = []
+    nx_frame0 = None
     d0 = 2.0 * 3.125e12
+    v0 = 10332860.
+    m0 = 2.0e34
 
     for pltfile in plotfiles:
         ds = yt.load(pltfile)
+        # print(ds.derived_field_list)
         Lx = ds.domain_right_edge[0] - ds.domain_left_edge[0]
         Nx = ds.domain_dimensions[0]
         cell_dx = Lx/Nx
@@ -15,27 +28,127 @@ def particle_dist(plotfiles):
         x = ad["CIC_particles", "particle_position_x"]
         y = ad["CIC_particles", "particle_position_y"]
         z = ad["CIC_particles", "particle_position_z"]
+        pos.append((float(x[0].value), float(y[0].value), float(z[0].value)))
+        vxs = ad["CIC_particles", "particle_real_comp1"]
+        vys = ad["CIC_particles", "particle_real_comp2"]
+        vzs = ad["CIC_particles", "particle_real_comp3"]
+        ms = ad["CIC_particles", "particle_real_comp0"]
+        assert ms[0] == m0 and ms[1] == m0
         dx = x[0] - x[1]
         dy = y[0] - y[1]
         dz = z[0] - z[1]
-        from math import sqrt
         d = sqrt(dx*dx + dy*dy + dz*dz)
         #fractional_err = (d-d0)/d0
-        grid_err = (d-d0)/cell_dx
+        grid_err = (d - d0) / cell_dx.value
+        vx = vxs[0]
+        vy = vys[0]
+        vz = vzs[0]
+        v_mag = sqrt(vx*vx + vy*vy + vz*vz)
+        err_vel = (v_mag - v0) / v0
         t_arr.append(float(ds.current_time) / 3.15e7)
         err_arr.append(grid_err)
-    
-    return t_arr, err_arr
+        err_vel_arr.append(err_vel)
 
-import glob
-files = glob.glob("plt*")
-files = sorted(files)
-t, err = particle_dist(files)
+        if nx_frame0 is None:
+            nx_frame0 = Nx
 
-import matplotlib.pyplot as plt
-plt.figure(figsize=(6,4))
-plt.plot(t, err)
-plt.xlabel("time (yr)")
-plt.ylabel(r"$(d-d_0)/\Delta x$")
-plt.tight_layout()
-plt.savefig("orbit.png", dpi=150)
+    return t_arr, err_arr, err_vel_arr, pos, nx_frame0
+
+def get_particle_orbit(plotfiles):
+    t_arr = []
+    pos1_arr = []
+    pos2_arr = []
+    for pltfile in plotfiles:
+        ds = yt.load(pltfile)
+        ad = ds.all_data()
+        x = ad["CIC_particles", "particle_position_x"]
+        y = ad["CIC_particles", "particle_position_y"]
+        z = ad["CIC_particles", "particle_position_z"]
+        t_arr.append(float(ds.current_time) / 3.15e7)
+        pos1_arr.append((float(x[0].value), float(y[0].value), float(z[0].value)))
+        pos2_arr.append((float(x[1].value), float(y[1].value), float(z[1].value)))
+    return t_arr, pos1_arr, pos2_arr
+
+def plot_orbit_and_error(pltdir):
+
+    files = glob.glob(pltdir + "/plt*")
+    files = sorted(files)
+    t, err_dist, err_vel, pos_particle0, nx_frame0 = get_particle_dist(files)
+
+    print("max rel_error distance: {:.1e}".format(np.max(np.abs(err_dist))))
+    print("max error velocity: {:.1e}".format(np.max(np.abs(err_vel))))
+
+    # print time vs err_vel as a table
+    print("time(yr) rel_err_vel within_tol_1e-3 within_tol_1e-2?")
+    for i in range(len(t)):
+        print("{:.1e} {:.1e} {} {}".format(t[i], err_vel[i], np.abs(err_vel[i]) < 1.0e-3, np.abs(err_vel[i]) < 1.0e-2))
+
+    # plot the orbit
+    t, pos1_arr, pos2_arr = get_particle_orbit(files)
+    import matplotlib.pyplot as plt
+    plt.figure(figsize=(6,6))
+    Nx = nx_frame0
+    plt.title(f"nx={Nx}")
+    plt.scatter([pos[0] for pos in pos1_arr], [pos[1] for pos in pos1_arr], color="red", label="particle 1")
+    plt.scatter([pos[0] for pos in pos2_arr], [pos[1] for pos in pos2_arr], color="blue", label="particle 2")
+    plt.legend()
+    ax = plt.gca()
+    ax.set(xlabel="x", ylabel="y")
+    ax.axis("equal")
+    ax.grid()
+    hw = 6.0e12
+    ax.set(xlim=(-hw, hw), ylim=(-hw, hw))
+    figdir = os.path.dirname(files[0])
+    plt.savefig(os.path.join(figdir, "orbit.png"), dpi=300)
+
+    import matplotlib.pyplot as plt
+    plt.figure(figsize=(6,4))
+    plt.plot(t[1:], np.abs(err_dist[1:]))
+    # plt.ylim(-0.1, 0.1)
+    plt.grid()
+    plt.xlabel("time (yr)")
+    plt.ylabel(r"$(d-d_0)/\Delta x$")
+    plt.yscale("log")
+    plt.tight_layout()
+    plt.savefig(os.path.join(figdir, "orbit_err.png"), dpi=300)
+
+    return
+
+
+def plot_debug_Poisson_rhs(pltdir):
+    max_idx = 300
+
+    for pltfile in sorted(glob.glob(pltdir + "/debug_*")):
+        # skip if not a directory
+        if not os.path.isdir(pltfile):
+            continue
+        # only plot accel fields
+        is_accel = "accel" in os.path.basename(pltfile)
+        if not is_accel:
+            continue
+        ds = yt.load(pltfile)
+        ad = ds.all_data()
+        # field = ("boxlib", "Poisson_RHS")
+        field = ("boxlib", "accel_x")
+        slc = yt.SlicePlot(ds, "z", field)
+        if is_accel:
+            slc.set_zlim(field, 1e0, 3e4)
+            slc.set_log(field, True)
+        slc.set_width((1.3e13, "cm"))
+        slc.annotate_grids()
+        slc.annotate_cell_edges(line_width=0.001, color='black')
+        figfn = pltfile
+        if figfn[-1] == '/':
+            figfn = figfn[:-1]
+        # figfn = figfn + "_Poisson_RHS.png"
+        figfn = figfn + "_accel_x.png"
+        slc.save(figfn, mpl_kwargs={"dpi": 300})
+
+
+if __name__ == "__main__":
+    pltdir = "."
+    if len(sys.argv) > 1:
+        pltdir = sys.argv[1]
+
+    plot_orbit_and_error(pltdir)
+    # plot_debug_Poisson_rhs(pltdir)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -12,7 +12,6 @@
 // c++ headers
 #include <cfenv>
 #include <cmath>
-#include <cstdint>
 #include <cstdio>
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -70,7 +69,6 @@ namespace filesystem = experimental::filesystem;
 
 #ifdef AMREX_PARTICLES
 #include "AMReX_AmrParticles.H"
-#include "AMReX_Particles.H"
 #include "particles/PhysicsParticles.hpp"
 #endif
 
@@ -187,7 +185,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) { initialize(); }
 
-	inline auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> &BCs_cc) -> amrex::Vector<amrex::BCRec>
+	auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> &BCs_cc) -> amrex::Vector<amrex::BCRec>
 	{
 		amrex::Vector<amrex::BCRec> BCs_fc(Physics_Indices<problem_t>::nvarPerDim_fc);
 
@@ -248,7 +246,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const = 0;
 
 	// compute projected vars
-	[[nodiscard]] virtual auto ComputeProjections(const amrex::Direction dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> = 0;
+	[[nodiscard]] virtual auto ComputeProjections(amrex::Direction dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> = 0;
 
 	// compute statistics
 	virtual auto ComputeStatistics() -> std::map<std::string, amrex::Real> = 0;
@@ -1185,8 +1183,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 		// set up elliptic solve object
 		amrex::OpenBCSolver poissonSolver(Geom(0, finest_level), boxArray(0, finest_level), DistributionMap(0, finest_level));
 		if (verbose) {
-			poissonSolver.setVerbose(true);
-			poissonSolver.setBottomVerbose(false);
+			poissonSolver.setVerbose(1);
+			poissonSolver.setBottomVerbose(0);
 			amrex::Print() << "Doing Poisson solve...\n\n";
 		}
 
@@ -1215,22 +1213,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 		particleRegister_.depositMass(amrex::GetVecOfPtrs(rhs), finest_level, Gconst_);
 #endif
 
-		// // For debugging: print rhs at nz = 16 and lev = 0
-		// amrex::Print() << "rhs[0].data() =";
-		// for (amrex::MFIter iter(rhs[0]); iter.isValid(); ++iter) {
-		// 	const amrex::Box &indexRange = iter.validbox();
-		// 	auto const &rhs_arr = rhs[0].array(iter);
-		// 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		// 		if (k == 8) {
-		// 			if (i == 0) {
-		// 				std::cout << "\n";
-		// 			}
-		// 			std::cout << rhs_arr(i, j, k) << ", ";
-		// 		}
-		// 	});
-		// 	std::cout << "\n";
-		// }
-
 		amrex::Real abstol = abstolPoisson_ * rhs_min;
 		poissonSolver.solve(amrex::GetVecOfPtrs(phi), amrex::GetVecOfConstPtrs(rhs), reltolPoisson_, abstol);
 		if (verbose) {
@@ -1239,7 +1221,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 
 		// check for NaN
 		for (int lev = 0; lev <= finest_level; ++lev) {
-			AMREX_ALWAYS_ASSERT(!phi[lev].contains_nan()); // this fails when max_level=2 for SphericalCollapse
+			AMREX_ALWAYS_ASSERT(!phi[lev].contains_nan()); // NOTE: this fails when multiple levels are fully refined
 		}
 	}
 #endif
@@ -1316,6 +1298,16 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		// check for NaN
 		AMREX_ALWAYS_ASSERT(!phi[lev].contains_nan());
 
+		amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
+		amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> fineBdryFunct(geom[lev], accelBC, boundaryFunctor);
+		if (lev > 0) {
+			// fill ghosts at coarse-fine boundary
+			// this *also* fills valid cells, so we have to do it *before* computing the real accelerations
+			amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> coarseBdryFunct(geom[lev - 1], accelBC, boundaryFunctor);
+			amrex::InterpFromCoarseLevel(accel[lev], 0., accel[lev - 1], 0, 0, AMREX_SPACEDIM, geom[lev - 1], geom[lev], coarseBdryFunct, 0,
+						     fineBdryFunct, 0, refRatio(lev - 1), getAmrInterpolaterCellCentered(), accelBC, 0);
+		}
+
 		amrex::ParallelFor(accel[lev], ng, AMREX_SPACEDIM, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) {
 			// compute cell-centered acceleration -grad(phi)
 			if (n == 0) {
@@ -1330,18 +1322,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		});
 		amrex::Gpu::streamSynchronizeAll();
 
-		// fill ghost cells for accel[lev]
-		amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
-		amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> fineBdryFunct(geom[lev], accelBC, boundaryFunctor);
-
-		if (lev == 0) {
-			accel[lev].FillBoundary(geom[lev].periodicity());
-			fineBdryFunct(accel[lev], 0, accel[lev].nComp(), accel[lev].nGrowVect(), 0., 0);
-		} else {
-			amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> coarseBdryFunct(geom[lev - 1], accelBC, boundaryFunctor);
-			amrex::InterpFromCoarseLevel(accel[lev], 0., accel[lev - 1], 0, 0, AMREX_SPACEDIM, geom[lev - 1], geom[lev], coarseBdryFunct, 0,
-						     fineBdryFunct, 0, refRatio(lev - 1), getAmrInterpolaterCellCentered(), accelBC, 0);
-		}
+		// fill ghost cells for accel[lev] that are NOT at coarse-fine boundary
+		accel[lev].FillBoundary(geom[lev].periodicity());
+		fineBdryFunct(accel[lev], 0, accel[lev].nComp(), accel[lev].nGrowVect(), 0., 0);
 
 		// check for NaN
 		AMREX_ALWAYS_ASSERT(!accel[lev].contains_nan(0, AMREX_SPACEDIM));

--- a/tests/BinaryOrbit.in
+++ b/tests/BinaryOrbit.in
@@ -14,20 +14,20 @@ amr.v              = 1       # verbosity in Amr
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell          = 32 32 32
-amr.max_level       = 0     # number of levels = max_level + 1
+amr.max_level       = 1     # number of levels = max_level + 1
 amr.blocking_factor = 32    # grid size must be divisible by this
 amr.max_grid_size   = 32    # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
 amr.grid_eff        = 1.0
 
 cfl = 0.3
-max_timesteps = 8000
+max_timesteps = 10
 stop_time = 5.0e7   # s
 
 do_reflux = 1
 do_subcycle = 0
 
 ascent_interval = -1
-checkpoint_interval = -1
+checkpoint_interval = 10
 plottime_interval = 2.0e5 # s
 derived_vars = gpot

--- a/tests/BinaryOrbitAMR.in
+++ b/tests/BinaryOrbitAMR.in
@@ -14,7 +14,7 @@ amr.v              = 1       # verbosity in Amr
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell          = 32 32 32
-amr.max_level       = 0     # number of levels = max_level + 1
+amr.max_level       = 1     # number of levels = max_level + 1
 amr.blocking_factor = 32    # grid size must be divisible by this
 amr.max_grid_size   = 32    # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells


### PR DESCRIPTION
### Description

Previously the binary_orbit test runs on uniform grid. This PR add a new test with the whole domain refined to `lev=1`. The orbit separation is checked against the expected value and the error is within 6%. Note that the orbit radius is resolved by only 4 cells. In the uniform-grid test, the orbit radius is resolved by 2 (!!!) cells and the the error is confined in 16%. 

More changes: 
- I also updated `computeAfterTimestep` in `binary_orbit.cpp` to copy all particles from the finest level to the IO processor and validate the answer on the go. Previously `computeAfterTimestep` only works when AMR is disabled (`lev_max = 0`). 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
