### PR TITLE
Fix all clang-tidy warnings in simulation.hpp

### DIFF
--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -16,31 +16,53 @@ show_help() {
     echo
     echo "Options:"
     echo "  -h, --help        Show this help message"
+    echo "  --fix            Apply clang-tidy fix-it hints"
     exit 0
 }
 
-# Check for help flag
-if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
-    show_help
-fi
+# Initialize variables
+fix_flag=""
 
-# Check if at least one argument is provided
-if [ $# -lt 1 ]; then
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help)
+            show_help
+            ;;
+        --fix)
+            fix_flag="-fix"
+            shift
+            ;;
+        *)
+            if [ -z "$BUILD_DIR" ]; then
+                BUILD_DIR="$1"
+            elif [ -z "$target" ]; then
+                target="$1"
+            else
+                echo "Error: Unexpected argument '$1'"
+                echo "Use -h or --help for usage information"
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Check if build directory is provided
+if [ -z "$BUILD_DIR" ]; then
     echo "Error: Missing required argument 'build_directory'"
     echo "Use -h or --help for usage information"
     exit 1
 fi
 
+# Set target type with default value "changed" if not specified
+target="${target:-changed}"
+
 # check if the first argument is a valid directory
-if [ ! -d "$1" ]; then
+if [ ! -d "$BUILD_DIR" ]; then
     echo "Invalid build directory. Please provide a valid directory path."
     exit 1
 fi
-
-# Store the build directory path from first argument
-BUILD_DIR="$1"
-# Set target type with default value "changed" if not specified
-target="${2:-changed}"
 
 # Get the name of the current git branch
 CURRENT_BRANCH=$(git branch --show-current)
