### PR TITLE
Fix GPU-related error in createInitialTestParticles()

### DIFF
--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -265,20 +265,20 @@ template <> void QuokkaSimulation<BinaryOrbit>::createInitialTestParticles()
 
 	// Get the particles at level 0
 	auto &particles = TestParticles->GetParticles(0);
-	
+
 	// Loop over all particle tiles and set first integer component to SNProgenitor on GPU
 	for (auto &kv : particles) {
 		auto &particle_array = kv.second.GetArrayOfStructs();
 		const int np = particle_array.numParticles();
 		auto *pdata = particle_array().data();
-		
+
 		// Launch GPU kernel to set integer components
 		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int i) {
 			auto &p = pdata[i];
 			p.idata(0) = static_cast<int>(quokka::StellarEvolutionStage::SNProgenitor);
 		});
 	}
-	
+
 	// Ensure GPU operations are complete
 	amrex::Gpu::streamSynchronize();
 }

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -274,7 +274,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::createInitialTestParticles()
 
 		// Launch GPU kernel to set integer components
 		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int i) {
-			auto &p = pdata[i];
+			auto &p = pdata[i]; // NOLINT
 			p.idata(0) = static_cast<int>(quokka::StellarEvolutionStage::SNProgenitor);
 		});
 	}

--- a/src/problems/Gravity3D/gravity_3d.cpp
+++ b/src/problems/Gravity3D/gravity_3d.cpp
@@ -263,16 +263,24 @@ template <> void QuokkaSimulation<BinaryOrbit>::createInitialTestParticles()
 	TestParticles->SetVerbose(1);
 	TestParticles->InitFromAsciiFile("TestParticles.txt", nreal_extra, nullptr);
 
-	// Loop over all particles and set first integer component to SNProgenitor
+	// Get the particles at level 0
 	auto &particles = TestParticles->GetParticles(0);
+	
+	// Loop over all particle tiles and set first integer component to SNProgenitor on GPU
 	for (auto &kv : particles) {
 		auto &particle_array = kv.second.GetArrayOfStructs();
 		const int np = particle_array.numParticles();
-		for (int i = 0; i < np; i++) {
-			auto &p = particle_array[i];
+		auto *pdata = particle_array().data();
+		
+		// Launch GPU kernel to set integer components
+		amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int i) {
+			auto &p = pdata[i];
 			p.idata(0) = static_cast<int>(quokka::StellarEvolutionStage::SNProgenitor);
-		}
+		});
 	}
+	
+	// Ensure GPU operations are complete
+	amrex::Gpu::streamSynchronize();
 }
 
 auto problem_main() -> int


### PR DESCRIPTION
### Description

That was an obvious mistake. I forgot to use GPU function in `createInitialTestParticles()` in gravity_3d.cpp. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
