### PR TITLE
[WIP] Stable particle redistribute on GPUs

### DIFF
--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -315,7 +315,7 @@ inline bool sink_particle_use_uniform_kernel = false; // NOLINT. If true, use un
 inline int particle_verbose = 0; // NOLINT print particle logistics
 
 // Random seed for particle creation. Default is 0, which means the random seed is not fixed.
-inline int particle_random_seed = 0; // NOLINT
+inline int particle_random_seed = 1024; // NOLINT
 
 // Stable redistribute for particle creation. Default is 0 (false).
 inline int particle_stable_redistribute = 0; // NOLINT

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -314,6 +314,12 @@ inline bool sink_particle_use_uniform_kernel = false; // NOLINT. If true, use un
 // Verbosity for particle operations
 inline int particle_verbose = 0; // NOLINT print particle logistics
 
+// Random seed for particle creation. Default is 0, which means the random seed is not fixed.
+inline int particle_random_seed = 0; // NOLINT
+
+// Stable redistribute for particle creation. Default is 0 (false).
+inline int particle_stable_redistribute = 0; // NOLINT
+
 // Function to parse particle parameters from input file
 // The 'inline' keyword allows this function to be defined in a header file without
 // causing multiple definition errors when the header is included in multiple source files.
@@ -339,6 +345,12 @@ inline void particleParmParse()
 	// Placeholder parameters for particles
 	pp.query("param1", particle_param1);
 	pp.query("param2", particle_param2);
+
+	// Handle random seed
+	pp.query("random_seed", particle_random_seed);
+
+	// Handle stable redistribute
+	pp.query("stable_redistribute", particle_stable_redistribute);
 }
 
 } // namespace quokka

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2324,7 +2324,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICParticles->SetVerbose(0);
 
 		if (quokka::particle_stable_redistribute != 0) {
-			RadParticles->setStableRedistribute(1);
+			CICParticles->setStableRedistribute(1);
 		}
 
 		// Register with particle register - CIC particles allow creation
@@ -2342,7 +2342,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICRadParticles->SetVerbose(0);
 
 		if (quokka::particle_stable_redistribute != 0) {
-			RadParticles->setStableRedistribute(1);
+			CICRadParticles->setStableRedistribute(1);
 		}
 
 		// Register with particle register - CICRad particles do not allow creation
@@ -2362,7 +2362,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		StochasticStellarPopParticles->SetVerbose(0);
 
 		if (quokka::particle_stable_redistribute != 0) {
-			RadParticles->setStableRedistribute(1);
+			StochasticStellarPopParticles->setStableRedistribute(1);
 		}
 
 		// Register with particle register - StochasticStellarPop particles allow creation
@@ -2380,7 +2380,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		SinkParticles->SetVerbose(0);
 
 		if (quokka::particle_stable_redistribute != 0) {
-			RadParticles->setStableRedistribute(1);
+			SinkParticles->setStableRedistribute(1);
 		}
 
 		// Register with particle register - Sink particles allow creation
@@ -2397,7 +2397,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		TestParticles->SetVerbose(0);
 
 		if (quokka::particle_stable_redistribute != 0) {
-			RadParticles->setStableRedistribute(1);
+			TestParticles->setStableRedistribute(1);
 		}
 
 		// Register with particle register - Test particles have all features enabled

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2293,12 +2293,20 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 	// Read particle parameters from input file
 	quokka::particleParmParse();
 
+	if (quokka::particle_random_seed != 0) {
+		amrex::InitRandom(static_cast<unsigned long>(quokka::particle_random_seed)); // NOLINT(google-runtime-int)
+	}
+
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
 		AMREX_ASSERT(RadParticles == nullptr);
 
 		// Create particle container
 		RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
 		RadParticles->SetVerbose(0);
+
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
 
 		// Register with particle register - Rad particles do not allow creation
 		particleRegister_.registerParticleType(RadParticles.get(), quokka::ParticleType::Rad);
@@ -2315,6 +2323,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		CICParticles = std::make_unique<quokka::CICParticleContainer>(this);
 		CICParticles->SetVerbose(0);
 
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
+
 		// Register with particle register - CIC particles allow creation
 		particleRegister_.registerParticleType(CICParticles.get(), quokka::ParticleType::CIC);
 
@@ -2328,6 +2340,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		// Create particle container
 		CICRadParticles = std::make_unique<quokka::CICRadParticleContainer<problem_t>>(this);
 		CICRadParticles->SetVerbose(0);
+
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
 
 		// Register with particle register - CICRad particles do not allow creation
 		particleRegister_.registerParticleType(CICRadParticles.get(), quokka::ParticleType::CICRad);
@@ -2345,6 +2361,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
 		StochasticStellarPopParticles->SetVerbose(0);
 
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
+
 		// Register with particle register - StochasticStellarPop particles allow creation
 		particleRegister_.registerStarParticleType(StochasticStellarPopParticles.get(), quokka::ParticleType::StochasticStellarPop);
 
@@ -2359,6 +2379,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		SinkParticles = std::make_unique<quokka::SinkParticleContainer>(this);
 		SinkParticles->SetVerbose(0);
 
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
+
 		// Register with particle register - Sink particles allow creation
 		particleRegister_.registerStarParticleType(SinkParticles.get(), quokka::ParticleType::Sink);
 
@@ -2371,6 +2395,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 		// Create particle container
 		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
 		TestParticles->SetVerbose(0);
+
+		if (quokka::particle_stable_redistribute != 0) {
+			RadParticles->setStableRedistribute(1);
+		}
 
 		// Register with particle register - Test particles have all features enabled
 		particleRegister_.registerStarParticleType(TestParticles.get(), quokka::ParticleType::Test);

--- a/tests/ParticleSF.in
+++ b/tests/ParticleSF.in
@@ -44,6 +44,8 @@ problem.T_amb = 718.0
 particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 particles.eps_ff = 0.5
+particles.particle_random_seed = 100
+particles.stable_redistribute = 1
 
 max_timesteps = 1
 plotfile_interval = -1


### PR DESCRIPTION
### Description

This PR attempts to add a new parameter to make particle redistribute stable on GPU. 

Related: https://github.com/AMReX-Codes/amrex/pull/4200 
Following implementation from: https://github.com/erf-model/ERF/pull/2021 

This is not tested. It compiles and runs, but I haven't tested it on GPUs. I couldn't reproduce different results on GPU runs (as reported in #1125). 

### Related issues
Closes #1125 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
