### PR TITLE
Include interpolate.cpp and fextract.cpp in src/CMakeLists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,8 @@ set (QuokkaSourcesNoEOS "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
                         "${CMAKE_CURRENT_SOURCE_DIR}/cooling/GrackleDataReader.cpp"
                         "${CMAKE_CURRENT_SOURCE_DIR}/cooling/TabulatedCooling.cpp" 
                         "${CMAKE_CURRENT_SOURCE_DIR}/cooling/CloudyDataReader.cpp" 
+                        "${CMAKE_CURRENT_SOURCE_DIR}/math/interpolate.cpp"
+                        "${CMAKE_CURRENT_SOURCE_DIR}/util/fextract.cpp"
                         "${openPMDSources}")
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")

--- a/src/problems/Advection/CMakeLists.txt
+++ b/src/problems/Advection/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection test_advection.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_advection test_advection.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection)

--- a/src/problems/AdvectionSemiellipse/CMakeLists.txt
+++ b/src/problems/AdvectionSemiellipse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_advection_se test_advection_semiellipse.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_advection_se test_advection_semiellipse.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_advection_se)

--- a/src/problems/FCQuantities/CMakeLists.txt
+++ b/src/problems/FCQuantities/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_fc_quantities test_fc_quantities.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_fc_quantities test_fc_quantities.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_fc_quantities)

--- a/src/problems/GravRadParticle3D/CMakeLists.txt
+++ b/src/problems/GravRadParticle3D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-	add_executable(test_grav_rad_particle_3D test_grav_rad_particle_3D.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+	add_executable(test_grav_rad_particle_3D test_grav_rad_particle_3D.cpp ${QuokkaObjSources})
 
 	if(AMReX_GPU_BACKEND MATCHES "CUDA")
 			setup_target_for_cuda_compilation(test_grav_rad_particle_3D)

--- a/src/problems/HydroContact/CMakeLists.txt
+++ b/src/problems/HydroContact/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_contact test_hydro_contact.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_hydro_contact test_hydro_contact.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_contact)

--- a/src/problems/HydroHighMach/CMakeLists.txt
+++ b/src/problems/HydroHighMach/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_highmach test_hydro_highmach.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_highmach test_hydro_highmach.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_highmach)

--- a/src/problems/HydroLeblanc/CMakeLists.txt
+++ b/src/problems/HydroLeblanc/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_leblanc test_hydro_leblanc.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_leblanc test_hydro_leblanc.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_leblanc)

--- a/src/problems/HydroSMS/CMakeLists.txt
+++ b/src/problems/HydroSMS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_sms test_hydro_sms.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_hydro_sms test_hydro_sms.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_sms)

--- a/src/problems/HydroShocktube/CMakeLists.txt
+++ b/src/problems/HydroShocktube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shocktube test_hydro_shocktube.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_shocktube test_hydro_shocktube.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shocktube)

--- a/src/problems/HydroShocktubeCMA/CMakeLists.txt
+++ b/src/problems/HydroShocktubeCMA/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shocktube_cma test_hydro_shocktube_cma.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_shocktube_cma test_hydro_shocktube_cma.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shocktube_cma)

--- a/src/problems/HydroShuOsher/CMakeLists.txt
+++ b/src/problems/HydroShuOsher/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_shuosher test_hydro_shuosher.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_shuosher test_hydro_shuosher.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_shuosher)

--- a/src/problems/HydroVacuum/CMakeLists.txt
+++ b/src/problems/HydroVacuum/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_vacuum test_hydro_vacuum.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_hydro_vacuum test_hydro_vacuum.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_vacuum)

--- a/src/problems/HydroWave/CMakeLists.txt
+++ b/src/problems/HydroWave/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_hydro_wave test_hydro_wave.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_hydro_wave test_hydro_wave.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_hydro_wave)

--- a/src/problems/NSCBC/CMakeLists.txt
+++ b/src/problems/NSCBC/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_channel_flow channel.cpp ${QuokkaObjSources} ../../util/fextract.cpp)
+add_executable(test_channel_flow channel.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_channel_flow)

--- a/src/problems/ParticleCreation/CMakeLists.txt
+++ b/src/problems/ParticleCreation/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(particle_creation particle_creation_from_cell.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+    add_executable(particle_creation particle_creation_from_cell.cpp ${QuokkaObjSources})
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(particle_creation)
     endif()

--- a/src/problems/ParticleSink/CMakeLists.txt
+++ b/src/problems/ParticleSink/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_particle_sink test_particle_sink.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+    add_executable(test_particle_sink test_particle_sink.cpp ${QuokkaObjSources})
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_particle_sink)
     endif()

--- a/src/problems/PassiveScalar/CMakeLists.txt
+++ b/src/problems/PassiveScalar/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_scalars test_scalars.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_scalars test_scalars.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_scalars)

--- a/src/problems/RadDust/CMakeLists.txt
+++ b/src/problems/RadDust/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_rad_dust test_rad_dust.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_rad_dust test_rad_dust.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_rad_dust)

