### PR TITLE
Move particle parameter specialization into PhysicsParticleRegister

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -710,7 +710,7 @@ template <typename problem_t> class PhysicsParticleRegister
 		// The parameters for the descriptor are: mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(container, -1, RadParticleLumIdx,
-															      -1, false, false);
+															      RadParticleBirthTimeIdx, false, false);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -138,7 +138,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	[[nodiscard]] static constexpr auto getParticleType() -> ParticleType { return particleType_; }
 
 	// Constructor initializing descriptor with container and particle properties
-	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, ContainerType *container, bool allows_creation, bool allows_destruction = false)
+	PhysicsParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false)
 	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction), container_(container)
 	{
 	}
@@ -628,9 +628,9 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 	[[nodiscard]] auto isStarParticle() -> bool override { return true; }
 
 	// Constructor - forwards all arguments to the base class
-	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container, bool allows_destruction = false,
+	StarParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false,
 			       int evolution_stage_idx = -1, bool allows_accretion = false)
-	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, container, allows_creation,
+	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(container, mass_idx, lum_idx, birth_time_idx, allows_creation,
 										allows_destruction)
 	{
 		this->setEvolutionStageIndex(evolution_stage_idx);
@@ -710,15 +710,15 @@ template <typename problem_t> class PhysicsParticleRegister
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
+			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
+			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
+			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -740,10 +740,10 @@ template <typename problem_t> class PhysicsParticleRegister
 		// Create the appropriate star particle descriptor based on the particle type
 		if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, allows_accretion);
+			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion);
 		} else if (type == ParticleType::StochasticStellarPop) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, allows_accretion);
+			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion);
 		} else {
 			amrex::Abort("Unknown particle type for star particles");
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -702,8 +702,7 @@ template <typename problem_t> class PhysicsParticleRegister
 
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
-	void registerParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, bool allows_creation = false, int birth_time_idx = -1,
-				  bool allows_destruction = false)
+	void registerParticleType(ContainerType *container, ParticleType type)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
@@ -732,8 +731,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new star particle type with specified properties
 	// Star particles have additional stellar evolution capabilities including supernova feedback
 	template <typename ContainerType>
-	void registerStarParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation = false,
-				      bool allows_destruction = false, int evolution_stage_idx = -1, bool allows_accretion = false)
+	void registerStarParticleType(ContainerType *container, ParticleType type)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -737,10 +737,10 @@ template <typename problem_t> class PhysicsParticleRegister
 
 		// Create the appropriate star particle descriptor based on the particle type
 		if (type == ParticleType::StochasticStellarPop) {
-			const bool StochasticStellarPop_allows_destruction = false;
+			const bool StochasticStellarPopAllowsDestruction = false;
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
 			    container, StochasticStellarPopParticleMassIdx, StochasticStellarPopParticleLumIdx, StochasticStellarPopParticleBirthTimeIdx, true,
-			    StochasticStellarPop_allows_destruction, StochasticStellarPopParticleStageIdx, true);
+			    StochasticStellarPopAllowsDestruction, StochasticStellarPopParticleStageIdx, true);
 		} else if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    container, TestParticleMassIdx, TestParticleLumIdx, TestParticleBirthTimeIdx, true, true, TestParticleStageIdx, true);

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -32,13 +32,13 @@ template <typename problem_t> class PhysicsParticleRegister;
 class PhysicsParticleDescriptorBase
 {
       protected:
-	int massIndex_{-1};		 // Index for particle mass (-1 if not used)
-	int lumIndex_{-1};		 // Index for radiation luminosity (-1 if not used)
-	int birthTimeIndex_{-1};	 // Index for birth time (-1 if not used)
-	bool allowsCreation_{false};	 // Whether particles can be created during simulation
-	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
-	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
-	bool allowsAccretion_{false}; // Whether particles can accrete gas
+	int massIndex_{-1};		// Index for particle mass (-1 if not used)
+	int lumIndex_{-1};		// Index for radiation luminosity (-1 if not used)
+	int birthTimeIndex_{-1};	// Index for birth time (-1 if not used)
+	bool allowsCreation_{false};	// Whether particles can be created during simulation
+	bool allowsDestruction_{false}; // Whether particles can be destroyed during simulation
+	int evolutionStageIndex_{-1};	// Index for evolution stage (-1 if not used)
+	bool allowsAccretion_{false};	// Whether particles can accrete gas
 
       public:
 	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false)
