### PR TITLE
Print the cell that sets the timestep on each level

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -182,7 +182,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
-	auto computeExtraPhysicsTimestep(int lev) -> amrex::Real override;
+	auto computeExtraPhysicsTimestep(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -515,11 +515,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignal
 	}
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::Real
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	BL_PROFILE("QuokkaSimulation::computeExtraPhysicsTimestep()");
 	// users can override this to enforce additional timestep constraints
-	return std::numeric_limits<amrex::Real>::max();
+	return amrex::ValLocPair<amrex::Real, amrex::IntVect>{.value = std::numeric_limits<amrex::Real>::max(),
+							      .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 }
 
 #if !defined(NDEBUG)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -11,6 +11,7 @@
 
 #include "hydro/EOS.hpp"
 #include <array>
+#include <iostream>
 #if __has_include(<filesystem>)
 #include <filesystem>
 #elif __has_include(<experimental/filesystem>)
@@ -536,9 +537,9 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 		const amrex::Real Ekin = 0.5 * rho * vsq;
 		const amrex::Real Eint = Etot - Ekin;
 		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
-		const amrex::Real T = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Eint);
-		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
-		std::cout << "cell density = " << rho << ", |v| = " << vel_mag << ", T = " << T << ", cs = " << cs << "\n";
+		constexpr amrex::Real gamma = quokka::EOS_Traits<problem_t>::gamma;
+		const amrex::Real cs = (gamma != 1.) ? quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P) : quokka::EOS_Traits<problem_t>::cs_isothermal;
+		std::cout << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
 	}
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -523,6 +523,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 	amrex::Vector<amrex::Real> cell_values = amrex::get_cell_data(state_new_cc_[lev], index);
 
 	// cell_values is *only* filled on the MPI rank that holds the box with this cell
+	// (NOTE: for Cray MPICH, standard output is NOT ordered with respect to different ranks.)
 	if (!cell_values.empty()) {
 		const amrex::Real rho = cell_values[HydroSystem<problem_t>::density_index];
 		const amrex::Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
@@ -537,9 +538,9 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 		const amrex::Real Ekin = 0.5 * rho * vsq;
 		const amrex::Real Eint = Etot - Ekin;
 		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
-
 		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
-		std::cout << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
+
+		amrex::AllPrint() << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
 	}
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -9,6 +9,7 @@
 /// \brief Implements classes and functions to organise the overall setup,
 /// timestepping, solving, and I/O of a simulation for radiation moments.
 
+#include "hydro/EOS.hpp"
 #include <array>
 #if __has_include(<filesystem>)
 #include <filesystem>
@@ -182,6 +183,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
+	void printCellProperties(int lev, amrex::IntVect const &index) override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -512,6 +514,32 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignal
 				     "compute a time step.");
 		}
 	}
+}
+
+template <typename problem_t> void QuokkaSimulation<problem_t>::printCellProperties(int lev, amrex::IntVect const &index)
+{
+	// print density, velocity magnitude, temperature, adiabatic sound speed
+	amrex::Vector<amrex::Real> cell_values = amrex::get_cell_data(state_new_cc_[lev], index);
+
+	const amrex::Real rho = cell_values[HydroSystem<problem_t>::density_index];
+	const amrex::Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
+	const amrex::Real px2 = cell_values[HydroSystem<problem_t>::x2Momentum_index];
+	const amrex::Real px3 = cell_values[HydroSystem<problem_t>::x3Momentum_index];
+	const amrex::Real Etot = cell_values[HydroSystem<problem_t>::energy_index];
+
+	const amrex::Real vx1 = px1 / rho;
+	const amrex::Real vx2 = px2 / rho;
+	const amrex::Real vx3 = px3 / rho;
+	const amrex::Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
+	const amrex::Real vel_mag = std::sqrt(vsq);
+
+	const amrex::Real Ekin = 0.5 * rho * vsq;
+	const amrex::Real Eint = Etot - Ekin;
+	const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
+	const amrex::Real T = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Eint);
+	const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
+
+	amrex::Print() << "cell density = " << rho << ", |v| = " << vel_mag << ", T = " << T << ", cs = " << cs << "\n";
 }
 
 #if !defined(NDEBUG)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -537,7 +537,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 		const amrex::Real Ekin = 0.5 * rho * vsq;
 		const amrex::Real Eint = Etot - Ekin;
 		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
-		constexpr amrex::Real gamma = quokka::EOS_Traits<problem_t>::gamma;
+
 		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
 		std::cout << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
 	}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -538,7 +538,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 		const amrex::Real Eint = Etot - Ekin;
 		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
 		constexpr amrex::Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-		const amrex::Real cs = (gamma != 1.) ? quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P) : quokka::EOS_Traits<problem_t>::cs_isothermal;
+		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
 		std::cout << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
 	}
 }

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -182,7 +182,6 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
-	auto computeExtraPhysicsTimestep(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -513,15 +512,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignal
 				     "compute a time step.");
 		}
 	}
