### PR TITLE
Remove default CUDA GPU architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,6 @@ if(AMReX_GPU_BACKEND MATCHES "CUDA")
   if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 11.7)
     message(FATAL_ERROR "You must use CUDA version 11.7 or newer to compile Quokka. All previous CUDA versions have compiler bugs that cause Quokka to crash.")
   endif()
-
-  set(CMAKE_CUDA_ARCHITECTURES 70 80 CACHE STRING "")
   
   if(CMAKE_VERSION VERSION_LESS 3.20)
     include(AMReX_SetupCUDA)


### PR DESCRIPTION
### Description
This removes the default settings for CUDA GPU architectures. (We have never set a default for AMD GPUs.)

This is done to reduce the compile time, since the default was set to 2 GPU architectures, which made the build time almost twice as large as it would be compared to setting only one GPU arch. This makes the GPU tests on avatargpu take significantly longer.

Users will need to specify which CUDA GPU architecture they want to build for explicitly using either `-DAMReX_CUDA_ARCH` or the `AMREX_CUDA_ARCH` environment variable. If a GPU is present on the machine used to build, CMake should (in principle) autodetect the correct GPU arch:
```
-- Autodetected CUDA architecture(s):  7.0
```

Documentation: https://amrex-codes.github.io/amrex/docs_html/GPU.html#enabling-cuda-support

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
