### PR TITLE
Change output behaviour 

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -977,6 +977,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 	double next_plot_file_time = 0;
 	if (plotTimeInterval_ > 0) {
+		// We have one plotfile at the start of the simulation, so we set next_plot_file_time to plotTimeInterval_
+		next_plot_file_time = plotTimeInterval_;
 		while (next_plot_file_time < cur_time) {
 			// advance next_plot_file_time until it is >= cur_time
 			// this is needed for restarts

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -790,7 +790,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 	}
 #endif
 
-	if (plotfileInterval_ > 0) {
+	if (plotfileInterval_ > 0 || plotTimeInterval_ > 0) {
 		WritePlotFile();
 	}
 
@@ -1111,7 +1111,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		doDiagnostics();
 
 		// Writing Plot files at time intervals
-		if (plotTimeInterval_ > 0 && next_plot_file_time <= cur_time) {
+		if (last_plot_file_step != step + 1 && plotTimeInterval_ > 0 && next_plot_file_time <= cur_time) {
 			next_plot_file_time += plotTimeInterval_;
 			WritePlotFile();
 		}
@@ -1180,7 +1180,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	amrex::Print() << '\n';
 
 	// write final plotfile
-	if (plotfileInterval_ > 0 && istep[0] > last_plot_file_step) {
+	if ((plotfileInterval_ > 0 || plotTimeInterval_ > 0) && istep[0] > last_plot_file_step) {
 		WritePlotFile();
 	}
 

--- a/tests/ParticleCreation.in
+++ b/tests/ParticleCreation.in
@@ -31,4 +31,5 @@ particles.disable_SN_feedback = true
 stop_time = 1.0
 max_timesteps = 4
 plotfile_interval = -1
+plottime_interval = 0.003
 checkpoint_interval = -1


### PR DESCRIPTION
### Description

As an example, let's run the ParticleCreation test, which has these time stamps: 0, 0.001, 0.002, 0.003, 0.004.  

If we set `plotfile_interval = 3` and `plottime_interval = 0.003` 
   1. Previously: `plt00003` will be written twice, because both `plotfile_interval` and `plottime_interval` checks will result in writing a plotfile. 
   2. Now: `plt00003` will be written once. 

If we set `plottime_interval = 0.003` 
   1. Previously: Will write the following outputs: 1, 3
   2. Now: Will write the following outputs: 0, 3, 4, i.e. will write the first (0) and last steps along with steps whose time is a multiple of `plottime_interval`. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