-}
-
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
-{
-	BL_PROFILE("QuokkaSimulation::computeExtraPhysicsTimestep()");
-	// users can override this to enforce additional timestep constraints
-	return amrex::ValLocPair<amrex::Real, amrex::IntVect>{.value = std::numeric_limits<amrex::Real>::max(),
-							      .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 }
 
 #if !defined(NDEBUG)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -521,25 +521,25 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 	// print density, velocity magnitude, temperature, adiabatic sound speed
 	amrex::Vector<amrex::Real> cell_values = amrex::get_cell_data(state_new_cc_[lev], index);
 
-	const amrex::Real rho = cell_values[HydroSystem<problem_t>::density_index];
-	const amrex::Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
-	const amrex::Real px2 = cell_values[HydroSystem<problem_t>::x2Momentum_index];
-	const amrex::Real px3 = cell_values[HydroSystem<problem_t>::x3Momentum_index];
-	const amrex::Real Etot = cell_values[HydroSystem<problem_t>::energy_index];
-
-	const amrex::Real vx1 = px1 / rho;
-	const amrex::Real vx2 = px2 / rho;
-	const amrex::Real vx3 = px3 / rho;
-	const amrex::Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
-	const amrex::Real vel_mag = std::sqrt(vsq);
-
-	const amrex::Real Ekin = 0.5 * rho * vsq;
-	const amrex::Real Eint = Etot - Ekin;
-	const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
-	const amrex::Real T = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Eint);
-	const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
-
-	amrex::Print() << "cell density = " << rho << ", |v| = " << vel_mag << ", T = " << T << ", cs = " << cs << "\n";
+	// cell_values is *only* filled on the MPI rank that holds the box with this cell
+	if (!cell_values.empty()) {
+		const amrex::Real rho = cell_values[HydroSystem<problem_t>::density_index];
+		const amrex::Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
+		const amrex::Real px2 = cell_values[HydroSystem<problem_t>::x2Momentum_index];
+		const amrex::Real px3 = cell_values[HydroSystem<problem_t>::x3Momentum_index];
+		const amrex::Real Etot = cell_values[HydroSystem<problem_t>::energy_index];
+		const amrex::Real vx1 = px1 / rho;
+		const amrex::Real vx2 = px2 / rho;
+		const amrex::Real vx3 = px3 / rho;
+		const amrex::Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
+		const amrex::Real vel_mag = std::sqrt(vsq);
+		const amrex::Real Ekin = 0.5 * rho * vsq;
+		const amrex::Real Eint = Etot - Ekin;
+		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
+		const amrex::Real T = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Eint);
+		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
+		std::cout << "cell density = " << rho << ", |v| = " << vel_mag << ", T = " << T << ", cs = " << cs << "\n";
+	}
 }
 
 #if !defined(NDEBUG)

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -121,7 +121,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeMaxSig
 	}
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>:: printCellProperties(int lev, amrex::IntVect const &index)
+template <typename problem_t> void AdvectionSimulation<problem_t>::printCellProperties(int lev, amrex::IntVect const &index)
 {
 	// deliberately empty
 }

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -61,7 +61,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { componentNames_cc_.push_back({"density"}); }
 
 	void computeMaxSignalLocal(int level) override;
-	auto computeExtraPhysicsTimestep(int level) -> amrex::Real override;
+	auto computeExtraPhysicsTimestep(int level) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -131,10 +131,12 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::applyPoissonG
 	// deliberately empty
 }
 
-template <typename problem_t> auto AdvectionSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::Real
+template <typename problem_t>
+auto AdvectionSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// user can override this
-	return std::numeric_limits<amrex::Real>::max();
+	return amrex::ValLocPair<amrex::Real, amrex::IntVect>{.value = std::numeric_limits<amrex::Real>::max(),
+							      .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::preCalculateInitialConditions()

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -61,6 +61,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { componentNames_cc_.push_back({"density"}); }
 
 	void computeMaxSignalLocal(int level) override;
+	void printCellProperties(int lev, amrex::IntVect const &index) override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -118,6 +119,11 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeMaxSig
 		auto const &maxSignal = max_signal_speed_[level].array(iter);
 		LinearAdvectionSystem<problem_t>::ComputeMaxSignalSpeed(stateOld, maxSignal, advectionVx_, advectionVy_, advectionVz_, indexRange);
 	}
+}
+
+template <typename problem_t> void AdvectionSimulation<problem_t>:: printCellProperties(int lev, amrex::IntVect const &index)
+{
+	// deliberately empty
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev)

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -61,7 +61,6 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { componentNames_cc_.push_back({"density"}); }
 
 	void computeMaxSignalLocal(int level) override;
-	auto computeExtraPhysicsTimestep(int level) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> override;
 	void preCalculateInitialConditions() override;
 	void setInitialConditionsOnGrid(quokka::grid const &grid_elem) override;
 	void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) override;
