### PR TITLE
Update Dockerfile

### DIFF
--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -1,6 +1,5 @@
 # Use the NVIDIA CUDA image as the base image
-# FROM nvidia/cuda:12.8.0-cudnn-devel-ubuntu22.04@sha256:c900a2ac7f3d860c854f7364eadfe32b8cd33933a838f96b71e9bb6525f77a8c
-FROM nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04@sha256:81d4dd36435f4ccf0aafb111c6b09182084f0a3ff044ffa5b74bbeb7c5a5fd33
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04@sha256:520292dbb4f755fd360766059e62956e9379485d9e073bbd2f6e3c20c270ed66
 
 # Set environment variables for NVIDIA
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -1,5 +1,6 @@
 # Use the NVIDIA CUDA image as the base image
-FROM nvidia/cuda:12.8.1-devel-ubuntu24.04@sha256:520292dbb4f755fd360766059e62956e9379485d9e073bbd2f6e3c20c270ed66
+# FROM nvidia/cuda:12.8.0-cudnn-devel-ubuntu22.04@sha256:c900a2ac7f3d860c854f7364eadfe32b8cd33933a838f96b71e9bb6525f77a8c
+FROM nvidia/cuda:12.8.0-cudnn-devel-ubuntu24.04@sha256:81d4dd36435f4ccf0aafb111c6b09182084f0a3ff044ffa5b74bbeb7c5a5fd33
 
 # Set environment variables for NVIDIA
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -1,5 +1,5 @@
 # Use the NVIDIA CUDA image as the base image
-FROM nvcr.io/nvidia/nvhpc:25.1-devel-cuda12.6-ubuntu24.04@sha256:6556aa06655bd91c46633266dcfeccb3fbfb1c589dc184ad2ce8b603e5215403
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04@sha256:520292dbb4f755fd360766059e62956e9379485d9e073bbd2f6e3c20c270ed66
 
 # Set environment variables for NVIDIA
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -10,7 +10,7 @@ RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get install -y -qq --no-install-recommends \
     build-essential wget curl git ninja-build gcc g++ \
     python3-dev python3-numpy python3-matplotlib python3-pip \
-    libhdf5-dev && \
+    libhdf5-dev openmpi-bin libopenmpi-dev && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/cuda-container/devcontainer.json
+++ b/.devcontainer/cuda-container/devcontainer.json
@@ -1,12 +1,7 @@
 // devcontainer.json
     {
       "name": "Quokka CUDA Dev Container",
-      // (NOTE: using the cloud image is temporarily disabled, since it doesn't exist yet)
-      // "image": "ghcr.io/quokka-astro/quokka:development",
-      "build": {
-        // Path is relative to the devcontainer.json file.
-        "dockerfile": "Dockerfile"
-      },
+      "image": "ghcr.io/chongchonghe/quokka-linux-amd64:development",
       "hostRequirements": {
         "cpus": 4
       },

--- a/.devcontainer/cuda-container/devcontainer.json
+++ b/.devcontainer/cuda-container/devcontainer.json
@@ -1,7 +1,7 @@
 // devcontainer.json
     {
       "name": "Quokka CUDA Dev Container",
-      "image": "ghcr.io/chongchonghe/quokka-linux-amd64:development",
+      "image": "ghcr.io/quokka-astro/quokka-linux-amd64-cuda:development",
       "hostRequirements": {
         "cpus": 4
       },

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qq && apt-get upgrade -y -qq && \
     rocrand-dev hiprand-dev rocprim-dev rocsparse-dev \
     build-essential wget curl git ninja-build gcc g++ \
     python3-dev python3-numpy python3-matplotlib python3-pip \
-    libhdf5-dev libopenmpi-dev && \
+    libhdf5-dev libopenmpi-dev netbase && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.devcontainer/rocm-container/devcontainer.json
+++ b/.devcontainer/rocm-container/devcontainer.json
@@ -1,7 +1,7 @@
 // devcontainer.json
     {
       "name": "Quokka ROCm Dev Container",
-      "image": "ghcr.io/chongchonghe/quokka-linux-amd64-rocm:development",
+      "image": "ghcr.io/quokka-astro/quokka-linux-amd64-rocm:development",
       "hostRequirements": {
         "cpus": 4
       },

--- a/.devcontainer/rocm-container/devcontainer.json
+++ b/.devcontainer/rocm-container/devcontainer.json
@@ -1,12 +1,7 @@
 // devcontainer.json
     {
       "name": "Quokka ROCm Dev Container",
-      // (NOTE: using the cloud image is temporarily disabled, since it doesn't exist yet)
-      // "image": "ghcr.io/quokka-astro/quokka:development",
-      "build": {
-        // Path is relative to the devcontainer.json file.
-        "dockerfile": "Dockerfile"
-      },
+      "image": "ghcr.io/chongchonghe/quokka-linux-amd64-rocm:development",
       "hostRequirements": {
         "cpus": 4
       },

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__
 *.sarif
 Backtrace.*
 
+# Singularity Docker images
+*.sif
+
 *.aux
 *.dbl
 *.bbl


### PR DESCRIPTION
### Description

This PR updates the image used in the CUDA Dockerfile from a nvhpc image to a smaller base CUDA image. Two images, built by cuda-container/Dockerfile and rocm-container/Dockerfile, are uploaded to `ghcr.io/quokka-astro/quokka-linux-amd64-cuda:development` and `ghcr.io/quokka-astro/quokka-linux-amd64-rocm:development`, respectively. Additionally, the `devcontainer.json` files have been updated to utilize those images from the ghcr.io server. Users can employ those pre-built images by either using Docker/singularityCE to pull them in the command line, or by initiating `Dev Containers: Reopen in Container` in VSCode. 

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] NOT NEEDED. I have added tests for any new physics that this PR adds to the code.
- [ ] NOT NEEDED. *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