@@ -138,7 +138,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	[[nodiscard]] static constexpr auto getParticleType() -> ParticleType { return particleType_; }
 
 	// Constructor initializing descriptor with container and particle properties
-	PhysicsParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false)
+	PhysicsParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation,
+				  bool allows_destruction = false)
 	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction), container_(container)
 	{
 	}
@@ -701,8 +702,7 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Register a new particle type with specified properties
-	template <typename ContainerType>
-	void registerParticleType(ContainerType *container, ParticleType type)
+	template <typename ContainerType> void registerParticleType(ContainerType *container, ParticleType type)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
@@ -713,8 +713,8 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
-			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    container, CICParticleMassIdx, -1, false, -1, false);
+			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(container, CICParticleMassIdx, -1,
+															      false, -1, false);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
 			    container, CICRadParticleMassIdx, CICRadParticleLumIdx, false, CICRadParticleBirthTimeIdx, false);
@@ -730,8 +730,7 @@ template <typename problem_t> class PhysicsParticleRegister
 #if AMREX_SPACEDIM == 3
 	// Register a new star particle type with specified properties
 	// Star particles have additional stellar evolution capabilities including supernova feedback
-	template <typename ContainerType>
-	void registerStarParticleType(ContainerType *container, ParticleType type)
+	template <typename ContainerType> void registerStarParticleType(ContainerType *container, ParticleType type)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -710,15 +710,15 @@ template <typename problem_t> class PhysicsParticleRegister
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
+			    container, -1, RadParticleLumIdx, false, RadParticleBirthTimeIdx, false);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
+			    container, CICParticleMassIdx, -1, false, -1, false);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction);
+			    container, CICRadParticleMassIdx, CICRadParticleLumIdx, false, CICRadParticleBirthTimeIdx, false);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -738,12 +738,14 @@ template <typename problem_t> class PhysicsParticleRegister
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate star particle descriptor based on the particle type
-		if (type == ParticleType::Test) {
-			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
-			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion);
-		} else if (type == ParticleType::StochasticStellarPop) {
+		if (type == ParticleType::StochasticStellarPop) {
+			const bool StochasticStellarPop_allows_destruction = false;
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
-			    container, mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion);
+			    container, StochasticStellarPopParticleMassIdx, StochasticStellarPopParticleLumIdx, StochasticStellarPopParticleBirthTimeIdx, true,
+			    StochasticStellarPop_allows_destruction, StochasticStellarPopParticleStageIdx, true);
+		} else if (type == ParticleType::Test) {
+			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
+			    container, TestParticleMassIdx, TestParticleLumIdx, TestParticleBirthTimeIdx, true, true, TestParticleStageIdx, true);
 		} else {
 			amrex::Abort("Unknown particle type for star particles");
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -38,13 +38,12 @@ class PhysicsParticleDescriptorBase
 	bool allowsCreation_{false};	 // Whether particles can be created during simulation
 	bool allowsDestruction_{false};	 // Whether particles can be destroyed during simulation
 	int evolutionStageIndex_{-1};	 // Index for evolution stage (-1 if not used)
-	bool interactsWithHydro_{false}; // Whether particles interact with hydrodynamics
+	bool allowsAccretion_{false}; // Whether particles can accrete gas
 
       public:
-	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false,
-				      int evolution_stage_idx = -1, bool hydro_interact = false)
+	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, bool allows_destruction = false)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), allowsCreation_(allows_creation),
-	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx), interactsWithHydro_(hydro_interact)
+	      allowsDestruction_(allows_destruction)
 	{
 	}
 
