### PR TITLE
Add the ability to split massive particles

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -119,7 +119,7 @@ class PhysicsParticleDescriptorBase
 
 	// Destroy particles at level lev_min and above
 	virtual void destroyParticles(int lev_min, amrex::Real current_time, amrex::Real dt) = 0;
-
+	virtual void splitParticles(int lev, int splitFactor) = 0;
 	[[nodiscard]] virtual auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> = 0;
 
 	// Tag cells around particles for refinement
@@ -474,6 +474,70 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		if (container_ != nullptr) {
 			ParticleDestructionTraits<particleType_>::template destroyParticles<problem_t, ContainerType>(
 			    container_, this->getMassIndex(), lev_min, current_time, dt, this->getBirthTimeIndex(), this->getEvolutionStageIndex());
+		}
+	}
+
+	void splitParticles(int const lev, int const splitFactor) override
+	{
+		if (container_ != nullptr && this->getMassIndex() >= 0) {
+			for (typename ContainerType::ParIterType pIter(*container_, lev); pIter.isValid(); ++pIter) {
+				// Update NextID to include particles that will be created
+				const amrex::Long npart_old = pIter.numParticles();
+				const unsigned int max_new_particles = splitFactor * npart_old;
+				const amrex::Long pid = ContainerType::ParticleType::NextID();
+				ContainerType::ParticleType::NextID(pid + max_new_particles);
+
+				// Resize particle tile
+				auto &particles = pIter.GetArrayOfStructs();
+				particles.resize(npart_old + max_new_particles);
+
+				// Create the particles
+				const auto &geom = container_->Geom(lev);
+				const auto dxinv = geom.InvCellSizeArray();
+				const auto dx = geom.CellSizeArray();
+				const auto plo = geom.ProbLoArray();
+				const int cpu_id = amrex::ParallelDescriptor::MyProc();
+				const int mass_idx = this->getMassIndex();
+				auto *pdata_old = particles().data();
+				auto *pdata_new = particles().data() + npart_old;
+
+				amrex::ParallelForRNG(npart_old, [=] AMREX_GPU_DEVICE(int64_t idx, amrex::RandomEngine const &rng) {
+					// compute cell corner position (x0, y0, z0) of the old particle
+					const int i = static_cast<int>((pdata_old[idx].pos(0) - plo[0]) * dxinv[0]); // NOLINT
+					const int j = static_cast<int>((pdata_old[idx].pos(1) - plo[1]) * dxinv[1]); // NOLINT
+					const int k = static_cast<int>((pdata_old[idx].pos(2) - plo[2]) * dxinv[2]); // NOLINT
+					amrex::Real const x0 = plo[0] + (i * dx[0]);
+					amrex::Real const y0 = plo[1] + (j * dx[1]);
+					amrex::Real const z0 = plo[2] + (k * dx[2]);
+
+					// mark old particle for deletion
+					auto &p_old = pdata_old[idx]; // NOLINT
+					p_old.id() = -1;
+					amrex::Real const old_mass = p_old.rdata(mass_idx);
+
+					// create new particles
+					auto *new_particles = &pdata_new[idx * splitFactor]; // NOLINT
+					for (int idx_new = 0; idx_new < splitFactor; ++idx_new) {
+						auto &p_new = new_particles[idx_new]; // NOLINT
+						// copy old particle properties
+						for (int rc = 0; rc < ContainerType::ParticleType::NReal; ++rc) {
+							p_new.rdata(rc) = p_old.rdata(rc);
+						}
+						for (int ic = 0; ic < ContainerType::ParticleType::NInt; ++ic) {
+							p_new.idata(ic) = p_old.idata(ic);
+						}
+						// set new particle properties
+						p_new.cpu() = cpu_id;
+						p_new.id() = pid + idx * splitFactor + idx_new;
+						p_new.pos(0) = x0 + dx[0] * amrex::Random(rng);
+						p_new.pos(1) = y0 + dx[1] * amrex::Random(rng);
+						p_new.pos(2) = z0 + dx[2] * amrex::Random(rng);
+						p_new.rdata(mass_idx) = old_mass / static_cast<amrex::Real>(splitFactor);
+					}
+				});
+			}
+			// Remove the old particles
+			container_->Redistribute(lev);
 		}
 	}
 

