### PR TITLE
Cooling: use functors instead of function pointers

### DIFF
--- a/src/cooling/GrackleLikeCooling.hpp
+++ b/src/cooling/GrackleLikeCooling.hpp
@@ -219,42 +219,47 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeTgasFromEgas(double rho, do
 	return T_sol;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs, void *user_data) -> int
-{
-	// unpack user_data
-	auto *udata = static_cast<ODEUserData *>(user_data);
-	const Real rho = udata->rho;
-	const Real gamma = udata->gamma;
-	grackleGpuConstTables const &tables = udata->tables;
+struct GrackleCoolingFunctor {
+	const Real rho;
+	const Real gamma;
+	grackleGpuConstTables const &tables;
 
-	// check whether temperature is out-of-bounds
-	const Real Tmin = tables.T_min;
-	const Real Tmax = tables.T_max;
-	const Real Eint_min = ComputeEgasFromTgas(rho, Tmin, gamma, tables);
-	const Real Eint_max = ComputeEgasFromTgas(rho, Tmax, gamma, tables);
-
-	// compute temperature and cooling rate
-	const Real Eint = y_data[0];
-
-	if (Eint <= Eint_min) {
-		// set cooling to value at Tmin
-		y_rhs[0] = cloudy_cooling_function(rho, Tmin, tables);
-	} else if (Eint >= Eint_max) {
-		// set cooling to value at Tmax
-		y_rhs[0] = cloudy_cooling_function(rho, Tmax, tables);
-	} else {
-		// ok, within tabulated cooling limits
-		const Real T = ComputeTgasFromEgas(rho, Eint, gamma, tables);
-		if (!std::isnan(T)) { // temp iteration succeeded
-			y_rhs[0] = cloudy_cooling_function(rho, T, tables);
-		} else { // temp iteration failed
-			y_rhs[0] = NAN;
-			return 1; // failed
-		}
+	AMREX_GPU_HOST_DEVICE GrackleCoolingFunctor(Real rho_in, Real gamma_in, grackleGpuConstTables const &tables_in)
+	    : rho(rho_in), gamma(gamma_in), tables(tables_in)
+	{
 	}
 
-	return 0; // success
-}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs) const -> int
+	{
+		// check whether temperature is out-of-bounds
+		const Real Tmin = tables.T_min;
+		const Real Tmax = tables.T_max;
+		const Real Eint_min = ComputeEgasFromTgas(rho, Tmin, gamma, tables);
+		const Real Eint_max = ComputeEgasFromTgas(rho, Tmax, gamma, tables);
+
+		// compute temperature and cooling rate
+		const Real Eint = y_data[0];
+
+		if (Eint <= Eint_min) {
+			// set cooling to value at Tmin
+			y_rhs[0] = cloudy_cooling_function(rho, Tmin, tables);
+		} else if (Eint >= Eint_max) {
+			// set cooling to value at Tmax
+			y_rhs[0] = cloudy_cooling_function(rho, Tmax, tables);
+		} else {
+			// ok, within tabulated cooling limits
+			const Real T = ComputeTgasFromEgas(rho, Eint, gamma, tables);
+			if (!std::isnan(T)) { // temp iteration succeeded
+				y_rhs[0] = cloudy_cooling_function(rho, T, tables);
+			} else { // temp iteration failed
+				y_rhs[0] = NAN;
+				return 1; // failed
+			}
+		}
+
+		return 0; // success
+	}
+};
 
 template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Real dt_in, grackle_tables &cloudyTables, const Real T_floor) -> bool
 {
@@ -284,13 +289,13 @@ template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Rea
 
 			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
 			const Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-			ODEUserData user_data{rho, gamma, tables};
+			GrackleCoolingFunctor coolingFunctor(rho, gamma, tables);
 			quokka::valarray<Real, 1> y = {Eint};
 			quokka::valarray<Real, 1> const abstol = {reltol_floor * ComputeEgasFromTgas(rho, T_floor, gamma, tables)};
 
 			// do integration with RK2 (Heun's method)
 			int nsteps = 0;
-			rk_adaptive_integrate(user_rhs, 0, y, dt, &user_data, rtol, abstol, nsteps);
+			rk_adaptive_integrate(coolingFunctor, 0, y, dt, rtol, abstol, nsteps);
 			nsubsteps(i, j, k) = nsteps;
 
 			// check if integration failed

--- a/src/cooling/GrackleLikeCooling.hpp
+++ b/src/cooling/GrackleLikeCooling.hpp
@@ -289,7 +289,7 @@ template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Rea
 
 			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
 			const Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-			GrackleCoolingFunctor coolingFunctor(rho, gamma, tables);
+			GrackleCoolingFunctor const coolingFunctor(rho, gamma, tables);
 			quokka::valarray<Real, 1> y = {Eint};
 			quokka::valarray<Real, 1> const abstol = {reltol_floor * ComputeEgasFromTgas(rho, T_floor, gamma, tables)};
 

--- a/src/cooling/GrackleLikeCooling.hpp
+++ b/src/cooling/GrackleLikeCooling.hpp
@@ -220,9 +220,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeTgasFromEgas(double rho, do
 }
 
 struct GrackleCoolingFunctor {
-	const Real rho;
-	const Real gamma;
-	grackleGpuConstTables const &tables;
+	Real rho;
+	Real gamma;
+	grackleGpuConstTables tables;
 
 	AMREX_GPU_HOST_DEVICE GrackleCoolingFunctor(Real rho_in, Real gamma_in, grackleGpuConstTables const &tables_in)
 	    : rho(rho_in), gamma(gamma_in), tables(tables_in)

--- a/src/cooling/TabulatedCooling.hpp
+++ b/src/cooling/TabulatedCooling.hpp
@@ -282,7 +282,7 @@ template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Rea
 
 			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
 			const Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-			CloudyCoolingFunctor coolingFunctor(rho, gamma, tables);
+			CloudyCoolingFunctor const coolingFunctor(rho, gamma, tables);
 			quokka::valarray<Real, 1> y = {Eint};
 			quokka::valarray<Real, 1> const abstol = {reltol_floor * ComputeEgasFromTgas(rho, T_floor, gamma, tables)};
 

--- a/src/cooling/TabulatedCooling.hpp
+++ b/src/cooling/TabulatedCooling.hpp
@@ -215,9 +215,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeMMW(double rho, double Egas
 }
 
 struct CloudyCoolingFunctor {
-	const Real rho;
-	const Real gamma;
-	cloudyGpuConstTables const &tables;
+	Real rho;
+	Real gamma;
+	cloudyGpuConstTables tables;
 
 	AMREX_GPU_HOST_DEVICE CloudyCoolingFunctor(Real rho_in, Real gamma_in, cloudyGpuConstTables const &tables_in)
 	    : rho(rho_in), gamma(gamma_in), tables(tables_in)

--- a/src/cooling/TabulatedCooling.hpp
+++ b/src/cooling/TabulatedCooling.hpp
@@ -214,40 +214,45 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeMMW(double rho, double Egas
 	return mu;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs, void *user_data) -> int
-{
-	// unpack user_data
-	auto *udata = static_cast<ODEUserData *>(user_data);
-	const Real rho = udata->rho;
-	const Real gamma = udata->gamma;
-	cloudyGpuConstTables const &tables = udata->tables;
+struct CloudyCoolingFunctor {
+	const Real rho;
+	const Real gamma;
+	cloudyGpuConstTables const &tables;
 
-	// check whether temperature is out-of-bounds
-	const Real Eint_min = ComputeEgasFromTgas(rho, tables.T_min, gamma, tables);
-	const Real Eint_max = ComputeEgasFromTgas(rho, tables.T_max, gamma, tables);
-
-	// compute temperature and cooling rate
-	const Real Eint = y_data[0];
-
-	if (Eint <= Eint_min) {
-		// set cooling to value at Tmin
-		y_rhs[0] = cloudy_cooling_function(rho, tables.T_min, tables);
-	} else if (Eint >= Eint_max) {
-		// set cooling to value at Tmax
-		y_rhs[0] = cloudy_cooling_function(rho, tables.T_max, tables);
-	} else {
-		// ok, within tabulated cooling limits
-		const Real T = ComputeTgasFromEgas(rho, Eint, gamma, tables);
-		if (!std::isnan(T)) { // temp iteration succeeded
-			y_rhs[0] = cloudy_cooling_function(rho, T, tables);
-		} else { // temp iteration failed
-			y_rhs[0] = NAN;
-			return 1; // failed
-		}
+	AMREX_GPU_HOST_DEVICE CloudyCoolingFunctor(Real rho_in, Real gamma_in, cloudyGpuConstTables const &tables_in)
+	    : rho(rho_in), gamma(gamma_in), tables(tables_in)
+	{
 	}
 
-	return 0; // success
-}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs) const -> int
+	{
+		// check whether temperature is out-of-bounds
+		const Real Eint_min = ComputeEgasFromTgas(rho, tables.T_min, gamma, tables);
+		const Real Eint_max = ComputeEgasFromTgas(rho, tables.T_max, gamma, tables);
+
+		// compute temperature and cooling rate
+		const Real Eint = y_data[0];
+
+		if (Eint <= Eint_min) {
+			// set cooling to value at Tmin
+			y_rhs[0] = cloudy_cooling_function(rho, tables.T_min, tables);
+		} else if (Eint >= Eint_max) {
+			// set cooling to value at Tmax
+			y_rhs[0] = cloudy_cooling_function(rho, tables.T_max, tables);
+		} else {
+			// ok, within tabulated cooling limits
+			const Real T = ComputeTgasFromEgas(rho, Eint, gamma, tables);
+			if (!std::isnan(T)) { // temp iteration succeeded
+				y_rhs[0] = cloudy_cooling_function(rho, T, tables);
+			} else { // temp iteration failed
+				y_rhs[0] = NAN;
+				return 1; // failed
+			}
+		}
+
+		return 0; // success
+	}
+};
 
 template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Real dt_in, cloudy_tables &cloudyTables, const Real T_floor) -> bool
 {
@@ -277,13 +282,13 @@ template <typename problem_t> auto computeCooling(amrex::MultiFab &mf, const Rea
 
 			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
 			const Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-			ODEUserData user_data{rho, gamma, tables};
+			CloudyCoolingFunctor coolingFunctor(rho, gamma, tables);
 			quokka::valarray<Real, 1> y = {Eint};
 			quokka::valarray<Real, 1> const abstol = {reltol_floor * ComputeEgasFromTgas(rho, T_floor, gamma, tables)};
 
 			// do integration with RK2 (Heun's method)
 			int nsteps = 0;
-			rk_adaptive_integrate(user_rhs, 0, y, dt, &user_data, rtol, abstol, nsteps);
+			rk_adaptive_integrate(coolingFunctor, 0, y, dt, rtol, abstol, nsteps);
 			nsubsteps(i, j, k) = nsteps;
 
 			// TODO(bwibking): move to separate kernel

--- a/src/math/ODEIntegrate.hpp
+++ b/src/math/ODEIntegrate.hpp
@@ -24,8 +24,8 @@
 using Real = amrex::Real;
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
-							       quokka::valarray<Real, N> &yerr) -> int
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt,
+							       quokka::valarray<Real, N> &ynew, quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Heun-Euler (1)2 method
 
@@ -57,8 +57,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F const &rhs, Rea
 }
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
-							       quokka::valarray<Real, N> &yerr) -> int
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt,
+							       quokka::valarray<Real, N> &ynew, quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Bogaki-Shampine (2)3 method
 	// https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#bogacki-shampine-4-2-3

--- a/src/math/ODEIntegrate.hpp
+++ b/src/math/ODEIntegrate.hpp
@@ -24,7 +24,7 @@
 using Real = amrex::Real;
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F &&rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
 							       quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Heun-Euler (1)2 method
@@ -57,7 +57,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F &&rhs, Real t0,
 }
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F const &rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
 							       quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Bogaki-Shampine (2)3 method
