### PR TITLE
Fix restarts when using `plottime_interval`

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -975,6 +975,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	if (plotTimeInterval_ > 0) {
 		while (next_plot_file_time < cur_time) {
 			// advance next_plot_file_time until it is >= cur_time
+			// this is needed for restarts
 			next_plot_file_time += plotTimeInterval_;
 		}
 	}
@@ -982,6 +983,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	if (checkpointTimeInterval_ > 0) {
 		while (next_chk_file_time < cur_time) {
 			// advance next_chk_file_time until it is >= cur_time
+			// this is needed for restarts
 			next_chk_file_time += checkpointTimeInterval_;
 		}
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -969,9 +969,23 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	int last_projection_step = 0;
 	int last_statistics_step = 0;
 	int last_plot_file_step = 0;
-	double next_plot_file_time = plotTimeInterval_;
-	double next_chk_file_time = checkpointTimeInterval_;
 	int last_chk_file_step = 0;
+
+	double next_plot_file_time = 0;
+	if (plotTimeInterval_ > 0) {
+		while (next_plot_file_time < cur_time) {
+			// advance next_plot_file_time until it is >= cur_time
+			next_plot_file_time += plotTimeInterval_;
+		}
+	}
+	double next_chk_file_time = 0;
+	if (checkpointTimeInterval_ > 0) {
+		while (next_chk_file_time < cur_time) {
+			// advance next_chk_file_time until it is >= cur_time
+			next_chk_file_time += checkpointTimeInterval_;
+		}
+	}
+
 	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();


### PR DESCRIPTION
### Description
Sets the correct output cadence when restarting from a run that sets `plottime_interval`.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1041.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
