### PR TITLE
add MPI_Barrier after writing each level in checkpoint files

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2872,6 +2872,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	// write the cell-centred MultiFab data to, e.g., chk00010/Level_0/
 	for (int lev = 0; lev <= finest_level; ++lev) {
 		amrex::VisMF::Write(state_new_cc_[lev], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "Cell"));
+		amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 	}
 
 	// write the face-centred MultiFab data to, e.g., chk00010/Level_0/
@@ -2880,6 +2881,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 			for (int lev = 0; lev <= finest_level; ++lev) {
 				amrex::VisMF::Write(state_new_fc_[lev][idim], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_",
 													    std::string("Face_") + quokka::face_dir_str[idim]));
+				amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This adds an `MPI_Barrier()` after writing each level in the checkpoint files. This seems to be necessary to avoid hangs while writing checkpoint files on Frontier.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