--- a/src/problems/RadDustMG/CMakeLists.txt
+++ b/src/problems/RadDustMG/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_rad_dust_MG test_rad_dust_MG.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_rad_dust_MG test_rad_dust_MG.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_rad_dust_MG)

--- a/src/problems/RadForce/CMakeLists.txt
+++ b/src/problems/RadForce/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_force test_radiation_force.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_force test_radiation_force.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_force)

--- a/src/problems/RadLineCooling/CMakeLists.txt
+++ b/src/problems/RadLineCooling/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_rad_line_cooling test_rad_line_cooling.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_rad_line_cooling test_rad_line_cooling.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_rad_line_cooling)

--- a/src/problems/RadLineCoolingMG/CMakeLists.txt
+++ b/src/problems/RadLineCoolingMG/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_rad_line_cooling_MG test_rad_line_cooling_MG.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_rad_line_cooling_MG test_rad_line_cooling_MG.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_rad_line_cooling_MG)

--- a/src/problems/RadMarshak/CMakeLists.txt
+++ b/src/problems/RadMarshak/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak test_radiation_marshak.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak test_radiation_marshak.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak)

--- a/src/problems/RadMarshakAsymptotic/CMakeLists.txt
+++ b/src/problems/RadMarshakAsymptotic/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_asymptotic test_radiation_marshak_asymptotic.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak_asymptotic test_radiation_marshak_asymptotic.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_asymptotic)

--- a/src/problems/RadMarshakCGS/CMakeLists.txt
+++ b/src/problems/RadMarshakCGS/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_marshak_cgs test_radiation_marshak_cgs.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak_cgs test_radiation_marshak_cgs.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_cgs)

--- a/src/problems/RadMarshakDust/CMakeLists.txt
+++ b/src/problems/RadMarshakDust/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_dust test_radiation_marshak_dust.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak_dust test_radiation_marshak_dust.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_dust)

--- a/src/problems/RadMarshakDustPE/CMakeLists.txt
+++ b/src/problems/RadMarshakDustPE/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_dust_PE test_radiation_marshak_dust_and_PE.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak_dust_PE test_radiation_marshak_dust_and_PE.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_dust_PE)

--- a/src/problems/RadMarshakVaytet/CMakeLists.txt
+++ b/src/problems/RadMarshakVaytet/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_marshak_Vaytet test_radiation_marshak_Vaytet.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_marshak_Vaytet test_radiation_marshak_Vaytet.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_marshak_Vaytet)

--- a/src/problems/RadMatterCoupling/CMakeLists.txt
+++ b/src/problems/RadMatterCoupling/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_matter_coupling test_radiation_matter_coupling.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_matter_coupling test_radiation_matter_coupling.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling)

--- a/src/problems/RadMatterCouplingRSLA/CMakeLists.txt
+++ b/src/problems/RadMatterCouplingRSLA/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_matter_coupling_rsla test_radiation_matter_coupling_rsla.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_matter_coupling_rsla test_radiation_matter_coupling_rsla.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_matter_coupling_rsla)

--- a/src/problems/RadParticle/CMakeLists.txt
+++ b/src/problems/RadParticle/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 1)
-	add_executable(test_radparticle test_radparticle.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+	add_executable(test_radparticle test_radparticle.cpp ${QuokkaObjSources})
 
 	if(AMReX_GPU_BACKEND MATCHES "CUDA")
 			setup_target_for_cuda_compilation(test_radparticle)

--- a/src/problems/RadParticle2D/CMakeLists.txt
+++ b/src/problems/RadParticle2D/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 2)
-	add_executable(test_radparticle_2D test_radparticle_2D.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+	add_executable(test_radparticle_2D test_radparticle_2D.cpp ${QuokkaObjSources})
 
 	if(AMReX_GPU_BACKEND MATCHES "CUDA")
 			setup_target_for_cuda_compilation(test_radparticle_2D)

--- a/src/problems/RadPulse/CMakeLists.txt
+++ b/src/problems/RadPulse/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_pulse test_radiation_pulse.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radiation_pulse test_radiation_pulse.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_pulse)

--- a/src/problems/RadStreaming/CMakeLists.txt
+++ b/src/problems/RadStreaming/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_streaming test_radiation_streaming.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radiation_streaming test_radiation_streaming.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_streaming)

--- a/src/problems/RadStreamingY/CMakeLists.txt
+++ b/src/problems/RadStreamingY/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-	add_executable(test_radiation_streaming_y test_radiation_streaming_y.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+	add_executable(test_radiation_streaming_y test_radiation_streaming_y.cpp ${QuokkaObjSources})
 
 	if(AMReX_GPU_BACKEND MATCHES "CUDA")
 			setup_target_for_cuda_compilation(test_radiation_streaming_y)

--- a/src/problems/RadSuOlson/CMakeLists.txt
+++ b/src/problems/RadSuOlson/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_executable(test_radiation_SuOlson test_radiation_SuOlson.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_SuOlson test_radiation_SuOlson.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_SuOlson)

--- a/src/problems/RadTube/CMakeLists.txt
+++ b/src/problems/RadTube/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radiation_tube test_radiation_tube.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radiation_tube test_radiation_tube.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radiation_tube)