@@ -129,14 +128,6 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::fillPoissonRh
 template <typename problem_t> void AdvectionSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt)
 {
 	// deliberately empty
-}
-
-template <typename problem_t>
-auto AdvectionSimulation<problem_t>::computeExtraPhysicsTimestep(int const /*level*/) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
-{
-	// user can override this
-	return amrex::ValLocPair<amrex::Real, amrex::IntVect>{.value = std::numeric_limits<amrex::Real>::max(),
-							      .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 }
 
 template <typename problem_t> void AdvectionSimulation<problem_t>::preCalculateInitialConditions()

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -372,7 +372,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			if (mass_idx + 3 < ContainerType::ParticleType::NReal) {
 				// Use ParticleReduce with ReduceOpMax for efficient parallel reduction
 				amrex::ReduceOps<amrex::ReduceOpMax> reduce_ops;
-				using ResultType = amrex::GpuTuple<amrex::ValLocPair<amrex::Real, amrex::RealVect>>;
+				using ResultType = amrex::ValLocPair<amrex::Real, amrex::RealVect>;
 				using ReduceDataType = amrex::ReduceData<ResultType>;
 
 				// Perform the reduction over all particles at this level
@@ -386,12 +386,12 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 					    const amrex::Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
 					    const amrex::Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
 					    const amrex::RealVect pos{p_type[i].pos(0), p_type[i].pos(1), p_type[i].pos(2)};
-					    return {amrex::ValLocPair<amrex::Real, amrex::RealVect> { std::sqrt(v2), pos }};
+					    return amrex::ValLocPair<amrex::Real, amrex::RealVect> { std::sqrt(v2), pos };
 				    },
 				    reduce_ops);
 
 				// Extract the value from the tuple
-				max_speed = std::max(0.0, amrex::get<0>(result_tuple));
+				max_speed = amrex::get<0>(result_tuple);
 
 				AMREX_ASSERT(!std::isnan(max_speed.value));
 				AMREX_ASSERT(!std::isinf(max_speed.value));

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -386,7 +386,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 					    const amrex::Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
 					    const amrex::Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
 					    const amrex::RealVect pos{p_type[i].pos(0), p_type[i].pos(1), p_type[i].pos(2)};
-					    return amrex::ValLocPair<amrex::Real, amrex::RealVect> { std::sqrt(v2), pos };
+					    return amrex::ValLocPair<amrex::Real, amrex::RealVect>{std::sqrt(v2), pos};
 				    },
 				    reduce_ops);
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -85,7 +85,7 @@ class PhysicsParticleDescriptorBase
 	virtual void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &acceleration) = 0;
 	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const = 0;
 	virtual void destroyParticles(int lev, amrex::Real current_time, amrex::Real dt) = 0;
-	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::Real = 0;
+	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> = 0;
 
 	// Methods that are implemented for some but not all particle types, so they cannot be pure virtual
 	virtual void depositSN(amrex::MultiFab &state, int lev, amrex::Real step_end_time) { /* Default empty implementation */ }
@@ -360,9 +360,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 
 	// Compute maximum particle speed at a given level
-	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::Real override
+	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> override
 	{
-		amrex::Real max_speed = 0.0;
+		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect { AMREX_D_DECL(NAN, NAN, NAN) }};
 
 		if (container_ != nullptr && this->getMassIndex() >= 0) {
 			// Only compute for particles that have velocity components
@@ -372,27 +372,29 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			if (mass_idx + 3 < ContainerType::ParticleType::NReal) {
 				// Use ParticleReduce with ReduceOpMax for efficient parallel reduction
 				amrex::ReduceOps<amrex::ReduceOpMax> reduce_ops;
-				using ReduceDataType = amrex::ReduceData<amrex::Real>;
+				using ResultType = amrex::GpuTuple<amrex::ValLocPair<amrex::Real, amrex::RealVect>>;
+				using ReduceDataType = amrex::ReduceData<ResultType>;
 
 				// Perform the reduction over all particles at this level
 				using PTDType = typename ContainerType::ParticleTileType::ConstParticleTileDataType;
 				auto result_tuple = amrex::ParticleReduce<ReduceDataType>(
 				    *container_, lev,
-				    [=] AMREX_GPU_DEVICE(const PTDType &p_type, const int i) noexcept -> amrex::Real {
+				    [=] AMREX_GPU_DEVICE(const PTDType &p_type, const int i) noexcept -> ResultType {
 					    // Compute velocity magnitude
 					    const amrex::Real vx = p_type.m_aos[i].rdata(mass_idx + 1);
 					    const amrex::Real vy = p_type.m_aos[i].rdata(mass_idx + 2);
 					    const amrex::Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
 					    const amrex::Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
-					    return std::sqrt(v2);
+					    const amrex::RealVect pos{p_type[i].pos(0), p_type[i].pos(1), p_type[i].pos(2)};
+					    return {amrex::ValLocPair<amrex::Real, amrex::RealVect> { std::sqrt(v2), pos }};
 				    },
 				    reduce_ops);
 
 				// Extract the value from the tuple
 				max_speed = std::max(0.0, amrex::get<0>(result_tuple));
 
-				AMREX_ASSERT(!std::isnan(max_speed));
-				AMREX_ASSERT(!std::isinf(max_speed));
+				AMREX_ASSERT(!std::isnan(max_speed.value));
+				AMREX_ASSERT(!std::isinf(max_speed.value));
 			}
 		}
 
@@ -745,13 +747,13 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Compute maximum particle speed across all particle types
-	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::Real
+	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect>
 	{
-		amrex::Real max_speed = 0.0;
+		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect{AMREX_D_DECL(NAN, NAN, NAN)}};
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
-				const amrex::Real speed = descriptor->computeMaxParticleSpeed(lev);
-				AMREX_ASSERT(!std::isnan(speed));
+				const amrex::ValLocPair<amrex::Real, amrex::RealVect> speed = descriptor->computeMaxParticleSpeed(lev);
+				AMREX_ASSERT(!std::isnan(speed.value));
 				max_speed = std::max(max_speed, speed);
 			}
 		}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -812,10 +812,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
 
 	if (verbose) {
-		amrex::Print() << "...[level " << lev << "] estimated hydro timestep: " << hydro_dt.value << '\n';
-		amrex::Print() << "...[level " << lev << "] hydro timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max
-			       << '\n';
-		amrex::Print() << "...[level " << lev << "] ";
+		amrex::Print() << fmt::format("...[level {}] estimated hydro timestep: {:e}\n", lev, hydro_dt.value);
+		amrex::Print() << fmt::format("...[level {}] \thydro timestep limited at cell ({}, {}, {}) with signal speed = {:e}\n", lev, hydro_dt.index[0],
+					      hydro_dt.index[1], hydro_dt.index[2], domain_signal_max);
 		printCellProperties(lev, hydro_dt.index);
 	}
 
