### PR TITLE
Replace CTest runner with Canary

### DIFF
--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install Canary
+      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
@@ -58,7 +61,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest -j 4 -T Test -E "RadhydroPulseMG*" --output-on-failure
+      run: canary run --output-on-failure --workers=4 -k 'not RadhydroPulseMG' .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
     - name: Install Canary
-      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+      run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/cmake-arm64-hwasan.yml
+++ b/.github/workflows/cmake-arm64-hwasan.yml
@@ -44,7 +44,7 @@ jobs:
       run: sudo mkdir -m 0755 -p /etc/apt/keyrings/ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && sudo echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null && sudo apt-get clean && sudo apt-get update -y && sudo apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev libclang-rt-20-dev clangd-20 lld-20
 
     - name: Install Canary
-      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+      run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/cmake-arm64-hwasan.yml
+++ b/.github/workflows/cmake-arm64-hwasan.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Install Clang 20.x
       run: sudo mkdir -m 0755 -p /etc/apt/keyrings/ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && sudo echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null && sudo apt-get clean && sudo apt-get update -y && sudo apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev libclang-rt-20-dev clangd-20 lld-20
 
+    - name: Install Canary
+      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
@@ -59,7 +62,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0:leak_check_at_exit=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=detect_leaks=0:leak_check_at_exit=0 ctest --output-on-failure -C $BUILD_TYPE -j4
+      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0:leak_check_at_exit=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=detect_leaks=0:leak_check_at_exit=0 canary run --output-on-failure --workers=4 .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-arm64-release.yml
+++ b/.github/workflows/cmake-arm64-release.yml
@@ -41,7 +41,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
     - name: Install Canary
-      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+      run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/cmake-arm64-release.yml
+++ b/.github/workflows/cmake-arm64-release.yml
@@ -40,6 +40,9 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install Canary
+      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
@@ -58,7 +61,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ctest --output-on-failure -C $BUILD_TYPE -j4
+      run: canary run --output-on-failure --workers=4 .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -80,8 +80,6 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: canary run --output-on-failure --workers=3 .
 
     - name: Upload test output

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -57,6 +57,9 @@ jobs:
     - name: Install pip dependencies
       run: python3 -m pip install --user numpy matplotlib
 
+    - name: Install Canary
+      run: python3 -m pip install --user "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
@@ -79,7 +82,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --output-on-failure -C $BUILD_TYPE -j3
+      run: canary run --output-on-failure --workers=3 .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -58,7 +58,7 @@ jobs:
       run: python3 -m pip install --user numpy matplotlib
 
     - name: Install Canary
-      run: python3 -m pip install --user "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+      run: python3 -m pip install --user "canary-wm @ git+https://github.com/sandialabs/canary"
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -80,7 +80,9 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: canary run --output-on-failure --workers=3 .
+      run: |
+        export PATH="$HOME/Library/Python/3.11/bin:$PATH"
+        canary run --output-on-failure --workers=3 .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,8 +68,6 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt canary run --output-on-failure --workers=4 .
 
     - name: Upload test output

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -44,7 +44,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
     - name: Install Canary
-      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+      run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install Canary
+      run: python3 -m pip install "canary-wm @ git+ssh://git@github.com/sandialabs/canary"
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
@@ -67,7 +70,7 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt ctest --output-on-failure -C $BUILD_TYPE -j4
+      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt canary run --output-on-failure --workers=4 .
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -68,7 +68,7 @@ jobs:
     - name: Test
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt canary run --output-on-failure --workers=4 .
+      run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt canary run --output-on-failure --workers=2 .
 
     - name: Upload test output
       if: always()


### PR DESCRIPTION
### Description
Replaces CTest with Canary (https://github.com/sandialabs/canary) as the test suite runner. 

### Related issues
Closes https://github.com/quokka-astro/quokka/issues/1073.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