--- a/src/problems/BinaryOrbitCIC/CMakeLists.txt
+++ b/src/problems/BinaryOrbitCIC/CMakeLists.txt
@@ -6,4 +6,5 @@ if (AMReX_SPACEDIM EQUAL 3)
 
     add_test(NAME BinaryOrbitCIC COMMAND binary_orbit BinaryOrbit.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
     add_test(NAME BinaryOrbitCICAMR COMMAND binary_orbit BinaryOrbitAMR.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    add_test(NAME BinaryOrbitCICSplit COMMAND binary_orbit BinaryOrbit_split.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -7,6 +7,7 @@
 /// \brief Defines a test problem for a binary orbit.
 ///
 
+#include "AMReX_BLassert.H"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include <algorithm>
@@ -120,19 +121,28 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 				amrex::Print() << "Computing particle statistics...\n";
 
 				// compute orbital elements
-				const auto &p1 = real_data[0];
-				const auto &p2 = real_data[1];
-				const double dx = p1[0] - p2[0]; // position x
-				const double dy = p1[1] - p2[1]; // position y
-				const double dz = p1[2] - p2[2]; // position z
-				const double dist = std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+				double dist = 0.0;
+				
+				// Loop over all pairs of particles
+				for (size_t i = 0; i < real_data.size(); ++i) {
+					for (size_t j = i + 1; j < real_data.size(); ++j) {
+						const auto &p1 = real_data[i];
+						const auto &p2 = real_data[j];
+						const double dx = p1[0] - p2[0]; // position x
+						const double dy = p1[1] - p2[1]; // position y
+						const double dz = p1[2] - p2[2]; // position z
+						const double pair_dist = std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+						dist = std::max(dist, pair_dist);
+					}
+				}
+				
 				const double dist0 = 6.25e12; // cm
 				const amrex::Real cell_dx0 = this->geom[finest_level].CellSize(0);
 
 				// save statistics
 				userData_.time.push_back(tNew_[finest_level]);
 				userData_.dist.push_back((dist - dist0) / cell_dx0);
-				amrex::Print() << "Particle separation: " << dist << " cm, initial separation is " << dist0 << " cm.\n";
+				amrex::Print() << "Maximum particle separation: " << dist << " cm, initial separation is " << dist0 << " cm.\n";
 			}
 		}
 	}
@@ -200,7 +210,7 @@ auto problem_main() -> int
 			auto result = std::max_element(sim.userData_.dist.begin(), sim.userData_.dist.end(),
 						       [](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
 			max_err = std::abs(*result);
-			amrex::Print() << "max particle separation = " << max_err << " cell widths.\n";
+			amrex::Print() << "max deviation from initial particle separation = " << max_err << " cell widths.\n";
 		} else {
 			max_err = 1.0;
 			amrex::Print() << "No particles in userData_.dist.\n";
@@ -208,9 +218,23 @@ auto problem_main() -> int
 	}
 
 	int status = 1;
-	const double max_err_tol = 0.18; // max error tol in cell widths
-	if (max_err < max_err_tol) {
-		status = 0;
+	if (do_split_particles) {
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(sim.maxTimesteps_ <= 20, "maxTimesteps_ must be <= 20 when do_split_particles is true");
+		const double split_max_err_tol = 0.6; // max error tol in cell widths
+		if (max_err < split_max_err_tol) {
+			status = 0;
+			amrex::Print() << "Test passed (split particles)\n";
+		} else {
+			amrex::Print() << "Test failed (split particles)\n";
+		}
+	} else {
+		const double max_err_tol = 0.18; // max error tol in cell widths
+		if (max_err < max_err_tol) {
+			status = 0;
+			amrex::Print() << "Test passed\n";
+		} else {
+			amrex::Print() << "Test failed\n";
+		}
 	}
 	return status;
 }

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -122,7 +122,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 
 				// compute orbital elements
 				double dist = 0.0;
-				
+
 				// Loop over all pairs of particles
 				for (size_t i = 0; i < real_data.size(); ++i) {
 					for (size_t j = i + 1; j < real_data.size(); ++j) {
@@ -135,7 +135,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 						dist = std::max(dist, pair_dist);
 					}
 				}
-				
+
 				const double dist0 = 6.25e12; // cm
 				const amrex::Real cell_dx0 = this->geom[finest_level].CellSize(0);
 

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -179,7 +179,7 @@ auto problem_main() -> int
 	}
 
 	// read in runtime parameters for this test problem
-	amrex::ParmParse const pp("particles");
+	amrex::ParmParse const pp("problem");
 	pp.query("do_split_particles", do_split_particles);
 	pp.query("split_factor", split_factor);
 

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -29,6 +29,9 @@
 struct BinaryOrbit {
 };
 
