### PR TITLE
Define a virtual function to tell if a particle type belongs to the Star particle class

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -71,6 +71,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getParticleData(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Pure virtual methods that must be implemented by derived classes
+	[[nodiscard]] virtual auto isStarParticle() -> bool = 0;
 	virtual void depositRadiation(amrex::MultiFab &radEnergySource, int lev, amrex::Real current_time, int nGroups) = 0;
 	virtual void redistribute(int lev) = 0;
 	virtual void redistribute(int lev, int ngrow) = 0;
@@ -101,6 +102,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	ContainerType *container_{}; // Pointer to the actual particle container - moved to protected
 
       public:
+	[[nodiscard]] auto isStarParticle() -> bool override { return false; }
+
 	// Get the particle type
 	[[nodiscard]] static constexpr auto getParticleType() -> ParticleType { return particleType_; }
 
@@ -491,6 +494,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, problem_t, particleType>
 {
       public:
+	[[nodiscard]] auto isStarParticle() -> bool override { return true; }
+
 	// Constructor - forwards all arguments to the base class
 	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container, bool allows_destruction = false,
 			       int evolution_stage_idx = -1, bool hydro_interact = false)
@@ -648,10 +653,12 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Deposit supernova energy and momentum from all particles
 	void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time)
 	{
-		// this function is only implemented for one particle type (Test particles), so we specify the particle type manually here
-		auto it = particleRegistry_.find(ParticleType::Test);
-		if (it != particleRegistry_.end()) {
-			it->second->depositSN(state, lev, step_end_time);
+		// this function is only implemented for particles that belong to the StarParticleDescriptor class whose unique signature is that the
+		// isStarParticle() method returns true
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			if (descriptor->isStarParticle()) {
+				descriptor->depositSN(state, lev, step_end_time);
+			}
 		}
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -180,7 +180,7 @@ constexpr int StochasticStellarPopParticleStageIdx = 0; // Evolution stage of th
 // Number of real components for StochasticStellarPop_particles, mass + 3 velocity components + luminosity
 template <typename problem_t>
 constexpr int StochasticStellarPopParticleRealComps = []() constexpr {
-	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && Physics_Traits<problem_t>::is_radiation_enabled) {
+	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
 		return 5 + Physics_Traits<problem_t>::nGroups; // mass, vx, vy, vz, birth_time, lum[nGroups]
 	} else {
 		return 5; // mass, vx, vy, vz, birth_time


### PR DESCRIPTION
### Description
We have `PhysicsParticleDescriptor` for most particle types and `StarParticleDescriptor` for star-like particle types, and some operations like `depositSN` only exists in the latter. However, the code does not know which of these two classes a `descriptor` belongs to. In this PR, I define a virtual function `isStarParticle()` that returns whether or not a particle type belongs to `StarParticleDescriptor` so that we can call `depositSN` on it. This makes `depositSN` in `PhysicsParticleRegister` very clean. 

This design can generalize to more particle classes , in which case I will change `isStarParticle()` to `getParticleClass` which returns the particle class: base_particles, star_particles, DM_particles, etc. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
