### PR TITLE
Be Real

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -133,13 +133,13 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	static constexpr int ncompHyperbolic_ = RadSystem<problem_t>::nvarHyperbolic_;
 	static constexpr int nstartHyperbolic_ = RadSystem<problem_t>::nstartHyperbolic_;
 
-	amrex::Real radiationCflNumber_ = 0.3;
+	Real radiationCflNumber_ = 0.3;
 	int maxSubsteps_ = 10;				// maximum number of radiation subcycles per hydro step
-	amrex::Real dustGasInteractionCoeff_ = 2.5e-34; // erg cm^3 s^−1 K^−3/2
+	Real dustGasInteractionCoeff_ = 2.5e-34; // erg cm^3 s^−1 K^−3/2
 
 	bool computeReferenceSolution_ = false;
-	amrex::Real errorNorm_ = NAN;
-	amrex::Real pressureFloor_ = 0.;
+	Real errorNorm_ = NAN;
+	Real pressureFloor_ = 0.;
 
 	bool use_wavespeed_correction_ = false;
 	bool print_rad_counter_ = false;
@@ -150,7 +150,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	int radiationReconstructionOrder_ = 3;	// 1 == donor cell; 2 == PLM; 3 == PPM (default)
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
-	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
+	Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
 
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
@@ -173,8 +173,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 		// initialize Microphysics params
 		init_extern_parameters();
 		// initialize Microphysics EOS
-		amrex::Real small_temp = 1e-10;
-		amrex::Real small_dens = 1e-100;
+		Real small_temp = 1e-10;
+		Real small_dens = 1e-100;
 		eos_init(small_temp, small_dens);
 	}
 
@@ -195,10 +195,10 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void createInitialStochasticStellarPopParticles() override;
 	void createInitialTestParticles() override;
 #endif // AMREX_SPACEDIM == 3
-	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) override;
+	void advanceSingleTimestepAtLevel(int lev, Real time, Real dt_lev, int ncycle) override;
 	void computeBeforeTimestep() override;
 	void computeAfterTimestep() override;
-	void computeAfterLevelAdvance(int lev, amrex::Real time, amrex::Real dt_lev, int /*ncycle*/);
+	void computeAfterLevelAdvance(int lev, Real time, Real dt_lev, int /*ncycle*/);
 	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
 	void computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo);
@@ -216,7 +216,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void FixupState(int level) override;
 
 	// implement FillPatch function
-	void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
+	void FillPatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 		       FillPatchType fptype) override;
 
 	// functions to operate on state vector before/after interpolating between levels
@@ -227,13 +227,13 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	template <typename F> auto computeAxisAlignedProfile(int axis, F const &user_f) -> amrex::Gpu::HostVector<amrex::Real>;
 
 	// tag cells for refinement
-	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
+	void ErrorEst(int lev, amrex::TagBoxArray &tags, Real time, int ngrow) override;
 
 	// fill rhs for Poisson solve
 	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;
 
 	// add gravitational acceleration to hydro state
-	void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) override;
+	void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, Real dt) override;
 
 	void addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &srcfluxes, int srccomp,
 			   int dstcomp);
@@ -243,28 +243,28 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
+	void advanceHydroAtLevelWithRetries(int lev, Real time, Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 					    amrex::YAFluxRegister *fr_as_fine);
 
 	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev,
-				 amrex::Real time, amrex::Real dt_lev) -> bool;
+				 Real time, Real dt_lev) -> bool;
 
-	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev);
-	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
+	void addStrangSplitSources(amrex::MultiFab &state, int lev, Real time, Real dt_lev);
+	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, Real time, Real dt_lev) -> bool;
 
-	auto isCflViolated(int lev, amrex::Real time, amrex::Real dt_actual) -> bool;
+	auto isCflViolated(int lev, Real time, Real dt_actual) -> bool;
 
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew);
-	auto computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int;
-	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps,
+	auto computeNumberOfRadiationSubsteps(int lev, Real dt_lev_hydro) -> int;
+	void advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps,
 					    amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
-	void advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
+	void advanceRadiationForwardEuler(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
 					  amrex::YAFluxRegister *fr_as_fine);
-	void advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
+	void advanceRadiationMidpointRK2(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
 					 amrex::YAFluxRegister *fr_as_fine);
 
-	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
+	void subcycleRadiationAtLevel(int lev, Real time, Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
 				      amrex::YAFluxRegister *fr_as_fine);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
@@ -379,7 +379,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::initializeSimulatio
 		simulationMetadata_["units"]["unit_temperature"] = unit_temperature;
 
 		// constants
-		double k_B = NAN;
+		Real k_B = NAN;
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			k_B = C::k_B;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CUSTOM) {
@@ -471,13 +471,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 	}
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, Real dt_lev_hydro) -> int
 {
 	// compute radiation timestep
 	auto const &dx = geom[lev].CellSizeArray();
-	amrex::Real c_hat = RadSystem<problem_t>::c_hat_;
-	amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
-	amrex::Real dtrad_tmp = radiationCflNumber_ * (dx_min / c_hat);
+	Real c_hat = RadSystem<problem_t>::c_hat_;
+	Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+	Real dtrad_tmp = radiationCflNumber_ * (dx_min / c_hat);
 	int nsubSteps = std::ceil(dt_lev_hydro / dtrad_tmp);
 	return nsubSteps;
 }
@@ -505,7 +505,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignal
 				const int maxSubsteps = maxSubsteps_;
 				// ensure that we use the smaller of the two timesteps
 				amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-					amrex::Real const maxSignalRadiation = maxSignal(i, j, k) / static_cast<double>(maxSubsteps);
+					Real const maxSignalRadiation = maxSignal(i, j, k) / static_cast<Real>(maxSubsteps);
 					maxSignal(i, j, k) = std::max(maxSignalRadiation, maxSignalHydro(i, j, k));
 				});
 			}
@@ -525,20 +525,20 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 	// cell_values is *only* filled on the MPI rank that holds the box with this cell
 	// (NOTE: for Cray MPICH, standard output is NOT ordered with respect to different ranks.)
 	if (!cell_values.empty()) {
-		const amrex::Real rho = cell_values[HydroSystem<problem_t>::density_index];
-		const amrex::Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
-		const amrex::Real px2 = cell_values[HydroSystem<problem_t>::x2Momentum_index];
-		const amrex::Real px3 = cell_values[HydroSystem<problem_t>::x3Momentum_index];
-		const amrex::Real Etot = cell_values[HydroSystem<problem_t>::energy_index];
-		const amrex::Real vx1 = px1 / rho;
-		const amrex::Real vx2 = px2 / rho;
-		const amrex::Real vx3 = px3 / rho;
-		const amrex::Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
-		const amrex::Real vel_mag = std::sqrt(vsq);
-		const amrex::Real Ekin = 0.5 * rho * vsq;
-		const amrex::Real Eint = Etot - Ekin;
-		const amrex::Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
-		const amrex::Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
+		const Real rho = cell_values[HydroSystem<problem_t>::density_index];
+		const Real px1 = cell_values[HydroSystem<problem_t>::x1Momentum_index];
+		const Real px2 = cell_values[HydroSystem<problem_t>::x2Momentum_index];
+		const Real px3 = cell_values[HydroSystem<problem_t>::x3Momentum_index];
+		const Real Etot = cell_values[HydroSystem<problem_t>::energy_index];
+		const Real vx1 = px1 / rho;
+		const Real vx2 = px2 / rho;
+		const Real vx3 = px3 / rho;
+		const Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
+		const Real vel_mag = std::sqrt(vsq);
+		const Real Ekin = 0.5 * rho * vsq;
+		const Real Eint = Etot - Ekin;
+		const Real P = quokka::EOS<problem_t>::ComputePressure(rho, Eint);
+		const Real cs = quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
 
 		amrex::AllPrint() << fmt::format("...[level {}] \tcell density = {:e}, |v| = {:e}, cs = {:e}\n", lev, rho, vel_mag, cs);
 	}
@@ -635,19 +635,19 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterTime
 	// do nothing -- user should implement if desired
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterLevelAdvance(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterLevelAdvance(int lev, Real time, Real dt_lev, int ncycle)
 {
 	// user should implement if desired
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt)
+template <typename problem_t> void QuokkaSimulation<problem_t>::addStrangSplitSources(amrex::MultiFab &state, int lev, Real time, Real dt)
 {
 	// user should implement
 	// (when Strang splitting is enabled, dt is actually 0.5*dt_lev)
 }
 
 template <typename problem_t>
-auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt) -> bool
+auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, Real time, Real dt) -> bool
 {
 	// start by assuming cooling integrator is successful.
 	bool cool_success = true;
@@ -696,7 +696,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::ComputeStatistic
 	return std::map<std::string, amrex::Real>{};
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <typename problem_t> void QuokkaSimulation<problem_t>::ErrorEst(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement -- user should implement
 }
@@ -711,21 +711,21 @@ void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref,
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
-	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
+	Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 
 	// check conservation of total energy
-	amrex::Real const Egas0 = initSumCons[RadSystem<problem_t>::gasEnergy_index];
-	amrex::Real const Egas = state_new_cc_[0].sum(RadSystem<problem_t>::gasEnergy_index) * vol;
+	Real const Egas0 = initSumCons[RadSystem<problem_t>::gasEnergy_index];
+	Real const Egas = state_new_cc_[0].sum(RadSystem<problem_t>::gasEnergy_index) * vol;
 
-	amrex::Real Etot0 = NAN;
-	amrex::Real Etot = NAN;
+	Real Etot0 = NAN;
+	Real Etot = NAN;
 	if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-		amrex::Real Erad0 = 0.;
+		Real Erad0 = 0.;
 		for (int g = 0; g < Physics_Traits<problem_t>::nGroups; ++g) {
 			Erad0 += initSumCons[RadSystem<problem_t>::radEnergy_index + Physics_NumVars::numRadVars * g];
 		}
 		Etot0 = Egas0 + (RadSystem<problem_t>::c_light_ / RadSystem<problem_t>::c_hat_) * Erad0;
-		amrex::Real Erad = 0.;
+		Real Erad = 0.;
 		for (int g = 0; g < Physics_Traits<problem_t>::nGroups; ++g) {
 			Erad += state_new_cc_[0].sum(RadSystem<problem_t>::radEnergy_index + Physics_NumVars::numRadVars * g) * vol;
 		}
@@ -735,8 +735,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		Etot = Egas;
 	}
 
-	amrex::Real const abs_err = (Etot - Etot0);
-	amrex::Real rel_err = NAN;
+	Real const abs_err = (Etot - Etot0);
+	Real rel_err = NAN;
 	if (Etot0 != 0) {
 		rel_err = abs_err / Etot0;
 	}
@@ -758,8 +758,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
 		amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
 
-		amrex::Real sol_norm = 0.;
-		amrex::Real err_norm = 0.;
+		Real sol_norm = 0.;
+		Real err_norm = 0.;
 		// compute rms of each component
 		for (int n = 0; n < ncomp; ++n) {
 			sol_norm += std::pow(state_ref_level0.norm1(n), 2);
@@ -768,7 +768,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		sol_norm = std::sqrt(sol_norm);
 		err_norm = std::sqrt(err_norm);
 
-		const double rel_error = err_norm / sol_norm;
+		const Real rel_error = err_norm / sol_norm;
 		errorNorm_ = rel_error;
 		amrex::Print() << "Relative rms L1 error norm = " << rel_error << '\n';
 	}
