### PR TITLE
Ensure runtime parameters override compile-time settings

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -186,6 +186,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	[[nodiscard]] static auto getScalarVariableNames() -> std::vector<std::string>;
 	void defineComponentNames();
 	void readParmParse();
+	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
 
 	void checkHydroStates(amrex::MultiFab &mf, char const *file, int line);
 	void computeMaxSignalLocal(int level) override;
@@ -478,6 +479,21 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		rpp.query("dust_gas_interaction_coeff", dustGasInteractionCoeff_);
 		rpp.query("print_iteration_counts", print_rad_counter_);
 	}
+}
+
+template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimeParameters()
+{
+	// Re-read runtime parameters to ensure they override any compile-time settings
+	// This is called at the beginning of evolve() to ensure user input takes precedence
+	
+	// Call parent class rereadRuntimeParameters
+	AMRSimulation<problem_t>::rereadRuntimeParameters();
+	
+	// Re-read QuokkaSimulation-specific parameters
+	readParmParse();
+	
+	// Re-read particle parameters
+	quokka::particleParmParse();
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -485,13 +485,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimePar
 {
 	// Re-read runtime parameters to ensure they override any compile-time settings
 	// This is called at the beginning of evolve() to ensure user input takes precedence
-	
+
 	// Call parent class rereadRuntimeParameters
 	AMRSimulation<problem_t>::rereadRuntimeParameters();
-	
+
 	// Re-read QuokkaSimulation-specific parameters
 	readParmParse();
-	
+
 	// Re-read particle parameters
 	quokka::particleParmParse();
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -222,6 +222,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void initialize();
 	void PerformanceHints();
 	void readParameters();
+	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
 	void setInitialConditions();
 	void setInitialConditionsAtLevel_cc(int level, amrex::Real time);
 	void setInitialConditionsAtLevel_fc(int level, amrex::Real time);
@@ -752,6 +753,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	}
 }
 
+template <typename problem_t> void AMRSimulation<problem_t>::rereadRuntimeParameters()
+{
+	// Re-read runtime parameters to ensure they override any compile-time settings
+	// This is called at the beginning of evolve() to ensure user input takes precedence
+	readParameters();
+}
+
 template <typename problem_t> void AMRSimulation<problem_t>::setInitialConditions()
 {
 	BL_PROFILE("AMRSimulation::setInitialConditions()"); // NOLINT(misc-const-correctness)
@@ -970,6 +978,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	BL_PROFILE("AMRSimulation::evolve()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ALWAYS_ASSERT(areInitialConditionsDefined_);
+
+	// Re-read runtime parameters to ensure they override any compile-time settings
+	// set in problem_main(). This ensures user input always takes precedence.
+	rereadRuntimeParameters();
 
 	amrex::Real cur_time = tNew_[0];
 #ifdef AMREX_USE_ASCENT

--- a/tests/hydro_wave_fc.in
+++ b/tests/hydro_wave_fc.in
@@ -26,7 +26,6 @@ do_subcycle = 0
 
 plotfile_interval = 1
 checkpoint_interval = -1
-cfl = 0.3
 stop_time = 1.0
 max_timesteps = 1
 do_tracers = 1


### PR DESCRIPTION
### Description
This pull request ensures that runtime parameters specified in input files always take precedence over compile-time values set in `problem_main()` functions. Previously, parameters directly assigned in problem code (before calling `sim.evolve()`) would override user input, which was counterintuitive and limited flexibility. The fix adds a `rereadRuntimeParameters()` method that is called at the beginning of evolve() to re-read all runtime parameters, ensuring that user-specified values take precedence over any compile-time assignments made earlier in `problem_main()`.

### Related issues
No related issues.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the
square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