@@ -60,10 +59,14 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getMassIndex() const -> int { return massIndex_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getLumIndex() const -> int { return lumIndex_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getBirthTimeIndex() const -> int { return birthTimeIndex_; }
-	[[nodiscard]] AMREX_FORCE_INLINE auto getInteractsWithHydro() const -> bool { return interactsWithHydro_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsCreation() const -> bool { return allowsCreation_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsDestruction() const -> bool { return allowsDestruction_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getEvolutionStageIndex() const -> int { return evolutionStageIndex_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsAccretion() const -> bool { return allowsAccretion_; }
+
+	// setter methods for particle properties
+	void setEvolutionStageIndex(int evolution_stage_idx) { evolutionStageIndex_ = evolution_stage_idx; }
+	void setAllowsAccretion(bool allows_accretion) { allowsAccretion_ = allows_accretion; }
 
 	// New method to get particle positions and data
 	[[nodiscard]] virtual auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
@@ -135,10 +138,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	[[nodiscard]] static constexpr auto getParticleType() -> ParticleType { return particleType_; }
 
 	// Constructor initializing descriptor with container and particle properties
-	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container,
-				  bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
-	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, hydro_interact),
-	      container_(container)
+	PhysicsParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, ContainerType *container, bool allows_creation, bool allows_destruction = false)
+	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction), container_(container)
 	{
 	}
 
@@ -628,10 +629,12 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 
 	// Constructor - forwards all arguments to the base class
 	StarParticleDescriptor(int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation, ContainerType *container, bool allows_destruction = false,
-			       int evolution_stage_idx = -1, bool hydro_interact = false)
-	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, allows_creation, container,
-										allows_destruction, evolution_stage_idx, hydro_interact)
+			       int evolution_stage_idx = -1, bool allows_accretion = false)
+	    : PhysicsParticleDescriptor<ContainerType, problem_t, particleType>(mass_idx, lum_idx, birth_time_idx, container, allows_creation,
+										allows_destruction)
 	{
+		this->setEvolutionStageIndex(evolution_stage_idx);
+		this->setAllowsAccretion(allows_accretion);
 	}
 
 #if AMREX_SPACEDIM == 3
@@ -700,22 +703,22 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Register a new particle type with specified properties
 	template <typename ContainerType>
 	void registerParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, bool allows_creation = false, int birth_time_idx = -1,
-				  bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
+				  bool allows_destruction = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate descriptor based on the particle type
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+			    mass_idx, lum_idx, birth_time_idx, container, allows_creation, allows_destruction);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -730,17 +733,17 @@ template <typename problem_t> class PhysicsParticleRegister
 	// Star particles have additional stellar evolution capabilities including supernova feedback
 	template <typename ContainerType>
 	void registerStarParticleType(ContainerType *container, ParticleType type, int mass_idx, int lum_idx, int birth_time_idx, bool allows_creation = false,
-				      bool allows_destruction = false, int evolution_stage_idx = -1, bool hydro_interact = false)
+				      bool allows_destruction = false, int evolution_stage_idx = -1, bool allows_accretion = false)
 	{
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate star particle descriptor based on the particle type
 		if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, allows_accretion);
 		} else if (type == ParticleType::StochasticStellarPop) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