@@ -776,7 +776,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 
 	// compute average number of radiation subcycles per timestep
 	if (cellUpdates_ > 0) {
-		double const avg_rad_subcycles = static_cast<double>(radiationCellUpdates_) / static_cast<double>(cellUpdates_);
+		Real const avg_rad_subcycles = static_cast<Real>(radiationCellUpdates_) / static_cast<Real>(cellUpdates_);
 		amrex::Print() << "avg. num. of radiation subcycles = " << avg_rad_subcycles << '\n';
 		amrex::Print() << '\n';
 	} else {
@@ -785,7 +785,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 	}
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
+template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, Real time, Real dt_lev, int ncycle)
 {
 	BL_PROFILE("QuokkaSimulation::advanceSingleTimestepAtLevel()");
 
@@ -856,7 +856,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAt
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const amrex::Real dt)
+template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const Real dt)
 {
 	if constexpr (AMREX_SPACEDIM == 3) {
 		// apply Poisson gravity operator on level 'lev'
@@ -866,22 +866,22 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGrav
 
 		amrex::ParallelFor(phi_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			// add operator-split gravitational acceleration
-			const amrex::Real rho = state[bx](i, j, k, HydroSystem<problem_t>::density_index);
-			amrex::Real px = state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-			amrex::Real py = state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-			amrex::Real pz = state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-			const amrex::Real KE_old = 0.5 * (px * px + py * py + pz * pz) / rho;
+			const Real rho = state[bx](i, j, k, HydroSystem<problem_t>::density_index);
+			Real px = state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+			Real py = state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+			Real pz = state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+			const Real KE_old = 0.5 * (px * px + py * py + pz * pz) / rho;
 
 			// g = -grad \phi
-			amrex::Real gx = -0.5 * (phi[bx](i + 1, j, k) - phi[bx](i - 1, j, k)) / dx[0];
-			amrex::Real gy = -0.5 * (phi[bx](i, j + 1, k) - phi[bx](i, j - 1, k)) / dx[1];
-			amrex::Real gz = -0.5 * (phi[bx](i, j, k + 1) - phi[bx](i, j, k - 1)) / dx[2];
+			Real gx = -0.5 * (phi[bx](i + 1, j, k) - phi[bx](i - 1, j, k)) / dx[0];
+			Real gy = -0.5 * (phi[bx](i, j + 1, k) - phi[bx](i, j - 1, k)) / dx[1];
+			Real gz = -0.5 * (phi[bx](i, j, k + 1) - phi[bx](i, j, k - 1)) / dx[2];
 
 			px += dt * rho * gx;
 			py += dt * rho * gy;
 			pz += dt * rho * gz;
-			const amrex::Real KE_new = 0.5 * (px * px + py * py + pz * pz) / rho;
-			const amrex::Real dKE = KE_new - KE_old;
+			const Real KE_new = 0.5 * (px * px + py * py + pz * pz) / rho;
+			const Real dKE = KE_new - KE_old;
 
 			state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index) = px;
 			state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index) = py;
@@ -909,7 +909,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::FixupState(int l
 // NOTE: This has to be implemented here because PreInterpState and PostInterpState
 // are implemented in this class (and must be *static* functions).
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
+void QuokkaSimulation<problem_t>::FillPatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					    FillPatchType fptype)
 {
 	BL_PROFILE("AMRSimulation::FillPatch()");
@@ -1010,7 +1010,7 @@ auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F co
 
 	// normalize profile
 	amrex::Long numCells = domain.numPts() / domain.length(axis);
-	for (double &bin : profile) {
+	for (Real &bin : profile) {
 		bin /= static_cast<amrex::Real>(numCells);
 	}
 
@@ -1018,7 +1018,7 @@ auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F co
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
+void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, Real time, Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 								 amrex::YAFluxRegister *fr_as_fine)
 {
 	BL_PROFILE_REGION("HydroSolver");
@@ -1046,7 +1046,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 	for (int retry_count = 0; retry_count <= max_retries; ++retry_count) {
 		// reduce timestep by a factor of 2^retry_count
 		const int nsubsteps = static_cast<int>(std::pow(2, retry_count));
-		const amrex::Real dt_step = dt_lev / nsubsteps;
+		const Real dt_step = dt_lev / nsubsteps;
 
 		if (retry_count > 0 && Verbose()) {
 			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (nsubsteps = " << nsubsteps
@@ -1124,21 +1124,21 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 	}
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::isCflViolated(int lev, amrex::Real /*time*/, amrex::Real dt_actual) -> bool
+template <typename problem_t> auto QuokkaSimulation<problem_t>::isCflViolated(int lev, Real /*time*/, Real dt_actual) -> bool
 {
 	// check whether dt_actual would violate CFL condition using the post-update hydro state
 
 	// compute max signal speed
-	amrex::Real max_signal = HydroSystem<problem_t>::maxSignalSpeedLocal(state_new_cc_[lev]);
+	Real max_signal = HydroSystem<problem_t>::maxSignalSpeedLocal(state_new_cc_[lev]);
 	amrex::ParallelDescriptor::ReduceRealMax(max_signal);
 
 	// compute dt_cfl
 	auto dx = geom[lev].CellSizeArray();
-	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
-	const amrex::Real dt_cfl = cflNumber_ * (dx_min / max_signal);
+	const Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+	const Real dt_cfl = cflNumber_ * (dx_min / max_signal);
 
 	// check whether dt_actual > dt_cfl (CFL violation)
-	const amrex::Real max_factor = 1.1;
+	const Real max_factor = 1.1;
 	const bool cflViolation = dt_actual > (max_factor * dt_cfl);
 	if (cflViolation && Verbose()) {
 		amrex::Print() << "\t>> CFL violation detected on level " << lev << " with dt_lev = " << dt_actual << " and dt_cfl = " << dt_cfl << "\n"
@@ -1150,9 +1150,9 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::isCflViolated(in
 template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates(int lev, const amrex::IntVect &cell_idx)
 {
 
-	amrex::Real x_coord = geom[lev].ProbLo(0) + (cell_idx[0] + 0.5) * geom[lev].CellSize(0);
-	amrex::Real y_coord = NAN;
-	amrex::Real z_coord = NAN;
+	Real x_coord = geom[lev].ProbLo(0) + (cell_idx[0] + 0.5) * geom[lev].CellSize(0);
+	Real y_coord = NAN;
+	Real z_coord = NAN;
 
 	if (AMREX_SPACEDIM > 1) {
 		y_coord = geom[lev].ProbLo(1) + (cell_idx[1] + 0.5) * geom[lev].CellSize(1);
@@ -1166,11 +1166,11 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      int lev, amrex::Real time, amrex::Real dt_lev) -> bool
+						      int lev, Real time, Real dt_lev) -> bool
 {
 	BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
-	amrex::Real fluxScaleFactor = NAN;
+	Real fluxScaleFactor = NAN;
 	if (integratorOrder_ == 2) {
 		fluxScaleFactor = 0.5;
 	} else if (integratorOrder_ == 1) {
@@ -1709,17 +1709,17 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationSta
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
+void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, Real time, Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
 							   amrex::YAFluxRegister *fr_as_fine)
 {
 	// compute radiation timestep
 	int nsubSteps = 0;
-	amrex::Real dt_radiation = NAN;
+	Real dt_radiation = NAN;
 
 	if (Physics_Traits<problem_t>::is_hydro_enabled && !(constantDt_ > 0.)) {
 		// adjust to get integer number of substeps
 		nsubSteps = computeNumberOfRadiationSubsteps(lev, dt_lev_hydro);
-		dt_radiation = dt_lev_hydro / static_cast<double>(nsubSteps);
+		dt_radiation = dt_lev_hydro / static_cast<Real>(nsubSteps);
 	} else { // no hydro, or using constant dt (this is necessary for radiation test problems)
 		dt_radiation = dt_lev_hydro;
 		nsubSteps = 1;
@@ -1734,7 +1734,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 	// perform subcycle
 	auto const &dx = geom[lev].CellSizeArray();
-	amrex::Real time_subcycle = time;
+	Real time_subcycle = time;
 	for (int i = 0; i < nsubSteps; ++i) {
 		if (i > 0) {
 			// since we are starting a new substep, we need to copy radiation state from
@@ -1860,12 +1860,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				const auto n_cells = CountCells(lev);
 				amrex::Print() << "time_subcycle = " << time_subcycle << ", total number of cells updated is " << n_cells << "\n";
 				if (n_cells > 0 && global_solver_count > 0) {
-					const double global_iteration_mean =
-					    static_cast<double>(global_iteration_sum) / static_cast<double>(global_solver_count);
-					const double global_solving_mean =
-					    static_cast<double>(global_solver_count) / static_cast<double>(n_cells) / 2.0; // 2 stages
-					const double global_decoupled_iteration_mean =
-					    static_cast<double>(global_decoupled_iteration_sum) / static_cast<double>(global_solver_count);
+					const Real global_iteration_mean =
+					    static_cast<Real>(global_iteration_sum) / static_cast<Real>(global_solver_count);
+					const Real global_solving_mean =
+					    static_cast<Real>(global_solver_count) / static_cast<Real>(n_cells) / 2.0; // 2 stages
+					const Real global_decoupled_iteration_mean =
+					    static_cast<Real>(global_decoupled_iteration_sum) / static_cast<Real>(global_solver_count);
 					amrex::Print() << "The average number of Newton-Raphson solvings per IMEX stage is " << global_solving_mean
 						       << ", (mean, max) number of Newton-Raphson iterations are " << global_iteration_mean << ", "
 						       << global_iteration_max << ".\n";
@@ -1909,7 +1909,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int const iter_count,
+void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int const iter_count,
 								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	if (Verbose()) {
@@ -1975,7 +1975,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
+void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, Real time, Real dt_radiation, int const /*iter_count*/,
 							       int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	// get cell sizes
@@ -2008,7 +2008,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
+void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, Real time, Real dt_radiation, int const /*iter_count*/,
 							      int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -134,7 +134,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	static constexpr int nstartHyperbolic_ = RadSystem<problem_t>::nstartHyperbolic_;
 
 	Real radiationCflNumber_ = 0.3;
-	int maxSubsteps_ = 10;				// maximum number of radiation subcycles per hydro step
+	int maxSubsteps_ = 10;			 // maximum number of radiation subcycles per hydro step
 	Real dustGasInteractionCoeff_ = 2.5e-34; // erg cm^3 s^−1 K^−3/2
 
 	bool computeReferenceSolution_ = false;
@@ -144,13 +144,13 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	bool use_wavespeed_correction_ = false;
 	bool print_rad_counter_ = false;
 
-	int lowLevelDebuggingOutput_ = 0;	// 0 == do nothing; 1 == output intermediate multifabs used in hydro each timestep (ONLY USE FOR DEBUGGING)
-	int integratorOrder_ = 2;		// 1 == forward Euler; 2 == RK2-SSP (default)
-	int reconstructionOrder_ = 3;		// 1 == donor cell; 2 == PLM; 3 == PPM (default)
-	int radiationReconstructionOrder_ = 3;	// 1 == donor cell; 2 == PLM; 3 == PPM (default)
-	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
-	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
-	Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
+	int lowLevelDebuggingOutput_ = 0;      // 0 == do nothing; 1 == output intermediate multifabs used in hydro each timestep (ONLY USE FOR DEBUGGING)
+	int integratorOrder_ = 2;	       // 1 == forward Euler; 2 == RK2-SSP (default)
+	int reconstructionOrder_ = 3;	       // 1 == donor cell; 2 == PLM; 3 == PPM (default)
+	int radiationReconstructionOrder_ = 3; // 1 == donor cell; 2 == PLM; 3 == PPM (default)
+	int useDualEnergy_ = 1;		       // 0 == disabled; 1 == use auxiliary internal energy equation (default)
+	int abortOnFofcFailure_ = 1;	       // 0 == keep going, 1 == abort hydro advance if FOFC fails
+	Real artificialViscosityK_ = 0.;       // artificial viscosity coefficient (default == None)
 
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
@@ -243,11 +243,10 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void advanceHydroAtLevelWithRetries(int lev, Real time, Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
-					    amrex::YAFluxRegister *fr_as_fine);
+	void advanceHydroAtLevelWithRetries(int lev, Real time, Real dt_lev, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
 
-	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev,
-				 Real time, Real dt_lev) -> bool;
+	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev, Real time,
+				 Real dt_lev) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, Real time, Real dt_lev);
 	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, Real time, Real dt_lev) -> bool;
@@ -257,15 +256,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew);
 	auto computeNumberOfRadiationSubsteps(int lev, Real dt_lev_hydro) -> int;
-	void advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps,
-					    amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
+	void advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
+					    amrex::YAFluxRegister *fr_as_fine);
 	void advanceRadiationForwardEuler(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
 					  amrex::YAFluxRegister *fr_as_fine);
 	void advanceRadiationMidpointRK2(int lev, Real time, Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
 					 amrex::YAFluxRegister *fr_as_fine);
 
-	void subcycleRadiationAtLevel(int lev, Real time, Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
-				      amrex::YAFluxRegister *fr_as_fine);
+	void subcycleRadiationAtLevel(int lev, Real time, Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
@@ -646,8 +644,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::addStrangSplitSo
 	// (when Strang splitting is enabled, dt is actually 0.5*dt_lev)
 }
 
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, Real time, Real dt) -> bool
+template <typename problem_t> auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, Real time, Real dt) -> bool
 {
 	// start by assuming cooling integrator is successful.
 	bool cool_success = true;
@@ -1860,10 +1857,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, Real time, R
 				const auto n_cells = CountCells(lev);
 				amrex::Print() << "time_subcycle = " << time_subcycle << ", total number of cells updated is " << n_cells << "\n";
 				if (n_cells > 0 && global_solver_count > 0) {
-					const Real global_iteration_mean =
-					    static_cast<Real>(global_iteration_sum) / static_cast<Real>(global_solver_count);
-					const Real global_solving_mean =
-					    static_cast<Real>(global_solver_count) / static_cast<Real>(n_cells) / 2.0; // 2 stages
+					const Real global_iteration_mean = static_cast<Real>(global_iteration_sum) / static_cast<Real>(global_solver_count);
+					const Real global_solving_mean = static_cast<Real>(global_solver_count) / static_cast<Real>(n_cells) / 2.0; // 2 stages
 					const Real global_decoupled_iteration_mean =
 					    static_cast<Real>(global_decoupled_iteration_sum) / static_cast<Real>(global_solver_count);
 					amrex::Print() << "The average number of Newton-Raphson solvings per IMEX stage is " << global_solving_mean
@@ -1909,8 +1904,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, Real time, R
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int const iter_count,
-								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, Real time, Real dt_radiation, int const iter_count, int const /*nsubsteps*/,
+								 amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	if (Verbose()) {
 		amrex::Print() << "\tsubstep " << iter_count << " t = " << time << '\n';
@@ -1975,8 +1970,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, Real t
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, Real time, Real dt_radiation, int const /*iter_count*/,
-							       int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, Real time, Real dt_radiation, int const /*iter_count*/, int const /*nsubsteps*/,
+							       amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
@@ -2008,8 +2003,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, Real tim
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, Real time, Real dt_radiation, int const /*iter_count*/,
-							      int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, Real time, Real dt_radiation, int const /*iter_count*/, int const /*nsubsteps*/,
+							      amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -65,10 +65,10 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getEvolutionStageIndex() const -> int { return evolutionStageIndex_; }
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
+	[[nodiscard]] virtual auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<Real>>, std::vector<std::vector<int>>> = 0;
 
 	// Get particle data at level lev
-	[[nodiscard]] virtual auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
+	[[nodiscard]] virtual auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<Real>>, std::vector<std::vector<int>>> = 0;
 
 	// Pure virtual methods that must be implemented by derived classes
 	[[nodiscard]] virtual auto isStarParticle() -> bool = 0;
@@ -151,9 +151,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	//   - Integer data (e.g., id, type, etc.)
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
-	[[nodiscard]] auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
+	[[nodiscard]] auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<Real>>, std::vector<std::vector<int>>> override
 	{
-		std::vector<std::vector<double>> real_data;
+		std::vector<std::vector<Real>> real_data;
 		std::vector<std::vector<int>> int_data;
 
 		// // If max level > 0, return empty vectors. This function does not support multi-level particles.
@@ -204,7 +204,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 						const auto &p = pData_h[i];
 
 						// Process real data (positions and rdata)
-						std::vector<double> r_data;
+						std::vector<Real> r_data;
 						// Pre-allocate to avoid reallocations
 						r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 
@@ -241,9 +241,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		return {real_data, int_data}; // Empty vectors on non-root ranks
 	}
 
-	[[nodiscard]] auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
+	[[nodiscard]] auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<Real>>, std::vector<std::vector<int>>> override
 	{
-		std::vector<std::vector<double>> real_data;
+		std::vector<std::vector<Real>> real_data;
 		std::vector<std::vector<int>> int_data;
 
 		if (container_ != nullptr) {
@@ -318,7 +318,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 						const auto &p = pData_h[i];
 
 						// Process real data (positions and rdata)
-						std::vector<double> r_data;
+						std::vector<Real> r_data;
 						// Pre-allocate to avoid reallocations
 						r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -111,7 +111,7 @@ class PhysicsParticleDescriptorBase
 	// Destroy particles at level lev_min and above
 	virtual void destroyParticles(int lev_min, Real current_time, Real dt) = 0;
 
-	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> = 0;
+	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<Real, amrex::RealVect> = 0;
 
 	// Methods that are implemented for some but not all particle types, so they cannot be pure virtual
 	virtual void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, Real step_end_time) { /* Default empty implementation */ }
@@ -426,7 +426,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 						// Interpolate acceleration from grid to particle and update velocity
 						interp.MeshToParticle(
 						    p, accel_arr, 0, mass_idx + 1, AMREX_SPACEDIM,
-						    [=] AMREX_GPU_DEVICE(amrex::Array4<const amrex::Real> const &acc, int i, int j, int k, int comp) {
+						    [=] AMREX_GPU_DEVICE(amrex::Array4<const Real> const &acc, int i, int j, int k, int comp) {
 							    return acc(i, j, k, comp); // no weighting
 						    },
 						    [=] AMREX_GPU_DEVICE(typename ContainerType::ParticleType & p, int comp, Real acc_comp) {
@@ -457,9 +457,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 
 	// Compute maximum particle speed at a given level
-	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> override
+	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<Real, amrex::RealVect> override
 	{
-		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect { AMREX_D_DECL(NAN, NAN, NAN) }};
+		amrex::ValLocPair<Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect { AMREX_D_DECL(NAN, NAN, NAN) }};
 
 		if (container_ != nullptr && this->getMassIndex() >= 0) {
 			// Only compute for particles that have velocity components
@@ -469,7 +469,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			if (mass_idx + 3 < ContainerType::ParticleType::NReal) {
 				// Use ParticleReduce with ReduceOpMax for efficient parallel reduction
 				amrex::ReduceOps<amrex::ReduceOpMax> reduce_ops;
-				using ResultType = amrex::ValLocPair<amrex::Real, amrex::RealVect>;
+				using ResultType = amrex::ValLocPair<Real, amrex::RealVect>;
 				using ReduceDataType = amrex::ReduceData<ResultType>;
 
 				// Perform the reduction over all particles at this level
@@ -483,7 +483,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 					    const Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
 					    const Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
 					    const amrex::RealVect pos{p_type[i].pos(0), p_type[i].pos(1), p_type[i].pos(2)};
-					    return amrex::ValLocPair<amrex::Real, amrex::RealVect>{std::sqrt(v2), pos};
+					    return amrex::ValLocPair<Real, amrex::RealVect>{std::sqrt(v2), pos};
 				    },
 				    reduce_ops);
 
@@ -876,12 +876,12 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Compute maximum particle speed across all particle types
-	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect>
+	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<Real, amrex::RealVect>
 	{
-		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect{AMREX_D_DECL(NAN, NAN, NAN)}};
+		amrex::ValLocPair<Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect{AMREX_D_DECL(NAN, NAN, NAN)}};
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
-				const amrex::ValLocPair<amrex::Real, amrex::RealVect> speed = descriptor->computeMaxParticleSpeed(lev);
+				const amrex::ValLocPair<Real, amrex::RealVect> speed = descriptor->computeMaxParticleSpeed(lev);
 				AMREX_ASSERT(!std::isnan(speed.value));
 				max_speed = std::max(max_speed, speed);
 			}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -72,7 +72,7 @@ class PhysicsParticleDescriptorBase
 
 	// Pure virtual methods that must be implemented by derived classes
 	[[nodiscard]] virtual auto isStarParticle() -> bool = 0;
-	virtual void depositRadiation(amrex::MultiFab &radEnergySource, int lev, amrex::Real current_time, int nGroups) = 0;
+	virtual void depositRadiation(amrex::MultiFab &radEnergySource, int lev, Real current_time, int nGroups) = 0;
 
 	// Redistribute particles at level lev and above
 	virtual void redistribute(int lev) = 0;
@@ -96,25 +96,25 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 
 #if AMREX_SPACEDIM == 3
-	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
+	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, Real Gconst) = 0;
 
 	// Drift particle at level lev_min and above for time dt. Note that subcycling is not supported.
-	virtual void driftParticles(int lev_min, int lev_max, amrex::Real dt) const = 0;
+	virtual void driftParticles(int lev_min, int lev_max, Real dt) const = 0;
 
 	// Kick particles at level lev_min and above for time dt. Note that subcycling is not supported.
-	virtual void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &accel) = 0;
+	virtual void kickParticles(int lev, Real dt, amrex::MultiFab const &accel) = 0;
 
 	// Create particles from hydro state at the finest level
 	// Note: particles are not allowed to spawn outside of real cells. If they do, we will need a redistribution immediately after this call.
-	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const = 0;
+	virtual void createParticlesFromState(amrex::MultiFab &state, int lev, Real current_time, Real dt) const = 0;
 
 	// Destroy particles at level lev_min and above
-	virtual void destroyParticles(int lev_min, amrex::Real current_time, amrex::Real dt) = 0;
+	virtual void destroyParticles(int lev_min, Real current_time, Real dt) = 0;
 
 	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> = 0;
 
 	// Methods that are implemented for some but not all particle types, so they cannot be pure virtual
-	virtual void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, amrex::Real step_end_time) { /* Default empty implementation */ }
+	virtual void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, Real step_end_time) { /* Default empty implementation */ }
 #endif // AMREX_SPACEDIM == 3
 };
 
@@ -366,7 +366,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 #if AMREX_SPACEDIM == 3
 
 	// Implementation of mass deposition from particles to grid
-	void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) override
+	void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, Real Gconst) override
 	{
 		if (container_ != nullptr && this->getMassIndex() >= 0) {
 			// zero_out_input is false because we want to accumulate mass
@@ -375,7 +375,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		}
 	}
 
-	void driftParticles(int lev_min, int lev_max, amrex::Real dt) const override
+	void driftParticles(int lev_min, int lev_max, Real dt) const override
 	{
 		if (container_ != nullptr) {
 			const int mass_idx = this->getMassIndex(); // capture value instead of this pointer
@@ -403,7 +403,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 
 	// Implementation of particle kick (velocity update based on acceleration)
-	void kickParticles(int lev, amrex::Real dt, amrex::MultiFab const &accel) override
+	void kickParticles(int lev, Real dt, amrex::MultiFab const &accel) override
 	{
 		if (container_ != nullptr) {
 			const int mass_idx = this->getMassIndex(); // capture value instead of this pointer
@@ -429,7 +429,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 						    [=] AMREX_GPU_DEVICE(amrex::Array4<const amrex::Real> const &acc, int i, int j, int k, int comp) {
 							    return acc(i, j, k, comp); // no weighting
 						    },
-						    [=] AMREX_GPU_DEVICE(typename ContainerType::ParticleType & p, int comp, amrex::Real acc_comp) {
+						    [=] AMREX_GPU_DEVICE(typename ContainerType::ParticleType & p, int comp, Real acc_comp) {
 							    // kick particle by updating its velocity
 							    if (comp < ContainerType::ParticleType::NReal) {
 								    p.rdata(comp) += 0.5 * dt * static_cast<amrex::ParticleReal>(acc_comp);
@@ -441,14 +441,14 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		}
 	}
 
-	void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt) const override
+	void createParticlesFromState(amrex::MultiFab &state, int lev, Real current_time, Real dt) const override
 	{
 		// Use the traits class to implement the specialized behavior
 		ParticleCreationTraits<particleType_>::template createParticles<problem_t, ContainerType>(
 		    container_, this->getMassIndex(), state, lev, current_time, dt, this->getEvolutionStageIndex(), this->getBirthTimeIndex());
 	}
 
-	void destroyParticles(int lev_min, amrex::Real current_time, amrex::Real dt) override
+	void destroyParticles(int lev_min, Real current_time, Real dt) override
 	{
 		if (container_ != nullptr) {
 			ParticleDestructionTraits<particleType_>::template destroyParticles<problem_t, ContainerType>(
@@ -478,10 +478,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				    *container_, lev,
 				    [=] AMREX_GPU_DEVICE(const PTDType &p_type, const int i) noexcept -> ResultType {
 					    // Compute velocity magnitude
-					    const amrex::Real vx = p_type.m_aos[i].rdata(mass_idx + 1);
-					    const amrex::Real vy = p_type.m_aos[i].rdata(mass_idx + 2);
-					    const amrex::Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
-					    const amrex::Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
+					    const Real vx = p_type.m_aos[i].rdata(mass_idx + 1);
+					    const Real vy = p_type.m_aos[i].rdata(mass_idx + 2);
+					    const Real vz = p_type.m_aos[i].rdata(mass_idx + 3);
+					    const Real v2 = (vx * vx) + (vy * vy) + (vz * vz);
 					    const amrex::RealVect pos{p_type[i].pos(0), p_type[i].pos(1), p_type[i].pos(2)};
 					    return amrex::ValLocPair<amrex::Real, amrex::RealVect>{std::sqrt(v2), pos};
 				    },
@@ -504,7 +504,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 #endif // AMREX_SPACEDIM == 3
 
 	// Implementation of radiation deposition from particles to grid
-	void depositRadiation(amrex::MultiFab &radEnergySource, int lev, amrex::Real current_time, int nGroups) override
+	void depositRadiation(amrex::MultiFab &radEnergySource, int lev, Real current_time, int nGroups) override
 	{
 		if (container_ != nullptr && this->getLumIndex() >= 0) {
 			amrex::ParticleToMesh(*container_, radEnergySource, lev,
@@ -635,7 +635,7 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 
 #if AMREX_SPACEDIM == 3
 	// Implementation of supernova energy and momentum deposition from particles to grid
-	void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, amrex::Real step_end_time) override
+	void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, Real step_end_time) override
 	{
 		if (this->container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
 			// Deposit supernova energy and momentum from level lev_min to finest level
@@ -760,7 +760,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Deposit radiation from all luminous particles
-	void depositRadiation(amrex::MultiFab &radEnergySource, int lev, amrex::Real current_time)
+	void depositRadiation(amrex::MultiFab &radEnergySource, int lev, Real current_time)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getLumIndex() >= 0) {
@@ -771,7 +771,7 @@ template <typename problem_t> class PhysicsParticleRegister
 
 #if AMREX_SPACEDIM == 3
 	// Deposit mass from all massive particles
-	void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst)
+	void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, Real Gconst)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
@@ -781,7 +781,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Deposit supernova energy and momentum from all particles
-	void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, amrex::Real step_end_time)
+	void depositSN(const amrex::Vector<amrex::MultiFab *> &state, int lev_min, Real step_end_time)
 	{
 		// this function is only implemented for particles that belong to the StarParticleDescriptor class whose unique signature is that the
 		// isStarParticle() method returns true
@@ -829,7 +829,7 @@ template <typename problem_t> class PhysicsParticleRegister
 
 #if AMREX_SPACEDIM == 3
 	// Update positions of all massive particles
-	void driftParticlesAllLevels(amrex::Real dt, int lev_max)
+	void driftParticlesAllLevels(Real dt, int lev_max)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
@@ -839,7 +839,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Update velocities of all massive particles
-	void kickParticlesAtLevel(int lev, amrex::Real dt, amrex::MultiFab &accel)
+	void kickParticlesAtLevel(int lev, Real dt, amrex::MultiFab &accel)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->getMassIndex() >= 0) {
@@ -849,7 +849,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Create particles based on particle type
-	void createParticlesFromState(amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt)
+	void createParticlesFromState(amrex::MultiFab &state, int lev, Real current_time, Real dt)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			// Only create particles if the descriptor allows creation
@@ -864,7 +864,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Destroy particles based on particle type
-	void destroyParticles(int lev_min, amrex::Real current_time, amrex::Real dt)
+	void destroyParticles(int lev_min, Real current_time, Real dt)
 	{
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			// Only destroy particles if the descriptor allows destruction

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -2,6 +2,7 @@
 #define PARTICLE_CREATION_HPP_
 
 #include "particle_types.hpp"
+#include "physics_info.hpp"
 
 namespace quokka
 {
@@ -115,8 +116,8 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 		template <typename ParticleType, typename StateArray>
 		AMREX_GPU_DEVICE void operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo, amrex::Long base_offset) const
+						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo,
+						 amrex::Long base_offset) const
 		{
 			// Default implementation does nothing
 			amrex::ignore_unused(particles, num_particles, state_arr, i, j, k, dx, plo, base_offset);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -11,7 +11,7 @@ namespace ParticleCreationImpl
 {
 // Common implementation of particle creation logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType, template <typename> class CreatorType>
-static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt,
+static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, Real current_time, Real dt,
 				int evolution_stage_index = -1, int birth_time_index = -1)
 {
 	if (container != nullptr) {
@@ -82,13 +82,13 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 template <ParticleType particleType> struct ParticleCreationTraits {
 	// Default nested ParticleChecker - determines if a particle should be created at a location
 	template <typename problem_t> struct ParticleChecker {
-		amrex::Real current_time;
-		amrex::Real dt;
+		Real current_time;
+		Real dt;
 
-		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
+		AMREX_GPU_HOST_DEVICE ParticleChecker(Real current_time, Real dt) : current_time(current_time), dt(dt) {}
 
-		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx) const -> int
+		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const Real> const &state_arr, int i, int j, int k,
+						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx) const -> int
 		{
 			// Default implementation creates no particles
 			amrex::ignore_unused(state_arr, i, j, k, dx);
@@ -103,11 +103,11 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 		int evolution_stage_index;
 		int cpu_id;
 		amrex::Long pid_start;
-		amrex::Real current_time;
+		Real current_time;
 
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
-				amrex::Real current_time)
+				Real current_time)
 		    : mass_idx(mass_index), birth_time_index(birth_time_index), evolution_stage_index(evolution_stage_index), cpu_id(processor_id),
 		      pid_start(particle_id_start), current_time(current_time)
 		{
@@ -115,8 +115,8 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 		template <typename ParticleType, typename StateArray>
 		AMREX_GPU_DEVICE void operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, int i, int j, int k,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo, amrex::Long base_offset) const
+						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
+						 amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo, amrex::Long base_offset) const
 		{
 			// Default implementation does nothing
 			amrex::ignore_unused(particles, num_particles, state_arr, i, j, k, dx, plo, base_offset);
@@ -125,7 +125,7 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 	// Main method to create particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, amrex::Real current_time, amrex::Real dt,
+	static void createParticles(ContainerType *container, int mass_idx, amrex::MultiFab &state, int lev, Real current_time, Real dt,
 				    int evolution_stage_index = -1, int birth_time_index = -1)
 	{
 		// Use the common implementation with our checker and creator types

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -16,7 +16,7 @@ namespace quokka
 
 // Functor for depositing radiation energy from particles onto the grid
 struct RadDeposition {
-	double current_time{}; // Current simulation time
+	Real current_time{}; // Current simulation time
 	int start_part_comp{}; // Starting component in particle data
 	int start_mesh_comp{}; // Starting component in mesh data
 	int num_comp{};	       // Number of components to deposit
@@ -24,9 +24,9 @@ struct RadDeposition {
 
 	// Operator to perform radiation deposition using linear interpolation
 	template <typename ContainerType>
-	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<amrex::Real> const &radEnergySource,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<Real> const &radEnergySource,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &dxi) const noexcept
 	{
 		amrex::ParticleInterpolator::Linear interp(p, plo, dxi);
 		// Deposit radiation energy only if particle is active
@@ -46,16 +46,16 @@ struct RadDeposition {
 
 // Functor for depositing particle mass onto the grid
 struct MassDeposition {
-	amrex::Real Gconst{};  // Gravitational constant
+	Real Gconst{};  // Gravitational constant
 	int start_part_comp{}; // Starting component in particle data
 	int start_mesh_comp{}; // Starting component in mesh data
 	int num_comp{};	       // Number of components to deposit
 
 	// Operator to perform mass deposition using linear interpolation
 	template <typename ContainerType>
-	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<amrex::Real> const &rho,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<Real> const &rho,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &dxi) const noexcept
 	{
 		amrex::ParticleInterpolator::Linear interp(p, plo, dxi);
 		// Deposit mass weighted by 4 pi G
@@ -72,12 +72,12 @@ struct MassDeposition {
 // to 5³ cells centered on the particle's cell. It is used for testing purposes.
 // Note: the deposition radius must be <= nghost_cc_
 struct SNDeposition {
-	double step_end_time{};	   // Current simulation time
+	Real step_end_time{};	   // Current simulation time
 	int start_part_comp{};	   // Starting component in particle data
 	int start_mesh_comp{};	   // Starting component in mesh data
 	int birthTimeIndex{};	   // Index for particle birth time
 	int evolutionStageIndex{}; // Index for particle evolution stage
-	double SN_time = particle_param2;
+	Real SN_time = particle_param2;
 
 	// For some unknown reason, stencil_width < 3 results in larger error in SNR mass when a particle is at the refinement boundary.
 	static constexpr int stencil_width = 3;
@@ -90,9 +90,9 @@ struct SNDeposition {
 
 	// Operator to perform supernova deposition using cloud-in-cell approach
 	template <typename ContainerType>
-	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<amrex::Real> const &state,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-							    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxi) const noexcept
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE void operator()(const ContainerType &p, amrex::Array4<Real> const &state,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &plo,
+							    amrex::GpuArray<Real, AMREX_SPACEDIM> const &dxi) const noexcept
 	{
 		// Check if the particle has an integer component for evolution stage
 		if constexpr (ContainerType::NInt > 0) {
@@ -110,12 +110,12 @@ struct SNDeposition {
 
 				// Calculate the volume factor for normalization (5³ cells)
 				const int num_cells = (2 * stencil_width + 1) * (2 * stencil_width + 1) * (2 * stencil_width + 1);
-				const amrex::Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
+				const Real vol_factor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2])) / num_cells;
 
 				// Deposit evenly to 5³ cells centered on the particle's cell
-				const amrex::Real pdensity = p.rdata(start_part_comp) * vol_factor;
-				const amrex::Real penergy = pdensity; // for testing: energy = mass
-				const amrex::Real pmomentum = 0.0;    // for testing: momentum = 0
+				const Real pdensity = p.rdata(start_part_comp) * vol_factor;
+				const Real penergy = pdensity; // for testing: energy = mass
+				const Real pmomentum = 0.0;    // for testing: momentum = 0
 
 				for (int kk = -stencil_width; kk <= stencil_width; ++kk) {
 					for (int jj = -stencil_width; jj <= stencil_width; ++jj) {
@@ -145,13 +145,13 @@ struct SNDeposition {
 
 // Function to update particle evolution stages from SNProgenitor to SNRemnant
 template <typename ContainerType>
-void updateEvolutionStage(ContainerType *container, int lev_min, amrex::Real step_end_time, int birthTimeIndex, int evolutionStageIndex)
+void updateEvolutionStage(ContainerType *container, int lev_min, Real step_end_time, int birthTimeIndex, int evolutionStageIndex)
 {
 	if (container == nullptr || evolutionStageIndex < 0 || birthTimeIndex < 0) {
 		return;
 	}
 
-	const double SN_time = particle_param2;
+	const Real SN_time = particle_param2;
 
 	for (int lev = lev_min; lev <= container->finestLevel(); ++lev) {
 		for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -8,6 +8,7 @@
 #include "AMReX_ParticleMesh.H"
 #include "AMReX_REAL.H"
 #include "particles/particle_types.hpp"
+#include "physics_info.hpp"
 
 namespace quokka
 {
@@ -16,7 +17,7 @@ namespace quokka
 
 // Functor for depositing radiation energy from particles onto the grid
 struct RadDeposition {
-	Real current_time{}; // Current simulation time
+	Real current_time{};   // Current simulation time
 	int start_part_comp{}; // Starting component in particle data
 	int start_mesh_comp{}; // Starting component in mesh data
 	int num_comp{};	       // Number of components to deposit
@@ -46,7 +47,7 @@ struct RadDeposition {
 
 // Functor for depositing particle mass onto the grid
 struct MassDeposition {
-	Real Gconst{};  // Gravitational constant
+	Real Gconst{};	       // Gravitational constant
 	int start_part_comp{}; // Starting component in particle data
 	int start_mesh_comp{}; // Starting component in mesh data
 	int num_comp{};	       // Number of components to deposit

--- a/src/particles/particle_destruction.hpp
+++ b/src/particles/particle_destruction.hpp
@@ -11,7 +11,7 @@ namespace ParticleDestructionImpl
 {
 // Common implementation of particle destruction logic
 template <typename problem_t, typename ContainerType, template <typename> class CheckerType>
-static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev_min, amrex::Real current_time, amrex::Real dt, int birth_time_index,
+static void destroyParticlesImpl(ContainerType *container, int mass_idx, int lev_min, Real current_time, Real dt, int birth_time_index,
 				 int evolution_stage_index)
 {
 	if (container != nullptr) {
@@ -72,7 +72,7 @@ template <ParticleType particleType> struct ParticleDestructionTraits {
 		}
 
 		template <typename ParticleType>
-		AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, amrex::Real current_time, amrex::Real dt) const -> bool
+		AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, Real current_time, Real dt) const -> bool
 		{
 			// Default implementation: destroy particles with mass < 1.0
 			amrex::ignore_unused(p, mass_idx, current_time, dt);
@@ -82,7 +82,7 @@ template <ParticleType particleType> struct ParticleDestructionTraits {
 
 	// Main method to destroy particles - uses the helper implementation
 	template <typename problem_t, typename ContainerType>
-	static void destroyParticles(ContainerType *container, int mass_idx, int lev_min, amrex::Real current_time, amrex::Real dt, int birth_time_index,
+	static void destroyParticles(ContainerType *container, int mass_idx, int lev_min, Real current_time, Real dt, int birth_time_index,
 				     int evolution_stage_index)
 	{
 		// Use the common implementation with our checker type

--- a/src/particles/particle_destruction.hpp
+++ b/src/particles/particle_destruction.hpp
@@ -2,6 +2,7 @@
 #define PARTICLE_DESTRUCTION_HPP_
 
 #include "particle_types.hpp"
+#include "physics_info.hpp"
 
 namespace quokka
 {
@@ -71,8 +72,7 @@ template <ParticleType particleType> struct ParticleDestructionTraits {
 		{
 		}
 
-		template <typename ParticleType>
-		AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, Real current_time, Real dt) const -> bool
+		template <typename ParticleType> AMREX_GPU_DEVICE auto operator()(ParticleType &p, int mass_idx, Real current_time, Real dt) const -> bool
 		{
 			// Default implementation: destroy particles with mass < 1.0
 			amrex::ignore_unused(p, mass_idx, current_time, dt);

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -80,9 +80,9 @@ enum class ParticleType {
 // is included in multiple source files. It ensures that all translation units that include
 // this header will refer to the same instance of these variables, rather than creating
 // their own copies.
-inline amrex::Real particle_param1 = -1.0; // NOLINT
-inline amrex::Real particle_param2 = -1.0; // NOLINT
-inline amrex::Real particle_param3 = -1.0; // NOLINT
+inline Real particle_param1 = -1.0; // NOLINT
+inline Real particle_param2 = -1.0; // NOLINT
+inline Real particle_param3 = -1.0; // NOLINT
 inline int particle_verbose = 0;	   // NOLINT print particle logistics
 
 //-------------------- Radiation particles --------------------

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -83,7 +83,7 @@ enum class ParticleType {
 inline Real particle_param1 = -1.0; // NOLINT
 inline Real particle_param2 = -1.0; // NOLINT
 inline Real particle_param3 = -1.0; // NOLINT
-inline int particle_verbose = 0;	   // NOLINT print particle logistics
+inline int particle_verbose = 0;    // NOLINT print particle logistics
 
 //-------------------- Radiation particles --------------------
 

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -1,9 +1,12 @@
 #ifndef PHYSICS_INFO_HPP_ // NOLINT
 #define PHYSICS_INFO_HPP_
 
+#include "AMReX_REAL.H"
 #include "fundamental_constants.H"
 #include "physics_numVars.hpp"
 #include <AMReX.H>
+
+using Real = amrex::Real;
 
 // enum for unit system, one of CGS, CONSTANTS, CUSTOM
 enum class UnitSystem { CGS, CONSTANTS, CUSTOM };

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -53,7 +53,7 @@ static constexpr Real IMEX_a32 = 0.5; // 0 < IMEX_a32 <= 0.5
 // static constexpr Real IMEX_a32 = 0.0;
 
 // physical constants in CGS units
-static constexpr Real c_light_cgs_ = C::c_light;	    // cgs
+static constexpr Real c_light_cgs_ = C::c_light;	  // cgs
 static constexpr Real radiation_constant_cgs_ = C::a_rad; // cgs
 static constexpr Real inf = std::numeric_limits<Real>::max();
 
@@ -88,7 +88,7 @@ template <typename problem_t> struct ISM_Traits {
 // A struct to hold the results of the ComputeRadPressure function.
 struct RadPressureResult {
 	quokka::valarray<Real, 4> F; // components of radiation pressure tensor
-	Real S;		       // maximum wavespeed for the radiation system
+	Real S;			     // maximum wavespeed for the radiation system
 };
 
 // A struct to hold the opacity terms for the radiation-matter energy exchange, containing the following elements:
@@ -106,9 +106,9 @@ template <typename problem_t> struct OpacityTerms {
 // A struct to hold the results of the Newton-Raphson iteration for energy update, containing the following elements:
 // Egas, T_gas, T_d, EradVec, work, opacity_terms
 template <typename problem_t> struct NewtonIterationResult {
-	Real Egas;							      // gas internal energy
-	Real T_gas;							      // gas temperature
-	Real T_d;							      // dust temperature
+	Real Egas;							    // gas internal energy
+	Real T_gas;							    // gas temperature
+	Real T_d;							    // dust temperature
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> EradVec; // radiation energy density
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> work;    // work term
 	OpacityTerms<problem_t> opacity_terms;
@@ -117,21 +117,21 @@ template <typename problem_t> struct NewtonIterationResult {
 // A struct to hold the results of ComputeJacobian functions, containing the following elements:
 // J00, F0, Fg_abs_sum, J0g, Jg0, Jgg, Fg
 template <typename problem_t> struct JacobianResult {
-	Real J00;	   // (0, 0) component of the Jacobian matrix
-	Real F0;	   // (0) component of the residual
+	Real J00;	 // (0, 0) component of the Jacobian matrix
+	Real F0;	 // (0) component of the residual
 	Real Fg_abs_sum; // sum of the absolute values of the (g) components of the residual, g = 1, 2, ..., nGroups, and tau(g) > 0
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> J0g; // (0, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jg0; // (g, 0) components of the Jacobian matrix, g = 1, 2, ..., nGroups
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jgg; // (g, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
 	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jg1; // (g, 1) components of the Jacobian matrix, g = 1, 2, ..., nGroups
-	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Fg;  // (g) components of the residual, g = 1, 2, ..., nGroups
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Fg;	// (g) components of the residual, g = 1, 2, ..., nGroups
 };
 
 // A struct to hold the results of UpdateFlux(), containing the following elements:
 // Erad, gasMomentum, Frad
 template <typename problem_t> struct FluxUpdateResult {
-	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Erad;			   // radiation energy density
-	amrex::GpuArray<Real, 3> gasMomentum;							   // gas momentum
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Erad;		    // radiation energy density
+	amrex::GpuArray<Real, 3> gasMomentum;						    // gas momentum
 	amrex::GpuArray<amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
 };
 
@@ -267,13 +267,13 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static void ConservedToPrimitive(amrex::Array4<const Real> const &cons, array_t &primVar, amrex::Box const &indexRange);
 
 	static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
-				amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in,
-				amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
+				amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in, amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in,
+				amrex::Box const &indexRange, int nvars);
 
 	static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArrayOld,
 				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArrayOld,
-				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in,
-				 amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
+				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in, amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in,
+				 amrex::Box const &indexRange, int nvars);
 
 	template <FluxDir DIR>
 	static void ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiffusive_in, amrex::Array4<const Real> const &x1LeftState_in,
@@ -281,8 +281,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				  amrex::GpuArray<Real, AMREX_SPACEDIM> dx, bool use_wavespeed_correction);
 
 	static void SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-				       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
-				       Real time);
+				       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi, Real time);
 
 	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, Real dt,
 						Real gas_update_factor, Real Ekin0) -> FluxUpdateResult<problem_t>;
@@ -341,8 +340,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_HOST_DEVICE static void SolveLinearEqsWithLastColumn(JacobianResult<problem_t> const &jacobian, Real &x0,
 								       quokka::valarray<Real, nGroups_> &xi);
 
-	AMREX_GPU_HOST_DEVICE static auto Solve3x3matrix(Real C00, Real C01, Real C02, Real C10, Real C11, Real C12, Real C20, Real C21,
-							 Real C22, Real Y0, Real Y1, Real Y2) -> std::tuple<Real, Real, Real>;
+	AMREX_GPU_HOST_DEVICE static auto Solve3x3matrix(Real C00, Real C01, Real C02, Real C10, Real C11, Real C12, Real C20, Real C21, Real C22, Real Y0,
+							 Real Y1, Real Y2) -> std::tuple<Real, Real, Real>;
 
 	AMREX_GPU_HOST_DEVICE static auto ComputePlanckEnergyFractions(amrex::GpuArray<Real, nGroups_ + 1> const &boundaries, Real temperature)
 	    -> quokka::valarray<Real, nGroups_>;
@@ -362,14 +361,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, Real x0, Real compare) -> Real;
 
 	AMREX_GPU_DEVICE static auto
-	ComputeDustTemperatureBateKeto(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt,
-				       Real R_sum, int n_step,
-				       amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{}) -> Real;
+	ComputeDustTemperatureBateKeto(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt, Real R_sum,
+				       int n_step, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{}) -> Real;
 
 	AMREX_GPU_DEVICE static auto
-	ComputeDustTemperatureGasOnly(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt,
-				      Real R_sum, int n_step,
-				      amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{},
+	ComputeDustTemperatureGasOnly(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt, Real R_sum,
+				      int n_step, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{},
 				      amrex::GpuArray<Real, nGroups_> const &rad_boundary_ratios = amrex::GpuArray<Real, nGroups_>{}) -> Real;
 
 	AMREX_GPU_HOST_DEVICE static auto DefinePhotoelectricHeatingE1Derivative(Real temperature, Real num_density) -> Real;
@@ -378,8 +375,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(Real temperature, Real num_density) -> quokka::valarray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(Real temperature, Real num_density)
-	    -> quokka::valarray<Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(Real temperature, Real num_density) -> quokka::valarray<Real, nGroups_>;
 
 	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(Real num_density) -> Real;
 
@@ -401,11 +397,10 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 							   quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t, Real num_den, Real dt)
 	    -> JacobianResult<problem_t>;
 
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(Real T_gas, Real T_d, Real Egas_diff,
-								  quokka::valarray<Real, nGroups_> const &Erad_diff,
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(Real T_gas, Real T_d, Real Egas_diff, quokka::valarray<Real, nGroups_> const &Erad_diff,
 								  quokka::valarray<Real, nGroups_> const &Rvec, quokka::valarray<Real, nGroups_> const &Src,
-								  Real coeff_n, quokka::valarray<Real, nGroups_> const &tau, Real c_v,
-								  Real lambda_gd_time_dt, quokka::valarray<Real, nGroups_> const &kappaPoverE,
+								  Real coeff_n, quokka::valarray<Real, nGroups_> const &tau, Real c_v, Real lambda_gd_time_dt,
+								  quokka::valarray<Real, nGroups_> const &kappaPoverE,
 								  quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t, Real num_den, Real dt)
 	    -> JacobianResult<problem_t>;
 
@@ -427,9 +422,9 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 					amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter)
 	    -> NewtonIterationResult<problem_t>;
 
-	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(Real Egas0, quokka::valarray<Real, nGroups_> const &Erad0Vec, Real rho,
-									 Real coeff_n, Real dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
-									 int n_outer_iter, quokka::valarray<Real, nGroups_> const &work,
+	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(Real Egas0, quokka::valarray<Real, nGroups_> const &Erad0Vec, Real rho, Real coeff_n,
+									 Real dt, amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter,
+									 quokka::valarray<Real, nGroups_> const &work,
 									 quokka::valarray<Real, nGroups_> const &vel_times_F,
 									 quokka::valarray<Real, nGroups_> const &Src,
 									 amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter,
@@ -443,9 +438,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						  int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	template <FluxDir DIR>
-	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar,
-							     amrex::GpuArray<Real, AMREX_SPACEDIM> dx, int i, int j, int k,
-							     const amrex::GpuArray<Real, nGroups_ + 1> &group_boundaries)
+	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar, amrex::GpuArray<Real, AMREX_SPACEDIM> dx,
+							     int i, int j, int k, const amrex::GpuArray<Real, nGroups_ + 1> &group_boundaries)
 	    -> quokka::valarray<Real, nGroups_>;
 
 	AMREX_GPU_DEVICE static auto isStateValid(std::array<Real, nvarHyperbolic_> &cons) -> bool;
@@ -453,8 +447,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_DEVICE static void amendRadState(std::array<Real, nvarHyperbolic_> &cons);
 
 	template <FluxDir DIR>
-	AMREX_GPU_DEVICE static auto ComputeRadPressure(Real erad_L, Real Fx_L, Real Fy_L, Real Fz_L, Real fx_L, Real fy_L, Real fz_L)
-	    -> RadPressureResult;
+	AMREX_GPU_DEVICE static auto ComputeRadPressure(Real erad_L, Real Fx_L, Real Fy_L, Real Fz_L, Real fx_L, Real fy_L, Real fz_L) -> RadPressureResult;
 
 	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(Real fx_L, Real fy_L, Real fz_L) -> std::array<std::array<Real, 3>, 3>;
 };
@@ -511,8 +504,7 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 
 // define ComputeThermalRadiationMultiGroup, returns the thermal radiation power for each photon group. = a_r * T^4 * radEnergyFractions
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGroup(Real temperature,
-										   amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGroup(Real temperature, amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
     -> quokka::valarray<Real, nGroups_>
 {
 	const Real power = radiation_constant_ * std::pow(temperature, 4);
@@ -545,10 +537,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDeri
 }
 
 // Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(Real const /*num_density*/) -> Real
-{
-	return 0.0;
-}
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(Real const /*num_density*/) -> Real { return 0.0; }
 
 // Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
 template <typename problem_t>
@@ -570,10 +559,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivat
 	return cooling;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(Real const /*num_density*/) -> Real
-{
-	return 0.0;
-}
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(Real const /*num_density*/) -> Real { return 0.0; }
 
 // Linear equation solver for matrix with non-zeros at the first row, first column, and diagonal only.
 // solve the linear system
@@ -589,9 +575,9 @@ AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqs(JacobianResult<p
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const Real C00, const Real C01, const Real C02, const Real C10, const Real C11,
-								const Real C12, const Real C20, const Real C21, const Real C22, const Real Y0,
-								const Real Y1, const Real Y2) -> std::tuple<Real, Real, Real>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const Real C00, const Real C01, const Real C02, const Real C10, const Real C11, const Real C12,
+								const Real C20, const Real C21, const Real C22, const Real Y0, const Real Y1, const Real Y2)
+    -> std::tuple<Real, Real, Real>
 {
 	// Solve the 3x3 matrix equation: C * X = Y under the assumption that only the diagonal terms
 	// are guaranteed to be non-zero and are thus allowed to be divided by.
@@ -611,8 +597,8 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const Real C00, 
 
 template <typename problem_t>
 void RadSystem<problem_t>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-					      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo,
-					      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi, Real time)
+					      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
+					      Real time)
 {
 	// do nothing -- user implemented
 }
@@ -948,8 +934,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const Real fx
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const Real erad, const Real Fx, const Real Fy, const Real Fz, const Real fx,
-							       const Real fy, const Real fz) -> RadPressureResult
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const Real erad, const Real Fx, const Real Fy, const Real Fz, const Real fx, const Real fy,
+							       const Real fz) -> RadPressureResult
 {
 	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct.
 
@@ -1135,7 +1121,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 				// no correction for odd zones
 				if ((i + j + k) % 2 == 0) {
 					const Real S_corr = std::min(1.0, 1.0 / tau_cell[g]); // Skinner et al.
-					epsilon = {S_corr, 1.0, 1.0, 1.0};			// Skinner et al. (2019)
+					epsilon = {S_corr, 1.0, 1.0, 1.0};		      // Skinner et al. (2019)
 				}
 			}
 
@@ -1416,8 +1402,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(con
 
 template <typename problem_t>
 template <typename RHSFunction, typename JacFunction>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const Real x0, const Real compare)
-    -> Real
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const Real x0, const Real compare) -> Real
 {
 	Real x = x0;
 	const Real rel_tol = 1.0e-8;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -47,16 +47,16 @@ static const bool PPL_free_slope_st_total = false; // PPL with free slopes for a
 
 // Time integration scheme
 // IMEX PD-ARS
-static constexpr double IMEX_a22 = 1.0;
-static constexpr double IMEX_a32 = 0.5; // 0 < IMEX_a32 <= 0.5
+static constexpr Real IMEX_a22 = 1.0;
+static constexpr Real IMEX_a32 = 0.5; // 0 < IMEX_a32 <= 0.5
 // SSP-RK2 + implicit radiation-matter exchange
-// static constexpr double IMEX_a22 = 0.0;
-// static constexpr double IMEX_a32 = 0.0;
+// static constexpr Real IMEX_a22 = 0.0;
+// static constexpr Real IMEX_a32 = 0.0;
 
 // physical constants in CGS units
-static constexpr double c_light_cgs_ = C::c_light;	    // cgs
-static constexpr double radiation_constant_cgs_ = C::a_rad; // cgs
-static constexpr double inf = std::numeric_limits<double>::max();
+static constexpr Real c_light_cgs_ = C::c_light;	    // cgs
+static constexpr Real radiation_constant_cgs_ = C::a_rad; // cgs
+static constexpr Real inf = std::numeric_limits<Real>::max();
 
 // enum for opacity_model
 enum class OpacityModel {
@@ -70,11 +70,11 @@ enum class OpacityModel {
 // this struct is specialized by the user application code
 //
 template <typename problem_t> struct RadSystem_Traits {
-	static constexpr double c_hat_over_c = 1.0;
-	static constexpr double Erad_floor = 0.;
-	static constexpr double energy_unit = C::ev2erg;
-	static constexpr amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups + 1> radBoundaries = {0., inf};
-	static constexpr double beta_order = 1;
+	static constexpr Real c_hat_over_c = 1.0;
+	static constexpr Real Erad_floor = 0.;
+	static constexpr Real energy_unit = C::ev2erg;
+	static constexpr amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups + 1> radBoundaries = {0., inf};
+	static constexpr Real beta_order = 1;
 	static constexpr OpacityModel opacity_model = OpacityModel::single_group;
 };
 
@@ -83,60 +83,60 @@ template <typename problem_t> struct RadSystem_Traits {
 template <typename problem_t> struct ISM_Traits {
 	static constexpr bool enable_dust_gas_thermal_coupling_model = false;
 	static constexpr bool enable_photoelectric_heating = false;
-	static constexpr double gas_dust_coupling_threshold = 1.0e-6;
+	static constexpr Real gas_dust_coupling_threshold = 1.0e-6;
 };
 
 // A struct to hold the results of the ComputeRadPressure function.
 struct RadPressureResult {
-	quokka::valarray<double, 4> F; // components of radiation pressure tensor
-	double S;		       // maximum wavespeed for the radiation system
+	quokka::valarray<Real, 4> F; // components of radiation pressure tensor
+	Real S;		       // maximum wavespeed for the radiation system
 };
 
 // A struct to hold the opacity terms for the radiation-matter energy exchange, containing the following elements:
 // kappaE, kappaP, kappaF, kappaPoverE, delta_nu_kappa_B_at_edge, alpha_P, alpha_E
 template <typename problem_t> struct OpacityTerms {
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> kappaE;
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> kappaP;
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> kappaF;
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> kappaPoverE;
-	amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups> delta_nu_kappa_B_at_edge; // Delta (nu * kappa * B)
-	amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups> alpha_P;
-	amrex::GpuArray<double, Physics_Traits<problem_t>::nGroups> alpha_E;
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> kappaE;
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> kappaP;
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> kappaF;
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> kappaPoverE;
+	amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups> delta_nu_kappa_B_at_edge; // Delta (nu * kappa * B)
+	amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups> alpha_P;
+	amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups> alpha_E;
 };
 
 // A struct to hold the results of the Newton-Raphson iteration for energy update, containing the following elements:
 // Egas, T_gas, T_d, EradVec, work, opacity_terms
 template <typename problem_t> struct NewtonIterationResult {
-	double Egas;							      // gas internal energy
-	double T_gas;							      // gas temperature
-	double T_d;							      // dust temperature
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> EradVec; // radiation energy density
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> work;    // work term
+	Real Egas;							      // gas internal energy
+	Real T_gas;							      // gas temperature
+	Real T_d;							      // dust temperature
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> EradVec; // radiation energy density
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> work;    // work term
 	OpacityTerms<problem_t> opacity_terms;
 };
 
 // A struct to hold the results of ComputeJacobian functions, containing the following elements:
 // J00, F0, Fg_abs_sum, J0g, Jg0, Jgg, Fg
 template <typename problem_t> struct JacobianResult {
-	double J00;	   // (0, 0) component of the Jacobian matrix
-	double F0;	   // (0) component of the residual
-	double Fg_abs_sum; // sum of the absolute values of the (g) components of the residual, g = 1, 2, ..., nGroups, and tau(g) > 0
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> J0g; // (0, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Jg0; // (g, 0) components of the Jacobian matrix, g = 1, 2, ..., nGroups
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Jgg; // (g, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Jg1; // (g, 1) components of the Jacobian matrix, g = 1, 2, ..., nGroups
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Fg;  // (g) components of the residual, g = 1, 2, ..., nGroups
+	Real J00;	   // (0, 0) component of the Jacobian matrix
+	Real F0;	   // (0) component of the residual
+	Real Fg_abs_sum; // sum of the absolute values of the (g) components of the residual, g = 1, 2, ..., nGroups, and tau(g) > 0
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> J0g; // (0, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jg0; // (g, 0) components of the Jacobian matrix, g = 1, 2, ..., nGroups
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jgg; // (g, g) components of the Jacobian matrix, g = 1, 2, ..., nGroups
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Jg1; // (g, 1) components of the Jacobian matrix, g = 1, 2, ..., nGroups
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Fg;  // (g) components of the residual, g = 1, 2, ..., nGroups
 };
 
 // A struct to hold the results of UpdateFlux(), containing the following elements:
 // Erad, gasMomentum, Frad
 template <typename problem_t> struct FluxUpdateResult {
-	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Erad;			   // radiation energy density
-	amrex::GpuArray<double, 3> gasMomentum;							   // gas momentum
+	quokka::valarray<Real, Physics_Traits<problem_t>::nGroups> Erad;			   // radiation energy density
+	amrex::GpuArray<Real, 3> gasMomentum;							   // gas momentum
 	amrex::GpuArray<amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
 };
 
-[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod_func(double a, double b) -> double
+[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod_func(Real a, Real b) -> Real
 {
 	return 0.5 * (sgn(a) + sgn(b)) * std::min(std::abs(a), std::abs(b));
 }
@@ -154,7 +154,7 @@ struct RadSystem_Has_Opacity_Model<problem_t, std::void_t<decltype(RadSystem_Tra
 template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_t>
 {
       public:
-	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(double a, double b) -> double
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(Real a, Real b) -> Real
 	{
 		return 0.5 * (sgn(a) + sgn(b)) * std::min(0.5 * std::abs(a + b), std::min(2.0 * std::abs(a), 2.0 * std::abs(b)));
 	}
@@ -197,9 +197,9 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 			return c_light_cgs_ / (Physics_Traits<problem_t>::unit_length / Physics_Traits<problem_t>::unit_time);
 		}
 	}();
-	static constexpr double c_hat_ = c_light_ * RadSystem_Traits<problem_t>::c_hat_over_c;
+	static constexpr Real c_hat_ = c_light_ * RadSystem_Traits<problem_t>::c_hat_over_c;
 
-	static constexpr double radiation_constant_ = []() constexpr {
+	static constexpr Real radiation_constant_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			return C::a_rad;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CONSTANTS) {
@@ -219,16 +219,16 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static constexpr bool enable_photoelectric_heating_ = ISM_Traits<problem_t>::enable_photoelectric_heating;
 
 	static constexpr int nGroups_ = Physics_Traits<problem_t>::nGroups;
-	static constexpr amrex::GpuArray<double, nGroups_ + 1> radBoundaries_ = []() constexpr {
+	static constexpr amrex::GpuArray<Real, nGroups_ + 1> radBoundaries_ = []() constexpr {
 		if constexpr (nGroups_ > 1) {
 			return RadSystem_Traits<problem_t>::radBoundaries;
 		} else {
-			amrex::GpuArray<double, 2> boundaries{0., inf};
+			amrex::GpuArray<Real, 2> boundaries{0., inf};
 			return boundaries;
 		}
 	}();
 
-	static constexpr double Erad_floor_ = RadSystem_Traits<problem_t>::Erad_floor / nGroups_;
+	static constexpr Real Erad_floor_ = RadSystem_Traits<problem_t>::Erad_floor / nGroups_;
 
 	static constexpr OpacityModel opacity_model_ = []() constexpr {
 		if constexpr (RadSystem_Has_Opacity_Model<problem_t>::value) {
@@ -246,8 +246,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static_assert(!(nGroups_ < 3 && opacity_model_ == OpacityModel::PPL_opacity_full_spectrum), // NOLINT
 		      "PPL_opacity_full_spectrum requires at least 3 photon groups.");
 
-	static constexpr double mean_molecular_mass_ = quokka::EOS_Traits<problem_t>::mean_molecular_weight;
-	static constexpr double gamma_ = quokka::EOS_Traits<problem_t>::gamma;
+	static constexpr Real mean_molecular_mass_ = quokka::EOS_Traits<problem_t>::mean_molecular_weight;
+	static constexpr Real gamma_ = quokka::EOS_Traits<problem_t>::gamma;
 
 	static constexpr Real boltzmann_constant_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
@@ -268,12 +268,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static void ConservedToPrimitive(amrex::Array4<const Real> const &cons, array_t &primVar, amrex::Box const &indexRange);
 
 	static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
-				amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, double dt_in,
+				amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in,
 				amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
 
 	static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArrayOld,
 				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArrayOld,
-				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, double dt_in,
+				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, Real dt_in,
 				 amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
 
 	template <FluxDir DIR>
@@ -285,14 +285,14 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
 				       Real time);
 
-	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
-						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
+	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, Real dt,
+						Real gas_update_factor, Real Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt, int stage,
-					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
+					     Real dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt, int stage,
-					      double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
+					      Real dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
 
@@ -300,170 +300,170 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	template <typename ArrayType>
 	AMREX_GPU_DEVICE static auto ComputeMassScalars(ArrayType const &arr, int i, int j, int k) -> amrex::GpuArray<Real, nmscalars_>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeEddingtonFactor(double f) -> double;
+	AMREX_GPU_HOST_DEVICE static auto ComputeEddingtonFactor(Real f) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeNumberDensityH(double rho, amrex::GpuArray<Real, nmscalars_> const &massScalars) -> double;
+	AMREX_GPU_HOST_DEVICE static auto ComputeNumberDensityH(Real rho, amrex::GpuArray<Real, nmscalars_> const &massScalars) -> Real;
 
 	// Used for single-group RHD only. Not used for multi-group RHD.
-	AMREX_GPU_HOST_DEVICE static auto ComputePlanckOpacity(double rho, double Tgas) -> Real;
-	AMREX_GPU_HOST_DEVICE static auto ComputeFluxMeanOpacity(double rho, double Tgas) -> Real;
-	AMREX_GPU_HOST_DEVICE static auto ComputeEnergyMeanOpacity(double rho, double Tgas) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto ComputePlanckOpacity(Real rho, Real Tgas) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto ComputeFluxMeanOpacity(Real rho, Real Tgas) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto ComputeEnergyMeanOpacity(Real rho, Real Tgas) -> Real;
 
 	// For multi-group RHD, use DefineOpacityExponentsAndLowerValues to define the opacities.
-	AMREX_GPU_HOST_DEVICE static auto DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> rad_boundaries, double rho, double Tgas)
-	    -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>;
+	AMREX_GPU_HOST_DEVICE static auto DefineOpacityExponentsAndLowerValues(amrex::GpuArray<Real, nGroups_ + 1> rad_boundaries, Real rho, Real Tgas)
+	    -> amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> const &kappa_expo_and_lower_value,
-								  amrex::GpuArray<double, nGroups_> const &radBoundaryRatios,
-								  amrex::GpuArray<double, nGroups_> const &alpha_quant) -> quokka::valarray<double, nGroups_>;
-	AMREX_GPU_HOST_DEVICE static auto ComputeBinCenterOpacity(amrex::GpuArray<double, nGroups_ + 1> rad_boundaries,
-								  amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> kappa_expo_and_lower_value)
-	    -> quokka::valarray<double, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> const &kappa_expo_and_lower_value,
+								  amrex::GpuArray<Real, nGroups_> const &radBoundaryRatios,
+								  amrex::GpuArray<Real, nGroups_> const &alpha_quant) -> quokka::valarray<Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeBinCenterOpacity(amrex::GpuArray<Real, nGroups_ + 1> rad_boundaries,
+								  amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> kappa_expo_and_lower_value)
+	    -> quokka::valarray<Real, nGroups_>;
 	// AMREX_GPU_HOST_DEVICE static auto
-	// ComputeGroupMeanOpacityWithMinusOneSlope(amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> kappa_expo_and_lower_value,
-	// 					 amrex::GpuArray<double, nGroups_> radBoundaryRatios) -> quokka::valarray<double, nGroups_>;
-	AMREX_GPU_HOST_DEVICE static auto ComputeEintFromEgas(double density, double X1GasMom, double X2GasMom, double X3GasMom, double Etot) -> double;
-	AMREX_GPU_HOST_DEVICE static auto ComputeEgasFromEint(double density, double X1GasMom, double X2GasMom, double X3GasMom, double Eint) -> double;
-	AMREX_GPU_HOST_DEVICE static auto PlanckFunction(double nu, double T) -> double;
+	// ComputeGroupMeanOpacityWithMinusOneSlope(amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> kappa_expo_and_lower_value,
+	// 					 amrex::GpuArray<Real, nGroups_> radBoundaryRatios) -> quokka::valarray<Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeEintFromEgas(Real density, Real X1GasMom, Real X2GasMom, Real X3GasMom, Real Etot) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto ComputeEgasFromEint(Real density, Real X1GasMom, Real X2GasMom, Real X3GasMom, Real Eint) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto PlanckFunction(Real nu, Real T) -> Real;
 	AMREX_GPU_HOST_DEVICE static auto
-	ComputeDiffusionFluxMeanOpacity(quokka::valarray<double, nGroups_> kappaPVec, quokka::valarray<double, nGroups_> kappaEVec,
-					quokka::valarray<double, nGroups_> fourPiBoverC, amrex::GpuArray<double, nGroups_> delta_nu_kappa_B_at_edge,
-					amrex::GpuArray<double, nGroups_> delta_nu_B_at_edge, amrex::GpuArray<double, nGroups_ + 1> kappa_slope)
-	    -> quokka::valarray<double, nGroups_>;
-	AMREX_GPU_HOST_DEVICE static auto ComputeFluxInDiffusionLimit(amrex::GpuArray<double, nGroups_ + 1> rad_boundaries, double T, double vel)
-	    -> amrex::GpuArray<double, nGroups_>;
+	ComputeDiffusionFluxMeanOpacity(quokka::valarray<Real, nGroups_> kappaPVec, quokka::valarray<Real, nGroups_> kappaEVec,
+					quokka::valarray<Real, nGroups_> fourPiBoverC, amrex::GpuArray<Real, nGroups_> delta_nu_kappa_B_at_edge,
+					amrex::GpuArray<Real, nGroups_> delta_nu_B_at_edge, amrex::GpuArray<Real, nGroups_ + 1> kappa_slope)
+	    -> quokka::valarray<Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeFluxInDiffusionLimit(amrex::GpuArray<Real, nGroups_ + 1> rad_boundaries, Real T, Real vel)
+	    -> amrex::GpuArray<Real, nGroups_>;
 
 	template <typename ArrayType>
-	AMREX_GPU_HOST_DEVICE static auto ComputeRadQuantityExponents(ArrayType const &quant, amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-	    -> amrex::GpuArray<double, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeRadQuantityExponents(ArrayType const &quant, amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
+	    -> amrex::GpuArray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static void SolveLinearEqs(JacobianResult<problem_t> const &jacobian, double &x0, quokka::valarray<double, nGroups_> &xi);
+	AMREX_GPU_HOST_DEVICE static void SolveLinearEqs(JacobianResult<problem_t> const &jacobian, Real &x0, quokka::valarray<Real, nGroups_> &xi);
 
-	AMREX_GPU_HOST_DEVICE static void SolveLinearEqsWithLastColumn(JacobianResult<problem_t> const &jacobian, double &x0,
-								       quokka::valarray<double, nGroups_> &xi);
+	AMREX_GPU_HOST_DEVICE static void SolveLinearEqsWithLastColumn(JacobianResult<problem_t> const &jacobian, Real &x0,
+								       quokka::valarray<Real, nGroups_> &xi);
 
-	AMREX_GPU_HOST_DEVICE static auto Solve3x3matrix(double C00, double C01, double C02, double C10, double C11, double C12, double C20, double C21,
-							 double C22, double Y0, double Y1, double Y2) -> std::tuple<Real, Real, Real>;
+	AMREX_GPU_HOST_DEVICE static auto Solve3x3matrix(Real C00, Real C01, Real C02, Real C10, Real C11, Real C12, Real C20, Real C21,
+							 Real C22, Real Y0, Real Y1, Real Y2) -> std::tuple<Real, Real, Real>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, Real temperature)
+	AMREX_GPU_HOST_DEVICE static auto ComputePlanckEnergyFractions(amrex::GpuArray<Real, nGroups_ + 1> const &boundaries, Real temperature)
 	    -> quokka::valarray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationSingleGroup(Real temperature) -> double;
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationSingleGroup(Real temperature) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationMultiGroup(Real temperature, amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationMultiGroup(Real temperature, amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
 	    -> quokka::valarray<Real, nGroups_>;
 
 	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeSingleGroup(Real temperature) -> Real;
 
 	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeMultiGroup(Real temperature,
-											  amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+											  amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
 	    -> quokka::valarray<Real, nGroups_>;
 
 	template <typename RHSFunction, typename JacFunction>
-	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, double x0, double compare) -> double;
+	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, Real x0, Real compare) -> Real;
 
 	AMREX_GPU_DEVICE static auto
-	ComputeDustTemperatureBateKeto(double T_gas, double T_d_init, double rho, quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt,
-				       double R_sum, int n_step,
-				       amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<double, nGroups_ + 1>{}) -> double;
+	ComputeDustTemperatureBateKeto(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt,
+				       Real R_sum, int n_step,
+				       amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{}) -> Real;
 
 	AMREX_GPU_DEVICE static auto
-	ComputeDustTemperatureGasOnly(double T_gas, double T_d_init, double rho, quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt,
-				      double R_sum, int n_step,
-				      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<double, nGroups_ + 1>{},
-				      amrex::GpuArray<double, nGroups_> const &rad_boundary_ratios = amrex::GpuArray<double, nGroups_>{}) -> double;
+	ComputeDustTemperatureGasOnly(Real T_gas, Real T_d_init, Real rho, quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt,
+				      Real R_sum, int n_step,
+				      amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<Real, nGroups_ + 1>{},
+				      amrex::GpuArray<Real, nGroups_> const &rad_boundary_ratios = amrex::GpuArray<Real, nGroups_>{}) -> Real;
 
 	AMREX_GPU_HOST_DEVICE static auto DefinePhotoelectricHeatingE1Derivative(Real temperature, Real num_density) -> Real;
 
 	AMREX_GPU_HOST_DEVICE static auto DefineBackgroundHeatingRate(Real num_density) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(Real temperature, Real num_density) -> quokka::valarray<double, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(Real temperature, Real num_density) -> quokka::valarray<Real, nGroups_>;
 
 	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(Real temperature, Real num_density)
-	    -> quokka::valarray<double, nGroups_>;
+	    -> quokka::valarray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(Real num_density) -> double;
+	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(Real num_density) -> Real;
 
-	AMREX_GPU_DEVICE static void ComputeModelDependentKappaFAndDeltaTerms(double T, double rho, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
-									      quokka::valarray<double, nGroups_> const &fourPiBoverC,
+	AMREX_GPU_DEVICE static void ComputeModelDependentKappaFAndDeltaTerms(Real T, Real rho, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries,
+									      quokka::valarray<Real, nGroups_> const &fourPiBoverC,
 									      OpacityTerms<problem_t> &opacity_terms);
 
-	AMREX_GPU_DEVICE static auto ComputeModelDependentKappaEAndKappaP(double T, double rho, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
-									  amrex::GpuArray<double, nGroups_> const &rad_boundary_ratios,
-									  quokka::valarray<double, nGroups_> const &fourPiBoverC,
-									  quokka::valarray<double, nGroups_> const &Erad, int n_iter,
-									  amrex::GpuArray<double, nGroups_> const &alpha_E = {},
-									  amrex::GpuArray<double, nGroups_> const &alpha_P = {}) -> OpacityTerms<problem_t>;
+	AMREX_GPU_DEVICE static auto ComputeModelDependentKappaEAndKappaP(Real T, Real rho, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries,
+									  amrex::GpuArray<Real, nGroups_> const &rad_boundary_ratios,
+									  quokka::valarray<Real, nGroups_> const &fourPiBoverC,
+									  quokka::valarray<Real, nGroups_> const &Erad, int n_iter,
+									  amrex::GpuArray<Real, nGroups_> const &alpha_E = {},
+									  amrex::GpuArray<Real, nGroups_> const &alpha_P = {}) -> OpacityTerms<problem_t>;
 
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGas(double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff,
-							   quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
-							   quokka::valarray<double, nGroups_> const &tau, double c_v,
-							   quokka::valarray<double, nGroups_> const &kappaPoverE,
-							   quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt)
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGas(Real T_d, Real Egas_diff, quokka::valarray<Real, nGroups_> const &Erad_diff,
+							   quokka::valarray<Real, nGroups_> const &Rvec, quokka::valarray<Real, nGroups_> const &Src,
+							   quokka::valarray<Real, nGroups_> const &tau, Real c_v,
+							   quokka::valarray<Real, nGroups_> const &kappaPoverE,
+							   quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t, Real num_den, Real dt)
 	    -> JacobianResult<problem_t>;
 
-	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(double T_gas, double T_d, double Egas_diff,
-								  quokka::valarray<double, nGroups_> const &Erad_diff,
-								  quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src,
-								  double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v,
-								  double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-								  quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt)
+	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDust(Real T_gas, Real T_d, Real Egas_diff,
+								  quokka::valarray<Real, nGroups_> const &Erad_diff,
+								  quokka::valarray<Real, nGroups_> const &Rvec, quokka::valarray<Real, nGroups_> const &Src,
+								  Real coeff_n, quokka::valarray<Real, nGroups_> const &tau, Real c_v,
+								  Real lambda_gd_time_dt, quokka::valarray<Real, nGroups_> const &kappaPoverE,
+								  quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t, Real num_den, Real dt)
 	    -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustDecoupled(
-	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad_diff, quokka::valarray<double, nGroups_> const &Rvec,
-	    quokka::valarray<double, nGroups_> const &Src, double coeff_n, quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt,
-	    quokka::valarray<double, nGroups_> const &kappaPoverE, quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
+	    Real T_gas, Real T_d, Real Egas_diff, quokka::valarray<Real, nGroups_> const &Erad_diff, quokka::valarray<Real, nGroups_> const &Rvec,
+	    quokka::valarray<Real, nGroups_> const &Src, Real coeff_n, quokka::valarray<Real, nGroups_> const &tau, Real c_v, Real lambda_gd_time_dt,
+	    quokka::valarray<Real, nGroups_> const &kappaPoverE, quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto ComputeJacobianForGasAndDustWithPE(
-	    double T_gas, double T_d, double Egas_diff, quokka::valarray<double, nGroups_> const &Erad, quokka::valarray<double, nGroups_> const &Erad0,
-	    double PE_heating_energy_derivative, quokka::valarray<double, nGroups_> const &Rvec, quokka::valarray<double, nGroups_> const &Src, double coeff_n,
-	    quokka::valarray<double, nGroups_> const &tau, double c_v, double lambda_gd_time_dt, quokka::valarray<double, nGroups_> const &kappaPoverE,
-	    quokka::valarray<double, nGroups_> const &d_fourpiboverc_d_t, double num_den, double dt) -> JacobianResult<problem_t>;
+	    Real T_gas, Real T_d, Real Egas_diff, quokka::valarray<Real, nGroups_> const &Erad, quokka::valarray<Real, nGroups_> const &Erad0,
+	    Real PE_heating_energy_derivative, quokka::valarray<Real, nGroups_> const &Rvec, quokka::valarray<Real, nGroups_> const &Src, Real coeff_n,
+	    quokka::valarray<Real, nGroups_> const &tau, Real c_v, Real lambda_gd_time_dt, quokka::valarray<Real, nGroups_> const &kappaPoverE,
+	    quokka::valarray<Real, nGroups_> const &d_fourpiboverc_d_t, Real num_den, Real dt) -> JacobianResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto
-	SolveGasRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double dt,
-					amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
-					quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter)
+	SolveGasRadiationEnergyExchange(Real Egas0, quokka::valarray<Real, nGroups_> const &Erad0Vec, Real rho, Real dt,
+					amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter, quokka::valarray<Real, nGroups_> const &work,
+					quokka::valarray<Real, nGroups_> const &vel_times_F, quokka::valarray<Real, nGroups_> const &Src,
+					amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter)
 	    -> NewtonIterationResult<problem_t>;
 
-	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho,
-									 double coeff_n, double dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
-									 int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
-									 quokka::valarray<double, nGroups_> const &vel_times_F,
-									 quokka::valarray<double, nGroups_> const &Src,
-									 amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter,
+	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(Real Egas0, quokka::valarray<Real, nGroups_> const &Erad0Vec, Real rho,
+									 Real coeff_n, Real dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
+									 int n_outer_iter, quokka::valarray<Real, nGroups_> const &work,
+									 quokka::valarray<Real, nGroups_> const &vel_times_F,
+									 quokka::valarray<Real, nGroups_> const &Src,
+									 amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter,
 									 int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto
-	SolveGasDustRadiationEnergyExchangeWithPE(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double coeff_n, double dt,
+	SolveGasDustRadiationEnergyExchangeWithPE(Real Egas0, quokka::valarray<Real, nGroups_> const &Erad0Vec, Real rho, Real coeff_n, Real dt,
 						  amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter,
-						  quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
-						  quokka::valarray<double, nGroups_> const &Src, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
+						  quokka::valarray<Real, nGroups_> const &work, quokka::valarray<Real, nGroups_> const &vel_times_F,
+						  quokka::valarray<Real, nGroups_> const &Src, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries,
 						  int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	template <FluxDir DIR>
 	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar,
 							     amrex::GpuArray<Real, AMREX_SPACEDIM> dx, int i, int j, int k,
-							     const amrex::GpuArray<double, nGroups_ + 1> &group_boundaries)
-	    -> quokka::valarray<double, nGroups_>;
+							     const amrex::GpuArray<Real, nGroups_ + 1> &group_boundaries)
+	    -> quokka::valarray<Real, nGroups_>;
 
 	AMREX_GPU_DEVICE static auto isStateValid(std::array<Real, nvarHyperbolic_> &cons) -> bool;
 
 	AMREX_GPU_DEVICE static void amendRadState(std::array<Real, nvarHyperbolic_> &cons);
 
 	template <FluxDir DIR>
-	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
+	AMREX_GPU_DEVICE static auto ComputeRadPressure(Real erad_L, Real Fx_L, Real Fy_L, Real Fz_L, Real fx_L, Real fy_L, Real fz_L)
 	    -> RadPressureResult;
 
-	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(double fx_L, double fy_L, double fz_L) -> std::array<std::array<double, 3>, 3>;
+	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(Real fx_L, Real fy_L, Real fz_L) -> std::array<std::array<Real, 3>, 3>;
 };
 
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
 // This function enforces that the total fraction is 1.0, no matter what are the group boundaries
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, Real temperature)
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(amrex::GpuArray<Real, nGroups_ + 1> const &boundaries, Real temperature)
     -> quokka::valarray<Real, nGroups_>
 {
 	quokka::valarray<Real, nGroups_> radEnergyFractions{};
@@ -494,7 +494,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(am
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityH(double rho, amrex::GpuArray<Real, nmscalars_> const & /*massScalars*/) -> double
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityH(Real rho, amrex::GpuArray<Real, nmscalars_> const & /*massScalars*/) -> Real
 {
 	return rho / mean_molecular_mass_;
 }
@@ -502,7 +502,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityH(double rh
 // define ComputeThermalRadiation for single-group, returns the thermal radiation power = a_r * T^4
 template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationSingleGroup(Real temperature) -> Real
 {
-	double power = radiation_constant_ * std::pow(temperature, 4);
+	Real power = radiation_constant_ * std::pow(temperature, 4);
 	// set floor
 	if (power < Erad_floor_) {
 		power = Erad_floor_;
@@ -513,10 +513,10 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 // define ComputeThermalRadiationMultiGroup, returns the thermal radiation power for each photon group. = a_r * T^4 * radEnergyFractions
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGroup(Real temperature,
-										   amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+										   amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
     -> quokka::valarray<Real, nGroups_>
 {
-	const double power = radiation_constant_ * std::pow(temperature, 4);
+	const Real power = radiation_constant_ * std::pow(temperature, 4);
 	const auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
 	auto Erad_g = power * radEnergyFractions;
 	// set floor
@@ -536,12 +536,12 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeMultiGroup(Real temperature,
-												 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+												 amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
     -> quokka::valarray<Real, nGroups_>
 {
 	// by default, d emission/dT = 4 emission / T
 	auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
-	double d_power_dt = 4. * radiation_constant_ * std::pow(temperature, 3);
+	Real d_power_dt = 4. * radiation_constant_ * std::pow(temperature, 3);
 	return d_power_dt * radEnergyFractions;
 }
 
@@ -554,9 +554,9 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::D
 // Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(Real const /*temperature*/, Real const /*num_density*/)
-    -> quokka::valarray<double, nGroups_>
+    -> quokka::valarray<Real, nGroups_>
 {
-	quokka::valarray<double, nGroups_> cooling{};
+	quokka::valarray<Real, nGroups_> cooling{};
 	cooling.fillin(0.0);
 	return cooling;
 }
@@ -564,14 +564,14 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(Real const
 // Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(Real const /*temperature*/, Real const /*num_density*/)
-    -> quokka::valarray<double, nGroups_>
+    -> quokka::valarray<Real, nGroups_>
 {
-	quokka::valarray<double, nGroups_> cooling{};
+	quokka::valarray<Real, nGroups_> cooling{};
 	cooling.fillin(0.0);
 	return cooling;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(Real const /*num_density*/) -> double
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(Real const /*num_density*/) -> Real
 {
 	return 0.0;
 }
@@ -582,7 +582,7 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::D
 //   [Jg0 Jgg] [xg] - [Fg] = 0
 // for x0 and xg, where g = 1, 2, ..., nGroups
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqs(JacobianResult<problem_t> const &jacobian, double &x0, quokka::valarray<double, nGroups_> &xi)
+AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqs(JacobianResult<problem_t> const &jacobian, Real &x0, quokka::valarray<Real, nGroups_> &xi)
 {
 	auto ratios = jacobian.J0g / jacobian.Jgg;
 	x0 = (sum(ratios * jacobian.Fg) - jacobian.F0) / (-sum(ratios * jacobian.Jg0) + jacobian.J00);
@@ -590,9 +590,9 @@ AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqs(JacobianResult<p
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00, const double C01, const double C02, const double C10, const double C11,
-								const double C12, const double C20, const double C21, const double C22, const double Y0,
-								const double Y1, const double Y2) -> std::tuple<Real, Real, Real>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const Real C00, const Real C01, const Real C02, const Real C10, const Real C11,
+								const Real C12, const Real C20, const Real C21, const Real C22, const Real Y0,
+								const Real Y1, const Real Y2) -> std::tuple<Real, Real, Real>
 {
 	// Solve the 3x3 matrix equation: C * X = Y under the assumption that only the diagonal terms
 	// are guaranteed to be non-zero and are thus allowed to be divided by.
@@ -650,7 +650,7 @@ void RadSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const Real> const
 {
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		const double signal_max = c_hat_;
+		const Real signal_max = c_hat_;
 		maxSignal(i, j, k) = signal_max;
 	});
 }
@@ -698,7 +698,7 @@ template <typename problem_t> AMREX_GPU_DEVICE void RadSystem<problem_t>::amendR
 
 template <typename problem_t>
 void RadSystem<problem_t>::PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
-				       amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const double dt_in,
+				       amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const Real dt_in,
 				       amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
 {
 	// By convention, the fluxes are defined on the left edge of each zone,
@@ -745,7 +745,7 @@ template <typename problem_t>
 void RadSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArrayOld,
 					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
 					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArrayOld*/,
-					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const double dt_in,
+					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const Real dt_in,
 					amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
 {
 	// By convention, the fluxes are defined on the left edge of each zone,
@@ -774,17 +774,17 @@ void RadSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayc
 		// y^n+1 = (1 - a32) y^n + a32 y^(2) + dt * (0.5 - a32) * s(y^n) + dt * 0.5 * s(y^(2)) + dt * (1 - a32) * f(y^n+1)          // the last term is
 		// implicit and not used here
 		for (int n = 0; n < nvarHyperbolic_; ++n) {
-			const double U_0 = U0(i, j, k, nstartHyperbolic_ + n);
-			const double U_1 = U1(i, j, k, nstartHyperbolic_ + n);
-			const double FxU_0 = (dt / dx) * (x1FluxOld(i, j, k, n) - x1FluxOld(i + 1, j, k, n));
-			const double FxU_1 = (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n));
+			const Real U_0 = U0(i, j, k, nstartHyperbolic_ + n);
+			const Real U_1 = U1(i, j, k, nstartHyperbolic_ + n);
+			const Real FxU_0 = (dt / dx) * (x1FluxOld(i, j, k, n) - x1FluxOld(i + 1, j, k, n));
+			const Real FxU_1 = (dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n));
 #if (AMREX_SPACEDIM >= 2)
-			const double FyU_0 = (dt / dy) * (x2FluxOld(i, j, k, n) - x2FluxOld(i, j + 1, k, n));
-			const double FyU_1 = (dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n));
+			const Real FyU_0 = (dt / dy) * (x2FluxOld(i, j, k, n) - x2FluxOld(i, j + 1, k, n));
+			const Real FyU_1 = (dt / dy) * (x2Flux(i, j, k, n) - x2Flux(i, j + 1, k, n));
 #endif
 #if (AMREX_SPACEDIM == 3)
-			const double FzU_0 = (dt / dz) * (x3FluxOld(i, j, k, n) - x3FluxOld(i, j, k + 1, n));
-			const double FzU_1 = (dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n));
+			const Real FzU_0 = (dt / dz) * (x3FluxOld(i, j, k, n) - x3FluxOld(i, j, k + 1, n));
+			const Real FzU_1 = (dt / dz) * (x3Flux(i, j, k, n) - x3Flux(i, j, k + 1, n));
 #endif
 			// save results in cons_new
 			cons_new[n] = (1.0 - IMEX_a32) * U_0 + IMEX_a32 * U_1 + ((0.5 - IMEX_a32) * (AMREX_D_TERM(FxU_0, +FyU_0, +FzU_0))) +
@@ -802,20 +802,20 @@ void RadSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayc
 	});
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEddingtonFactor(double f_in) -> double
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEddingtonFactor(Real f_in) -> Real
 {
 	// f is the reduced flux == |F|/cE.
 	// compute Levermore (1984) closure [Eq. 25]
 	// the is the M1 closure that is derived from Lorentz invariance
-	const double f = clamp(f_in, 0., 1.); // restrict f to be within [0, 1]
-	const double f_fac = std::sqrt(4.0 - 3.0 * (f * f));
-	const double chi = (3.0 + 4.0 * (f * f)) / (5.0 + 2.0 * f_fac);
+	const Real f = clamp(f_in, 0., 1.); // restrict f to be within [0, 1]
+	const Real f_fac = std::sqrt(4.0 - 3.0 * (f * f));
+	const Real chi = (3.0 + 4.0 * (f * f)) / (5.0 + 2.0 * f_fac);
 
 #if 0 // NOLINT
       // compute Minerbo (1978) closure [piecewise approximation]
       // (For unknown reasons, this closure tends to work better
       // than the Levermore/Lorentz closure on the Su & Olson 1997 test.)
-	const double chi = (f < 1. / 3.) ? (1. / 3.) : (0.5 - f + 1.5 * f*f);
+	const Real chi = (f < 1. / 3.) ? (1. / 3.) : (0.5 - f + 1.5 * f*f);
 #endif
 
 	return chi;
@@ -836,8 +836,8 @@ template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar,
 								    amrex::GpuArray<Real, AMREX_SPACEDIM> dx, int i, int j, int k,
-								    const amrex::GpuArray<double, nGroups_ + 1> &group_boundaries)
-    -> quokka::valarray<double, nGroups_>
+								    const amrex::GpuArray<Real, nGroups_ + 1> &group_boundaries)
+    -> quokka::valarray<Real, nGroups_>
 {
 	// compute interface-averaged cell optical depth
 
@@ -847,28 +847,28 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 	// interface at the *left* edge of zone i.]
 
 	// piecewise-constant reconstruction
-	const double rho_L = consVar(i - 1, j, k, gasDensity_index);
-	const double rho_R = consVar(i, j, k, gasDensity_index);
+	const Real rho_L = consVar(i - 1, j, k, gasDensity_index);
+	const Real rho_R = consVar(i, j, k, gasDensity_index);
 
-	const double x1GasMom_L = consVar(i - 1, j, k, x1GasMomentum_index);
-	const double x1GasMom_R = consVar(i, j, k, x1GasMomentum_index);
+	const Real x1GasMom_L = consVar(i - 1, j, k, x1GasMomentum_index);
+	const Real x1GasMom_R = consVar(i, j, k, x1GasMomentum_index);
 
-	const double x2GasMom_L = consVar(i - 1, j, k, x2GasMomentum_index);
-	const double x2GasMom_R = consVar(i, j, k, x2GasMomentum_index);
+	const Real x2GasMom_L = consVar(i - 1, j, k, x2GasMomentum_index);
+	const Real x2GasMom_R = consVar(i, j, k, x2GasMomentum_index);
 
-	const double x3GasMom_L = consVar(i - 1, j, k, x3GasMomentum_index);
-	const double x3GasMom_R = consVar(i, j, k, x3GasMomentum_index);
+	const Real x3GasMom_L = consVar(i - 1, j, k, x3GasMomentum_index);
+	const Real x3GasMom_R = consVar(i, j, k, x3GasMomentum_index);
 
-	const double Egas_L = consVar(i - 1, j, k, gasEnergy_index);
-	const double Egas_R = consVar(i, j, k, gasEnergy_index);
+	const Real Egas_L = consVar(i - 1, j, k, gasEnergy_index);
+	const Real Egas_R = consVar(i, j, k, gasEnergy_index);
 
 	auto massScalars_L = RadSystem<problem_t>::ComputeMassScalars(consVar, i - 1, j, k);
 	auto massScalars_R = RadSystem<problem_t>::ComputeMassScalars(consVar, i, j, k);
 
-	double Eint_L = NAN;
-	double Eint_R = NAN;
-	double Tgas_L = NAN;
-	double Tgas_R = NAN;
+	Real Eint_L = NAN;
+	Real Eint_R = NAN;
+	Real Tgas_L = NAN;
+	Real Tgas_R = NAN;
 
 	if constexpr (gamma_ != 1.0) {
 		Eint_L = RadSystem<problem_t>::ComputeEintFromEgas(rho_L, x1GasMom_L, x2GasMom_L, x3GasMom_L, Egas_L);
@@ -877,7 +877,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 		Tgas_R = quokka::EOS<problem_t>::ComputeTgasFromEint(rho_R, Eint_R, massScalars_R);
 	}
 
-	double dl = NAN;
+	Real dl = NAN;
 	if constexpr (DIR == FluxDir::X1) {
 		dl = dx[0];
 	} else if constexpr (DIR == FluxDir::X2) {
@@ -886,10 +886,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 		dl = dx[2];
 	}
 
-	quokka::valarray<double, nGroups_> optical_depths{};
+	quokka::valarray<Real, nGroups_> optical_depths{};
 	if constexpr (nGroups_ == 1) {
-		const double tau_L = dl * rho_L * RadSystem<problem_t>::ComputeFluxMeanOpacity(rho_L, Tgas_L);
-		const double tau_R = dl * rho_R * RadSystem<problem_t>::ComputeFluxMeanOpacity(rho_R, Tgas_R);
+		const Real tau_L = dl * rho_L * RadSystem<problem_t>::ComputeFluxMeanOpacity(rho_L, Tgas_L);
+		const Real tau_R = dl * rho_R * RadSystem<problem_t>::ComputeFluxMeanOpacity(rho_R, Tgas_R);
 		optical_depths[0] = (tau_L * tau_R * 2.) / (tau_L + tau_R); // harmonic mean. Alternative: 0.5*(tau_L + tau_R)
 	} else {
 		const auto opacity_L = DefineOpacityExponentsAndLowerValues(group_boundaries, rho_L, Tgas_L);
@@ -903,7 +903,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double fx, const double fy, const double fz) -> std::array<std::array<double, 3>, 3>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const Real fx, const Real fy, const Real fz) -> std::array<std::array<Real, 3>, 3>
 {
 	// Compute the radiation pressure tensor
 
@@ -923,23 +923,23 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	}
 
 	// compute radiation pressure tensors
-	const double chi = RadSystem<problem_t>::ComputeEddingtonFactor(f);
+	const Real chi = RadSystem<problem_t>::ComputeEddingtonFactor(f);
 
 	AMREX_ASSERT((chi >= 1. / 3.) && (chi <= 1.0)); // NOLINT
 
 	// diagonal term of Eddington tensor
-	const double Tdiag = (1.0 - chi) / 2.0;
+	const Real Tdiag = (1.0 - chi) / 2.0;
 
 	// anisotropic term of Eddington tensor (in the direction of the
 	// rad. flux)
-	const double Tf = (3.0 * chi - 1.0) / 2.0;
+	const Real Tf = (3.0 * chi - 1.0) / 2.0;
 
 	// assemble Eddington tensor
-	std::array<std::array<double, 3>, 3> T{};
+	std::array<std::array<Real, 3>, 3> T{};
 
 	for (int ii = 0; ii < 3; ++ii) {
 		for (int jj = 0; jj < 3; ++jj) {
-			const double delta_ij = (ii == jj) ? 1 : 0;
+			const Real delta_ij = (ii == jj) ? 1 : 0;
 			T[ii][jj] = Tdiag * delta_ij + Tf * (n[ii] * n[jj]);
 		}
 	}
@@ -949,8 +949,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad, const double Fx, const double Fy, const double Fz, const double fx,
-							       const double fy, const double fz) -> RadPressureResult
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const Real erad, const Real Fx, const Real Fy, const Real Fz, const Real fx,
+							       const Real fy, const Real fz) -> RadPressureResult
 {
 	// Compute the radiation pressure tensor and the maximum signal speed and return them as a struct.
 
@@ -962,7 +962,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 
 	// frozen Eddington tensor approximation, following Balsara
 	// (1999) [JQSRT Vol. 61, No. 5, pp. 617–627, 1999], Eq. 46.
-	double Tnormal = NAN;
+	Real Tnormal = NAN;
 	if constexpr (DIR == FluxDir::X1) {
 		Tnormal = T[0][0];
 	} else if constexpr (DIR == FluxDir::X2) {
@@ -975,10 +975,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 	// T_nx, T_ny, T_nz indicate components where 'n' is the direction of the
 	// face normal. F_n is the radiation flux component in the direction of the
 	// face normal
-	double Fn = NAN;
-	double Tnx = NAN;
-	double Tny = NAN;
-	double Tnz = NAN;
+	Real Fn = NAN;
+	Real Tnx = NAN;
+	Real Tny = NAN;
+	Real Tnz = NAN;
 
 	if constexpr (DIR == FluxDir::X1) {
 		Fn = Fx;
@@ -1038,7 +1038,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in) {
 		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
-		amrex::GpuArray<double, nGroups_ + 1> radBoundaries_g_copy{};
+		amrex::GpuArray<Real, nGroups_ + 1> radBoundaries_g_copy{};
 		for (int g = 0; g < nGroups_ + 1; ++g) {
 			radBoundaries_g_copy[g] = radBoundaries_g[g];
 		}
@@ -1048,38 +1048,38 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 		// calculate cell optical depth for each photon group
 		// Similar to the asymptotic-preserving flux correction in Skinner et al. (2019). Use optionally apply it here to reduce odd-even instability.
-		quokka::valarray<double, nGroups_> tau_cell{};
+		quokka::valarray<Real, nGroups_> tau_cell{};
 		if (use_wavespeed_correction) {
 			tau_cell = ComputeCellOpticalDepth<DIR>(consVar, dx, i, j, k, radBoundaries_g_copy);
 		}
 
 		// gather left- and right- state variables
 		for (int g = 0; g < nGroups_; ++g) {
-			double erad_L = x1LeftState(i, j, k, primRadEnergy_index + numRadVars_ * g);
-			double erad_R = x1RightState(i, j, k, primRadEnergy_index + numRadVars_ * g);
+			Real erad_L = x1LeftState(i, j, k, primRadEnergy_index + numRadVars_ * g);
+			Real erad_R = x1RightState(i, j, k, primRadEnergy_index + numRadVars_ * g);
 
-			double fx_L = x1LeftState(i, j, k, x1ReducedFlux_index + numRadVars_ * g);
-			double fx_R = x1RightState(i, j, k, x1ReducedFlux_index + numRadVars_ * g);
+			Real fx_L = x1LeftState(i, j, k, x1ReducedFlux_index + numRadVars_ * g);
+			Real fx_R = x1RightState(i, j, k, x1ReducedFlux_index + numRadVars_ * g);
 
-			double fy_L = x1LeftState(i, j, k, x2ReducedFlux_index + numRadVars_ * g);
-			double fy_R = x1RightState(i, j, k, x2ReducedFlux_index + numRadVars_ * g);
+			Real fy_L = x1LeftState(i, j, k, x2ReducedFlux_index + numRadVars_ * g);
+			Real fy_R = x1RightState(i, j, k, x2ReducedFlux_index + numRadVars_ * g);
 
-			double fz_L = x1LeftState(i, j, k, x3ReducedFlux_index + numRadVars_ * g);
-			double fz_R = x1RightState(i, j, k, x3ReducedFlux_index + numRadVars_ * g);
+			Real fz_L = x1LeftState(i, j, k, x3ReducedFlux_index + numRadVars_ * g);
+			Real fz_R = x1RightState(i, j, k, x3ReducedFlux_index + numRadVars_ * g);
 
 			// compute scalar reduced flux f
-			double f_L = std::sqrt(fx_L * fx_L + fy_L * fy_L + fz_L * fz_L);
-			double f_R = std::sqrt(fx_R * fx_R + fy_R * fy_R + fz_R * fz_R);
+			Real f_L = std::sqrt(fx_L * fx_L + fy_L * fy_L + fz_L * fz_L);
+			Real f_R = std::sqrt(fx_R * fx_R + fy_R * fy_R + fz_R * fz_R);
 
 			// Compute "un-reduced" Fx, Fy, Fz
-			double Fx_L = fx_L * (c_light_ * erad_L);
-			double Fx_R = fx_R * (c_light_ * erad_R);
+			Real Fx_L = fx_L * (c_light_ * erad_L);
+			Real Fx_R = fx_R * (c_light_ * erad_R);
 
-			double Fy_L = fy_L * (c_light_ * erad_L);
-			double Fy_R = fy_R * (c_light_ * erad_R);
+			Real Fy_L = fy_L * (c_light_ * erad_L);
+			Real Fy_R = fy_R * (c_light_ * erad_R);
 
-			double Fz_L = fz_L * (c_light_ * erad_L);
-			double Fz_R = fz_R * (c_light_ * erad_R);
+			Real Fz_L = fz_L * (c_light_ * erad_L);
+			Real Fz_R = fz_R * (c_light_ * erad_R);
 
 			// check that states are physically admissible; if not, use first-order
 			// reconstruction
@@ -1125,17 +1125,17 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 			S_L *= c_hat_;
 			S_R *= c_hat_;
 
-			const quokka::valarray<double, numRadVars_> U_L = {erad_L, Fx_L, Fy_L, Fz_L};
-			const quokka::valarray<double, numRadVars_> U_R = {erad_R, Fx_R, Fy_R, Fz_R};
+			const quokka::valarray<Real, numRadVars_> U_L = {erad_L, Fx_L, Fy_L, Fz_L};
+			const quokka::valarray<Real, numRadVars_> U_R = {erad_R, Fx_R, Fy_R, Fz_R};
 
 			// Adjusting wavespeeds is no longer necessary with the IMEX PD-ARS scheme.
 			// Read more in https://github.com/quokka-astro/quokka/pull/582
 			// However, we let the user optionally apply it to reduce odd-even instability.
-			quokka::valarray<double, numRadVars_> epsilon = {1.0, 1.0, 1.0, 1.0};
+			quokka::valarray<Real, numRadVars_> epsilon = {1.0, 1.0, 1.0, 1.0};
 			if (use_wavespeed_correction) {
 				// no correction for odd zones
 				if ((i + j + k) % 2 == 0) {
-					const double S_corr = std::min(1.0, 1.0 / tau_cell[g]); // Skinner et al.
+					const Real S_corr = std::min(1.0, 1.0 / tau_cell[g]); // Skinner et al.
 					epsilon = {S_corr, 1.0, 1.0, 1.0};			// Skinner et al. (2019)
 				}
 			}
@@ -1145,7 +1145,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 
 			// in the frozen Eddington tensor approximation, we are always
 			// in the star region, so F = F_star
-			const quokka::valarray<double, numRadVars_> F =
+			const quokka::valarray<Real, numRadVars_> F =
 			    (S_R / (S_R - S_L)) * F_L - (S_L / (S_R - S_L)) * F_R + epsilon * (S_R * S_L / (S_R - S_L)) * (U_R - U_L);
 
 			// check states are valid
@@ -1159,7 +1159,7 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 			x1Flux(i, j, k, x2RadFlux_index + numRadVars_ * g - nstartHyperbolic_) = F[2];
 			x1Flux(i, j, k, x3RadFlux_index + numRadVars_ * g - nstartHyperbolic_) = F[3];
 
-			const quokka::valarray<double, numRadVars_> diffusiveF =
+			const quokka::valarray<Real, numRadVars_> diffusiveF =
 			    (S_R / (S_R - S_L)) * F_L - (S_L / (S_R - S_L)) * F_R + (S_R * S_L / (S_R - S_L)) * (U_R - U_L);
 
 			x1FluxDiffusive(i, j, k, radEnergy_index + numRadVars_ * g - nstartHyperbolic_) = diffusiveF[0];
@@ -1170,27 +1170,27 @@ void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiff
 	});
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckOpacity(const Real /*rho*/, const Real /*Tgas*/) -> Real
 {
 	return NAN;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxMeanOpacity(const double rho, const double Tgas) -> Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxMeanOpacity(const Real rho, const Real Tgas) -> Real
 {
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEnergyMeanOpacity(const double rho, const double Tgas) -> Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEnergyMeanOpacity(const Real rho, const Real Tgas) -> Real
 {
 	return ComputePlanckOpacity(rho, Tgas);
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<double, nGroups_ + 1> /*rad_boundaries*/,
-										      const double /*rho*/, const double /*Tgas*/)
-    -> amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineOpacityExponentsAndLowerValues(amrex::GpuArray<Real, nGroups_ + 1> /*rad_boundaries*/,
+										      const Real /*rho*/, const Real /*Tgas*/)
+    -> amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2>
 {
-	amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> exponents_and_values{};
+	amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> exponents_and_values{};
 	for (int g = 0; g < nGroups_ + 1; ++g) {
 		exponents_and_values[0][g] = NAN;
 		exponents_and_values[1][g] = NAN;
@@ -1200,16 +1200,16 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineOpacityExponentsAndLowerV
 
 template <typename problem_t>
 template <typename ArrayType>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeRadQuantityExponents(ArrayType const &quant, amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-    -> amrex::GpuArray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeRadQuantityExponents(ArrayType const &quant, amrex::GpuArray<Real, nGroups_ + 1> const &boundaries)
+    -> amrex::GpuArray<Real, nGroups_>
 {
 	// Compute the exponents for the radiation energy density, radiation flux, radiation pressure, or Planck function.
 
 	// Note: Could save some memory by using bin_center_previous and bin_center_current
-	amrex::GpuArray<double, nGroups_> bin_center{};
-	amrex::GpuArray<double, nGroups_> quant_mean{};
-	amrex::GpuArray<double, nGroups_ - 1> logslopes{};
-	amrex::GpuArray<double, nGroups_> exponents{};
+	amrex::GpuArray<Real, nGroups_> bin_center{};
+	amrex::GpuArray<Real, nGroups_> quant_mean{};
+	amrex::GpuArray<Real, nGroups_ - 1> logslopes{};
+	amrex::GpuArray<Real, nGroups_> exponents{};
 	for (int g = 0; g < nGroups_; ++g) {
 		bin_center[g] = std::sqrt(boundaries[g] * boundaries[g + 1]);
 		quant_mean[g] = quant[g] / (boundaries[g + 1] - boundaries[g]);
@@ -1262,8 +1262,8 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeRadQuantityExponents(Arr
 		}
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(peak_idx < nGroups_ - 1,
 						 "Peak index not found. Here peak_index is the index at which the exponent changes its sign.");
-		double quant_sum = 0.0;
-		double part_sum = 0.0;
+		Real quant_sum = 0.0;
+		Real part_sum = 0.0;
 		for (int g = 0; g < nGroups_; ++g) {
 			quant_sum += quant[g];
 			if (g == peak_idx) {
@@ -1281,16 +1281,16 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeRadQuantityExponents(Arr
 
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto
-RadSystem<problem_t>::ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> const &kappa_expo_and_lower_value,
-					      amrex::GpuArray<double, nGroups_> const &radBoundaryRatios, amrex::GpuArray<double, nGroups_> const &alpha_quant)
-    -> quokka::valarray<double, nGroups_>
+RadSystem<problem_t>::ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> const &kappa_expo_and_lower_value,
+					      amrex::GpuArray<Real, nGroups_> const &radBoundaryRatios, amrex::GpuArray<Real, nGroups_> const &alpha_quant)
+    -> quokka::valarray<Real, nGroups_>
 {
-	amrex::GpuArray<double, nGroups_ + 1> const &alpha_kappa = kappa_expo_and_lower_value[0];
-	amrex::GpuArray<double, nGroups_ + 1> const &kappa_lower = kappa_expo_and_lower_value[1];
+	amrex::GpuArray<Real, nGroups_ + 1> const &alpha_kappa = kappa_expo_and_lower_value[0];
+	amrex::GpuArray<Real, nGroups_ + 1> const &kappa_lower = kappa_expo_and_lower_value[1];
 
-	quokka::valarray<double, nGroups_> kappa{};
+	quokka::valarray<Real, nGroups_> kappa{};
 	for (int g = 0; g < nGroups_; ++g) {
-		double alpha = alpha_quant[g] + 1.0;
+		Real alpha = alpha_quant[g] + 1.0;
 		if (alpha > 100.) {
 			kappa[g] = kappa_lower[g] * std::pow(radBoundaryRatios[g], kappa_expo_and_lower_value[0][g]);
 			continue;
@@ -1299,14 +1299,14 @@ RadSystem<problem_t>::ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<do
 			kappa[g] = kappa_lower[g];
 			continue;
 		}
-		double part1 = 0.0;
+		Real part1 = 0.0;
 		if (std::abs(alpha) < 1e-8) {
 			part1 = std::log(radBoundaryRatios[g]);
 		} else {
 			part1 = (std::pow(radBoundaryRatios[g], alpha) - 1.0) / alpha;
 		}
 		alpha += alpha_kappa[g];
-		double part2 = 0.0;
+		Real part2 = 0.0;
 		if (std::abs(alpha) < 1e-8) {
 			part2 = std::log(radBoundaryRatios[g]);
 		} else {
@@ -1319,35 +1319,35 @@ RadSystem<problem_t>::ComputeGroupMeanOpacity(amrex::GpuArray<amrex::GpuArray<do
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEintFromEgas(const double density, const double X1GasMom, const double X2GasMom, const double X3GasMom,
-								     const double Etot) -> double
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEintFromEgas(const Real density, const Real X1GasMom, const Real X2GasMom, const Real X3GasMom,
+								     const Real Etot) -> Real
 {
-	const double p_sq = X1GasMom * X1GasMom + X2GasMom * X2GasMom + X3GasMom * X3GasMom;
-	const double Ekin = p_sq / (2.0 * density);
-	const double Eint = Etot - Ekin;
+	const Real p_sq = X1GasMom * X1GasMom + X2GasMom * X2GasMom + X3GasMom * X3GasMom;
+	const Real Ekin = p_sq / (2.0 * density);
+	const Real Eint = Etot - Ekin;
 	AMREX_ASSERT_WITH_MESSAGE(Eint > 0., "Gas internal energy is not positive!");
 	return Eint;
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEgasFromEint(const double density, const double X1GasMom, const double X2GasMom, const double X3GasMom,
-								     const double Eint) -> double
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeEgasFromEint(const Real density, const Real X1GasMom, const Real X2GasMom, const Real X3GasMom,
+								     const Real Eint) -> Real
 {
-	const double p_sq = X1GasMom * X1GasMom + X2GasMom * X2GasMom + X3GasMom * X3GasMom;
-	const double Ekin = p_sq / (2.0 * density);
-	const double Etot = Eint + Ekin;
+	const Real p_sq = X1GasMom * X1GasMom + X2GasMom * X2GasMom + X3GasMom * X3GasMom;
+	const Real Ekin = p_sq / (2.0 * density);
+	const Real Etot = Eint + Ekin;
 	return Etot;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::PlanckFunction(const double nu, const double T) -> double
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::PlanckFunction(const Real nu, const Real T) -> Real
 {
 	// returns 4 pi B(nu) / c
-	double const coeff = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * T);
-	double const x = coeff * nu;
+	Real const coeff = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * T);
+	Real const x = coeff * nu;
 	if (x > 100.) {
 		return 0.0;
 	}
-	double planck_integral = NAN;
+	Real planck_integral = NAN;
 	if (x <= 1.0e-10) {
 		// Taylor series
 		planck_integral = x * x - x * x * x / 2.;
@@ -1358,15 +1358,15 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::P
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeDiffusionFluxMeanOpacity(const quokka::valarray<double, nGroups_> kappaPVec,
-										 const quokka::valarray<double, nGroups_> kappaEVec,
-										 const quokka::valarray<double, nGroups_> fourPiBoverC,
-										 const amrex::GpuArray<double, nGroups_> delta_nu_kappa_B_at_edge,
-										 const amrex::GpuArray<double, nGroups_> delta_nu_B_at_edge,
-										 const amrex::GpuArray<double, nGroups_ + 1> kappa_slope)
-    -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeDiffusionFluxMeanOpacity(const quokka::valarray<Real, nGroups_> kappaPVec,
+										 const quokka::valarray<Real, nGroups_> kappaEVec,
+										 const quokka::valarray<Real, nGroups_> fourPiBoverC,
+										 const amrex::GpuArray<Real, nGroups_> delta_nu_kappa_B_at_edge,
+										 const amrex::GpuArray<Real, nGroups_> delta_nu_B_at_edge,
+										 const amrex::GpuArray<Real, nGroups_ + 1> kappa_slope)
+    -> quokka::valarray<Real, nGroups_>
 {
-	quokka::valarray<double, nGroups_> kappaF{};
+	quokka::valarray<Real, nGroups_> kappaF{};
 	for (int g = 0; g < nGroups_; ++g) {
 		// kappaF[g] = 4. / 3. * kappaPVec[g] * fourPiBoverC[g] + 1. / 3. * kappa_slope[g] * kappaPVec[g] * fourPiBoverC[g] - 1. / 3. *
 		// delta_nu_kappa_B_at_edge[g];
@@ -1384,11 +1384,11 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeDiffusionFluxMeanOpacity
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeBinCenterOpacity(amrex::GpuArray<double, nGroups_ + 1> rad_boundaries,
-									 amrex::GpuArray<amrex::GpuArray<double, nGroups_ + 1>, 2> kappa_expo_and_lower_value)
-    -> quokka::valarray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeBinCenterOpacity(amrex::GpuArray<Real, nGroups_ + 1> rad_boundaries,
+									 amrex::GpuArray<amrex::GpuArray<Real, nGroups_ + 1>, 2> kappa_expo_and_lower_value)
+    -> quokka::valarray<Real, nGroups_>
 {
-	quokka::valarray<double, nGroups_> kappa_center{};
+	quokka::valarray<Real, nGroups_> kappa_center{};
 	for (int g = 0; g < nGroups_; ++g) {
 		kappa_center[g] =
 		    kappa_expo_and_lower_value[1][g] * std::pow(rad_boundaries[g + 1] / rad_boundaries[g], 0.5 * kappa_expo_and_lower_value[0][g]);
@@ -1397,12 +1397,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeBinCenterOpacity(amrex::
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(const amrex::GpuArray<double, nGroups_ + 1> rad_boundaries, const double T,
-									     const double vel) -> amrex::GpuArray<double, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(const amrex::GpuArray<Real, nGroups_ + 1> rad_boundaries, const Real T,
+									     const Real vel) -> amrex::GpuArray<Real, nGroups_>
 {
-	double const coeff = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * T);
-	amrex::GpuArray<double, nGroups_ + 1> edge_values{};
-	amrex::GpuArray<double, nGroups_> flux{};
+	Real const coeff = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * T);
+	amrex::GpuArray<Real, nGroups_ + 1> edge_values{};
+	amrex::GpuArray<Real, nGroups_> flux{};
 	for (int g = 0; g < nGroups_ + 1; ++g) {
 		auto x = coeff * rad_boundaries[g];
 		edge_values[g] = 4. / 3. * integrate_planck_from_0_to_x(x) - 1. / 3. * x * (std::pow(x, 3) / (std::exp(x) - 1.0)) / gInf;
@@ -1417,12 +1417,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeFluxInDiffusionLimit(con
 
 template <typename problem_t>
 template <typename RHSFunction, typename JacFunction>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const double x0, const double compare)
-    -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, const Real x0, const Real compare)
+    -> Real
 {
-	double x = x0;
-	const double rel_tol = 1.0e-8;
-	const double rel_change_tol = 1.0e-6;
+	Real x = x0;
+	const Real rel_tol = 1.0e-8;
+	const Real rel_change_tol = 1.0e-6;
 	const int max_iter_td = 100;
 	int iter_Td = 0;
 	for (; iter_Td < max_iter_td; ++iter_Td) {
@@ -1431,7 +1431,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 			break;
 		}
 
-		const double dT = -the_rhs / jac(x);
+		const Real dT = -the_rhs / jac(x);
 		x += dT;
 
 		if (iter_Td > 0) {
@@ -1450,9 +1450,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(double const T_gas, double const T_d_init, double const rho,
-									   quokka::valarray<double, nGroups_> const &Erad, double N_d, double dt, double R_sum,
-									   int n_step, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries) -> double
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(Real const T_gas, Real const T_d_init, Real const rho,
+									   quokka::valarray<Real, nGroups_> const &Erad, Real N_d, Real dt, Real R_sum,
+									   int n_step, amrex::GpuArray<Real, nGroups_ + 1> const &rad_boundaries) -> Real
 {
 	if (n_step > 0) {
 		const auto T_d = T_gas - R_sum / (N_d * std::sqrt(T_gas));
@@ -1460,7 +1460,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 		return T_d;
 	}
 
-	amrex::GpuArray<double, nGroups_> rad_boundary_ratios{};
+	amrex::GpuArray<Real, nGroups_> rad_boundary_ratios{};
 
 	if constexpr (nGroups_ > 1 && opacity_model_ != OpacityModel::piecewise_constant_opacity) {
 		for (int g = 0; g < nGroups_; ++g) {
@@ -1469,8 +1469,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 	}
 
 	// the RHS of the equation 0 = c_hat_ dt rho (kappa_E * E_g - kappa_P * B_g) + N_d sqrt(T_gas) (T_gas - T_d)
-	auto rhs = [=](double T_d) -> double {
-		double LHS = NAN;
+	auto rhs = [=](Real T_d) -> Real {
+		Real LHS = NAN;
 
 		if constexpr (nGroups_ == 1) {
 			const auto fourPiBoverC = ComputeThermalRadiationSingleGroup(T_d);
@@ -1488,8 +1488,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 	};
 
 	// the Jacobian of the RHS of the equation 0 = c_hat_ dt rho (kappa_E * E_g - kappa_P * B_g) + N_d sqrt(T_gas) (T_gas - T_d)
-	auto jac = [=](double T_d) -> double {
-		double dLHS_dTd = NAN;
+	auto jac = [=](Real T_d) -> Real {
+		Real dLHS_dTd = NAN;
 
 		if constexpr (nGroups_ == 1) {
 			const auto kappaP = ComputePlanckOpacity(rho, T_d);
@@ -1505,7 +1505,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeDustTemperatureBateKeto(doubl
 		return dLHS_dTd;
 	};
 
-	const double Lambda_compare = N_d * std::sqrt(T_gas) * T_gas;
+	const Real Lambda_compare = N_d * std::sqrt(T_gas) * T_gas;
 
 	const auto T_d = BackwardEulerOneVariable(rhs, jac, T_d_init, Lambda_compare);
 	AMREX_ASSERT_WITH_MESSAGE(T_d >= 0., "Dust temperature is negative!");

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -19,7 +19,6 @@
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuQualifiers.H"
-#include "AMReX_REAL.H"
 
 // internal headers
 #include "fundamental_constants.H"

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -133,7 +133,7 @@ template <typename problem_t> struct JacobianResult {
 template <typename problem_t> struct FluxUpdateResult {
 	quokka::valarray<double, Physics_Traits<problem_t>::nGroups> Erad;			   // radiation energy density
 	amrex::GpuArray<double, 3> gasMomentum;							   // gas momentum
-	amrex::GpuArray<amrex::GpuArray<amrex::Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
+	amrex::GpuArray<amrex::GpuArray<Real, Physics_Traits<problem_t>::nGroups>, 3> Frad; // radiation flux
 };
 
 [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod_func(double a, double b) -> double
@@ -187,7 +187,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	// C++ standard does not allow constexpr to be uninitialized, even in a
 	// templated class!
 
-	static constexpr amrex::Real c_light_ = []() constexpr {
+	static constexpr Real c_light_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			return c_light_cgs_;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CONSTANTS) {
@@ -249,7 +249,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	static constexpr double mean_molecular_mass_ = quokka::EOS_Traits<problem_t>::mean_molecular_weight;
 	static constexpr double gamma_ = quokka::EOS_Traits<problem_t>::gamma;
 
-	static constexpr amrex::Real boltzmann_constant_ = []() constexpr {
+	static constexpr Real boltzmann_constant_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			return C::k_B;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CONSTANTS) {
@@ -264,34 +264,34 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	// static functions
 
-	static void ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange);
-	static void ConservedToPrimitive(amrex::Array4<const amrex::Real> const &cons, array_t &primVar, amrex::Box const &indexRange);
+	static void ComputeMaxSignalSpeed(amrex::Array4<const Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange);
+	static void ConservedToPrimitive(amrex::Array4<const Real> const &cons, array_t &primVar, amrex::Box const &indexRange);
 
 	static void PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
 				amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, double dt_in,
-				amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
+				amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
 
 	static void AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayconst_t &U1, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArrayOld,
 				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArrayOld,
 				 amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxDiffusiveArray, double dt_in,
-				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
+				 amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, int nvars);
 
 	template <FluxDir DIR>
-	static void ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiffusive_in, amrex::Array4<const amrex::Real> const &x1LeftState_in,
-				  amrex::Array4<const amrex::Real> const &x1RightState_in, amrex::Box const &indexRange, arrayconst_t &consVar_in,
-				  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, bool use_wavespeed_correction);
+	static void ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiffusive_in, amrex::Array4<const Real> const &x1LeftState_in,
+				  amrex::Array4<const Real> const &x1RightState_in, amrex::Box const &indexRange, arrayconst_t &consVar_in,
+				  amrex::GpuArray<Real, AMREX_SPACEDIM> dx, bool use_wavespeed_correction);
 
-	static void SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
-				       amrex::Real time);
+	static void SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
+				       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi,
+				       Real time);
 
 	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
 						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
-	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
+	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt, int stage,
 					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
 
-	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
+	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt, int stage,
 					      double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
@@ -343,21 +343,21 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 								       quokka::valarray<double, nGroups_> &xi);
 
 	AMREX_GPU_HOST_DEVICE static auto Solve3x3matrix(double C00, double C01, double C02, double C10, double C11, double C12, double C20, double C21,
-							 double C22, double Y0, double Y1, double Y2) -> std::tuple<amrex::Real, amrex::Real, amrex::Real>;
+							 double C22, double Y0, double Y1, double Y2) -> std::tuple<Real, Real, Real>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, amrex::Real temperature)
-	    -> quokka::valarray<amrex::Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, Real temperature)
+	    -> quokka::valarray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationSingleGroup(amrex::Real temperature) -> double;
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationSingleGroup(Real temperature) -> double;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationMultiGroup(amrex::Real temperature, amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-	    -> quokka::valarray<amrex::Real, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationMultiGroup(Real temperature, amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+	    -> quokka::valarray<Real, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeSingleGroup(amrex::Real temperature) -> Real;
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeSingleGroup(Real temperature) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeMultiGroup(amrex::Real temperature,
+	AMREX_GPU_HOST_DEVICE static auto ComputeThermalRadiationTempDerivativeMultiGroup(Real temperature,
 											  amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-	    -> quokka::valarray<amrex::Real, nGroups_>;
+	    -> quokka::valarray<Real, nGroups_>;
 
 	template <typename RHSFunction, typename JacFunction>
 	AMREX_GPU_DEVICE static auto BackwardEulerOneVariable(RHSFunction const &rhs, JacFunction const &jac, double x0, double compare) -> double;
@@ -373,16 +373,16 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries = amrex::GpuArray<double, nGroups_ + 1>{},
 				      amrex::GpuArray<double, nGroups_> const &rad_boundary_ratios = amrex::GpuArray<double, nGroups_>{}) -> double;
 
-	AMREX_GPU_HOST_DEVICE static auto DefinePhotoelectricHeatingE1Derivative(amrex::Real temperature, amrex::Real num_density) -> amrex::Real;
+	AMREX_GPU_HOST_DEVICE static auto DefinePhotoelectricHeatingE1Derivative(Real temperature, Real num_density) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineBackgroundHeatingRate(amrex::Real num_density) -> amrex::Real;
+	AMREX_GPU_HOST_DEVICE static auto DefineBackgroundHeatingRate(Real num_density) -> Real;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(amrex::Real temperature, amrex::Real num_density) -> quokka::valarray<double, nGroups_>;
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRate(Real temperature, Real num_density) -> quokka::valarray<double, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(amrex::Real temperature, amrex::Real num_density)
+	AMREX_GPU_HOST_DEVICE static auto DefineNetCoolingRateTempDerivative(Real temperature, Real num_density)
 	    -> quokka::valarray<double, nGroups_>;
 
-	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(amrex::Real num_density) -> double;
+	AMREX_GPU_HOST_DEVICE static auto DefineCosmicRayHeatingRate(Real num_density) -> double;
 
 	AMREX_GPU_DEVICE static void ComputeModelDependentKappaFAndDeltaTerms(double T, double rho, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
 									      quokka::valarray<double, nGroups_> const &fourPiBoverC,
@@ -444,14 +444,14 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						  int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	template <FluxDir DIR>
-	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const amrex::Real, DIR> &consVar,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, int i, int j, int k,
+	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar,
+							     amrex::GpuArray<Real, AMREX_SPACEDIM> dx, int i, int j, int k,
 							     const amrex::GpuArray<double, nGroups_ + 1> &group_boundaries)
 	    -> quokka::valarray<double, nGroups_>;
 
-	AMREX_GPU_DEVICE static auto isStateValid(std::array<amrex::Real, nvarHyperbolic_> &cons) -> bool;
+	AMREX_GPU_DEVICE static auto isStateValid(std::array<Real, nvarHyperbolic_> &cons) -> bool;
 
-	AMREX_GPU_DEVICE static void amendRadState(std::array<amrex::Real, nvarHyperbolic_> &cons);
+	AMREX_GPU_DEVICE static void amendRadState(std::array<Real, nvarHyperbolic_> &cons);
 
 	template <FluxDir DIR>
 	AMREX_GPU_DEVICE static auto ComputeRadPressure(double erad_L, double Fx_L, double Fy_L, double Fz_L, double fx_L, double fy_L, double fz_L)
@@ -463,19 +463,19 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 // Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
 // This function enforces that the total fraction is 1.0, no matter what are the group boundaries
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, amrex::Real temperature)
-    -> quokka::valarray<amrex::Real, nGroups_>
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, Real temperature)
+    -> quokka::valarray<Real, nGroups_>
 {
-	quokka::valarray<amrex::Real, nGroups_> radEnergyFractions{};
+	quokka::valarray<Real, nGroups_> radEnergyFractions{};
 	if constexpr (nGroups_ == 1) {
 		radEnergyFractions[0] = 1.0;
 		return radEnergyFractions;
 	} else {
-		amrex::Real const energy_unit_over_kT = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * temperature);
-		amrex::Real y = NAN;
-		amrex::Real previous = 0.0;
+		Real const energy_unit_over_kT = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * temperature);
+		Real y = NAN;
+		Real previous = 0.0;
 		for (int g = 0; g < nGroups_ - 1; ++g) {
-			const amrex::Real x = boundaries[g + 1] * energy_unit_over_kT;
+			const Real x = boundaries[g + 1] * energy_unit_over_kT;
 			if (x >= 100.) { // 100. is the upper limit of x in the table
 				y = 1.0;
 			} else {
@@ -500,7 +500,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeNumberDensityH(double rh
 }
 
 // define ComputeThermalRadiation for single-group, returns the thermal radiation power = a_r * T^4
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationSingleGroup(amrex::Real temperature) -> Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationSingleGroup(Real temperature) -> Real
 {
 	double power = radiation_constant_ * std::pow(temperature, 4);
 	// set floor
@@ -512,9 +512,9 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 
 // define ComputeThermalRadiationMultiGroup, returns the thermal radiation power for each photon group. = a_r * T^4 * radEnergyFractions
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGroup(amrex::Real temperature,
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGroup(Real temperature,
 										   amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-    -> quokka::valarray<amrex::Real, nGroups_>
+    -> quokka::valarray<Real, nGroups_>
 {
 	const double power = radiation_constant_ * std::pow(temperature, 4);
 	const auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
@@ -528,16 +528,16 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGro
 	return Erad_g;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeSingleGroup(amrex::Real temperature) -> Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeSingleGroup(Real temperature) -> Real
 {
 	// by default, d emission/dT = 4 emission / T
 	return 4. * radiation_constant_ * std::pow(temperature, 3);
 }
 
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeMultiGroup(amrex::Real temperature,
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeMultiGroup(Real temperature,
 												 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
-    -> quokka::valarray<amrex::Real, nGroups_>
+    -> quokka::valarray<Real, nGroups_>
 {
 	// by default, d emission/dT = 4 emission / T
 	auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
@@ -546,14 +546,14 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDeri
 }
 
 // Define the background heating rate for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(amrex::Real const /*num_density*/) -> amrex::Real
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineBackgroundHeatingRate(Real const /*num_density*/) -> Real
 {
 	return 0.0;
 }
 
 // Define the net cooling rate (line cooling + heating) for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(Real const /*temperature*/, Real const /*num_density*/)
     -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
@@ -563,7 +563,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRate(amrex::Rea
 
 // Define the derivative of the net cooling rate with respect to temperature for the gas-dust-radiation system. Units in cgs: erg cm^-3 s^-1 K^-1
 template <typename problem_t>
-AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(amrex::Real const /*temperature*/, amrex::Real const /*num_density*/)
+AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivative(Real const /*temperature*/, Real const /*num_density*/)
     -> quokka::valarray<double, nGroups_>
 {
 	quokka::valarray<double, nGroups_> cooling{};
@@ -571,7 +571,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineNetCoolingRateTempDerivat
 	return cooling;
 }
 
-template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(amrex::Real const /*num_density*/) -> double
+template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::DefineCosmicRayHeatingRate(Real const /*num_density*/) -> double
 {
 	return 0.0;
 }
@@ -592,7 +592,7 @@ AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqs(JacobianResult<p
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00, const double C01, const double C02, const double C10, const double C11,
 								const double C12, const double C20, const double C21, const double C22, const double Y0,
-								const double Y1, const double Y2) -> std::tuple<amrex::Real, amrex::Real, amrex::Real>
+								const double Y1, const double Y2) -> std::tuple<Real, Real, Real>
 {
 	// Solve the 3x3 matrix equation: C * X = Y under the assumption that only the diagonal terms
 	// are guaranteed to be non-zero and are thus allowed to be divided by.
@@ -611,15 +611,15 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
+void RadSystem<problem_t>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
+					      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo,
+					      amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_hi, Real time)
 {
 	// do nothing -- user implemented
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::ConservedToPrimitive(amrex::Array4<const amrex::Real> const &cons, array_t &primVar, amrex::Box const &indexRange)
+void RadSystem<problem_t>::ConservedToPrimitive(amrex::Array4<const Real> const &cons, array_t &primVar, amrex::Box const &indexRange)
 {
 	// keep radiation energy density as-is
 	// convert (Fx,Fy,Fz) into reduced flux components (fx,fy,fx):
@@ -646,7 +646,7 @@ void RadSystem<problem_t>::ConservedToPrimitive(amrex::Array4<const amrex::Real>
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const & /*cons*/, array_t &maxSignal, amrex::Box const &indexRange)
+void RadSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const Real> const & /*cons*/, array_t &maxSignal, amrex::Box const &indexRange)
 {
 	// cell-centered kernel
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
@@ -655,7 +655,7 @@ void RadSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real
 	});
 }
 
-template <typename problem_t> AMREX_GPU_DEVICE auto RadSystem<problem_t>::isStateValid(std::array<amrex::Real, nvarHyperbolic_> &cons) -> bool
+template <typename problem_t> AMREX_GPU_DEVICE auto RadSystem<problem_t>::isStateValid(std::array<Real, nvarHyperbolic_> &cons) -> bool
 {
 	// check if the state variable 'cons' is a valid state
 	bool isValid = true;
@@ -675,7 +675,7 @@ template <typename problem_t> AMREX_GPU_DEVICE auto RadSystem<problem_t>::isStat
 	return isValid;
 }
 
-template <typename problem_t> AMREX_GPU_DEVICE void RadSystem<problem_t>::amendRadState(std::array<amrex::Real, nvarHyperbolic_> &cons)
+template <typename problem_t> AMREX_GPU_DEVICE void RadSystem<problem_t>::amendRadState(std::array<Real, nvarHyperbolic_> &cons)
 {
 	// amend the state variable 'cons' to be a valid state
 	for (int g = 0; g < nGroups_; ++g) {
@@ -699,7 +699,7 @@ template <typename problem_t> AMREX_GPU_DEVICE void RadSystem<problem_t>::amendR
 template <typename problem_t>
 void RadSystem<problem_t>::PredictStep(arrayconst_t &consVarOld, array_t &consVarNew, amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
 				       amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const double dt_in,
-				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
+				       amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
 {
 	// By convention, the fluxes are defined on the left edge of each zone,
 	// i.e. flux_(i) is the flux *into* zone i through the interface on the
@@ -722,7 +722,7 @@ void RadSystem<problem_t>::PredictStep(arrayconst_t &consVarOld, array_t &consVa
 #endif
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-		std::array<amrex::Real, nvarHyperbolic_> cons{};
+		std::array<Real, nvarHyperbolic_> cons{};
 
 		for (int n = 0; n < nvarHyperbolic_; ++n) {
 			cons[n] = consVarOld(i, j, k, nstartHyperbolic_ + n) + (AMREX_D_TERM((dt / dx) * (x1Flux(i, j, k, n) - x1Flux(i + 1, j, k, n)),
@@ -746,7 +746,7 @@ void RadSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayc
 					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> fluxArray,
 					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArrayOld*/,
 					amrex::GpuArray<arrayconst_t, AMREX_SPACEDIM> /*fluxDiffusiveArray*/, const double dt_in,
-					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
+					amrex::GpuArray<Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange, const int /*nvars*/)
 {
 	// By convention, the fluxes are defined on the left edge of each zone,
 	// i.e. flux_(i) is the flux *into* zone i through the interface on the
@@ -769,7 +769,7 @@ void RadSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0, arrayc
 #endif
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-		std::array<amrex::Real, nvarHyperbolic_> cons_new{};
+		std::array<Real, nvarHyperbolic_> cons_new{};
 
 		// y^n+1 = (1 - a32) y^n + a32 y^(2) + dt * (0.5 - a32) * s(y^n) + dt * 0.5 * s(y^(2)) + dt * (1 - a32) * f(y^n+1)          // the last term is
 		// implicit and not used here
@@ -834,8 +834,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeMassScalars(ArrayType const &
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka::Array4View<const amrex::Real, DIR> &consVar,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, int i, int j, int k,
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeCellOpticalDepth(const quokka::Array4View<const Real, DIR> &consVar,
+								    amrex::GpuArray<Real, AMREX_SPACEDIM> dx, int i, int j, int k,
 								    const amrex::GpuArray<double, nGroups_ + 1> &group_boundaries)
     -> quokka::valarray<double, nGroups_>
 {
@@ -911,12 +911,12 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeEddingtonTensor(const double 
 	// limiting violation when using P1 AMREX_ASSERT(f_R < 1.0);
 
 	auto f = std::sqrt(fx * fx + fy * fy + fz * fz);
-	std::array<amrex::Real, 3> fvec = {fx, fy, fz};
+	std::array<Real, 3> fvec = {fx, fy, fz};
 
 	// angle between interface and radiation flux \hat{n}
 	// If direction is undefined, just drop direction-dependent
 	// terms.
-	std::array<amrex::Real, 3> n{};
+	std::array<Real, 3> n{};
 
 	for (int ii = 0; ii < 3; ++ii) {
 		n[ii] = (f > 0.) ? (fvec[ii] / f) : 0.;
@@ -1016,17 +1016,17 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 
 template <typename problem_t>
 template <FluxDir DIR>
-void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiffusive_in, amrex::Array4<const amrex::Real> const &x1LeftState_in,
-					 amrex::Array4<const amrex::Real> const &x1RightState_in, amrex::Box const &indexRange, arrayconst_t &consVar_in,
-					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, bool const use_wavespeed_correction)
+void RadSystem<problem_t>::ComputeFluxes(array_t &x1Flux_in, array_t &x1FluxDiffusive_in, amrex::Array4<const Real> const &x1LeftState_in,
+					 amrex::Array4<const Real> const &x1RightState_in, amrex::Box const &indexRange, arrayconst_t &consVar_in,
+					 amrex::GpuArray<Real, AMREX_SPACEDIM> dx, bool const use_wavespeed_correction)
 {
-	quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in);
-	quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in);
-	quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in);
-	quokka::Array4View<amrex::Real, DIR> x1FluxDiffusive(x1FluxDiffusive_in);
-	quokka::Array4View<const amrex::Real, DIR> consVar(consVar_in);
+	quokka::Array4View<const Real, DIR> x1LeftState(x1LeftState_in);
+	quokka::Array4View<const Real, DIR> x1RightState(x1RightState_in);
+	quokka::Array4View<Real, DIR> x1Flux(x1Flux_in);
+	quokka::Array4View<Real, DIR> x1FluxDiffusive(x1FluxDiffusive_in);
+	quokka::Array4View<const Real, DIR> consVar(consVar_in);
 
-	amrex::GpuArray<amrex::Real, nGroups_ + 1> radBoundaries_g = radBoundaries_;
+	amrex::GpuArray<Real, nGroups_ + 1> radBoundaries_g = radBoundaries_;
 
 	// By convention, the interfaces are defined on the left edge of each
 	// zone, i.e. xinterface_(i) is the solution to the Riemann problem at

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -30,8 +30,6 @@
 #include "radiation/planck_integral.hpp"
 #include "util/valarray.hpp"
 
-using Real = amrex::Real;
-
 // Hyper parameters for the radiation solver
 static constexpr bool add_line_cooling_to_radiation_in_jac = false;
 static constexpr bool include_delta_B = true;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -153,18 +153,18 @@ enum class FillPatchType { fillpatch_class, fillpatch_function };
 template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 {
       public:
-	Real maxDt_ = std::numeric_limits<Real>::max();  // no limit by default
+	Real maxDt_ = std::numeric_limits<Real>::max();	 // no limit by default
 	Real initDt_ = std::numeric_limits<Real>::max(); // no limit by default
 	Real constantDt_ = 0.0;
-	amrex::Vector<int> istep;	      // which step?
-	amrex::Vector<int> nsubsteps;	      // how many substeps on each level?
-	amrex::Vector<amrex::Real> tNew_;     // for state_new_cc_
-	amrex::Vector<amrex::Real> tOld_;     // for state_old_cc_
-	amrex::Vector<amrex::Real> dt_;	      // timestep for each level
-	Real stopTime_ = 1.0;	      // default
-	Real cflNumber_ = 0.3;	      // default
-	Real particleCflNumber_ = 0.5; // default
-	Real dtToleranceFactor_ = 1.1; // default
+	amrex::Vector<int> istep;	  // which step?
+	amrex::Vector<int> nsubsteps;	  // how many substeps on each level?
+	amrex::Vector<amrex::Real> tNew_; // for state_new_cc_
+	amrex::Vector<amrex::Real> tOld_; // for state_old_cc_
+	amrex::Vector<amrex::Real> dt_;	  // timestep for each level
+	Real stopTime_ = 1.0;		  // default
+	Real cflNumber_ = 0.3;		  // default
+	Real particleCflNumber_ = 0.5;	  // default
+	Real dtToleranceFactor_ = 1.1;	  // default
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;				     // default: don't print
 	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit
@@ -173,17 +173,17 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int plotfileInterval_ = -1;				     // -1 == no output
 	int projectionInterval_ = -1;				     // -1 == no output
 	int statisticsInterval_ = -1;				     // -1 == no output
-	Real plotTimeInterval_ = -1.0;			     // time interval for plt file
-	Real checkpointTimeInterval_ = -1.0;		     // time interval for checkpoints
+	Real plotTimeInterval_ = -1.0;				     // time interval for plt file
+	Real checkpointTimeInterval_ = -1.0;			     // time interval for checkpoints
 	int checkpointInterval_ = -1;				     // -1 == no output
 	int amrInterpMethod_ = 1;				     // 0 == piecewise constant, 1 == lincc_interp
-	Real reltolPoisson_ = 1.0e-5;			     // default
-	Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
+	Real reltolPoisson_ = 1.0e-5;				     // default
+	Real abstolPoisson_ = 1.0e-5;				     // default (scaled by minimum RHS value)
 	int doPoissonSolve_ = 0;				     // 1 == self-gravity enabled, 0 == disabled
 	amrex::Vector<amrex::MultiFab> phi;
 
 	Real densityFloor_ = 0.0; // default
-	Real tempFloor_ = 0.0;	 // default
+	Real tempFloor_ = 0.0;	  // default
 
 	YAML::Node simulationMetadata_;
 
@@ -285,10 +285,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 				    PreInterpHook const &pre_interp, PostInterpHook const &post_interp, FillPatchType fptype = FillPatchType::fillpatch_class);
 
 	template <typename PreInterpHook, typename PostInterpHook>
-	void FillPatchWithData(int lev, Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
-			       amrex::Vector<amrex::Real> &coarseTime, amrex::Vector<amrex::MultiFab *> &fineData, amrex::Vector<amrex::Real> &fineTime,
-			       int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs, quokka::centering &cen, FillPatchType fptype,
-			       PreInterpHook const &pre_interp, PostInterpHook const &post_interp);
+	void FillPatchWithData(int lev, Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData, amrex::Vector<amrex::Real> &coarseTime,
+			       amrex::Vector<amrex::MultiFab *> &fineData, amrex::Vector<amrex::Real> &fineTime, int icomp, int ncomp,
+			       amrex::Vector<amrex::BCRec> &BCs, quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
+			       PostInterpHook const &post_interp);
 
 	static void InterpHookNone(amrex::MultiFab &mf, int scomp, int ncomp);
 	virtual void FillPatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
@@ -826,7 +826,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 	// compute maximum particle speed on level 'lev'
 	amrex::ValLocPair<Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
-								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+							    .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
 		const amrex::ValLocPair<Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
@@ -1273,8 +1273,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLev
 
 struct setFunctorParticleAccel {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
-					 const int &orig_comp) const
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp, const int &orig_comp) const
 	{
 		amrex::ignore_unused(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
 	}
@@ -1628,8 +1627,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, Real time, cons
 // Remake an existing level using provided BoxArray and DistributionMapping and
 // fill with existing fine and coarse data. Overrides the pure virtual function
 // in AmrCore
-template <typename problem_t>
-void AMRSimulation<problem_t>::RemakeLevel(int level, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
+template <typename problem_t> void AMRSimulation<problem_t>::RemakeLevel(int level, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
 	BL_PROFILE("AMRSimulation::RemakeLevel()");
 
@@ -1700,8 +1698,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InterpHookNone(amre
 
 template <typename problem_t> struct setBoundaryFunctor {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
-					 const int &orig_comp) const
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp, const int &orig_comp) const
 	{
 		AMRSimulation<problem_t>::setCustomBoundaryConditions(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
 	}
@@ -1709,18 +1706,16 @@ template <typename problem_t> struct setBoundaryFunctor {
 
 template <typename problem_t> struct setBoundaryFunctorFaceVar {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
-					 const int &orig_comp) const
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp, const int &orig_comp) const
 	{
 		AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
 	}
 };
 
 template <typename problem_t>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest,
-											       int dcomp, int numcomp, amrex::GeometryData const &geom,
-											       const Real time, const amrex::BCRec *bcr, int bcomp,
-											       int orig_comp)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+AMRSimulation<problem_t>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, int dcomp, int numcomp,
+						      amrex::GeometryData const &geom, const Real time, const amrex::BCRec *bcr, int bcomp, int orig_comp)
 {
 	// user should implement if needed using template specialization
 	// (This is only called when amrex::BCType::ext_dir is set for a given
@@ -1872,9 +1867,9 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, Real time, con
 
 template <typename problem_t>
 template <typename PreInterpHook, typename PostInterpHook>
-void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int const lev, Real const time,
-						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
-						      PostInterpHook const &post_interp, FillPatchType fptype)
+void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int const lev, Real const time, quokka::centering cen,
+						      quokka::direction dir, PreInterpHook const &pre_interp, PostInterpHook const &post_interp,
+						      FillPatchType fptype)
 {
 	BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
 
@@ -2062,8 +2057,8 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, Real time, amrex::MultiF
 // utility to copy in data from state_old_cc_[lev] and/or state_new_cc_[lev]
 // into another multifab
 template <typename problem_t>
-void AMRSimulation<problem_t>::GetData(int lev, Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
-				       quokka::centering cen, quokka::direction dir)
+void AMRSimulation<problem_t>::GetData(int lev, Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime, quokka::centering cen,
+				       quokka::direction dir)
 {
 	BL_PROFILE("AMRSimulation::GetData()");
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -153,8 +153,8 @@ enum class FillPatchType { fillpatch_class, fillpatch_function };
 template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 {
       public:
-	Real maxDt_ = std::numeric_limits<double>::max();  // no limit by default
-	Real initDt_ = std::numeric_limits<double>::max(); // no limit by default
+	Real maxDt_ = std::numeric_limits<Real>::max();  // no limit by default
+	Real initDt_ = std::numeric_limits<Real>::max(); // no limit by default
 	Real constantDt_ = 0.0;
 	amrex::Vector<int> istep;	      // which step?
 	amrex::Vector<int> nsubsteps;	      // how many substeps on each level?
@@ -964,8 +964,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	int last_projection_step = 0;
 	int last_statistics_step = 0;
 	int last_plot_file_step = 0;
-	double next_plot_file_time = plotTimeInterval_;
-	double next_chk_file_time = checkpointTimeInterval_;
+	Real next_plot_file_time = plotTimeInterval_;
+	Real next_chk_file_time = checkpointTimeInterval_;
 	int last_chk_file_step = 0;
 	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 
@@ -1144,8 +1144,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	// compute zone-cycles/sec
 	const int IOProc = amrex::ParallelDescriptor::IOProcessorNumber();
 	amrex::ParallelDescriptor::ReduceRealMax(elapsed_sec, IOProc);
-	const double microseconds_per_update = 1.0e6 * elapsed_sec / cellUpdates_;
-	const double megaupdates_per_second = 1.0 / microseconds_per_update;
+	const Real microseconds_per_update = 1.0e6 * elapsed_sec / cellUpdates_;
+	const Real megaupdates_per_second = 1.0 / microseconds_per_update;
 	amrex::Print() << "Performance figure-of-merit: " << microseconds_per_update << " μs/zone-update [" << megaupdates_per_second << " Mupdates/s]\n";
 	for (int lev = 0; lev <= max_level; ++lev) {
 		amrex::Print() << "Zone-updates on level " << lev << ": " << cellUpdatesEachLevel_[lev] << "\n";
@@ -2469,7 +2469,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions
 	scenes["s1/renders/r1/image_prefix"] = "render_density%05d";
 
 	// set camera position
-	amrex::Array<double, 3> position = {-0.6, -0.6, -0.8};
+	amrex::Array<Real, 3> position = {-0.6, -0.6, -0.8};
 	scenes["s1/renders/r1/camera/position"].set_float64_ptr(position.data(), 3);
 
 	// setup actions

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -112,7 +112,7 @@ template <> struct fmt::formatter<amrex::IntVect> : formatter<std::vector<int>> 
 	};
 };
 
-using variant_t = std::variant<amrex::Real, std::string>;
+using variant_t = std::variant<Real, std::string>;
 
 namespace YAML
 {
@@ -153,18 +153,18 @@ enum class FillPatchType { fillpatch_class, fillpatch_function };
 template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 {
       public:
-	amrex::Real maxDt_ = std::numeric_limits<double>::max();  // no limit by default
-	amrex::Real initDt_ = std::numeric_limits<double>::max(); // no limit by default
-	amrex::Real constantDt_ = 0.0;
+	Real maxDt_ = std::numeric_limits<double>::max();  // no limit by default
+	Real initDt_ = std::numeric_limits<double>::max(); // no limit by default
+	Real constantDt_ = 0.0;
 	amrex::Vector<int> istep;	      // which step?
 	amrex::Vector<int> nsubsteps;	      // how many substeps on each level?
 	amrex::Vector<amrex::Real> tNew_;     // for state_new_cc_
 	amrex::Vector<amrex::Real> tOld_;     // for state_old_cc_
 	amrex::Vector<amrex::Real> dt_;	      // timestep for each level
-	amrex::Real stopTime_ = 1.0;	      // default
-	amrex::Real cflNumber_ = 0.3;	      // default
-	amrex::Real particleCflNumber_ = 0.5; // default
-	amrex::Real dtToleranceFactor_ = 1.1; // default
+	Real stopTime_ = 1.0;	      // default
+	Real cflNumber_ = 0.3;	      // default
+	Real particleCflNumber_ = 0.5; // default
+	Real dtToleranceFactor_ = 1.1; // default
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;				     // default: don't print
 	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit
@@ -173,17 +173,17 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int plotfileInterval_ = -1;				     // -1 == no output
 	int projectionInterval_ = -1;				     // -1 == no output
 	int statisticsInterval_ = -1;				     // -1 == no output
-	amrex::Real plotTimeInterval_ = -1.0;			     // time interval for plt file
-	amrex::Real checkpointTimeInterval_ = -1.0;		     // time interval for checkpoints
+	Real plotTimeInterval_ = -1.0;			     // time interval for plt file
+	Real checkpointTimeInterval_ = -1.0;		     // time interval for checkpoints
 	int checkpointInterval_ = -1;				     // -1 == no output
 	int amrInterpMethod_ = 1;				     // 0 == piecewise constant, 1 == lincc_interp
-	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
-	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
+	Real reltolPoisson_ = 1.0e-5;			     // default
+	Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
 	int doPoissonSolve_ = 0;				     // 1 == self-gravity enabled, 0 == disabled
 	amrex::Vector<amrex::MultiFab> phi;
 
-	amrex::Real densityFloor_ = 0.0; // default
-	amrex::Real tempFloor_ = 0.0;	 // default
+	Real densityFloor_ = 0.0; // default
+	Real tempFloor_ = 0.0;	 // default
 
 	YAML::Node simulationMetadata_;
 
@@ -221,17 +221,17 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void PerformanceHints();
 	void readParameters();
 	void setInitialConditions();
-	void setInitialConditionsAtLevel_cc(int level, amrex::Real time);
-	void setInitialConditionsAtLevel_fc(int level, amrex::Real time);
+	void setInitialConditionsAtLevel_cc(int level, Real time);
+	void setInitialConditionsAtLevel_fc(int level, Real time);
 	void evolve();
 	void computeTimestep();
-	auto computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>;
+	auto computeTimestepAtLevel(int lev) -> amrex::ValLocPair<Real, amrex::IntVect>;
 
 	void AverageFCToCC(amrex::MultiFab &mf_cc, const amrex::MultiFab &mf_fc, int idim, int dstcomp_start, int srccomp_start, int srccomp_total) const;
 
 	virtual void computeMaxSignalLocal(int level) = 0;
 	virtual void printCellProperties(int lev, amrex::IntVect const &index) = 0;
-	virtual void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle) = 0;
+	virtual void advanceSingleTimestepAtLevel(int lev, Real time, Real dt_lev, int ncycle) = 0;
 	virtual void preCalculateInitialConditions() = 0;
 	virtual void setInitialConditionsOnGrid(quokka::grid const &grid_elem) = 0;
 	virtual void setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem) = 0;
@@ -248,7 +248,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual void computeAfterTimestep() = 0;
 	virtual void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) = 0;
 	virtual void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) = 0;
-	virtual void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) = 0;
+	virtual void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, Real dt) = 0;
 
 	// compute derived variables
 	virtual void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const = 0;
@@ -264,63 +264,63 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual void FixupState(int level) = 0;
 
 	// tag cells for refinement
-	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override = 0;
+	void ErrorEst(int lev, amrex::TagBoxArray &tags, Real time, int ngrow) override = 0;
 
 	// Make a new level using provided BoxArray and DistributionMapping
-	void MakeNewLevelFromCoarse(int lev, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
+	void MakeNewLevelFromCoarse(int lev, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
 
 	// Remake an existing level using provided BoxArray and DistributionMapping
-	void RemakeLevel(int lev, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
+	void RemakeLevel(int lev, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
 
 	// Delete level data
 	void ClearLevel(int lev) override;
 
 	// Make a new level from scratch using provided BoxArray and
 	// DistributionMapping
-	void MakeNewLevelFromScratch(int lev, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
+	void MakeNewLevelFromScratch(int lev, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm) override;
 
 	// AMR utility functions
 	template <typename PreInterpHook, typename PostInterpHook>
-	void fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int lev, amrex::Real time, quokka::centering cen, quokka::direction dir,
+	void fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int lev, Real time, quokka::centering cen, quokka::direction dir,
 				    PreInterpHook const &pre_interp, PostInterpHook const &post_interp, FillPatchType fptype = FillPatchType::fillpatch_class);
 
 	template <typename PreInterpHook, typename PostInterpHook>
-	void FillPatchWithData(int lev, amrex::Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
+	void FillPatchWithData(int lev, Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
 			       amrex::Vector<amrex::Real> &coarseTime, amrex::Vector<amrex::MultiFab *> &fineData, amrex::Vector<amrex::Real> &fineTime,
 			       int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs, quokka::centering &cen, FillPatchType fptype,
 			       PreInterpHook const &pre_interp, PostInterpHook const &post_interp);
 
 	static void InterpHookNone(amrex::MultiFab &mf, int scomp, int ncomp);
-	virtual void FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
+	virtual void FillPatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 			       FillPatchType fptype);
 
 	auto getAmrInterpolaterCellCentered() -> amrex::MFInterpolater *;
 	auto getAmrInterpolaterFaceCentered() -> amrex::Interpolater *;
-	void FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs, quokka::centering cen,
+	void FillCoarsePatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs, quokka::centering cen,
 			     quokka::direction dir);
-	void GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime, quokka::centering cen,
+	void GetData(int lev, Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime, quokka::centering cen,
 		     quokka::direction dir);
 	void AverageDown();
 	void AverageDownTo(int crse_lev);
-	void timeStepWithSubcycling(int lev, amrex::Real time, int iteration);
+	void timeStepWithSubcycling(int lev, Real time, int iteration);
 	void calculateGpotAllLevels();
-	void gravAccelAllLevels(amrex::Real dt);
-	void ellipticSolveAllLevels(amrex::Real dt);
+	void gravAccelAllLevels(Real dt);
+	void ellipticSolveAllLevels(Real dt);
 
 	void incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-				    std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int lev, amrex::Real dt_lev);
+				    std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int lev, Real dt_lev);
 
 	void incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int lev, amrex::Real dt_lev);
+				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int lev, Real dt_lev);
 
 	// boundary condition
 	AMREX_GPU_DEVICE static void setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, int dcomp, int numcomp,
-								 amrex::GeometryData const &geom, amrex::Real time, const amrex::BCRec *bcr, int bcomp,
+								 amrex::GeometryData const &geom, Real time, const amrex::BCRec *bcr, int bcomp,
 								 int orig_comp); // template specialized by problem generator
 
 	// boundary condition
 	AMREX_GPU_DEVICE static void setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, int dcomp,
-									int numcomp, amrex::GeometryData const &geom, amrex::Real time, const amrex::BCRec *bcr,
+									int numcomp, amrex::GeometryData const &geom, Real time, const amrex::BCRec *bcr,
 									int bcomp,
 									int orig_comp); // template specialized by problem generator
 
@@ -354,7 +354,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// particle functions
 #if AMREX_SPACEDIM == 3
-	void kickParticlesAllLevels(amrex::Real dt);
+	void kickParticlesAllLevels(Real dt);
 #endif // AMREX_SPACEDIM == 3
 
 	// simulation metadata
@@ -414,7 +414,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<amrex::Long> cellUpdatesEachLevel_;
 
 	// gravity
-	static constexpr amrex::Real Gconst_ = []() constexpr {
+	static constexpr Real Gconst_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			return C::Gconst; // gravitational constant G, CGS units
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CONSTANTS) {
@@ -428,7 +428,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	}();
 
 	// unit length, mass, time, temperature
-	static constexpr amrex::Real unit_length = []() constexpr {
+	static constexpr Real unit_length = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CUSTOM) {
 			return Physics_Traits<problem_t>::unit_length;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
@@ -437,7 +437,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 			return NAN;
 		}
 	}();
-	static constexpr amrex::Real unit_mass = []() constexpr {
+	static constexpr Real unit_mass = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CUSTOM) {
 			return Physics_Traits<problem_t>::unit_mass;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
@@ -446,7 +446,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 			return NAN;
 		}
 	}();
-	static constexpr amrex::Real unit_time = []() constexpr {
+	static constexpr Real unit_time = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CUSTOM) {
 			return Physics_Traits<problem_t>::unit_time;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
@@ -455,7 +455,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 			return NAN;
 		}
 	}();
-	static constexpr amrex::Real unit_temperature = []() constexpr {
+	static constexpr Real unit_temperature = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CUSTOM) {
 			return Physics_Traits<problem_t>::unit_temperature;
 		} else if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
@@ -744,7 +744,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 
 	if (restart_chkfile.empty()) {
 		// start simulation from the beginning
-		const amrex::Real time = 0.0;
+		const Real time = 0.0;
 		InitFromScratch(time);
 		AverageDown();
 
@@ -802,19 +802,19 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 	PerformanceHints();
 }
 
-template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
+template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
 	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
 
-	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
+	using dtloc_t = amrex::ValLocPair<Real, amrex::IntVect>;
 
 	// compute hydro timestep on level 'lev'
 	computeMaxSignalLocal(lev);
-	const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
+	const Real domain_signal_max = max_signal_speed_[lev].norminf();
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
-	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
-	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
+	const amrex::GpuArray<Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
+	const Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
 	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
 
 	if (verbose) {
@@ -825,11 +825,11 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 
 	// compute maximum particle speed on level 'lev'
-	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
+	amrex::ValLocPair<Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
 								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 #if AMREX_SPACEDIM == 3
 	if (particleRegister_.HasMassiveParticles()) {
-		const amrex::ValLocPair<amrex::Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
+		const amrex::ValLocPair<Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
 		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
@@ -837,8 +837,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
 			// compute IntVect from RealVect and geom[lev]
 			amrex::IntVect cell_idx;
-			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxinv = geom[lev].InvCellSizeArray();
-			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo = geom[lev].ProbLoArray();
+			amrex::GpuArray<Real, AMREX_SPACEDIM> const &dxinv = geom[lev].InvCellSizeArray();
+			amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo = geom[lev].ProbLoArray();
 			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 				cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
 			}
@@ -879,7 +879,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 	}
 
 	// limit change in timestep on each level
-	constexpr amrex::Real change_max = 1.1;
+	constexpr Real change_max = 1.1;
 
 	for (int level = 0; level <= finest_level; ++level) {
 		dt_tmp[level] = std::min(dt_tmp[level], change_max * dt_[level]);
@@ -893,13 +893,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 	}
 
 	// compute root level timestep given nsubsteps
-	amrex::Real dt_0 = dt_tmp[0];
+	Real dt_0 = dt_tmp[0];
 	int level_that_sets_dt_0 = 0; // keep track of which level sets the min dt
 	amrex::Long n_factor = 1;
 
 	for (int level = 0; level <= finest_level; ++level) {
 		n_factor *= nsubsteps[level];
-		const amrex::Real dt_0_old = dt_0; // save old dt_0
+		const Real dt_0_old = dt_0; // save old dt_0
 		dt_0 = std::min(dt_0, static_cast<amrex::Real>(n_factor) * dt_tmp[level]);
 		if (dt_0 < dt_0_old) {
 			// level 'level' has now set the timestep
@@ -921,7 +921,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 	}
 
 	// Limit dt to avoid overshooting stop_time
-	const amrex::Real eps = 1.e-3 * dt_0;
+	const Real eps = 1.e-3 * dt_0;
 
 	if (tNew_[0] + dt_0 > stopTime_ - eps) {
 		dt_0 = stopTime_ - tNew_[0];
@@ -937,16 +937,16 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getWalltime() -> amrex::Real
 {
-	const static amrex::Real start_time = amrex::ParallelDescriptor::second(); // initialized on first call
-	const amrex::Real time = amrex::ParallelDescriptor::second();
+	const static Real start_time = amrex::ParallelDescriptor::second(); // initialized on first call
+	const Real time = amrex::ParallelDescriptor::second();
 	return time - start_time;
 }
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getCycleWalltime() -> amrex::Real
 {
-	static amrex::Real start_time = amrex::ParallelDescriptor::second(); // initialized on first call
-	const amrex::Real current_time = amrex::ParallelDescriptor::second();
-	const amrex::Real elapsed_time = current_time - start_time;
+	static Real start_time = amrex::ParallelDescriptor::second(); // initialized on first call
+	const Real current_time = amrex::ParallelDescriptor::second();
+	const Real elapsed_time = current_time - start_time;
 	start_time = current_time;
 	return elapsed_time;
 }
@@ -957,7 +957,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
 
-	amrex::Real cur_time = tNew_[0];
+	Real cur_time = tNew_[0];
 #ifdef AMREX_USE_ASCENT
 	int last_ascent_step = 0;
 #endif
@@ -969,8 +969,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	int last_chk_file_step = 0;
 	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 
-	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
-	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
+	amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
+	Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 	amrex::Vector<amrex::Real> init_sum_cons(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		const int lev = 0;
@@ -991,7 +991,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 		// output per-cycle timing
 		if (printCycleTiming_ == 1) {
-			amrex::Real elapsed_sec = getCycleWalltime();
+			Real elapsed_sec = getCycleWalltime();
 			amrex::Print() << "(cycle time: " << elapsed_sec << " s) ...\n";
 		} else {
 			amrex::Print() << "...\n";
@@ -1123,19 +1123,19 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		return;
 	}
 
-	amrex::Real elapsed_sec = getWalltime();
+	Real elapsed_sec = getWalltime();
 
 	// compute reference solution (if it's a test problem)
 	computeAfterEvolve(init_sum_cons);
 
 	// compute conservation error
 	for (int n = 0; n < ncomp_cc; ++n) {
-		amrex::Real const final_sum = state_new_cc_[0].sum(n) * vol;
-		amrex::Real const abs_err = (final_sum - init_sum_cons[n]);
+		Real const final_sum = state_new_cc_[0].sum(n) * vol;
+		Real const abs_err = (final_sum - init_sum_cons[n]);
 		amrex::Print() << "Initial " << componentNames_cc_[n] << " = " << init_sum_cons[n] << '\n';
 		amrex::Print() << "\tabsolute conservation error = " << abs_err << '\n';
 		if (init_sum_cons[n] != 0.0) {
-			amrex::Real const rel_err = abs_err / init_sum_cons[n];
+			Real const rel_err = abs_err / init_sum_cons[n];
 			amrex::Print() << "\trelative conservation error = " << rel_err << '\n';
 		}
 		amrex::Print() << '\n';
@@ -1206,7 +1206,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 		constexpr int nghost_drift = 1;	  // particle can drift up to 1 cell
 		constexpr int nghost_rhs = nghost_deposit + nghost_drift;
 		constexpr int ncomp = 1;
-		amrex::Real rhs_min = std::numeric_limits<amrex::Real>::max();
+		Real rhs_min = std::numeric_limits<amrex::Real>::max();
 		for (int lev = 0; lev <= finest_level; ++lev) {
 			phi[lev].define(grids[lev], dmap[lev], ncomp, nghost_phi);
 			rhs[lev].define(grids[lev], dmap[lev], ncomp, nghost_rhs);
@@ -1230,7 +1230,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			AMREX_ALWAYS_ASSERT(!rhs[lev].contains_nan());
 		}
 
-		amrex::Real abstol = abstolPoisson_ * rhs_min;
+		Real abstol = abstolPoisson_ * rhs_min;
 		poissonSolver.solve(amrex::GetVecOfPtrs(phi), amrex::GetVecOfConstPtrs(rhs), reltolPoisson_, abstol);
 		if (verbose) {
 			amrex::Print() << "\n";
@@ -1244,7 +1244,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 #endif
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(const amrex::Real dt)
+template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(const Real dt)
 {
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
@@ -1259,7 +1259,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 #endif
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLevels(const amrex::Real dt)
+template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLevels(const Real dt)
 {
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
@@ -1273,7 +1273,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLev
 
 struct setFunctorParticleAccel {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const amrex::Real &time, const amrex::BCRec *bcr, int bcomp,
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
 					 const int &orig_comp) const
 	{
 		amrex::ignore_unused(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
@@ -1281,7 +1281,7 @@ struct setFunctorParticleAccel {
 };
 
 #if AMREX_SPACEDIM == 3
-template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLevels(const amrex::Real dt)
+template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLevels(const Real dt)
 {
 	// kick particles (do: vel[i] += 0.5 * dt * accel[i])
 
@@ -1386,7 +1386,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 
 // N.B.: This function actually works for subcycled or not subcycled, as long as
 // nsubsteps[lev] is set correctly.
-template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
+template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, Real time, int iteration)
 {
 	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
 
@@ -1513,7 +1513,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 
 template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
+						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, Real const dt_lev)
 {
 	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
@@ -1534,7 +1534,7 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex:
 
 template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
+						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, Real const dt_lev)
 {
 	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
@@ -1587,7 +1587,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterF
 // with interpolated coarse level data. Overrides the pure virtual function in
 // AmrCore
 template <typename problem_t>
-void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
+void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
 	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
 
@@ -1629,7 +1629,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 // fill with existing fine and coarse data. Overrides the pure virtual function
 // in AmrCore
 template <typename problem_t>
-void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
+void AMRSimulation<problem_t>::RemakeLevel(int level, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
 	BL_PROFILE("AMRSimulation::RemakeLevel()");
 
@@ -1700,7 +1700,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InterpHookNone(amre
 
 template <typename problem_t> struct setBoundaryFunctor {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const amrex::Real &time, const amrex::BCRec *bcr, int bcomp,
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
 					 const int &orig_comp) const
 	{
 		AMRSimulation<problem_t>::setCustomBoundaryConditions(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
@@ -1709,7 +1709,7 @@ template <typename problem_t> struct setBoundaryFunctor {
 
 template <typename problem_t> struct setBoundaryFunctorFaceVar {
 	AMREX_GPU_DEVICE void operator()(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, const int &dcomp, const int &numcomp,
-					 amrex::GeometryData const &geom, const amrex::Real &time, const amrex::BCRec *bcr, int bcomp,
+					 amrex::GeometryData const &geom, const Real &time, const amrex::BCRec *bcr, int bcomp,
 					 const int &orig_comp) const
 	{
 		AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(iv, dest, dcomp, numcomp, geom, time, bcr, bcomp, orig_comp);
@@ -1719,7 +1719,7 @@ template <typename problem_t> struct setBoundaryFunctorFaceVar {
 template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest,
 											       int dcomp, int numcomp, amrex::GeometryData const &geom,
-											       const amrex::Real time, const amrex::BCRec *bcr, int bcomp,
+											       const Real time, const amrex::BCRec *bcr, int bcomp,
 											       int orig_comp)
 {
 	// user should implement if needed using template specialization
@@ -1732,7 +1732,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setCustomBoun
 template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest, int dcomp, int numcomp,
-							     amrex::GeometryData const &geom, const amrex::Real time, const amrex::BCRec *bcr, int bcomp,
+							     amrex::GeometryData const &geom, const Real time, const amrex::BCRec *bcr, int bcomp,
 							     int orig_comp)
 {
 	// user should implement if needed using template specialization
@@ -1747,7 +1747,7 @@ AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(const amrex::IntVec
 // NOTE: This implementation is only used by AdvectionSimulation.
 //  QuokkaSimulation provides its own implementation.
 template <typename problem_t>
-void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
+void AMRSimulation<problem_t>::FillPatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)
 {
 	BL_PROFILE("AMRSimulation::FillPatch()");
@@ -1774,7 +1774,7 @@ void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::Multi
 	}
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditionsAtLevel_cc(int level, amrex::Real time)
+template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditionsAtLevel_cc(int level, Real time)
 {
 	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 	const int nghost_cc = nghost_cc_;
@@ -1794,7 +1794,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 	state_old_cc_[level].ParallelCopy(state_new_cc_[level], 0, 0, ncomp_cc, nghost_cc, nghost_cc);
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditionsAtLevel_fc(int level, amrex::Real time)
+template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditionsAtLevel_fc(int level, Real time)
 {
 	const int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;
 	const int nghost_fc = nghost_fc_;
@@ -1823,7 +1823,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 // DistributionMapping. Only used during initialization. Overrides the pure
 // virtual function in AmrCore
 template <typename problem_t>
-void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
+void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
 	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
 
@@ -1872,7 +1872,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real ti
 
 template <typename problem_t>
 template <typename PreInterpHook, typename PostInterpHook>
-void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int const lev, amrex::Real const time,
+void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int const lev, Real const time,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
 						      PostInterpHook const &post_interp, FillPatchType fptype)
 {
@@ -1957,7 +1957,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 // ghost cells
 template <typename problem_t>
 template <typename PreInterpHook, typename PostInterpHook>
-void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
+void AMRSimulation<problem_t>::FillPatchWithData(int lev, Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
 						 amrex::Vector<amrex::Real> &coarseTime, amrex::Vector<amrex::MultiFab *> &fineData,
 						 amrex::Vector<amrex::Real> &fineTime, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 						 quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
@@ -2029,7 +2029,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 // Fill an entire multifab by interpolating from the coarser level
 // this comes into play when a new level of refinement appears
 template <typename problem_t>
-void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
+void AMRSimulation<problem_t>::FillCoarsePatch(int lev, Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
 { // here neco
 	BL_PROFILE("AMRSimulation::FillCoarsePatch()");
@@ -2062,7 +2062,7 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex:
 // utility to copy in data from state_old_cc_[lev] and/or state_new_cc_[lev]
 // into another multifab
 template <typename problem_t>
-void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
+void AMRSimulation<problem_t>::GetData(int lev, Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
 				       quokka::centering cen, quokka::direction dir)
 {
 	BL_PROFILE("AMRSimulation::GetData()");
@@ -2154,7 +2154,7 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 	amrex::Gpu::streamSynchronize();
 
 	// call amrex::volumeWeightedSum
-	const amrex::Real result = amrex::volumeWeightedSum(amrex::GetVecOfConstPtrs(q), 0, geom, ref_ratio);
+	const Real result = amrex::volumeWeightedSum(amrex::GetVecOfConstPtrs(q), 0, geom, ref_ratio);
 	return result;
 }
 
@@ -2501,12 +2501,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 	// rescale geometry
 	// (Ascent fails to render if you use parsec-size boxes in units of cm...)
 	amrex::Vector<amrex::Geometry> rescaledGeom = Geom();
-	const amrex::Real length = geom[0].ProbLength(0);
+	const Real length = geom[0].ProbLength(0);
 	for (int i = 0; i < rescaledGeom.size(); ++i) {
 		auto const &dlo = rescaledGeom[i].ProbLoArray();
 		auto const &dhi = rescaledGeom[i].ProbHiArray();
-		std::array<amrex::Real, AMREX_SPACEDIM> new_dlo{};
-		std::array<amrex::Real, AMREX_SPACEDIM> new_dhi{};
+		std::array<Real, AMREX_SPACEDIM> new_dlo{};
+		std::array<Real, AMREX_SPACEDIM> new_dhi{};
 		for (int k = 0; k < AMREX_SPACEDIM; ++k) {
 			new_dlo[k] = dlo[k] / length;
 			new_dhi[k] = dhi[k] / length;
@@ -2618,7 +2618,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 
 	for (YAML::const_iterator it = metadata.begin(); it != metadata.end(); ++it) {
 		const auto key = it->first.as<std::string>();
-		const std::optional<amrex::Real> value_real = YAML::as_if<amrex::Real, std::optional<amrex::Real>>(it->second)();
+		const std::optional<amrex::Real> value_real = YAML::as_if<Real, std::optional<amrex::Real>>(it->second)();
 		const std::optional<std::string> value_string = YAML::as_if<std::string, std::optional<std::string>>(it->second)();
 
 		if (value_real) {


### PR DESCRIPTION
Let's use amrex::Real consistently. This is part of the effort to prepare for a potential transition to single precision. More importantly, this is for coding consistency. Currently, the use of `double` and `amrex::Real` is mixed and inconsistent. One barrier to using amrex::Real is that it's cumbersome to type. Therefore, I added a line `using Real = amrex::Real;` in physics_info.hpp which every file imports, so we can use `Real` instead of `amrex::Real` anywhere. 

### Related issues
Related to #666 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