@@ -840,8 +839,10 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			particle_dt.index = cell_idx;
 		}
 		if (verbose) {
-			amrex::Print() << "...[level " << lev << "] estimated particle timestep: " << particle_dt.value << '\n';
-			amrex::Print() << "...[level " << lev << "] particle timestep limited at cell " << particle_dt.index << '\n';
+			amrex::Print() << fmt::format("...[level {}] estimated particle timestep: {:e}\n", lev, particle_dt.value);
+			amrex::Print() << fmt::format("...[level {}] \tmax particle velocity: {:e}\n", lev, max_particle_speed.value);
+			amrex::Print() << fmt::format("...[level {}] \tparticle timestep limited at position ({:e}, {:e}, {:e})\n", lev,
+						      max_particle_speed.index[0], max_particle_speed.index[1], max_particle_speed.index[2]);
 		}
 	}
 #endif
@@ -851,14 +852,11 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end(), [](dtloc_t *const p1, dtloc_t *const p2) { return p1->value < p2->value; });
 
 	if (verbose) {
-		amrex::Print() << "...[level " << lev << "] estimated timestep: " << dt_min_ptr->value << '\n';
-		amrex::Print() << "...[level " << lev << "] timestep limited at cell " << dt_min_ptr->index << '\n';
-
 		// print the physics that limits the timestep
 		if (dt_min_ptr == &hydro_dt) {
-			amrex::Print() << "...[level " << lev << "] timestep limited by hydro.\n";
+			amrex::Print() << fmt::format("...[level {}] timestep limited by HYDRO\n", lev);
 		} else if (dt_min_ptr == &particle_dt) {
-			amrex::Print() << "...[level " << lev << "] timestep limited by particle velocity.\n";
+			amrex::Print() << fmt::format("...[level {}] timestep limited by PARTICLES\n", lev);
 		}
 	}
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -820,7 +820,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 
 	// compute maximum particle speed on level 'lev'
-	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(), .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
+								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
 		const amrex::ValLocPair<amrex::Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -820,15 +820,23 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 
 	// compute maximum particle speed on level 'lev'
