### PR TITLE
set FPE strict mode to avoid spurious FPEs with AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Wno-psabi)
 endif()
 
+# this is necessary to avoid spurious FPEs due to vectorization
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  add_compile_options(-ffp-exception-behavior=strict)
+endif()
+
 execute_process(COMMAND git rev-parse --abbrev-ref HEAD
     WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}
     OUTPUT_VARIABLE QUOKKA_GIT_BRANCH


### PR DESCRIPTION
### Description
This prevents AppleClang from vectorizing code in a way that causes spurious FPEs. This has a performance cost, but when AppleClang is used, the user is probably running the code on their laptop and running the test suite (which turns on FPEs by default).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
