### PR TITLE
Fix bug: FillBoundary before computing accretion rate

### DIFF
--- a/src/problems/ParticleSink/test_particle_sink.cpp
+++ b/src/problems/ParticleSink/test_particle_sink.cpp
@@ -155,6 +155,7 @@ auto problem_main() -> int
 	sim.stopTime_ = 10.0 * dt_init;
 	sim.initDt_ = dt_init;
 	sim.tempFloor_ = 10.0; // K
+	sim.doPoissonSolve_ = 1;
 
 	// initialize
 	sim.setInitialConditions();
@@ -178,11 +179,14 @@ auto problem_main() -> int
 		amrex::Print() << "Total particle mass = " << total_particle_mass << "\n";
 	}
 
+	const double total_total_mass_init = total_mass_init + total_particle_mass;
+
 	// evolve
+	sim.maxTimesteps_ = 1;
 	sim.evolve();
 
 	// get total gas mass in the final state
-	amrex::Real const total_mass_final = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
+	amrex::Real const total_mass_step1 = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	auto [position, values] = fextract(sim.state_new_cc_[0], sim.Geom(0), 0, 0.0, true);
 	const int nx = static_cast<int>(position.size());
@@ -193,28 +197,34 @@ auto problem_main() -> int
 
 	int status = 0;
 
-	const auto &real_data_final = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
+	const auto &real_data_ste1 = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// compute total particle mass and error
-		double total_particle_mass_final = 0.0;
-		for (const auto &p : real_data_final) {
-			total_particle_mass_final += p[3];
+		double total_particle_mass_step1 = 0.0;
+		for (const auto &p : real_data_ste1) {
+			total_particle_mass_step1 += p[3];
 		}
+		const double total_total_mass_step1 = total_mass_step1 + total_particle_mass_step1;
 
-		// change in gas mass
-		const double gas_mass_change = total_mass_final - total_mass_init;
-		const double particle_mass_change = total_particle_mass_final - total_particle_mass;
-		const double rel_mass_error = std::abs(gas_mass_change + particle_mass_change) / std::abs(gas_mass_change);
+		// compute difference in mass changes
+		const double gas_mass_change = total_mass_step1 - total_mass_init;
+		const double particle_mass_change = total_particle_mass_step1 - total_particle_mass;
+		const double rel_mass_error = gas_mass_change == 0.0 ? 0.0 : std::abs(gas_mass_change + particle_mass_change) / std::abs(gas_mass_change);
 		amrex::Print() << "\nAfter evolution:\n";
 		amrex::Print() << "Gas mass change = " << gas_mass_change << "\n";
 		amrex::Print() << "Particle mass change = " << particle_mass_change << "\n";
 		amrex::Print() << "Total mass change = " << gas_mass_change + particle_mass_change << "\n";
-		amrex::Print() << "Relative mass error = " << rel_mass_error << "\n";
+		amrex::Print() << "Relative error in change of mass = " << rel_mass_error << "\n";
 
-		// should be machine precision (1e-14), but the change is 5 orders of magnitude smaller than the initial mass, so an error of 1e-9 is expected
-		const double rel_mass_error_tol = 1.0e-8;
-		if (!(rel_mass_error < rel_mass_error_tol)) {
+		// compute relative error in the change of total mass
+		const double rel_error_total_mass = std::abs(total_total_mass_step1 - total_total_mass_init) / total_total_mass_init;
+		amrex::Print() << "Relative error in change of total mass = " << rel_error_total_mass << "\n";
+
+		// Note that while the error relative to the total mass (gas + particles) should be within machine precision (1e-14), the error relative
+		// to the *change* could be large because the change is several orders of magnitude smaller than the total mass.
+		const double mass_rel_error_tol = 1.0e-9;
+		if (!(rel_error_total_mass < mass_rel_error_tol)) {
 			status = 1;
 		}
 
@@ -262,12 +272,6 @@ auto problem_main() -> int
 			status = 1;
 		}
 
-		if (status == 1) {
-			amrex::Print() << "Test failed\n";
-		} else {
-			amrex::Print() << "Test passed\n";
-		}
-
 #ifdef HAVE_PYTHON
 		matplotlibcpp::clf();
 		matplotlibcpp::ylim(0.0, 1.1);
@@ -297,6 +301,41 @@ auto problem_main() -> int
 		matplotlibcpp::legend();
 		matplotlibcpp::save("./sink_density_vs_x_over_dx.png");
 #endif
+	}
+
+	// evolve
+	sim.maxTimesteps_ = 10;
+	sim.evolve();
+
+	// get total particle mass in the final state
+	const auto &real_data_final = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
+	double total_particle_mass_final = 0.0;
+	for (const auto &p : real_data_final) {
+		total_particle_mass_final += p[3];
+	}
+	amrex::Print() << "Total particle mass = " << total_particle_mass_final << "\n";
+
+	// get total gas mass in the final state
+	amrex::Real const total_mass_final = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
+
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::Print() << "Total gas mass = " << total_mass_final << "\n";
+		const double total_total_mass_final = total_mass_final + total_particle_mass_final;
+
+		// compute relative error in the change of total mass
+		const double rel_error_total_mass_final = std::abs(total_total_mass_final - total_total_mass_init) / total_total_mass_init;
+		amrex::Print() << "Relative error in change of total mass = " << rel_error_total_mass_final << "\n";
+
+		// Total mass should be conserved to machine precision
+		if (!(rel_error_total_mass_final < 1.0e-13)) {
+			status = 1;
+		}
+
+		if (status == 1) {
+			amrex::Print() << "Test failed\n";
+		} else {
+			amrex::Print() << "Test passed\n";
+		}
 	}
 
 	return status;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2706,7 +2706,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 		std::vector<std::string> dimNames = {"x", "y", "z"};
 		auto varnames_fc = GetPlotfileVarNames_fc();
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::Vector<const amrex::MultiFab *> mf_fc_ptr = amrex::GetVecOfConstPtrs(mf_fc[idim]);
+			const amrex::Vector<const amrex::MultiFab *> mf_fc_ptr = amrex::GetVecOfConstPtrs(mf_fc[idim]);
 			auto plotfilename_base = plotfilename + "/fc_vars/" + dimNames[idim];
 			const std::string &plotfilename_fc = CustomPlotFileName(plotfilename_base.c_str(), istep[0]);
 			auto varnames_fc_dim = varnames_fc[idim];

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1430,6 +1430,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	// Assume all SN progenitors are at the finest level
 	const int lev = finest_level;
 