@@ -80,5 +102,5 @@ echo
 
 # Only run clang-tidy if there are files to process
 if [ ${#files_select[@]} -gt 0 ]; then
-    clang-tidy "${files_select[@]}" -p "$BUILD_DIR"
+    clang-tidy "${files_select[@]}" -p "$BUILD_DIR" $fix_flag
 fi

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1974,6 +1974,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 		for (auto &i : coarseData) {
 			AMREX_ASSERT(!i->contains_nan(0, state.nComp()));
 			AMREX_ASSERT(!i->contains_nan()); // check ghost zones
+			amrex::ignore_unused(i);
 		}
 
 		FillPatchWithData(lev, time, S_filled, coarseData, coarseTime, fineData, fineTime, 0, S_filled.nComp(), BCs, cen, fptype, pre_interp,

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1971,9 +1971,9 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 		GetData(lev - 1, time, coarseData, coarseTime, cen, dir);
 		AMREX_ASSERT(!state.contains_nan(0, state.nComp()));
 
-		for (int i = 0; i < coarseData.size(); ++i) {
-			AMREX_ASSERT(!coarseData[i]->contains_nan(0, state.nComp()));
-			AMREX_ASSERT(!coarseData[i]->contains_nan()); // check ghost zones
+		for (auto & i : coarseData) {
+			AMREX_ASSERT(!i->contains_nan(0, state.nComp()));
+			AMREX_ASSERT(!i->contains_nan()); // check ghost zones
 		}
 
 		FillPatchWithData(lev, time, S_filled, coarseData, coarseTime, fineData, fineTime, 0, S_filled.nComp(), BCs, cen, fptype, pre_interp,
@@ -2841,20 +2841,20 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 		HeaderFile << finest_level << "\n";
 
 		// write out array of istep
-		for (int i = 0; i < istep.size(); ++i) {
-			HeaderFile << istep[i] << " ";
+		for (int const i : istep) {
+			HeaderFile << i << " ";
 		}
 		HeaderFile << "\n";
 
 		// write out array of dt
-		for (int i = 0; i < dt_.size(); ++i) {
-			HeaderFile << dt_[i] << " ";
+		for (double const i : dt_) {
+			HeaderFile << i << " ";
 		}
 		HeaderFile << "\n";
 
 		// write out array of t_new
-		for (int i = 0; i < tNew_.size(); ++i) {
-			HeaderFile << tNew_[i] << " ";
+		for (double const i : tNew_) {
+			HeaderFile << i << " ";
 		}
 		HeaderFile << "\n";
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2624,7 +2624,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	int included_ghosts = std::min(nghost_cc_, nghost_fc_);
 #endif
 	amrex::Vector<amrex::MultiFab> mf = PlotFileMF(included_ghosts);
-	const amrex::Vector<const amrex::MultiFab *> mf_ptr = amrex::GetVecOfConstPtrs(mf);
+	amrex::Vector<const amrex::MultiFab *> mf_ptr = amrex::GetVecOfConstPtrs(mf); // NOLINT(misc-const-correctness)
 
 	const std::string &plotfilename = PlotFileName(istep[0]);
 	auto varnames = GetPlotfileVarNames();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -524,7 +524,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getNewMF_fc() const
 
 template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 {
-	BL_PROFILE("AMRSimulation::initialize()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::initialize()");
 
 	readParameters();
 
@@ -652,7 +652,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 
 template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 {
-	BL_PROFILE("AMRSimulation::readParameters()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::readParameters()");
 
 	// ParmParse reads inputs from the *.inputs file
 	const amrex::ParmParse pp;
@@ -749,7 +749,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditions()
 {
-	BL_PROFILE("AMRSimulation::setInitialConditions()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::setInitialConditions()");
 
 	if (restart_chkfile.empty()) {
 		// start simulation from the beginning
@@ -814,7 +814,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
-	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
 
 	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
@@ -879,7 +879,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 {
-	BL_PROFILE("AMRSimulation::computeTimestep()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::computeTimestep()");
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
@@ -962,7 +962,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getCycleWalltime() 
 
 template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 {
-	BL_PROFILE("AMRSimulation::evolve()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::evolve()");
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
 
@@ -1217,7 +1217,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			amrex::Abort("Poisson solve is not support when AMR subcycling is enabled! You must set do_subcycle = 0.");
 		}
 
-		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
+		BL_PROFILE_REGION("GravitySolver");
 
 		// set up elliptic solve object
 		amrex::OpenBCSolver poissonSolver(Geom(0, finest_level), boxArray(0, finest_level), DistributionMap(0, finest_level));
@@ -1278,7 +1278,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
 
-		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
+		BL_PROFILE_REGION("GravitySolver");
 
 		// add gravitational acceleration to hydro state (using operator splitting)
 		for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1449,7 +1449,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 // nsubsteps[lev] is set correctly.
 template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
 {
-	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
 
 	// perform regrid if needed
 	if (regrid_int > 0) {
@@ -1576,7 +1576,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
@@ -1597,7 +1597,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (fr_as_crse != nullptr) {
@@ -1650,7 +1650,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterF
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level - 1].nComp();
@@ -1692,7 +1692,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 template <typename problem_t>
 void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::RemakeLevel()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::RemakeLevel()");
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level].nComp();
@@ -1737,7 +1737,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 // Delete level data. Overrides the pure virtual function in AmrCore
 template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int level)
 {
-	BL_PROFILE("AMRSimulation::ClearLevel()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::ClearLevel()");
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
@@ -1811,7 +1811,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::FillPatch()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::FillPatch()");
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::MultiFab *> fmf;
@@ -1886,7 +1886,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
 
 	// define empty MultiFab containers with the right number of components and ghost-zones
 
@@ -1937,7 +1937,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
 						      PostInterpHook const &post_interp, FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::fillBoundaryConditions()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
 
 	// On a single level, any periodic boundaries are filled first
 	// 	then built-in boundary conditions are filled (with amrex::FilccCell()),
@@ -2025,7 +2025,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 						 quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
 						 PostInterpHook const &post_interp)
 {
-	BL_PROFILE("AMRSimulation::FillPatchWithData()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::FillPatchWithData()");
 
 	amrex::MFInterpolater *mapper_cc = getAmrInterpolaterCellCentered();
 
@@ -2093,8 +2093,8 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 template <typename problem_t>
 void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
-{							// here neco
-	BL_PROFILE("AMRSimulation::FillCoarsePatch()"); // NOLINT(misc-const-correctness)
+{ // here neco
+	BL_PROFILE("AMRSimulation::FillCoarsePatch()");
 
 	AMREX_ASSERT(lev > 0);
 
@@ -2127,7 +2127,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
 				       quokka::centering cen, quokka::direction dir)
 {
-	BL_PROFILE("AMRSimulation::GetData()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::GetData()");
 
 	if ((cen != quokka::centering::cc) && (cen != quokka::centering::fc)) {
 		amrex::Print() << "Centering passed to GetData(): " << static_cast<int>(cen) << "\n";
@@ -2169,7 +2169,7 @@ void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<
 // average down on all levels
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 {
-	BL_PROFILE("AMRSimulation::AverageDown()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::AverageDown()");
 
 	for (int lev = finest_level - 1; lev >= 0; --lev) {
 		AverageDownTo(lev);
@@ -2179,7 +2179,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 // set covered coarse cells to be the average of overlying fine cells
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDownTo(int crse_lev)
 {
-	BL_PROFILE("AMRSimulation::AverageDownTo()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::AverageDownTo()");
 
 	// cell-centred
 	amrex::average_down(state_new_cc_[crse_lev + 1], state_new_cc_[crse_lev], geom[crse_lev + 1], geom[crse_lev], 0, state_new_cc_[crse_lev].nComp(),
@@ -2524,7 +2524,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 #ifdef AMREX_USE_ASCENT
 template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions(conduit::Node const &blueprintMesh)
 {
-	BL_PROFILE("AMRSimulation::AscentCustomActions()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::AscentCustomActions()");
 
 	// add a scene with a pseudocolor plot
 	Node scenes;
@@ -2554,7 +2554,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions
 // do Ascent render
 template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 {
-	BL_PROFILE("AMRSimulation::RenderAscent()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::RenderAscent()");
 
 	// combine multifabs
 	const int included_ghosts = std::min(nghost_cc_, nghost_fc_);
@@ -2610,7 +2610,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::GetPlotfileVarNames
 // write plotfile to disk
 template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 {
-	BL_PROFILE("AMRSimulation::WritePlotFile()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::WritePlotFile()");
 
 	if (amrex::AsyncOut::UseAsyncOut()) {
 		// ensure that we flush any plotfiles that are currently being written
@@ -2795,7 +2795,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::SetLastCheckpointSy
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile() const
 {
-	BL_PROFILE("AMRSimulation::WriteCheckpointFile()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::WriteCheckpointFile()");
 
 	// chk00010            write a checkpoint file with this root directory
 	// chk00010/Header     this contains information you need to save (e.g.,
@@ -2907,7 +2907,7 @@ inline void GotoNextLine(std::istream &is)
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile()
 {
-	BL_PROFILE("AMRSimulation::ReadCheckpointFile()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::ReadCheckpointFile()");
 
 	amrex::Print() << "Restart from checkpoint " << restart_chkfile << "\n";
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -524,7 +524,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getNewMF_fc() const
 
 template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 {
-	const BL_PROFILE("AMRSimulation::initialize()");
+	BL_PROFILE("AMRSimulation::initialize()"); // NOLINT(misc-const-correctness)
 
 	readParameters();
 
@@ -652,7 +652,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 
 template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 {
-	const BL_PROFILE("AMRSimulation::readParameters()");
+	BL_PROFILE("AMRSimulation::readParameters()"); // NOLINT(misc-const-correctness)
 
 	// ParmParse reads inputs from the *.inputs file
 	const amrex::ParmParse pp;
@@ -749,7 +749,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditions()
 {
-	const BL_PROFILE("AMRSimulation::setInitialConditions()");
+	BL_PROFILE("AMRSimulation::setInitialConditions()"); // NOLINT(misc-const-correctness)
 
 	if (restart_chkfile.empty()) {
 		// start simulation from the beginning
@@ -814,7 +814,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
-	const BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
+	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()"); // NOLINT(misc-const-correctness)
 
 	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
@@ -879,7 +879,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 {
-	const BL_PROFILE("AMRSimulation::computeTimestep()");
+	BL_PROFILE("AMRSimulation::computeTimestep()"); // NOLINT(misc-const-correctness)
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
@@ -962,7 +962,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getCycleWalltime() 
 
 template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 {
-	const BL_PROFILE("AMRSimulation::evolve()");
+	BL_PROFILE("AMRSimulation::evolve()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
 
@@ -1217,7 +1217,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			amrex::Abort("Poisson solve is not support when AMR subcycling is enabled! You must set do_subcycle = 0.");
 		}
 
-		const BL_PROFILE_REGION("GravitySolver");
+		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
 
 		// set up elliptic solve object
 		amrex::OpenBCSolver poissonSolver(Geom(0, finest_level), boxArray(0, finest_level), DistributionMap(0, finest_level));
@@ -1278,7 +1278,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
 
-		const BL_PROFILE_REGION("GravitySolver");
+		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
 
 		// add gravitational acceleration to hydro state (using operator splitting)
 		for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1449,7 +1449,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 // nsubsteps[lev] is set correctly.
 template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
 {
-	const BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
+	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()"); // NOLINT(misc-const-correctness)
 
 	// perform regrid if needed
 	if (regrid_int > 0) {
@@ -1576,7 +1576,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	const BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
@@ -1597,7 +1597,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	const BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (fr_as_crse != nullptr) {
@@ -1650,7 +1650,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterF
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	const BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level - 1].nComp();
@@ -1692,7 +1692,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 template <typename problem_t>
 void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	const BL_PROFILE("AMRSimulation::RemakeLevel()");
+	BL_PROFILE("AMRSimulation::RemakeLevel()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level].nComp();
@@ -1737,7 +1737,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 // Delete level data. Overrides the pure virtual function in AmrCore
 template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int level)
 {
-	const BL_PROFILE("AMRSimulation::ClearLevel()");
+	BL_PROFILE("AMRSimulation::ClearLevel()"); // NOLINT(misc-const-correctness)
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
@@ -1811,7 +1811,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)
 {
-	const BL_PROFILE("AMRSimulation::FillPatch()");
+	BL_PROFILE("AMRSimulation::FillPatch()"); // NOLINT(misc-const-correctness)
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::MultiFab *> fmf;
@@ -1886,7 +1886,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	const BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()"); // NOLINT(misc-const-correctness)
 
 	// define empty MultiFab containers with the right number of components and ghost-zones
 
@@ -1937,7 +1937,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
 						      PostInterpHook const &post_interp, FillPatchType fptype)
 {
-	const BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
+	BL_PROFILE("AMRSimulation::fillBoundaryConditions()"); // NOLINT(misc-const-correctness)
 
 	// On a single level, any periodic boundaries are filled first
 	// 	then built-in boundary conditions are filled (with amrex::FilccCell()),
@@ -2025,7 +2025,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 						 quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
 						 PostInterpHook const &post_interp)
 {
-	const BL_PROFILE("AMRSimulation::FillPatchWithData()");
+	BL_PROFILE("AMRSimulation::FillPatchWithData()"); // NOLINT(misc-const-correctness)
 
 	amrex::MFInterpolater *mapper_cc = getAmrInterpolaterCellCentered();
 
@@ -2093,8 +2093,8 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 template <typename problem_t>
 void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
-{ // here neco
-	const BL_PROFILE("AMRSimulation::FillCoarsePatch()");
+{							// here neco
+	BL_PROFILE("AMRSimulation::FillCoarsePatch()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ASSERT(lev > 0);
 
@@ -2127,7 +2127,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
 				       quokka::centering cen, quokka::direction dir)
 {
-	const BL_PROFILE("AMRSimulation::GetData()");
+	BL_PROFILE("AMRSimulation::GetData()"); // NOLINT(misc-const-correctness)
 
 	if ((cen != quokka::centering::cc) && (cen != quokka::centering::fc)) {
 		amrex::Print() << "Centering passed to GetData(): " << static_cast<int>(cen) << "\n";
@@ -2169,7 +2169,7 @@ void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<
 // average down on all levels
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 {
-	const BL_PROFILE("AMRSimulation::AverageDown()");
+	BL_PROFILE("AMRSimulation::AverageDown()"); // NOLINT(misc-const-correctness)
 
 	for (int lev = finest_level - 1; lev >= 0; --lev) {
 		AverageDownTo(lev);
@@ -2179,7 +2179,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 // set covered coarse cells to be the average of overlying fine cells
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDownTo(int crse_lev)
 {
-	const BL_PROFILE("AMRSimulation::AverageDownTo()");
+	BL_PROFILE("AMRSimulation::AverageDownTo()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	amrex::average_down(state_new_cc_[crse_lev + 1], state_new_cc_[crse_lev], geom[crse_lev + 1], geom[crse_lev], 0, state_new_cc_[crse_lev].nComp(),
@@ -2524,7 +2524,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 #ifdef AMREX_USE_ASCENT
 template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions(conduit::Node const &blueprintMesh)
 {
-	const BL_PROFILE("AMRSimulation::AscentCustomActions()");
+	BL_PROFILE("AMRSimulation::AscentCustomActions()"); // NOLINT(misc-const-correctness)
 
 	// add a scene with a pseudocolor plot
 	Node scenes;
@@ -2554,7 +2554,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions
 // do Ascent render
 template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 {
-	const BL_PROFILE("AMRSimulation::RenderAscent()");
+	BL_PROFILE("AMRSimulation::RenderAscent()"); // NOLINT(misc-const-correctness)
 
 	// combine multifabs
 	const int included_ghosts = std::min(nghost_cc_, nghost_fc_);
@@ -2610,7 +2610,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::GetPlotfileVarNames
 // write plotfile to disk
 template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 {
-	const BL_PROFILE("AMRSimulation::WritePlotFile()");
+	BL_PROFILE("AMRSimulation::WritePlotFile()"); // NOLINT(misc-const-correctness)
 
 	if (amrex::AsyncOut::UseAsyncOut()) {
 		// ensure that we flush any plotfiles that are currently being written
@@ -2795,7 +2795,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::SetLastCheckpointSy
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile() const
 {
-	const BL_PROFILE("AMRSimulation::WriteCheckpointFile()");
+	BL_PROFILE("AMRSimulation::WriteCheckpointFile()"); // NOLINT(misc-const-correctness)
 
 	// chk00010            write a checkpoint file with this root directory
 	// chk00010/Header     this contains information you need to save (e.g.,
@@ -2907,7 +2907,7 @@ inline void GotoNextLine(std::istream &is)
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile()
 {
-	const BL_PROFILE("AMRSimulation::ReadCheckpointFile()");
+	BL_PROFILE("AMRSimulation::ReadCheckpointFile()"); // NOLINT(misc-const-correctness)
 
 	amrex::Print() << "Restart from checkpoint " << restart_chkfile << "\n";
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1601,9 +1601,9 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (fr_as_crse != nullptr) {
-				AMREX_ASSERT(lev < finestLevel());
-				AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
-				fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
+			AMREX_ASSERT(lev < finestLevel());
+			AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
+			fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
 					    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
 		}
 
@@ -1971,7 +1971,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 		GetData(lev - 1, time, coarseData, coarseTime, cen, dir);
 		AMREX_ASSERT(!state.contains_nan(0, state.nComp()));
 
-		for (auto & i : coarseData) {
+		for (auto &i : coarseData) {
 			AMREX_ASSERT(!i->contains_nan(0, state.nComp()));
 			AMREX_ASSERT(!i->contains_nan()); // check ghost zones
 		}
@@ -2092,7 +2092,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 template <typename problem_t>
 void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
-{ // here neco
+{							// here neco
 	BL_PROFILE("AMRSimulation::FillCoarsePatch()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ASSERT(lev > 0);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -524,7 +524,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getNewMF_fc() const
 
 template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 {
-	BL_PROFILE("AMRSimulation::initialize()");
+	const BL_PROFILE("AMRSimulation::initialize()");
 
 	readParameters();
 
@@ -652,7 +652,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 
 template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 {
-	BL_PROFILE("AMRSimulation::readParameters()");
+	const BL_PROFILE("AMRSimulation::readParameters()");
 
 	// ParmParse reads inputs from the *.inputs file
 	const amrex::ParmParse pp;
@@ -749,7 +749,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditions()
 {
-	BL_PROFILE("AMRSimulation::setInitialConditions()");
+	const BL_PROFILE("AMRSimulation::setInitialConditions()");
 
 	if (restart_chkfile.empty()) {
 		// start simulation from the beginning
@@ -814,7 +814,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
-	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
+	const BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
 
 	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
@@ -879,7 +879,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 {
-	BL_PROFILE("AMRSimulation::computeTimestep()");
+	const BL_PROFILE("AMRSimulation::computeTimestep()");
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
@@ -962,7 +962,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getCycleWalltime() 
 
 template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 {
-	BL_PROFILE("AMRSimulation::evolve()");
+	const BL_PROFILE("AMRSimulation::evolve()");
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
 
@@ -1217,7 +1217,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			amrex::Abort("Poisson solve is not support when AMR subcycling is enabled! You must set do_subcycle = 0.");
 		}
 
-		BL_PROFILE_REGION("GravitySolver");
+		const BL_PROFILE_REGION("GravitySolver");
 
 		// set up elliptic solve object
 		amrex::OpenBCSolver poissonSolver(Geom(0, finest_level), boxArray(0, finest_level), DistributionMap(0, finest_level));
@@ -1278,7 +1278,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
 
-		BL_PROFILE_REGION("GravitySolver");
+		const BL_PROFILE_REGION("GravitySolver");
 
 		// add gravitational acceleration to hydro state (using operator splitting)
 		for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1449,7 +1449,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 // nsubsteps[lev] is set correctly.
 template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
 {
-	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
+	const BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
 
 	// perform regrid if needed
 	if (regrid_int > 0) {
@@ -1576,7 +1576,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	const BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
@@ -1597,7 +1597,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	const BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (fr_as_crse != nullptr) {
@@ -1650,7 +1650,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterF
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
+	const BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level - 1].nComp();
@@ -1692,7 +1692,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 template <typename problem_t>
 void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::RemakeLevel()");
+	const BL_PROFILE("AMRSimulation::RemakeLevel()");
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level].nComp();
@@ -1737,7 +1737,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 // Delete level data. Overrides the pure virtual function in AmrCore
 template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int level)
 {
-	BL_PROFILE("AMRSimulation::ClearLevel()");
+	const BL_PROFILE("AMRSimulation::ClearLevel()");
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
@@ -1811,7 +1811,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::FillPatch()");
+	const BL_PROFILE("AMRSimulation::FillPatch()");
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::MultiFab *> fmf;
@@ -1886,7 +1886,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
+	const BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
 
 	// define empty MultiFab containers with the right number of components and ghost-zones
 
@@ -1937,7 +1937,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
 						      PostInterpHook const &post_interp, FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
+	const BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
 
 	// On a single level, any periodic boundaries are filled first
 	// 	then built-in boundary conditions are filled (with amrex::FilccCell()),
@@ -2025,7 +2025,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 						 quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
 						 PostInterpHook const &post_interp)
 {
-	BL_PROFILE("AMRSimulation::FillPatchWithData()");
+	const BL_PROFILE("AMRSimulation::FillPatchWithData()");
 
 	amrex::MFInterpolater *mapper_cc = getAmrInterpolaterCellCentered();
 
@@ -2094,7 +2094,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
 { // here neco
-	BL_PROFILE("AMRSimulation::FillCoarsePatch()");
+	const BL_PROFILE("AMRSimulation::FillCoarsePatch()");
 
 	AMREX_ASSERT(lev > 0);
 
@@ -2127,7 +2127,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
 				       quokka::centering cen, quokka::direction dir)
 {
-	BL_PROFILE("AMRSimulation::GetData()");
+	const BL_PROFILE("AMRSimulation::GetData()");
 
 	if ((cen != quokka::centering::cc) && (cen != quokka::centering::fc)) {
 		amrex::Print() << "Centering passed to GetData(): " << static_cast<int>(cen) << "\n";
@@ -2169,7 +2169,7 @@ void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<
 // average down on all levels
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 {
-	BL_PROFILE("AMRSimulation::AverageDown()");
+	const BL_PROFILE("AMRSimulation::AverageDown()");
 
 	for (int lev = finest_level - 1; lev >= 0; --lev) {
 		AverageDownTo(lev);
@@ -2179,7 +2179,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 // set covered coarse cells to be the average of overlying fine cells
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDownTo(int crse_lev)
 {
-	BL_PROFILE("AMRSimulation::AverageDownTo()");
+	const BL_PROFILE("AMRSimulation::AverageDownTo()");
 
 	// cell-centred
 	amrex::average_down(state_new_cc_[crse_lev + 1], state_new_cc_[crse_lev], geom[crse_lev + 1], geom[crse_lev], 0, state_new_cc_[crse_lev].nComp(),
@@ -2524,7 +2524,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 #ifdef AMREX_USE_ASCENT
 template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions(conduit::Node const &blueprintMesh)
 {
-	BL_PROFILE("AMRSimulation::AscentCustomActions()");
+	const BL_PROFILE("AMRSimulation::AscentCustomActions()");
 
 	// add a scene with a pseudocolor plot
 	Node scenes;
@@ -2554,7 +2554,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions
 // do Ascent render
 template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 {
-	BL_PROFILE("AMRSimulation::RenderAscent()");
+	const BL_PROFILE("AMRSimulation::RenderAscent()");
 
 	// combine multifabs
 	const int included_ghosts = std::min(nghost_cc_, nghost_fc_);
@@ -2610,7 +2610,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::GetPlotfileVarNames
 // write plotfile to disk
 template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 {
-	BL_PROFILE("AMRSimulation::WritePlotFile()");
+	const BL_PROFILE("AMRSimulation::WritePlotFile()");
 
 	if (amrex::AsyncOut::UseAsyncOut()) {
 		// ensure that we flush any plotfiles that are currently being written
@@ -2795,7 +2795,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::SetLastCheckpointSy
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile() const
 {
-	BL_PROFILE("AMRSimulation::WriteCheckpointFile()");
+	const BL_PROFILE("AMRSimulation::WriteCheckpointFile()");
 
 	// chk00010            write a checkpoint file with this root directory
 	// chk00010/Header     this contains information you need to save (e.g.,
@@ -2907,7 +2907,7 @@ inline void GotoNextLine(std::istream &is)
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile()
 {
-	BL_PROFILE("AMRSimulation::ReadCheckpointFile()");
+	const BL_PROFILE("AMRSimulation::ReadCheckpointFile()");
 
 	amrex::Print() << "Restart from checkpoint " << restart_chkfile << "\n";
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -524,7 +524,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getNewMF_fc() const
 
 template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 {
-	BL_PROFILE("AMRSimulation::initialize()");
+	BL_PROFILE("AMRSimulation::initialize()"); // NOLINT(misc-const-correctness)
 
 	readParameters();
 
@@ -652,10 +652,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::PerformanceHints()
 
 template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 {
-	BL_PROFILE("AMRSimulation::readParameters()");
+	BL_PROFILE("AMRSimulation::readParameters()"); // NOLINT(misc-const-correctness)
 
 	// ParmParse reads inputs from the *.inputs file
-	amrex::ParmParse pp;
+	const amrex::ParmParse pp;
 
 	// Default nsteps == INT_MAX
 	pp.query("max_timesteps", maxTimesteps_);
@@ -749,7 +749,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditions()
 {
-	BL_PROFILE("AMRSimulation::setInitialConditions()");
+	BL_PROFILE("AMRSimulation::setInitialConditions()"); // NOLINT(misc-const-correctness)
 
 	if (restart_chkfile.empty()) {
 		// start simulation from the beginning
@@ -814,7 +814,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>
 {
 	// compute CFL timestep on level 'lev'
-	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()");
+	BL_PROFILE("AMRSimulation::computeTimestepAtLevel()"); // NOLINT(misc-const-correctness)
 
 	using dtloc_t = amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
@@ -879,7 +879,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 {
-	BL_PROFILE("AMRSimulation::computeTimestep()");
+	BL_PROFILE("AMRSimulation::computeTimestep()"); // NOLINT(misc-const-correctness)
 
 	// compute candidate timestep dt_tmp on each level
 	amrex::Vector<amrex::Real> dt_tmp(finest_level + 1);
@@ -962,7 +962,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getCycleWalltime() 
 
 template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 {
-	BL_PROFILE("AMRSimulation::evolve()");
+	BL_PROFILE("AMRSimulation::evolve()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
 
@@ -1217,7 +1217,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			amrex::Abort("Poisson solve is not support when AMR subcycling is enabled! You must set do_subcycle = 0.");
 		}
 
-		BL_PROFILE_REGION("GravitySolver");
+		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
 
 		// set up elliptic solve object
 		amrex::OpenBCSolver poissonSolver(Geom(0, finest_level), boxArray(0, finest_level), DistributionMap(0, finest_level));
@@ -1278,7 +1278,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 #if AMREX_SPACEDIM == 3
 	if (doPoissonSolve_ != 0) {
 
-		BL_PROFILE_REGION("GravitySolver");
+		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
 
 		// add gravitational acceleration to hydro state (using operator splitting)
 		for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1449,7 +1449,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 // nsubsteps[lev] is set correctly.
 template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycling(int lev, amrex::Real time, int iteration)
 {
-	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()");
+	BL_PROFILE("AMRSimulation::timeStepWithSubcycling()"); // NOLINT(misc-const-correctness)
 
 	// perform regrid if needed
 	if (regrid_int > 0) {
@@ -1576,7 +1576,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
@@ -1597,13 +1597,13 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()");
+	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (fr_as_crse != nullptr) {
-			AMREX_ASSERT(lev < finestLevel());
-			AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
-			fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
+				AMREX_ASSERT(lev < finestLevel());
+				AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
+				fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
 					    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
 		}
 
@@ -1650,7 +1650,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterF
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()");
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromCoarse()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level - 1].nComp();
@@ -1692,7 +1692,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 template <typename problem_t>
 void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::RemakeLevel()");
+	BL_PROFILE("AMRSimulation::RemakeLevel()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	const int ncomp_cc = state_new_cc_[level].nComp();
@@ -1737,7 +1737,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 // Delete level data. Overrides the pure virtual function in AmrCore
 template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int level)
 {
-	BL_PROFILE("AMRSimulation::ClearLevel()");
+	BL_PROFILE("AMRSimulation::ClearLevel()"); // NOLINT(misc-const-correctness)
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
@@ -1811,7 +1811,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					 FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::FillPatch()");
+	BL_PROFILE("AMRSimulation::FillPatch()"); // NOLINT(misc-const-correctness)
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::MultiFab *> fmf;
@@ -1886,7 +1886,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 template <typename problem_t>
 void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real time, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm)
 {
-	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()");
+	BL_PROFILE("AMRSimulation::MakeNewLevelFromScratch()"); // NOLINT(misc-const-correctness)
 
 	// define empty MultiFab containers with the right number of components and ghost-zones
 
@@ -1937,7 +1937,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
 						      PostInterpHook const &post_interp, FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::fillBoundaryConditions()");
+	BL_PROFILE("AMRSimulation::fillBoundaryConditions()"); // NOLINT(misc-const-correctness)
 
 	// On a single level, any periodic boundaries are filled first
 	// 	then built-in boundary conditions are filled (with amrex::FilccCell()),
@@ -2024,7 +2024,7 @@ void AMRSimulation<problem_t>::FillPatchWithData(int lev, amrex::Real time, amre
 						 quokka::centering &cen, FillPatchType fptype, PreInterpHook const &pre_interp,
 						 PostInterpHook const &post_interp)
 {
-	BL_PROFILE("AMRSimulation::FillPatchWithData()");
+	BL_PROFILE("AMRSimulation::FillPatchWithData()"); // NOLINT(misc-const-correctness)
 
 	amrex::MFInterpolater *mapper_cc = getAmrInterpolaterCellCentered();
 
@@ -2093,7 +2093,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, amrex::Vector<amrex::BCRec> &BCs,
 					       quokka::centering cen, quokka::direction dir)
 { // here neco
-	BL_PROFILE("AMRSimulation::FillCoarsePatch()");
+	BL_PROFILE("AMRSimulation::FillCoarsePatch()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ASSERT(lev > 0);
 
@@ -2126,7 +2126,7 @@ template <typename problem_t>
 void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime,
 				       quokka::centering cen, quokka::direction dir)
 {
-	BL_PROFILE("AMRSimulation::GetData()");
+	BL_PROFILE("AMRSimulation::GetData()"); // NOLINT(misc-const-correctness)
 
 	if ((cen != quokka::centering::cc) && (cen != quokka::centering::fc)) {
 		amrex::Print() << "Centering passed to GetData(): " << static_cast<int>(cen) << "\n";
@@ -2136,7 +2136,7 @@ void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<
 	data.clear();
 	datatime.clear();
 
-	int dim = static_cast<int>(dir);
+	const int dim = static_cast<int>(dir);
 
 	if (amrex::almostEqual(time, tNew_[lev], 5)) { // if time == tNew_[lev] within roundoff
 		datatime.push_back(tNew_[lev]);
@@ -2168,7 +2168,7 @@ void AMRSimulation<problem_t>::GetData(int lev, amrex::Real time, amrex::Vector<
 // average down on all levels
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 {
-	BL_PROFILE("AMRSimulation::AverageDown()");
+	BL_PROFILE("AMRSimulation::AverageDown()"); // NOLINT(misc-const-correctness)
 
 	for (int lev = finest_level - 1; lev >= 0; --lev) {
 		AverageDownTo(lev);
@@ -2178,7 +2178,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AverageDown()
 // set covered coarse cells to be the average of overlying fine cells
 template <typename problem_t> void AMRSimulation<problem_t>::AverageDownTo(int crse_lev)
 {
-	BL_PROFILE("AMRSimulation::AverageDownTo()");
+	BL_PROFILE("AMRSimulation::AverageDownTo()"); // NOLINT(misc-const-correctness)
 
 	// cell-centred
 	amrex::average_down(state_new_cc_[crse_lev + 1], state_new_cc_[crse_lev], geom[crse_lev + 1], geom[crse_lev], 0, state_new_cc_[crse_lev].nComp(),
@@ -2523,7 +2523,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::doDiagnostics()
 #ifdef AMREX_USE_ASCENT
 template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions(conduit::Node const &blueprintMesh)
 {
-	BL_PROFILE("AMRSimulation::AscentCustomActions()");
+	BL_PROFILE("AMRSimulation::AscentCustomActions()"); // NOLINT(misc-const-correctness)
 
 	// add a scene with a pseudocolor plot
 	Node scenes;
@@ -2553,7 +2553,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::AscentCustomActions
 // do Ascent render
 template <typename problem_t> void AMRSimulation<problem_t>::RenderAscent()
 {
-	BL_PROFILE("AMRSimulation::RenderAscent()");
+	BL_PROFILE("AMRSimulation::RenderAscent()"); // NOLINT(misc-const-correctness)
 
 	// combine multifabs
 	const int included_ghosts = std::min(nghost_cc_, nghost_fc_);
@@ -2609,7 +2609,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::GetPlotfileVarNames
 // write plotfile to disk
 template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 {
-	BL_PROFILE("AMRSimulation::WritePlotFile()");
+	BL_PROFILE("AMRSimulation::WritePlotFile()"); // NOLINT(misc-const-correctness)
 
 	if (amrex::AsyncOut::UseAsyncOut()) {
 		// ensure that we flush any plotfiles that are currently being written
@@ -2623,7 +2623,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	int included_ghosts = std::min(nghost_cc_, nghost_fc_);
 #endif
 	amrex::Vector<amrex::MultiFab> mf = PlotFileMF(included_ghosts);
-	amrex::Vector<const amrex::MultiFab *> mf_ptr = amrex::GetVecOfConstPtrs(mf);
+	const amrex::Vector<const amrex::MultiFab *> mf_ptr = amrex::GetVecOfConstPtrs(mf);
 
 	const std::string &plotfilename = PlotFileName(istep[0]);
 	auto varnames = GetPlotfileVarNames();
@@ -2781,7 +2781,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::SetLastCheckpointSy
 	// creates a symlink pointing to the most recent checkpoint
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
-		std::string lastSymlinkName = "last_chk";
+		const std::string lastSymlinkName = "last_chk";
 
 		// remove previous symlink, if it exists
 		if (std::filesystem::is_symlink(lastSymlinkName)) {
@@ -2794,7 +2794,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::SetLastCheckpointSy
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile() const
 {
-	BL_PROFILE("AMRSimulation::WriteCheckpointFile()");
+	BL_PROFILE("AMRSimulation::WriteCheckpointFile()"); // NOLINT(misc-const-correctness)
 
 	// chk00010            write a checkpoint file with this root directory
 	// chk00010/Header     this contains information you need to save (e.g.,
@@ -2906,18 +2906,18 @@ inline void GotoNextLine(std::istream &is)
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile()
 {
-	BL_PROFILE("AMRSimulation::ReadCheckpointFile()");
+	BL_PROFILE("AMRSimulation::ReadCheckpointFile()"); // NOLINT(misc-const-correctness)
 
 	amrex::Print() << "Restart from checkpoint " << restart_chkfile << "\n";
 
 	// Header
 	std::string File(restart_chkfile + "/Header");
 
-	amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::GetIOBufferSize());
+	const amrex::VisMF::IO_Buffer io_buffer(amrex::VisMF::GetIOBufferSize());
 
 	amrex::Vector<char> fileCharPtr;
 	amrex::ParallelDescriptor::ReadAndBcastFile(File, fileCharPtr);
-	std::string fileCharPtrString(fileCharPtr.dataPtr());
+	const std::string fileCharPtrString(fileCharPtr.dataPtr());
 	std::istringstream is(fileCharPtrString, std::istringstream::in);
 
 	std::string line;


### PR DESCRIPTION
### Description

`simulation.hpp` is tidy-free now. Any future edits to `simulation.hpp` will not trigger a clangt-tidy warning unless it's new in that change. 

Also updated `tidy.sh` to support `--fix` option to apply automatic fix. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
