### PR TITLE
TotalNumberOfParticles(false, false)

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -354,11 +354,13 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		return {real_data, int_data}; // Empty vectors on non-root ranks
 	}
 
-	// Get the number of particles in the container
+	// Get the number of particles in the container on all levels
 	[[nodiscard]] auto getNumParticles() const -> int override
 	{
 		if (container_ != nullptr) {
-			return static_cast<int>(container_->TotalNumberOfParticles(true, false));
+			// only_valid=false: count invalid particles as well
+			// only_local=false: count particles on all ranks
+			return static_cast<int>(container_->TotalNumberOfParticles(false, false));
 		}
 		return 0;
 	}


### PR DESCRIPTION
### Description

Changed `TotalNumberOfParticles(true, false)` to `TotalNumberOfParticles(false, false)`. 

`container_->TotalNumberOfParticles(true, false)` only counts valid particles, which are particles with positive IDs. However, the particle IDs are not being set correctly when creating the particles, causing `getNumParticles()` to return 0. 

By setting the first argument of `TotalNumberOfParticles` to `false`, we do not require valid IDs when counting. Since we always do redistribute to remove invalid particles, this is a fine choice. 

### Related issues
Fixes a bug that caused failure in #996 . 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
