### PR TITLE
Update .clang-tidy again

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,*,-fuchsia-*,-llvmlibc-*,-altera-*,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-non-private-member-variables-in-classes,-google-runtime-references,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-pro-bounds-constant-array-index,-readability-function-cognitive-complexity,-llvm-header-guard,-performance-enum-size,-misc-include-cleaner,-cppcoreguidelines-misleading-capture-default-by-value,-readability-math-missing-parentheses,-misc-use-internal-linkage'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,*,-fuchsia-*,-llvmlibc-*,-altera-*,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-non-private-member-variables-in-classes,-google-runtime-references,-readability-magic-numbers,-cppcoreguidelines-avoid-magic-numbers,-bugprone-easily-swappable-parameters,-readability-identifier-length,-cppcoreguidelines-pro-bounds-constant-array-index,-readability-function-cognitive-complexity,-llvm-header-guard,-performance-enum-size,-misc-include-cleaner,-cppcoreguidelines-misleading-capture-default-by-value,-readability-math-missing-parentheses,-misc-use-internal-linkage,-boost-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 FormatStyle:     none


### PR DESCRIPTION
### Description
Suppress Boost-related warnings (e.g., https://clang.llvm.org/extra/clang-tidy/checks/boost/use-ranges.html).

While a nice library, we don't want to add Boost as a dependency.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
