### PR TITLE
Add `using Real = amrex::Real;`

### DIFF
--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -1,9 +1,12 @@
 #ifndef PHYSICS_INFO_HPP_ // NOLINT
 #define PHYSICS_INFO_HPP_
 
+#include "AMReX_REAL.H"
 #include "fundamental_constants.H"
 #include "physics_numVars.hpp"
 #include <AMReX.H>
+
+using Real = amrex::Real;
 
 // enum for unit system, one of CGS, CONSTANTS, CUSTOM
 enum class UnitSystem { CGS, CONSTANTS, CUSTOM };


### PR DESCRIPTION
### Description

Add `using Real = amrex::Real;` in physics_info.hpp. Since physics_info.hpp is included in almost all source files in Quokka, this allows you to use Real to replace `double` or `amrex::Real` everywhere.  

We will gradually make this switch from double to Real and support single precision, but this change brings immediate convenience that we can replace the long `amrex::Real` with the short `Real`. 

### Related issues
#666 and #1003 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