--- a/src/problems/RadhydroBB/CMakeLists.txt
+++ b/src/problems/RadhydroBB/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_bb test_radhydro_bb.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_bb test_radhydro_bb.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_bb)

--- a/src/problems/RadhydroPulse/CMakeLists.txt
+++ b/src/problems/RadhydroPulse/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 1)
-  add_executable(test_radhydro_pulse test_radhydro_pulse.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+  add_executable(test_radhydro_pulse test_radhydro_pulse.cpp ${QuokkaObjSources})
 
   if(AMReX_GPU_BACKEND MATCHES "CUDA")
       setup_target_for_cuda_compilation(test_radhydro_pulse)

--- a/src/problems/RadhydroPulseDyn/CMakeLists.txt
+++ b/src/problems/RadhydroPulseDyn/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 1)
-  add_executable(test_radhydro_pulse_dyn test_radhydro_pulse_dyn.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+  add_executable(test_radhydro_pulse_dyn test_radhydro_pulse_dyn.cpp ${QuokkaObjSources})
 
   if(AMReX_GPU_BACKEND MATCHES "CUDA")
       setup_target_for_cuda_compilation(test_radhydro_pulse_dyn)

--- a/src/problems/RadhydroPulseGrey/CMakeLists.txt
+++ b/src/problems/RadhydroPulseGrey/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 1)
-  add_executable(test_radhydro_pulse_grey test_radhydro_pulse_grey.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+  add_executable(test_radhydro_pulse_grey test_radhydro_pulse_grey.cpp ${QuokkaObjSources})
 
   if(AMReX_GPU_BACKEND MATCHES "CUDA")
       setup_target_for_cuda_compilation(test_radhydro_pulse_grey)

--- a/src/problems/RadhydroPulseMGconst/CMakeLists.txt
+++ b/src/problems/RadhydroPulseMGconst/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_pulse_MG_const_kappa test_radhydro_pulse_MG_const_kappa.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_pulse_MG_const_kappa test_radhydro_pulse_MG_const_kappa.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
 		setup_target_for_cuda_compilation(test_radhydro_pulse_MG_const_kappa)

--- a/src/problems/RadhydroPulseMGint/CMakeLists.txt
+++ b/src/problems/RadhydroPulseMGint/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_pulse_MG_int test_radhydro_pulse_MG_int.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_pulse_MG_int test_radhydro_pulse_MG_int.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
 		setup_target_for_cuda_compilation(test_radhydro_pulse_MG_int)

--- a/src/problems/RadhydroShell/CMakeLists.txt
+++ b/src/problems/RadhydroShell/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_radhydro3d_shell test_radhydro_shell.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+    add_executable(test_radhydro3d_shell test_radhydro_shell.cpp ${QuokkaObjSources})
 
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_radhydro3d_shell)

--- a/src/problems/RadhydroShock/CMakeLists.txt
+++ b/src/problems/RadhydroShock/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock test_radhydro_shock.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_shock test_radhydro_shock.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock)

--- a/src/problems/RadhydroShockCGS/CMakeLists.txt
+++ b/src/problems/RadhydroShockCGS/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock_cgs test_radhydro_shock_cgs.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_shock_cgs test_radhydro_shock_cgs.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock_cgs)

--- a/src/problems/RadhydroShockMultigroup/CMakeLists.txt
+++ b/src/problems/RadhydroShockMultigroup/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_shock_multigroup test_radhydro_shock_multigroup.cpp ../../util/fextract.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_shock_multigroup test_radhydro_shock_multigroup.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_shock_multigroup)

--- a/src/problems/RadhydroUniformAdvecting/CMakeLists.txt
+++ b/src/problems/RadhydroUniformAdvecting/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(test_radhydro_uniform_advecting test_radhydro_uniform_advecting.cpp ../../util/fextract.cpp ${QuokkaObjSources})
+add_executable(test_radhydro_uniform_advecting test_radhydro_uniform_advecting.cpp ${QuokkaObjSources})
 
 if(AMReX_GPU_BACKEND MATCHES "CUDA")
     setup_target_for_cuda_compilation(test_radhydro_uniform_advecting)

--- a/src/problems/SN/CMakeLists.txt
+++ b/src/problems/SN/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (AMReX_SPACEDIM EQUAL 3)
-    add_executable(test_SN test_SN.cpp ../../math/interpolate.cpp ${QuokkaObjSources})
+    add_executable(test_SN test_SN.cpp ${QuokkaObjSources})
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
         setup_target_for_cuda_compilation(test_SN)
     endif()


### PR DESCRIPTION
### Description

Include interpolate.cpp and fextract.cpp in src/CMakeLists.txt so that we can remove them from all problem CMakeLists.txt

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/1023.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