-	dtloc_t particle_dt{.value = std::numeric_limits<amrex::Real>::max(), .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(), .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
-		const dtloc_t max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
+		const amrex::ValLocPair<amrex::Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
 		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
+			// compute IntVect from RealVect and geom[lev]
+			amrex::IntVect cell_idx;
+			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxinv = geom[lev].InvCellSizeArray();
+			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo = geom[lev].ProbLoArray();
+			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+				cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
+			}
+			particle_dt.index = cell_idx;
 		}
 		if (verbose) {
 			amrex::Print() << "...[level " << lev << "] estimated particle timestep: " << particle_dt.value << '\n';

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -223,7 +223,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void AverageFCToCC(amrex::MultiFab &mf_cc, const amrex::MultiFab &mf_fc, int idim, int dstcomp_start, int srccomp_start, int srccomp_total) const;
 
 	virtual void computeMaxSignalLocal(int level) = 0;
-	virtual auto computeExtraPhysicsTimestep(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> = 0;
 	virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) = 0;
 	virtual void preCalculateInitialConditions() = 0;
 	virtual void setInitialConditionsOnGrid(quokka::grid const &grid_elem) = 0;
@@ -811,7 +810,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 	if (verbose) {
 		amrex::Print() << "...estimated hydro timestep at level " << lev << ": " << hydro_dt.value << '\n';
-		amrex::Print() << "...timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max << '\n';
+		amrex::Print() << "...hydro timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max << '\n';
 	}
 
 	// compute maximum particle speed on level 'lev'
@@ -829,22 +828,24 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 #endif
 
-	// compute timestep due to extra physics on level 'lev'
-	amrex::ValLocPair<amrex::Real, amrex::IntVect> extra_physics_dt = computeExtraPhysicsTimestep(lev);
+	if (verbose) {
+		amrex::Print() << "...estimated particle timestep at level " << lev << ": " << particle_dt.value << '\n';
+		amrex::Print() << "...particle timestep limited at cell " << particle_dt.index << '\n';
+	}
 
 	// compute minimum timestep
-	std::vector<amrex::ValLocPair<amrex::Real, amrex::IntVect>*> dts = {&hydro_dt, &particle_dt, &extra_physics_dt};
+	std::vector<amrex::ValLocPair<amrex::Real, amrex::IntVect>*> dts = {&hydro_dt, &particle_dt};
 	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end());
 
 	if (verbose) {
 		amrex::Print() << "...estimated timestep at level " << lev << ": " << dt_min_ptr->value << '\n';
 		amrex::Print() << "...timestep limited at cell " << dt_min_ptr->index << '\n';
+
+		// print the physics that limits the timestep
 		if (dt_min_ptr == &hydro_dt) {
 			amrex::Print() << "...timestep limited by hydro.\n";
 		} else if (dt_min_ptr == &particle_dt) {
 			amrex::Print() << "...timestep limited by particle velocity.\n";
-		} else if (dt_min_ptr == &extra_physics_dt) {
-			amrex::Print() << "...timestep limited by extra physics.\n";
 		}
 	}
 
@@ -857,11 +858,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
-	amrex::Vector<amrex::IntVect> dt_loc_tmp(finest_level + 1);
 	for (int level = 0; level <= finest_level; ++level) {
-		auto const dt_tmp_lev = computeTimestepAtLevel(level);
-		dt_tmp[level] = dt_tmp_lev.value;
-		dt_loc_tmp[level] = dt_tmp_lev.index;
+		dt_tmp[level] = computeTimestepAtLevel(level).value;
 	}
 
 	// limit change in timestep on each level

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -161,7 +161,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<amrex::Real> tNew_;     // for state_new_cc_
 	amrex::Vector<amrex::Real> tOld_;     // for state_old_cc_
 	amrex::Vector<amrex::Real> dt_;	      // timestep for each level
-	amrex::Vector<int> reductionFactor_;  // timestep reduction factor for each level
 	amrex::Real stopTime_ = 1.0;	      // default
 	amrex::Real cflNumber_ = 0.3;	      // default
 	amrex::Real particleCflNumber_ = 0.5; // default
@@ -544,7 +543,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	tNew_.resize(nlevs_max, 0.0);
 	tOld_.resize(nlevs_max, -1.e100);
 	dt_.resize(nlevs_max, 1.e100);
-	reductionFactor_.resize(nlevs_max, 1);
 	state_new_cc_.resize(nlevs_max);
 	state_old_cc_.resize(nlevs_max);
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
@@ -891,7 +889,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 	if (do_subcycle == 1) {
 		for (int lev = 1; lev <= max_level; ++lev) {
 			nsubsteps[lev] = MaxRefRatio(lev - 1);
-			reductionFactor_[lev] = 1; // reset additional subcycling
 		}
 	}
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -218,12 +218,12 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void setInitialConditionsAtLevel_fc(int level, amrex::Real time);
 	void evolve();
 	void computeTimestep();
-	auto computeTimestepAtLevel(int lev) -> amrex::Real;
+	auto computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
 	void AverageFCToCC(amrex::MultiFab &mf_cc, const amrex::MultiFab &mf_fc, int idim, int dstcomp_start, int srccomp_start, int srccomp_total) const;
 
 	virtual void computeMaxSignalLocal(int level) = 0;
-	virtual auto computeExtraPhysicsTimestep(int lev) -> amrex::Real = 0;
+	virtual auto computeExtraPhysicsTimestep(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect> = 0;
 	virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) = 0;
 	virtual void preCalculateInitialConditions() = 0;
 	virtual void setInitialConditionsOnGrid(quokka::grid const &grid_elem) = 0;
@@ -796,7 +796,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 	PerformanceHints();
 }
 
-template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::Real
+template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
 	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
@@ -804,32 +804,51 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	// compute hydro timestep on level 'lev'
 	computeMaxSignalLocal(lev);
 	const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
-
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx = geom[lev].CellSizeArray();
+	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
 	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
 
-	// compute hydro timestep first
-	const amrex::Real hydro_dt = cflNumber_ * (dx_min / domain_signal_max);
+	if (verbose) {
+		amrex::Print() << "...estimated hydro timestep at level " << lev << ": " << hydro_dt.value << '\n';
+		amrex::Print() << "...timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max << '\n';
+	}
 
 	// compute maximum particle speed on level 'lev'