-			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, hydro_interact);
+			    mass_idx, lum_idx, birth_time_idx, allows_creation, container, allows_destruction, evolution_stage_idx, allows_accretion);
 		} else {
 			amrex::Abort("Unknown particle type for star particles");
 		}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -707,17 +707,18 @@ template <typename problem_t> class PhysicsParticleRegister
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate descriptor based on the particle type
+		// The parameters for the descriptor are: mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction
 		if (type == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
-			    container, -1, RadParticleLumIdx, false, RadParticleBirthTimeIdx, false);
+			    container, -1, RadParticleLumIdx, -1, false, false);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CIC>>(
-			    container, CICParticleMassIdx, -1, false, -1, false);
+			    container, CICParticleMassIdx, -1, -1, false, false);
 		} else if (type == ParticleType::CICRad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::CICRad>>(
-			    container, CICRadParticleMassIdx, CICRadParticleLumIdx, false, CICRadParticleBirthTimeIdx, false);
+			    container, CICRadParticleMassIdx, CICRadParticleLumIdx, CICRadParticleBirthTimeIdx, false, false);
 		}
 #endif // AMREX_SPACEDIM == 3
 		else {
@@ -736,11 +737,10 @@ template <typename problem_t> class PhysicsParticleRegister
 		std::unique_ptr<PhysicsParticleDescriptorBase> descriptor;
 
 		// Create the appropriate star particle descriptor based on the particle type
+		// The parameters for the descriptor are: mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion
 		if (type == ParticleType::StochasticStellarPop) {
-			const bool StochasticStellarPopAllowsDestruction = false;
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::StochasticStellarPop>>(
-			    container, StochasticStellarPopParticleMassIdx, StochasticStellarPopParticleLumIdx, StochasticStellarPopParticleBirthTimeIdx, true,
-			    StochasticStellarPopAllowsDestruction, StochasticStellarPopParticleStageIdx, true);
+			    container, StochasticStellarPopParticleMassIdx, StochasticStellarPopParticleLumIdx, StochasticStellarPopParticleBirthTimeIdx, true, false, StochasticStellarPopParticleStageIdx, true);
 		} else if (type == ParticleType::Test) {
 			descriptor = std::make_unique<StarParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    container, TestParticleMassIdx, TestParticleLumIdx, TestParticleBirthTimeIdx, true, true, TestParticleStageIdx, true);

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -709,8 +709,8 @@ template <typename problem_t> class PhysicsParticleRegister
 		// Create the appropriate descriptor based on the particle type
 		// The parameters for the descriptor are: mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction
 		if (type == ParticleType::Rad) {
-			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(container, -1, RadParticleLumIdx,
-															      RadParticleBirthTimeIdx, false, false);
+			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
+			    container, -1, RadParticleLumIdx, RadParticleBirthTimeIdx, false, false);
 		}
 #if AMREX_SPACEDIM == 3
 		else if (type == ParticleType::CIC) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2190,7 +2190,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - Rad particles do not allow creation
 		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false,
-						       quokka::RadParticleBirthTimeIdx);
+						       quokka::RadParticleBirthTimeIdx, false);
 
 		// Initialize particles through user-defined function
 		createInitialRadParticles();
@@ -2205,7 +2205,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICParticles->SetVerbose(0);
 
 		// Register with particle register - CIC particles allow creation
-		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1);
+		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1, false, -1, false);
 
 		// Initialize particles through user-defined function
 		createInitialCICParticles();
@@ -2220,7 +2220,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 		// Register with particle register - CICRad particles do not allow creation
 		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
-						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx);
+						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx, false);
 
 		// Initialize particles through user-defined function
 		createInitialCICRadParticles();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2189,8 +2189,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		RadParticles->SetVerbose(0);
 
 		// Register with particle register - Rad particles do not allow creation
-		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false,
-						       quokka::RadParticleBirthTimeIdx, false);
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad);
 
 		// Initialize particles through user-defined function
 		createInitialRadParticles();
@@ -2205,7 +2204,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICParticles->SetVerbose(0);
 
 		// Register with particle register - CIC particles allow creation
-		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1, false, -1, false);
+		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC);
 
 		// Initialize particles through user-defined function
 		createInitialCICParticles();
@@ -2219,8 +2218,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICRadParticles->SetVerbose(0);
 
 		// Register with particle register - CICRad particles do not allow creation
-		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
-						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx, false);
+		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad);
 
 		// Initialize particles through user-defined function
 		createInitialCICRadParticles();
@@ -2234,11 +2232,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		StochasticStellarPopParticles->SetVerbose(0);
 
 		// Register with particle register - StochasticStellarPop particles allow creation