@@ -125,7 +125,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto error_norm(quokka::valarray<Real, 
 constexpr int maxStepsODEIntegrate = 2000;
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Real t0, quokka::valarray<Real, N> &y0, Real t1, Real reltol,
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F const &rhs, Real t0, quokka::valarray<Real, N> &y0, Real t1, Real reltol,
 								    quokka::valarray<Real, N> const &abstol, int &steps_taken)
 {
 	// Integrate dy/dt = rhs(y, t) from t0 to t1,

--- a/src/math/ODEIntegrate.hpp
+++ b/src/math/ODEIntegrate.hpp
@@ -25,14 +25,14 @@ using Real = amrex::Real;
 
 template <typename F, int N>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F &&rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
-							       quokka::valarray<Real, N> &yerr, void *user_data) -> int
+							       quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Heun-Euler (1)2 method
 
 	// stage 1 [Forward Euler step at t0]
 	quokka::valarray<Real, N> k1{};
 	quokka::valarray<Real, N> y_arg = y;
-	int ierr = rhs(t0, y_arg, k1, user_data);
+	int ierr = rhs(t0, y_arg, k1);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -41,7 +41,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F &&rhs, Real t0,
 	// stage 2 [Forward Euler step at t1]
 	quokka::valarray<Real, N> k2{};
 	y_arg = y + k1;
