### PR TITLE
Disable FPE on AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # this is necessary to avoid spurious FPEs due to vectorization
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
 	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" OFF)
 else()
 	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ option(QUOKKA_PYTHON "Compile with Python support (on/off)" ON)
 option(DISABLE_FMAD "Disable fused multiply-add instructions on GPU (on/off)" ON)
 option(ENABLE_ASAN "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 option(ENABLE_HWASAN "Enable HWAddressSanitizer" OFF)
-option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(QUOKKA_OPENPMD "Enable OpenPMD output (on/off)" OFF)
 
@@ -79,7 +78,9 @@ endif()
 
 # this is necessary to avoid spurious FPEs due to vectorization
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-  add_compile_options(-ffp-exception-behavior=strict)
+	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" OFF)
+else()
+	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
 endif()
 
 execute_process(COMMAND git rev-parse --abbrev-ref HEAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,10 +77,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # this is necessary to avoid spurious FPEs due to vectorization
-if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" OFF)
-else()
-	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
 endif()
 
 execute_process(COMMAND git rev-parse --abbrev-ref HEAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,10 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 # this is necessary to avoid spurious FPEs due to vectorization
-option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
 if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
 	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" OFF)
+else()
+	option(ENABLE_TESTS_FPE "Enable floating-point exceptions when running tests" ON)
 endif()
 
 execute_process(COMMAND git rev-parse --abbrev-ref HEAD


### PR DESCRIPTION
### Description

FPE behaves spuriously on macOS with Apple chips, so we'd better turn it off for all compilers on macOS.

### Related issues
None. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
