### PR TITLE
update Dockerfiles to use Clang 20

### DIFF
--- a/.devcontainer/cuda-container/Dockerfile
+++ b/.devcontainer/cuda-container/Dockerfile
@@ -14,17 +14,17 @@ RUN apt-get update -qq && apt-get upgrade -y -qq && \
     apt-get --yes -qq clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install Clang 19.x
+# Install Clang 20.x
 RUN mkdir -m 0755 -p /etc/apt/keyrings/ && \
  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && \
- echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
+ echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
 
 RUN apt-get clean && apt-get update -y && \
- apt-get install -y --no-install-recommends clang-19 llvm-19 libomp-19-dev libclang-rt-19-dev clangd-19 && \
+ apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev libclang-rt-20-dev clangd-20 && \
  rm -rf /var/lib/apt/lists/*
 
 # Create symlink for clangd
-RUN ln -s /usr/bin/clangd-19 /usr/bin/clangd
+RUN ln -s /usr/bin/clangd-20 /usr/bin/clangd
 
 # Install the latest version of CMake
 RUN test -f /usr/share/doc/kitware-archive-keyring/copyright || wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null && \

--- a/.devcontainer/gcc-container/Dockerfile
+++ b/.devcontainer/gcc-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04@sha256:a7cddc16b93b4ccfab0d33c805460a826703211ec30e3c04761aec17d71275cb
+.devcontainer/gcc-container/DockerfileFROM mcr.microsoft.com/devcontainers/cpp:ubuntu-24.04@sha256:a7cddc16b93b4ccfab0d33c805460a826703211ec30e3c04761aec17d71275cb
 
 RUN apt-get --yes -qq update \
  && apt-get --yes -qq upgrade \
@@ -10,17 +10,17 @@ RUN apt-get --yes -qq update \
  && apt-get --yes -qq clean \
  && rm -rf /var/lib/apt/lists/*
 
-# install Clang 19.x
+# install Clang 20.x
 RUN mkdir -m 0755 -p /etc/apt/keyrings/ && \
  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && \
- echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
+ echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null
 
 RUN apt-get clean && apt-get update -y && \
- apt-get install -y --no-install-recommends clang-19 llvm-19 libomp-19-dev libclang-rt-19-dev clangd-19 && \
+ apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev libclang-rt-20-dev clangd-20 && \
  rm -rf /var/lib/apt/lists/*
  
 # Create symlink for clangd
-RUN ln -s /usr/bin/clangd-19 /usr/bin/clangd
+RUN ln -s /usr/bin/clangd-20 /usr/bin/clangd
 
 # install blosc2 (needed for ADIOS2)
 RUN pip3 install blosc2 --break-system-packages


### PR DESCRIPTION
### Description
Updates Dockerfiles to use Clang 20 instead of Clang 19.

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/1129.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
