### PR TITLE
Update Dockerfile to use ROCm 6.4

### DIFF
--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -1,12 +1,12 @@
 # Use the AMD ROCm image as the base image
-FROM rocm/dev-ubuntu-24.04@sha256:708bbb9e2031a81e949a0847f0655c4fb1a790f8ac7cd0031116f56b04ada7d5
+FROM rocm/dev-ubuntu-24.04@sha256:4fbcf879d22aaca65b756c7c6c3586ee75090ae55953c4e44e7e88960fbb1e1c
 
 # Set environment variables for CMake
-ENV hip_DIR=/opt/rocm/lib/cmake/hip
-ENV rocrand_DIR=/opt/rocm-6.3.4/lib/cmake/rocrand
-ENV hiprand_DIR=/opt/rocm-6.3.4/lib/cmake/hiprand
-ENV rocprim_DIR=/opt/rocm-6.3.4/lib/cmake/rocprim
-ENV rocsparse_DIR=/opt/rocm-6.3.4/lib/cmake/rocsparse
+ENV hip_DIR=/opt/rocm-6.4.0/lib/cmake/hip
+ENV rocrand_DIR=/opt/rocm-6.4.0/lib/cmake/rocrand
+ENV hiprand_DIR=/opt/rocm-6.4.0/lib/cmake/hiprand
+ENV rocprim_DIR=/opt/rocm-6.4.0/lib/cmake/rocprim
+ENV rocsparse_DIR=/opt/rocm-6.4.0/lib/cmake/rocsparse
 ENV AMREX_AMD_ARCH=gfx908
 ENV CC=hipcc
 ENV CXX=hipcc


### PR DESCRIPTION
### Description
This updates the Dockerfile to use this [ROCm 6.4 base image](https://hub.docker.com/layers/rocm/dev-ubuntu-24.04/6.4/images/sha256-4fbcf879d22aaca65b756c7c6c3586ee75090ae55953c4e44e7e88960fbb1e1c).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
