### PR TITLE
change default SNScheme to hybrid thermal/momentum and use AMREX_ENUM

### DIFF
--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -302,8 +302,7 @@ inline amrex::Real particle_param1 = -1.0; // NOLINT
 inline amrex::Real particle_param2 = -1.0; // NOLINT
 
 // Scheme for SN feedback
-// FIXME: why is this the default? this is the worst one...
-inline SNScheme SN_scheme = SNScheme::SN_thermal_only; // NOLINT
+inline SNScheme SN_scheme = SNScheme::SN_thermal_or_thermal_momentum; // NOLINT
 
 // Sink particle accretion
 inline bool sink_particle_use_uniform_kernel = false; // NOLINT. If true, use uniform accretion kernel in a (7 dx)^3 box

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -78,12 +78,12 @@ enum class ParticleType {
 };
 
 // Enum for SN schemes: ThermalOnly, ThermalAndMomentum
-enum class SNScheme {
+AMREX_ENUM(SNScheme, // NOLINT
 	SN_thermal_only,			// pure thermal
 	SN_thermal_or_thermal_momentum,		// pure thermal (RM<1) or thermal+momentum (RM>=1)
 	SN_thermal_kinetic_or_thermal_momentum, // thermal+kinetic (RM<1) or thermal+momentum (RM>=1)
 	SN_pure_kinetic_or_thermal_momentum	// pure kinetic (RM<1) or thermal+momentum (RM>=1)
-};
+);
 
 //-------------------- Radiation particles --------------------
 
@@ -324,9 +324,7 @@ inline void particleParmParse()
 	pp.query("sink_particle_use_uniform_kernel", sink_particle_use_uniform_kernel);
 
 	// Handle SNScheme enum
-	int sn_scheme_int = static_cast<int>(SN_scheme);
-	pp.query("SN_scheme", sn_scheme_int);
-	SN_scheme = static_cast<SNScheme>(sn_scheme_int);
+	pp.query("SN_scheme", SN_scheme);
 
 	// Handle integer verbose flag
 	pp.query("verbose", particle_verbose);

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -78,11 +78,11 @@ enum class ParticleType {
 };
 
 // Enum for SN schemes: ThermalOnly, ThermalAndMomentum
-AMREX_ENUM(SNScheme, // NOLINT
-	SN_thermal_only,			// pure thermal
-	SN_thermal_or_thermal_momentum,		// pure thermal (RM<1) or thermal+momentum (RM>=1)
-	SN_thermal_kinetic_or_thermal_momentum, // thermal+kinetic (RM<1) or thermal+momentum (RM>=1)
-	SN_pure_kinetic_or_thermal_momentum	// pure kinetic (RM<1) or thermal+momentum (RM>=1)
+AMREX_ENUM(SNScheme,				   // NOLINT
+	   SN_thermal_only,			   // pure thermal
+	   SN_thermal_or_thermal_momentum,	   // pure thermal (RM<1) or thermal+momentum (RM>=1)
+	   SN_thermal_kinetic_or_thermal_momentum, // thermal+kinetic (RM<1) or thermal+momentum (RM>=1)
+	   SN_pure_kinetic_or_thermal_momentum	   // pure kinetic (RM<1) or thermal+momentum (RM>=1)
 );
 
 //-------------------- Radiation particles --------------------

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -302,6 +302,7 @@ inline amrex::Real particle_param1 = -1.0; // NOLINT
 inline amrex::Real particle_param2 = -1.0; // NOLINT
 
 // Scheme for SN feedback
+// FIXME: why is this the default? this is the worst one...
 inline SNScheme SN_scheme = SNScheme::SN_thermal_only; // NOLINT
 
 // Sink particle accretion

--- a/tests/ParticleSink.in
+++ b/tests/ParticleSink.in
@@ -40,7 +40,7 @@ problem.refine_half_domain = false
 
 problem.n_amb = 1.0
 problem.T_amb = 718.0
-particles.SN_scheme = 1 					# 1: SN_thermal_or_thermal_momentum
+particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 particles.sink_particle_use_uniform_kernel = true
 

--- a/tests/SN.in
+++ b/tests/SN.in
@@ -43,7 +43,7 @@ problem.refine_half_domain = false
 
 problem.n_amb = 1.0
 problem.T_amb = 718.0
-particles.SN_scheme = 1 					# 1: SN_thermal_or_thermal_momentum
+particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 10


### PR DESCRIPTION
### Description
This uses the `AMREX_ENUM` macro for `SNScheme`, so users can specify the SN scheme using the full string corresponding to each enum entry:
```
particles.SN_scheme = SN_pure_kinetic_or_thermal_momentum
```

The full set of options is:
```
AMREX_ENUM(SNScheme,
	SN_thermal_only,			// pure thermal
	SN_thermal_or_thermal_momentum,		// pure thermal (RM<1) or thermal+momentum (RM>=1)
	SN_thermal_kinetic_or_thermal_momentum, // thermal+kinetic (RM<1) or thermal+momentum (RM>=1)
	SN_pure_kinetic_or_thermal_momentum	// pure kinetic (RM<1) or thermal+momentum (RM>=1)
);
```

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/713.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
