### PR TITLE
[WIP] implement extremum-preserving MC limiter

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2184,7 +2184,7 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 										x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 2) {
 		// PLM and donor cell are interface-centered kernels
-		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::MC>(primVar.array(), x1LeftState.array(), x1RightState.array(),
+		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::EP>(primVar.array(), x1LeftState.array(), x1RightState.array(),
 												  x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(),

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -35,7 +35,7 @@ enum redoFlag { none = 0, redo = 1 };
 } // namespace quokka
 
 // Define enum for slope limiter type
-enum SlopeLimiter { minmod = 0, MC };
+enum SlopeLimiter { minmod = 0, MC, EP };
 
 using array_t = amrex::Array4<amrex::Real> const;
 using arrayconst_t = amrex::Array4<const amrex::Real> const;
@@ -46,12 +46,15 @@ template <typename problem_t> class HyperbolicSystem
       public:
 	template <SlopeLimiter limiter> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto SlopeFunc(amrex::Real x, amrex::Real y) -> amrex::Real
 	{
-		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::MC, "Invalid slope limiter specified.");
+		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::MC || limiter == SlopeLimiter::EP, "Invalid slope limiter specified.");
 		if constexpr (limiter == SlopeLimiter::minmod) {
 			return minmod(x, y);
 		}
 		if constexpr (limiter == SlopeLimiter::MC) {
 			return MC(x, y);
+		}
+		if constexpr (limiter == SlopeLimiter::EP) {
+			return EP(x, y);
 		}
 	}
 
@@ -64,6 +67,16 @@ template <typename problem_t> class HyperbolicSystem
 	{
 		return 0.5 * (sgn(a) + sgn(b)) * std::min(std::abs(a), std::abs(b));
 	}