+	// Fill boundary before computing accretion rate. This is necessary because the computation of accretion rate uses 3 ghost cells, but the
+	// boundaries are not filled at this point.
+	// TODO(cch): we can fill the hydro variables only if no other variables are used in accretion rate computation
+	state_new_cc_[lev].FillBoundary(geom[lev].periodicity());
+
 	// Create a MultiFab to hold the change of states (density, 3 x momentum, internal energy, energy) during particle-mesh interaction
 	amrex::MultiFab accretion_rate_at_level(grids[lev], dmap[lev], Physics_NumVars::numHydroVars, nghost);
 

--- a/tests/ParticleSink.in
+++ b/tests/ParticleSink.in
@@ -3,7 +3,7 @@
 # *****************************************************************
 geometry.prob_lo     =  -2.393565931e+17 -2.393565931e+17 -2.393565931e+17 
 geometry.prob_hi     =  2.393565931e+17 2.393565931e+17 2.393565931e+17 
-geometry.is_periodic =  1    1    1
+geometry.is_periodic =  0    0    0
 
 # *****************************************************************
 # VERBOSITY
@@ -22,27 +22,14 @@ amr.grid_eff        = 0.7   # default
 
 do_reflux = 1
 do_subcycle = 0
-do_tracers = 0      # turn on tracer particles
-
-hydro.artificial_viscosity_coefficient = 0.1
-
-# quokka.diagnostics = slice_z
-quokka.slice_z.type = DiagFramePlane         # Diagnostic type
-quokka.slice_z.file = slicez_plt             # Output file prefix (must end in "plt")
-quokka.slice_z.normal = 2                    # Plane normal (0 == x, 1 == y, 2 == z)
-quokka.slice_z.center = 0.1                # Coordinate in the normal direction (cannot lie *exactly* on domain boundary)
-quokka.slice_z.int    = 1                   # Output cadence (in number of coarse steps)
-quokka.slice_z.interpolation = Linear        # (Optional, default is Linear) Interpolation type: Linear or Quadratic
-quokka.slice_z.field_names = gasDensity gasInternalEnergy x-GasMomentum y-GasMomentum z-GasMomentum # List of variables included in output
 
 problem.particles_file = "Sink_4.txt"
 problem.refine_half_domain = false
 
-problem.n_amb = 1.0
-problem.T_amb = 718.0
-particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 particles.sink_particle_use_uniform_kernel = true
 
 max_timesteps = 1
-plotfile_interval = 1
+plotfile_interval = -1
+
+tiny_profiler.enabled = 0


### PR DESCRIPTION
### Description

Fixed a bug: need to `FillBoundary` before computing sink particle accretion rates. Failing to do so causes the two stages of the sink accretion scheme to calculate the accretion rate differently because somehow (?) `state_new_cc_` has boundaries filled in the second stage. 

This has been bugging me for a little while. I found that the total mass (gas + particle) is not conserved to machine precision when testing the sink formation PR #1045; the relative error can be as large as 1e-5. This happens when a particle is at a box boundary.

This PR fixed this problem. I also updated the `test_particle_sink` test to validate that the total mass is conserved to machine precision in our sink accretion scheme (#1017 and #1055) 

### Related issues

None.

### Checklist

_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [[Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md)](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.