-	amrex::Real particle_dt = std::numeric_limits<amrex::Real>::max();
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
+								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
-		const amrex::Real max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
-		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed));
-		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed));
+		const amrex::ValLocPair<amrex::Real, amrex::IntVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
+		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
+		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
-		if (max_particle_speed > 1e-5 * (dx_min / hydro_dt)) {
-			particle_dt = particleCflNumber_ * (dx_min / max_particle_speed);
+		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
+			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
 		}
 	}
 #endif
 
 	// compute timestep due to extra physics on level 'lev'
-	const amrex::Real extra_physics_dt = computeExtraPhysicsTimestep(lev);
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> extra_physics_dt = computeExtraPhysicsTimestep(lev);
 
-	// return minimum timestep
-	return std::min({hydro_dt, particle_dt, extra_physics_dt});
+	// compute minimum timestep
+	std::vector<amrex::ValLocPair<amrex::Real, amrex::IntVect>*> dts = {&hydro_dt, &particle_dt, &extra_physics_dt};
+	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end());
+
+	if (verbose) {
+		amrex::Print() << "...estimated timestep at level " << lev << ": " << dt_min_ptr->value << '\n';
+		amrex::Print() << "...timestep limited at cell " << dt_min_ptr->index << '\n';
+		if (dt_min_ptr == &hydro_dt) {
+			amrex::Print() << "...timestep limited by hydro.\n";
+		} else if (dt_min_ptr == &particle_dt) {
+			amrex::Print() << "...timestep limited by particle velocity.\n";
+		} else if (dt_min_ptr == &extra_physics_dt) {
+			amrex::Print() << "...timestep limited by extra physics.\n";
+		}
+	}
+
+	return *dt_min_ptr;
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
@@ -838,8 +857,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
+	amrex::Vector<amrex::IntVect> dt_loc_tmp(finest_level + 1);
 	for (int level = 0; level <= finest_level; ++level) {
-		dt_tmp[level] = computeTimestepAtLevel(level);
+		auto const dt_tmp_lev = computeTimestepAtLevel(level);
+		dt_tmp[level] = dt_tmp_lev.value;
+		dt_loc_tmp[level] = dt_tmp_lev.index;
 	}
 
 	// limit change in timestep on each level
@@ -859,11 +881,18 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 
 	// compute root level timestep given nsubsteps
 	amrex::Real dt_0 = dt_tmp[0];
+	int level_that_sets_dt_0 = 0; // keep track of which level sets the min dt
 	amrex::Long n_factor = 1;
 
 	for (int level = 0; level <= finest_level; ++level) {
 		n_factor *= nsubsteps[level];
+		const amrex::Real dt_0_old = dt_0; // save old dt_0
 		dt_0 = std::min(dt_0, static_cast<amrex::Real>(n_factor) * dt_tmp[level]);
+		if (dt_0 < dt_0_old) {
+			// level 'level' has now set the timestep
+			level_that_sets_dt_0 = level;
+		}
+
 		dt_0 = std::min(dt_0, maxDt_); // limit to maxDt_
 
 		if (tNew_[level] == 0.0) { // first timestep
@@ -872,6 +901,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 		if (constantDt_ > 0.0) { // use constant timestep if set
 			dt_0 = constantDt_;
 		}
+	}
+
+	if (verbose) {
+		amrex::Print() << "...coarse timestep set by level " << level_that_sets_dt_0 << "\n";
 	}
 
 	// compute global timestep assuming no subcycling

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -920,47 +920,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 		amrex::Print() << "...coarse timestep set by level " << level_that_sets_dt_0 << "\n";
 	}
 
-	// compute global timestep assuming no subcycling
-	amrex::Real dt_global = dt_tmp[0];
-
-	for (int level = 0; level <= finest_level; ++level) {
-		dt_global = std::min(dt_global, dt_tmp[level]);
-		dt_global = std::min(dt_global, maxDt_); // limit to maxDt_
-
-		if (tNew_[level] == 0.0) { // special case: first timestep
-			dt_global = std::min(dt_global, initDt_);
-		}
-		if (constantDt_ > 0.0) { // special case: constant timestep
-			dt_global = constantDt_;
-		}
-	}
-
-	// compute work estimate for subcycling
-	amrex::Long n_factor_work = 1;
-	amrex::Long work_subcycling = 0;
-	for (int level = 0; level <= finest_level; ++level) {
-		n_factor_work *= nsubsteps[level];
-		work_subcycling += n_factor_work * CountCells(level);
-	}
-
-	// compute work estimate for non-subcycling
-	amrex::Long total_cells = 0;
-	for (int level = 0; level <= finest_level; ++level) {
-		total_cells += CountCells(level);
-	}
-	const amrex::Real work_nonsubcycling = static_cast<amrex::Real>(total_cells) * (dt_0 / dt_global);
-
-	if (work_nonsubcycling <= static_cast<amrex::Real>(work_subcycling)) {
-		// use global timestep on this coarse step
-		if (verbose) {
-			const amrex::Real ratio = work_nonsubcycling / static_cast<amrex::Real>(work_subcycling);
-			amrex::Print() << "\t>> Using global timestep on this coarse step (estimated work ratio: " << ratio << ").\n";
-		}
-		for (int lev = 1; lev <= max_level; ++lev) {
-			nsubsteps[lev] = 1;
-		}
-	}
-
 	// Limit dt to avoid overshooting stop_time
 	const amrex::Real eps = 1.e-3 * dt_0;
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -64,7 +64,8 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Vector.H"
 #include "AMReX_VisMF.H"
 #include "AMReX_YAFluxRegister.H"