-	ierr = rhs(t0 + dt, y_arg, k2, user_data);
+	ierr = rhs(t0 + dt, y_arg, k2);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -58,7 +58,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk12_single_step(F &&rhs, Real t0,
 
 template <typename F, int N>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0, quokka::valarray<Real, N> const &y, Real dt, quokka::valarray<Real, N> &ynew,
-							       quokka::valarray<Real, N> &yerr, void *user_data) -> int
+							       quokka::valarray<Real, N> &yerr) -> int
 {
 	// Compute one step of the RK Bogaki-Shampine (2)3 method
 	// https://sundials.readthedocs.io/en/latest/arkode/Butcher_link.html#bogacki-shampine-4-2-3
@@ -66,7 +66,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0,
 	// stage 1
 	quokka::valarray<Real, N> k1{};
 	quokka::valarray<Real, N> y_arg = y;
-	int ierr = rhs(t0, y_arg, k1, user_data);
+	int ierr = rhs(t0, y_arg, k1);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -75,7 +75,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0,
 	// stage 2
 	quokka::valarray<Real, N> k2{};
 	y_arg = y + 0.5 * k1;
-	ierr = rhs(t0 + 0.5 * dt, y_arg, k2, user_data);
+	ierr = rhs(t0 + 0.5 * dt, y_arg, k2);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -84,7 +84,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0,
 	// stage 3
 	quokka::valarray<Real, N> k3{};
 	y_arg = y + (3. / 4.) * k2;
-	ierr = rhs(t0 + (3. / 4.) * dt, y_arg, k3, user_data);
+	ierr = rhs(t0 + (3. / 4.) * dt, y_arg, k3);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -93,7 +93,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto rk23_single_step(F &&rhs, Real t0,
 	// stage 4
 	quokka::valarray<Real, N> k4{};
 	y_arg = y + (2. / 9.) * k1 + (1. / 3.) * k2 + (4. / 9.) * k3;
-	ierr = rhs(t0 + dt, y_arg, k4, user_data);
+	ierr = rhs(t0 + dt, y_arg, k4);
 	if (ierr != 0) {
 		return ierr;
 	}
@@ -125,7 +125,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto error_norm(quokka::valarray<Real, 
 constexpr int maxStepsODEIntegrate = 2000;
 
 template <typename F, int N>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Real t0, quokka::valarray<Real, N> &y0, Real t1, void *user_data, Real reltol,
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Real t0, quokka::valarray<Real, N> &y0, Real t1, Real reltol,
 								    quokka::valarray<Real, N> const &abstol, int &steps_taken)
 {
 	// Integrate dy/dt = rhs(y, t) from t0 to t1,
@@ -134,7 +134,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 
 	// initial timestep
 	quokka::valarray<Real, N> ydot0{};
-	rhs(t0, y0, ydot0, user_data);
+	rhs(t0, y0, ydot0);
 	const Real dt_guess = 0.1 * min(abs(y0 / ydot0));
 	AMREX_ASSERT(dt_guess > 0.0);
 
@@ -164,7 +164,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F &&rhs, Rea
 		bool step_success = false;
 		for (int k = 0; k < maxRetries; ++k) {
 			// compute single step of chosen RK method
-			int ierr = rk12_single_step(rhs, time, y, dt, ynew, yerr, user_data);
+			int ierr = rk12_single_step(rhs, time, y, dt, ynew, yerr);
 
 			Real eta = NAN;
 			Real epsilon = NAN;

--- a/src/problems/ODEIntegration/test_ode.cpp
+++ b/src/problems/ODEIntegration/test_ode.cpp
@@ -46,7 +46,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cooling_function(Real const rho, R
 }
 
 struct ODECoolingFunctor {
-	const Real rho;
+	Real rho;
 
 	AMREX_GPU_HOST_DEVICE explicit ODECoolingFunctor(Real rho_in) : rho(rho_in) {}
 
@@ -81,7 +81,7 @@ auto problem_main() -> int
 	std::cout << "Initial edot = " << Edot0 << '\n';
 
 	// solve cooling
-	ODECoolingFunctor coolingFunctor(rho0);
+	ODECoolingFunctor const coolingFunctor(rho0);
 	quokka::valarray<Real, 1> y = {Eint0};
 	quokka::valarray<Real, 1> const abstol = 1.0e-20 * y;
 	const Real rtol = 1.0e-4; // appropriate for RK12

--- a/src/problems/ODEIntegration/test_ode.cpp
+++ b/src/problems/ODEIntegration/test_ode.cpp
@@ -45,20 +45,22 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto cooling_function(Real const rho, R
 	return cooling_source_term;
 }
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto user_rhs(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs, void *user_data) -> int
-{
-	// unpack user_data
-	auto *udata = static_cast<ODEUserData *>(user_data);
-	Real const rho = udata->rho;
+struct ODECoolingFunctor {
+	const Real rho;
 
-	// compute temperature
-	Real const Eint = y_data[0];
-	Real const T = quokka::EOS<ODETest>::ComputeTgasFromEint(rho, Eint);
+	AMREX_GPU_HOST_DEVICE explicit ODECoolingFunctor(Real rho_in) : rho(rho_in) {}
 
-	// compute cooling function
-	y_rhs[0] = cooling_function(rho, T);
-	return 0;
-}
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(Real /*t*/, quokka::valarray<Real, 1> &y_data, quokka::valarray<Real, 1> &y_rhs) const -> int
+	{
+		// compute temperature
+		Real const Eint = y_data[0];
+		Real const T = quokka::EOS<ODETest>::ComputeTgasFromEint(rho, Eint);
+
+		// compute cooling function
+		y_rhs[0] = cooling_function(rho, T);
+		return 0;
+	}
+};
 
 auto problem_main() -> int
 {
@@ -79,12 +81,12 @@ auto problem_main() -> int
 	std::cout << "Initial edot = " << Edot0 << '\n';
 
 	// solve cooling
-	ODEUserData user_data{rho0};
+	ODECoolingFunctor coolingFunctor(rho0);
 	quokka::valarray<Real, 1> y = {Eint0};
 	quokka::valarray<Real, 1> const abstol = 1.0e-20 * y;
 	const Real rtol = 1.0e-4; // appropriate for RK12
 	int steps_taken = 0;
-	rk_adaptive_integrate(user_rhs, 0, y, max_time, &user_data, rtol, abstol, steps_taken);
+	rk_adaptive_integrate(coolingFunctor, 0, y, max_time, rtol, abstol, steps_taken);
 
 	const Real Tgas = quokka::EOS<ODETest>::ComputeTgasFromEint(rho0, y[0]);
 	// for n_H = 0.01 cm^{-3} (for IK cooling function)


### PR DESCRIPTION
### Description
Converts the cooling modules to use functors instead of function pointers when calling the integrator in `math/ODEIntegrate.hpp`.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