+static bool do_split_particles = false; // NOLINT
+static int split_factor = 8;		// NOLINT
+
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	       // isothermal
 	static constexpr double cs_isothermal = 1.3e7; // cm s^{-1}
@@ -80,6 +83,14 @@ template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
 	const int nreal_extra = 4; // mass vx vy vz
 	CICParticles->SetVerbose(1);
 	CICParticles->InitFromAsciiFile("BinaryOrbit_particles.txt", nreal_extra, nullptr);
+
+	// test particle splitting
+	// (this is intended to only be used when restarting at a higher resolution)
+	if (do_split_particles) {
+		amrex::Print() << "Splitting CICParticles using split_factor = " << split_factor << "\n";
+		int const lev = 0; // all CICParticles are on level 0
+		particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->splitParticles(lev, split_factor);
+	}
 }
 
 template <> void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
@@ -166,6 +177,11 @@ auto problem_main() -> int
 			}
 		}
 	}
+
+	// read in runtime parameters for this test problem
+	amrex::ParmParse const pp("particles");
+	pp.query("do_split_particles", do_split_particles);
+	pp.query("split_factor", split_factor);
 
 	// Problem initialization
 	QuokkaSimulation<BinaryOrbit> sim(BCs_cc);

--- a/tests/BinaryOrbit.in
+++ b/tests/BinaryOrbit.in
@@ -30,5 +30,5 @@ plotfile_interval = -1
 tiny_profiler.enabled = 0
 
 cfl = 0.3
-max_timesteps = 20
+max_timesteps = 2000
 stop_time = 5.0e7   # s

--- a/tests/BinaryOrbit.in
+++ b/tests/BinaryOrbit.in
@@ -20,15 +20,15 @@ amr.max_grid_size   = 32    # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
 amr.grid_eff        = 1.0
 
-cfl = 0.3
-max_timesteps = 4000
-stop_time = 5.0e7   # s
-
 do_reflux = 1
 do_subcycle = 0
 
 ascent_interval = -1
 checkpoint_interval = -1
-#plottime_interval = 2.0e5 # s
 plotfile_interval = -1
-derived_vars = gpot
+
+tiny_profiler.enabled = 0
+
+cfl = 0.3
+max_timesteps = 20
+stop_time = 5.0e7   # s

--- a/tests/BinaryOrbitAMR.in
+++ b/tests/BinaryOrbitAMR.in
@@ -21,7 +21,7 @@ amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
 amr.grid_eff        = 1.0
 
 cfl = 0.3
-max_timesteps = 4000
+max_timesteps = 2000
 stop_time = 5.0e7   # s
 
 do_reflux = 1

--- a/tests/BinaryOrbit_split.in
+++ b/tests/BinaryOrbit_split.in
@@ -33,7 +33,7 @@ cfl = 0.3
 max_timesteps = 20
 stop_time = 5.0e7   # s
 
-particles.do_split_particles = true
-particles.split_factor = 8
+problem.do_split_particles = true
+problem.split_factor = 8
 
 particles.verbose = 1

--- a/tests/BinaryOrbit_split.in
+++ b/tests/BinaryOrbit_split.in
@@ -35,3 +35,5 @@ stop_time = 5.0e7   # s
 
 particles.do_split_particles = true
 particles.split_factor = 8
+
+particles.verbose = 1

--- a/tests/BinaryOrbit_split.in
+++ b/tests/BinaryOrbit_split.in
@@ -1,0 +1,37 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -2.5e13 -2.5e13 -2.5e13
+geometry.prob_hi     =   2.5e13  2.5e13  2.5e13
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 32 32 32
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 32    # grid size must be divisible by this
+amr.max_grid_size   = 32    # at least 128 for GPUs
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 1.0
+
+do_reflux = 1
+do_subcycle = 0
+
+ascent_interval = -1
+checkpoint_interval = -1
+plotfile_interval = -1
+
+tiny_profiler.enabled = 0
+
+cfl = 0.3
+max_timesteps = 20
+stop_time = 5.0e7   # s
+
+particles.do_split_particles = true
+particles.split_factor = 8


### PR DESCRIPTION
### Description
This adds the ability to split each massive particle into an integer number `splitFactor` new particles of equal mass.

This is needed in order to scale the disk galaxy problem to higher resolutions.

### Related issues
Replace #996 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