-#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <yaml-cpp/yaml.h>
 
 #ifdef AMREX_PARTICLES
@@ -102,7 +103,14 @@ using namespace ascent;
 // Quokka version string to be stored in metadata. This is used in post-processing tools like YT to do version checks.
 static constexpr auto QUOKKA_VERSION = "25.03";
 
-enum class ParticleStep { BeforePoissonSolve, AfterPoissonSolve };
+template <> struct fmt::formatter<amrex::IntVect> : formatter<std::vector<int>> {
+	// parse is inherited from formatter<std::vector<int>>.
+	auto format(amrex::IntVect iv, format_context &ctx) const -> format_context::iterator
+	{
+		std::vector<int> vec{AMREX_D_DECL(iv[0], iv[1], iv[2])};
+		return formatter<std::vector<int>>::format(vec, ctx);
+	};
+};
 
 using variant_t = std::variant<amrex::Real, std::string>;
 
@@ -813,8 +821,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 	if (verbose) {
 		amrex::Print() << fmt::format("...[level {}] estimated hydro timestep: {:e}\n", lev, hydro_dt.value);
-		amrex::Print() << fmt::format("...[level {}] \thydro timestep limited at cell ({}, {}, {}) with signal speed = {:e}\n", lev, hydro_dt.index[0],
-					      hydro_dt.index[1], hydro_dt.index[2], domain_signal_max);
+		amrex::Print() << fmt::format("...[level {}] \thydro timestep limited at cell {} with signal speed = {:e}\n", lev, hydro_dt.index,
+					      domain_signal_max);
 		printCellProperties(lev, hydro_dt.index);
 	}
 
@@ -841,8 +849,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		if (verbose) {
 			amrex::Print() << fmt::format("...[level {}] estimated particle timestep: {:e}\n", lev, particle_dt.value);
 			amrex::Print() << fmt::format("...[level {}] \tmax particle velocity: {:e}\n", lev, max_particle_speed.value);
-			amrex::Print() << fmt::format("...[level {}] \tparticle timestep limited at position ({:e}, {:e}, {:e})\n", lev,
-						      max_particle_speed.index[0], max_particle_speed.index[1], max_particle_speed.index[2]);
+			amrex::Print() << fmt::format("...[level {}] \tparticle timestep limited at position {::e}\n", lev, max_particle_speed.index);
 		}
 	}
 #endif

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -107,7 +107,7 @@ template <> struct fmt::formatter<amrex::IntVect> : formatter<std::vector<int>> 
 	// parse is inherited from formatter<std::vector<int>>.
 	auto format(amrex::IntVect iv, format_context &ctx) const -> format_context::iterator
 	{
-		std::vector<int> vec{AMREX_D_DECL(iv[0], iv[1], iv[2])};
+		std::vector<int> const vec{AMREX_D_DECL(iv[0], iv[1], iv[2])};
 		return formatter<std::vector<int>>::format(vec, ctx);
 	};
 };

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -800,13 +800,15 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	// compute CFL timestep on level 'lev'
 	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
 
+	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
+
 	// compute hydro timestep on level 'lev'
 	computeMaxSignalLocal(lev);
 	const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
 	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
-	amrex::ValLocPair<amrex::Real, amrex::IntVect> hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
+	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
 
 	if (verbose) {
 		amrex::Print() << "...estimated hydro timestep at level " << lev << ": " << hydro_dt.value << '\n';
@@ -814,11 +816,10 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 
 	// compute maximum particle speed on level 'lev'
-	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
-								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+	dtloc_t particle_dt{.value = std::numeric_limits<amrex::Real>::max(), .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
-		const amrex::ValLocPair<amrex::Real, amrex::IntVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
+		const dtloc_t max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
 		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
@@ -834,8 +835,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 
 	// compute minimum timestep
-	std::vector<amrex::ValLocPair<amrex::Real, amrex::IntVect>*> dts = {&hydro_dt, &particle_dt};
-	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end());
+	std::vector<dtloc_t *> dts = {&hydro_dt, &particle_dt};
+	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end(), [](dtloc_t *const p1, dtloc_t *const p2) { return p1->value < p2->value; });
 
 	if (verbose) {
 		amrex::Print() << "...estimated timestep at level " << lev << ": " << dt_min_ptr->value << '\n';

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -827,13 +827,12 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
 		}
+		if (verbose) {
+			amrex::Print() << "...[level " << lev << "] estimated particle timestep: " << particle_dt.value << '\n';
+			amrex::Print() << "...[level " << lev << "] particle timestep limited at cell " << particle_dt.index << '\n';
+		}
 	}
 #endif
