### PR TITLE
Add a simple script to run clang-tidy on modified files

### DIFF
--- a/docs/markdown/howto_clang_tidy.md
+++ b/docs/markdown/howto_clang_tidy.md
@@ -13,7 +13,7 @@ The easiest way to use `clang-tidy` on your own computer is to install the [clan
 The clangd extension for VSCode might not always work, so you can also run `clang-tidy` from the command line (see the [documentation](https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy)). Here is a minimal example of how to use it:
 
 ```bash
-clang-tidy src/particles/* -p build
+clang-tidy src/particles/* -p ./build
 ```
 
 which will run `clang-tidy` on all the files in the `src/particles` directory.
@@ -21,19 +21,19 @@ which will run `clang-tidy` on all the files in the `src/particles` directory.
 To see the `clang-tidy` warnings that are relevant only to the code changes you've made, you can use `scripts/tidy.sh`. Example usage:
 
 ```bash
-bash ./scripts/tidy.sh build
+bash ./scripts/tidy.sh ./build
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the previous commit.
 
 ```bash
-bash ./scripts/tidy.sh build previous
+bash ./scripts/tidy.sh ./build previous
 ```
 
 This will run `clang-tidy` on all the files that have been modified in the last commit.
 
 ```bash
-bash ./scripts/tidy.sh build origin
+bash ./scripts/tidy.sh ./build origin
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the remote branch.

--- a/docs/markdown/howto_clang_tidy.md
+++ b/docs/markdown/howto_clang_tidy.md
@@ -24,7 +24,7 @@ To see the `clang-tidy` warnings that are relevant only to the code changes you'
 bash ./scripts/tidy.sh build
 ```
 
-This will run `clang-tidy` on all the files that have been modified in the current working directory.
+This will run `clang-tidy` on all the files that have been modified with respect to the previous commit.
 
 ```bash
 bash ./scripts/tidy.sh build previous

--- a/docs/markdown/howto_clang_tidy.md
+++ b/docs/markdown/howto_clang_tidy.md
@@ -10,6 +10,30 @@ The easiest way to use `clang-tidy` on your own computer is to install the [clan
 
 ## Command-line alternative
 
-You can also run `clang-tidy` from the command line (see the [documentation](https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy)).
+The clangd extension for VSCode might not always work, so you can also run `clang-tidy` from the command line (see the [documentation](https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy)). Here is a minimal example of how to use it:
 
-To see the `clang-tidy` warnings that are relevant only to the code changes you've made, you can use the *clang-tidy-diff.py* [Python script](https://clang.llvm.org/extra/doxygen/clang-tidy-diff_8py_source.html).
+```bash
+clang-tidy src/particles/* -p build
+```
+
+which will run `clang-tidy` on all the files in the `src/particles` directory.
+
+To see the `clang-tidy` warnings that are relevant only to the code changes you've made, you can use `scripts/tidy.sh`. Example usage:
+
+```bash
+bash ./scripts/tidy.sh build
+```
+
+This will run `clang-tidy` on all the files that have been modified in the current working directory.
+
+```bash
+bash ./scripts/tidy.sh build previous
+```
+
+This will run `clang-tidy` on all the files that have been modified in the last commit.
+
+```bash
+bash ./scripts/tidy.sh build origin
+```
+
+This will run `clang-tidy` on all the files that have been modified with respect to the remote branch.

--- a/docs/markdown/howto_clang_tidy.md
+++ b/docs/markdown/howto_clang_tidy.md
@@ -8,9 +8,9 @@ The easiest way to use `clang-tidy` on your own computer is to install the [clan
 
 (VSCode itself can be downloaded [here](https://code.visualstudio.com/).)
 
-## Command-line alternative
+## Command-line tools
 
-The clangd extension for VSCode might not always work, so you can also run `clang-tidy` from the command line (see the [documentation](https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy)). Here is a minimal example of how to use it:
+The clangd extension for VSCode might not check all warnings, so you can also run `clang-tidy` from the command line (see the [documentation](https://clang.llvm.org/extra/clang-tidy/#using-clang-tidy)). Here is a minimal example of how to use it:
 
 ```bash
 clang-tidy src/particles/* -p ./build
@@ -37,3 +37,11 @@ bash ./scripts/tidy.sh ./build origin
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the remote branch.
+
+```bash
+bash ./scripts/tidy.sh ./build dev
+```
+
+This will run `clang-tidy` on all the files that have been modified with respect to the local development branch.
+
+To see the `clang-tidy` warnings that are relevant only to individual lines of code you've changed, you can use the *clang-tidy-diff.py* [Python script](https://clang.llvm.org/extra/doxygen/clang-tidy-diff_8py_source.html).

--- a/docs/markdown/howto_clang_tidy.md
+++ b/docs/markdown/howto_clang_tidy.md
@@ -21,25 +21,25 @@ which will run `clang-tidy` on all the files in the `src/particles` directory.
 To see the `clang-tidy` warnings that are relevant only to the code changes you've made, you can use `scripts/tidy.sh`. Example usage:
 
 ```bash
-bash ./scripts/tidy.sh ./build
+./scripts/tidy.sh ./build
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the previous commit.
 
 ```bash
-bash ./scripts/tidy.sh ./build previous
+./scripts/tidy.sh ./build previous
 ```
 
 This will run `clang-tidy` on all the files that have been modified in the last commit.
 
 ```bash
-bash ./scripts/tidy.sh ./build origin
+./scripts/tidy.sh ./build origin
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the remote branch.
 
 ```bash
-bash ./scripts/tidy.sh ./build dev
+./scripts/tidy.sh ./build dev
 ```
 
 This will run `clang-tidy` on all the files that have been modified with respect to the local development branch.

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -7,7 +7,7 @@ show_help() {
     echo "Usage: $0 <build_directory> [target]"
     echo
     echo "Arguments:"
-    echo "  build_directory   Path to the build directory containing compile_commands.json"
+    echo "  build_directory   Path to the build directory containing compile_commands.json. clang-tidy will use this to find the compile commands for the files."
     echo "  target            Optional argument to specify which files to check (default: 'changed')"
     echo "                    - 'changed': Files modified in current working directory"
     echo "                    - 'previous': Files modified in the last commit"

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Function to display help message
 show_help() {
     echo "Usage: $0 <build_directory> [target]"

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -10,6 +10,7 @@ show_help() {
     echo "                    - 'changed': Files modified in current working directory"
     echo "                    - 'previous': Files modified in the last commit"
     echo "                    - 'origin': Files different from the remote branch"
+    echo "                    - 'dev': Files different from the development branch"
     echo
     echo "Options:"
     echo "  -h, --help        Show this help message"
@@ -54,8 +55,11 @@ elif [ "$target" = "previous" ]; then
 elif [ "$target" = "origin" ]; then
     # Get files that differ from the remote branch
     files=$(git diff --name-only "origin/$CURRENT_BRANCH")
+elif [ "$target" = "dev" ]; then
+    # Get files that differ from the development branch
+    files=$(git diff --name-only development)
 else
-    echo "Invalid target argument. Use 'changed', 'previous' or 'origin'"
+    echo "Invalid target argument. Use 'changed', 'previous', 'origin' or 'dev'"
     exit 1
 fi
 

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -65,22 +65,15 @@ fi
 
 # Display the list of files that will be processed
 echo "Will process the following files with clang-tidy:"
+files_select=""
 for file in $files; do
     # Only process C++ source and header files
     if [[ "$file" == *.cpp || "$file" == *.hpp ]]; then
         echo "$file"
+        files_select="$files_select $file"
     fi
 done
 
 echo
 
-# Process each file with clang-tidy
-for file in $files; do
-    # Only process C++ source and header files
-    if [[ "$file" == *.cpp || "$file" == *.hpp ]]; then
-        echo "Processing $file..."
-        # Run clang-tidy on the file using the specified build directory
-        # -p flag points to the build directory containing compile_commands.json
-        clang-tidy "$file" -p "$BUILD_DIR"
-    fi
-done
+clang-tidy $files_select -p "$BUILD_DIR"

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# Function to display help message
+show_help() {
+    echo "Usage: $0 <build_directory> [target]"
+    echo
+    echo "Arguments:"
+    echo "  build_directory   Path to the build directory containing compile_commands.json"
+    echo "  target            Optional argument to specify which files to check (default: 'changed')"
+    echo "                    - 'changed': Files modified in current working directory"
+    echo "                    - 'previous': Files modified in the last commit"
+    echo "                    - 'origin': Files different from the remote branch"
+    echo
+    echo "Options:"
+    echo "  -h, --help        Show this help message"
+    exit 0
+}
+
+# Check for help flag
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    show_help
+fi
+
+# Check if at least one argument is provided
+if [ $# -lt 1 ]; then
+    echo "Error: Missing required argument 'build_directory'"
+    echo "Use -h or --help for usage information"
+    exit 1
+fi
+
+# check if the first argument is a valid directory
+if [ ! -d "$1" ]; then
+    echo "Invalid build directory. Please provide a valid directory path."
+    exit 1
+fi
+
+# Store the build directory path from first argument
+BUILD_DIR="$1"
+# Set target type with default value "changed" if not specified
+target="${2:-changed}"
+
+# Get the name of the current git branch
+CURRENT_BRANCH=$(git branch --show-current)
+
+# Initialize files variable
+files=""
+# Determine which files to process based on the target argument
+if [ "$target" = "changed" ]; then
+    # Get files modified in working directory
+    files=$(git diff --name-only HEAD)
+elif [ "$target" = "previous" ]; then
+    # Get files modified in the last commit
+    files=$(git diff --name-only HEAD^)
+elif [ "$target" = "origin" ]; then
+    # Get files that differ from the remote branch
+    files=$(git diff --name-only "origin/$CURRENT_BRANCH")
+else
+    echo "Invalid target argument. Use 'changed', 'previous' or 'origin'"
+    exit 1
+fi
+
+# Display the list of files that will be processed
+echo "Will process the following files with clang-tidy:"
+for file in $files; do
+    # Only process C++ source and header files
+    if [[ "$file" == *.cpp || "$file" == *.hpp ]]; then
+        echo "$file"
+    fi
+done
+
+echo
+
+# Process each file with clang-tidy
+for file in $files; do
+    # Only process C++ source and header files
+    if [[ "$file" == *.cpp || "$file" == *.hpp ]]; then
+        echo "Processing $file..."
+        # Run clang-tidy on the file using the specified build directory
+        # -p flag points to the build directory containing compile_commands.json
+        clang-tidy "$file" -p "$BUILD_DIR"
+    fi
+done

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -65,15 +65,18 @@ fi
 
 # Display the list of files that will be processed
 echo "Will process the following files with clang-tidy:"
-files_select=""
+files_select=()
 for file in $files; do
     # Only process C++ source and header files
     if [[ "$file" == *.cpp || "$file" == *.hpp ]]; then
         echo "$file"
-        files_select="$files_select $file"
+        files_select+=("$file")
     fi
 done
 
 echo
 
-clang-tidy $files_select -p "$BUILD_DIR"
+# Only run clang-tidy if there are files to process
+if [ ${#files_select[@]} -gt 0 ]; then
+    clang-tidy "${files_select[@]}" -p "$BUILD_DIR"
+fi


### PR DESCRIPTION
### Description

This will run `clang-tidy` on all the files that have been modified:
```bash
./scripts/tidy.sh ./build
```
where `./build` is the directory to the build folder.

This will run `clang-tidy` on all the files that have been modified in the last commit:
```bash
./scripts/tidy.sh ./build previous
```

This will run `clang-tidy` on all the files that have been modified with respect to the remote branch:
```bash
./scripts/tidy.sh ./build origin
```

This will run `clang-tidy` on all the files that have been modified with respect to the local development branch:
```bash
./scripts/tidy.sh ./build dev
```

Also update the documentation on how to use tidy. The python script Ben originally recommended is too complicated and I couldn't make it work the way I wanted. The new bash script is a lot simpler and easy to use. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