-		const bool StochasticStellarPop_allows_destruction = false;
-		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop,
-							   quokka::StochasticStellarPopParticleMassIdx, quokka::StochasticStellarPopParticleLumIdx,
-							   quokka::StochasticStellarPopParticleBirthTimeIdx, true, StochasticStellarPop_allows_destruction,
-							   quokka::StochasticStellarPopParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop);
 
 		// Initialize particles through user-defined function
 		createInitialStochasticStellarPopParticles();
@@ -2252,10 +2246,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		TestParticles->SetVerbose(0);
 
 		// Register with particle register - Test particles have all features enabled
-		// mass_idx = 0, birth_time_idx = 4, stage_idx = 5, all bool attributes = true
-		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx,
-							   quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true, true,
-							   quokka::TestParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test);
 
 		// Initialize particles through user-defined function
 		createInitialTestParticles();
@@ -2995,8 +2986,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
 		AMREX_ASSERT(RadParticles == nullptr);
 		RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad, -1, quokka::RadParticleLumIdx, false,
-						       quokka::RadParticleBirthTimeIdx);
+		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad);
 		RadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Rad));
 	}
 
@@ -3004,35 +2994,28 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CIC) {
 		AMREX_ASSERT(CICParticles == nullptr);
 		CICParticles = std::make_unique<quokka::CICParticleContainer>(this);
-		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC, quokka::CICParticleMassIdx, -1);
+		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC);
 		CICParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CIC));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CICRad) {
 		AMREX_ASSERT(CICRadParticles == nullptr);
 		CICRadParticles = std::make_unique<quokka::CICRadParticleContainer<problem_t>>(this);
-		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad, quokka::CICRadParticleMassIdx,
-						       quokka::CICRadParticleLumIdx, false, quokka::CICRadParticleBirthTimeIdx);
+		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad);
 		CICRadParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::CICRad));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
 		AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
-		const bool StochasticStellarPop_allows_destruction = false;
 		StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
-		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop,
-							   quokka::StochasticStellarPopParticleMassIdx, quokka::StochasticStellarPopParticleLumIdx,
-							   quokka::StochasticStellarPopParticleBirthTimeIdx, true, StochasticStellarPop_allows_destruction,
-							   quokka::StochasticStellarPopParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop);
 		StochasticStellarPopParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::StochasticStellarPop));
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
 		AMREX_ASSERT(TestParticles == nullptr);
 		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
-		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test, quokka::TestParticleMassIdx,
-							   quokka::TestParticleLumIdx, quokka::TestParticleBirthTimeIdx, true, true,
-							   quokka::TestParticleStageIdx, true);
+		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test);
 		TestParticles->Restart(restart_chkfile, particleRegister_.getParticleTypeName(quokka::ParticleType::Test));
 	}
 #endif // AMREX_SPACEDIM == 3


### PR DESCRIPTION
### Description

Since the parameter specialization for a given particle type is not meant to be customizable (e.g. Rad_particles always have massIndex_ = -1 and allowsCreation_ = false), we don't have to pass those parameters from simulation.hpp. Instead, we can hard-code those parameters inside `registerParticleType` and `registerStarParticleType`. This cleans up `registerParticleType` in simulation.hpp. 

I also cleaned up and reordered the particle paramters. Now, the base particle type (registered in `PhysicsParticleDescriptor`) has the following parameters:
```
mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction
```
and the derived `StarParticleDescriptor` has the following parameters:
```
mass_idx, lum_idx, birth_time_idx, allows_creation, allows_destruction, evolution_stage_idx, allows_accretion 
```

All particles that belong to `PhysicsParticleDescriptor` have only 5 relavent parameters listed above, and all particles that belong to `StarParticleDescriptor` have those 5 mandatory parameters plus 2 extra parameters. In the future, we can define other derived classes (e.g. `DustParticleDescriptor`) with 5 + n parameters.

Note that all parameters have to present in the base class `ParticleDescriptorBase` because all particles actions are casted to `ParticleDescriptorBase` and the compiler will not be able to resolve the correct overload if the parameters are not in the base class.

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
