### PR TITLE
allow supercycling of Poisson solves

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -180,6 +180,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
 	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
 	int doPoissonSolve_ = 0;				     // 1 == self-gravity enabled, 0 == disabled
+	int poissonSupercycleInterval_ = 1;			     // number of coarse steps between Poisson solves (default: 1)
 	amrex::Vector<amrex::MultiFab> phi;
 
 	amrex::Real densityFloor_ = 0.0; // default
@@ -703,6 +704,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// Default do_subcycle = 1
 	pp.query("do_subcycle", do_subcycle);
+
+	// Default poisson_supercycle_interval = 1
+	pp.query("poisson_supercycle_interval", poissonSupercycleInterval_);
 
 	// Default do_tracers = 0 (turns on/off tracer particles)
 	pp.query("do_tracers", do_tracers);
@@ -1286,9 +1290,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLev
 {
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
-
-		calculateGpotAllLevels();
-
+		if (istep[0] % poissonSupercycleInterval_ == 0) {
+			// do Poisson solve every poissonSupercycleInterval_ coarse steps
+			calculateGpotAllLevels();
+		}
+		// this must be done every step
 		gravAccelAllLevels(dt);
 	}
 #endif

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1290,6 +1290,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLev
 {
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
+		if (poissonSupercycleInterval_ > 1) {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(regrid_int <= 0, "Poisson supercycling is only allowed for static meshes!");
+		}
 		if (istep[0] % poissonSupercycleInterval_ == 0) {
 			// do Poisson solve every poissonSupercycleInterval_ coarse steps
 			calculateGpotAllLevels();


### PR DESCRIPTION
### Description
This adds a user-defined parameter for supercycling Poisson solves, redoing the Poisson solve only every $N$ coarse steps. (Whether this is appropriate is problem-dependent.) Because AMR interpolation would be required otherwise, we only allow this for static meshes for now.

The gravitational acceleration is still always applied to the hydro and to the particles every step.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/1040.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