-
-	if (verbose) {
-		amrex::Print() << "...[level " << lev << "] estimated particle timestep: " << particle_dt.value << '\n';
-		amrex::Print() << "...[level " << lev << "] particle timestep limited at cell " << particle_dt.index << '\n';
-	}
 
 	// compute minimum timestep
 	std::vector<dtloc_t *> dts = {&hydro_dt, &particle_dt};

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -223,6 +223,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void AverageFCToCC(amrex::MultiFab &mf_cc, const amrex::MultiFab &mf_fc, int idim, int dstcomp_start, int srccomp_start, int srccomp_total) const;
 
 	virtual void computeMaxSignalLocal(int level) = 0;
+	virtual void printCellProperties(int lev, amrex::IntVect const &index) = 0;
 	virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) = 0;
 	virtual void preCalculateInitialConditions() = 0;
 	virtual void setInitialConditionsOnGrid(quokka::grid const &grid_elem) = 0;
@@ -814,6 +815,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		amrex::Print() << "...[level " << lev << "] estimated hydro timestep: " << hydro_dt.value << '\n';
 		amrex::Print() << "...[level " << lev << "] hydro timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max
 			       << '\n';
+		amrex::Print() << "...[level " << lev << "] ";
+		printCellProperties(lev, hydro_dt.index);
 	}
 
 	// compute maximum particle speed on level 'lev'

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -811,8 +811,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
 
 	if (verbose) {
-		amrex::Print() << "...estimated hydro timestep at level " << lev << ": " << hydro_dt.value << '\n';
-		amrex::Print() << "...hydro timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max << '\n';
+		amrex::Print() << "...[level " << lev << "] estimated hydro timestep: " << hydro_dt.value << '\n';
+		amrex::Print() << "...[level " << lev << "] hydro timestep limited at cell " << hydro_dt.index << " with signal speed = " << domain_signal_max
+			       << '\n';
 	}
 
 	// compute maximum particle speed on level 'lev'
@@ -830,8 +831,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 #endif
 
 	if (verbose) {
-		amrex::Print() << "...estimated particle timestep at level " << lev << ": " << particle_dt.value << '\n';
-		amrex::Print() << "...particle timestep limited at cell " << particle_dt.index << '\n';
+		amrex::Print() << "...[level " << lev << "] estimated particle timestep: " << particle_dt.value << '\n';
+		amrex::Print() << "...[level " << lev << "] particle timestep limited at cell " << particle_dt.index << '\n';
 	}
 
 	// compute minimum timestep
@@ -839,14 +840,14 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end(), [](dtloc_t *const p1, dtloc_t *const p2) { return p1->value < p2->value; });
 
 	if (verbose) {
-		amrex::Print() << "...estimated timestep at level " << lev << ": " << dt_min_ptr->value << '\n';
-		amrex::Print() << "...timestep limited at cell " << dt_min_ptr->index << '\n';
+		amrex::Print() << "...[level " << lev << "] estimated timestep: " << dt_min_ptr->value << '\n';
+		amrex::Print() << "...[level " << lev << "] timestep limited at cell " << dt_min_ptr->index << '\n';
 
 		// print the physics that limits the timestep
 		if (dt_min_ptr == &hydro_dt) {
-			amrex::Print() << "...timestep limited by hydro.\n";
+			amrex::Print() << "...[level " << lev << "] timestep limited by hydro.\n";
 		} else if (dt_min_ptr == &particle_dt) {
-			amrex::Print() << "...timestep limited by particle velocity.\n";
+			amrex::Print() << "...[level " << lev << "] timestep limited by particle velocity.\n";
 		}
 	}
 


### PR DESCRIPTION
### Description
When `amr.v = 1`, this will print the cell that sets the candidate timestep for hydro (and also for particles, if applicable) for each level, as well as which level sets the overall coarse timestep.

Example output:
```
Coarse STEP 74 at t = 638990.8046 (1.277981609%) starts ...
...[level 0] estimated hydro timestep: 1.009208e+04
...[level 0]    hydro timestep limited at cell [16, 17, 15] with signal speed = 4.644731e+07
...[level 0]    cell density = 9.641857e-22, |v| = 3.344731e+07, cs = nan
...[level 0] estimated particle timestep: 7.274247e+04
...[level 0]    max particle velocity: 1.073994e+07
...[level 0]    particle timestep limited at position [1.724770e+12, -2.473514e+12, -9.395845e+03]
...[level 0] timestep limited by HYDRO
...coarse timestep set by level 0
```

**Note that for Cray MPICH, standard output is not ordered with respect to different ranks, so the cell density, velocity and sound speed may be printed later in the output.** (We could copy the cell to rank 0 and then print, but that will incur a performance cost.)

This PR also gets rid of old timestepping code that was used when the hydro update was insufficiently stable to take timesteps longer than the cooling time for some problems. Since that is no longer necessary, that code is removed.

### Related issues
Implementation based on https://github.com/AMReX-Astro/Castro/pull/2273.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
