### PR TITLE
only kick particles when Poisson solver is turned on

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -998,7 +998,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 #if AMREX_SPACEDIM == 3
 		// do particle leapfrog (first kick at time t)
-		kickParticlesAllLevels(dt_[0]);
+		if (doPoissonSolve_ != 0) {
+			kickParticlesAllLevels(dt_[0]);
+		}
 #endif
 
 		// hyperbolic advance over all levels
@@ -1018,7 +1020,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 		// do particle leapfrog (second kick at t + dt)
 #if AMREX_SPACEDIM == 3
-		kickParticlesAllLevels(dt_[0]);
+		if (doPoissonSolve_ != 0) {
+			kickParticlesAllLevels(dt_[0]);
+		}
 
 		// Use the new type-aware particle creation method
 		// TODO(cch): Need to take care of AMR subscycling


### PR DESCRIPTION
### Description

We should only kick particles when Poisson solver is turned on. Otherwise, if we have massive particles in a sim and forget to turn on gravity, the code will complain that `phi` is not defined. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