+
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto EP(double a, double b) -> double
+	{
+		return MC(a, b);
+	}
+
+	template <FluxDir DIR>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void
+	ReconstructStatesPLM_EP(quokka::Array4View<amrex::Real const, DIR> const &q, quokka::Array4View<amrex::Real, DIR> const &leftState,
+				quokka::Array4View<amrex::Real, DIR> const &rightState, int n, int i_in, int j_in, int k_in);
 
 	[[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static auto GetMinmaxSurroundingCell(arrayconst_t &q, int i, int j, int k, int n)
 	    -> std::pair<double, double>;
@@ -221,6 +234,11 @@ AMREX_GPU_HOST_DEVICE void
 HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real const, DIR> const &q, quokka::Array4View<amrex::Real, DIR> const &leftState,
 						  quokka::Array4View<amrex::Real, DIR> const &rightState, int n, int i_in, int j_in, int k_in)
 {
+	if constexpr (limiter == SlopeLimiter::EP) {
+		HyperbolicSystem<problem_t>::template ReconstructStatesPLM_EP<DIR>(q, leftState, rightState, n, i_in, j_in, k_in);
+		return;
+	}
+
 	// permute array indices according to dir
 	auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
@@ -290,6 +308,55 @@ AMREX_GPU_DEVICE auto HyperbolicSystem<problem_t>::GetMinmaxSurroundingCell(arra
 #endif // AMREX_SPACEDIM
 
 	return bounds;
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
+AMREX_GPU_HOST_DEVICE void
+HyperbolicSystem<problem_t>::ReconstructStatesPLM_EP(quokka::Array4View<amrex::Real const, DIR> const &q, quokka::Array4View<amrex::Real, DIR> const &leftState,
+						     quokka::Array4View<amrex::Real, DIR> const &rightState, int n, int i_in, int j_in, int k_in)
+{
+	// permute array indices according to dir
+	auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
+
+	// Extremum-preserving PLM limiter based on Colella & Sekora (2008)
+	// Preserves accuracy at smooth extrema while maintaining TVD property
+
+	// Standard PLM slopes
+	const auto delta_l = q(i, j, k, n) - q(i - 1, j, k, n);
+	const auto delta_r = q(i + 1, j, k, n) - q(i, j, k, n);
+	const auto delta_ll = q(i - 1, j, k, n) - q(i - 2, j, k, n);
+
+	// Check for extrema at current cell
+	const bool is_extremum = (delta_l * delta_r <= 0.0);
+
+	// Left slope computation
+	auto lslope = MC(delta_l, delta_ll);
+	if (is_extremum) {
+		// At extrema, use a less restrictive limiter that preserves accuracy
+		// Use second-order differences to maintain higher-order accuracy
+		const auto d2_l = (q(i + 1, j, k, n) - 2.0 * q(i, j, k, n) + q(i - 1, j, k, n));
+		const auto d2_ll = (q(i, j, k, n) - 2.0 * q(i - 1, j, k, n) + q(i - 2, j, k, n));
+		
+		// Use a combination of first and second derivatives for EP limiting
+		const auto ep_factor = std::min(1.0, std::abs(d2_l) > 1e-12 ? std::abs(d2_ll / d2_l) : 1.0);
+		lslope = ep_factor * delta_l;
+	}
+
+	// Right slope computation  
+	auto rslope = MC(delta_r, delta_l);
+	if (is_extremum) {
+		// Similar EP limiting for right slope
+		const auto d2_r = (q(i + 2, j, k, n) - 2.0 * q(i + 1, j, k, n) + q(i, j, k, n));
+		const auto d2_c = (q(i + 1, j, k, n) - 2.0 * q(i, j, k, n) + q(i - 1, j, k, n));
+		
+		const auto ep_factor = std::min(1.0, std::abs(d2_c) > 1e-12 ? std::abs(d2_r / d2_c) : 1.0);
+		rslope = ep_factor * delta_r;
+	}
+
+	// Standard PLM reconstruction with computed slopes
+	leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.25 * lslope;
+	rightState(i, j, k, n) = q(i, j, k, n) - 0.25 * rslope;
 }
 
 template <typename problem_t>

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -46,7 +46,8 @@ template <typename problem_t> class HyperbolicSystem
       public:
 	template <SlopeLimiter limiter> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto SlopeFunc(amrex::Real x, amrex::Real y) -> amrex::Real
 	{
-		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::MC || limiter == SlopeLimiter::EP, "Invalid slope limiter specified.");
+		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::MC || limiter == SlopeLimiter::EP,
+			      "Invalid slope limiter specified.");
 		if constexpr (limiter == SlopeLimiter::minmod) {
 			return minmod(x, y);
 		}
@@ -68,10 +69,7 @@ template <typename problem_t> class HyperbolicSystem
 		return 0.5 * (sgn(a) + sgn(b)) * std::min(std::abs(a), std::abs(b));
 	}
 
-	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto EP(double a, double b) -> double
-	{
-		return MC(a, b);
-	}
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto EP(double a, double b) -> double { return MC(a, b); }
 
 	template <FluxDir DIR>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void
@@ -337,19 +335,19 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM_EP(quokka::Array4View<amrex::R
 		// Use second-order differences to maintain higher-order accuracy
 		const auto d2_l = (q(i + 1, j, k, n) - 2.0 * q(i, j, k, n) + q(i - 1, j, k, n));
 		const auto d2_ll = (q(i, j, k, n) - 2.0 * q(i - 1, j, k, n) + q(i - 2, j, k, n));
-		
+
 		// Use a combination of first and second derivatives for EP limiting
 		const auto ep_factor = std::min(1.0, std::abs(d2_l) > 1e-12 ? std::abs(d2_ll / d2_l) : 1.0);
 		lslope = ep_factor * delta_l;
 	}
 
-	// Right slope computation  
+	// Right slope computation
 	auto rslope = MC(delta_r, delta_l);
 	if (is_extremum) {
 		// Similar EP limiting for right slope
 		const auto d2_r = (q(i + 2, j, k, n) - 2.0 * q(i + 1, j, k, n) + q(i, j, k, n));
 		const auto d2_c = (q(i + 1, j, k, n) - 2.0 * q(i, j, k, n) + q(i - 1, j, k, n));
-		
+
 		const auto ep_factor = std::min(1.0, std::abs(d2_c) > 1e-12 ? std::abs(d2_r / d2_c) : 1.0);
 		rslope = ep_factor * delta_r;
 	}


### PR DESCRIPTION
### Description
Implements the extremum-preserving MC limiter of Sekora & Colella: https://arxiv.org/abs/0903.4200

This may give better results for MHD emf reconstruction.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
