### PR TITLE
Relocate regression test folder 

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
     - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
-    - publish: /data/mash/cche/azp-agent-regression-tests/web
+    - publish: /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
       condition: succeededOrFailed()
       artifact: regressionHTMLOutput
       displayName: 'Upload results to Azure Pipelines'
-    - script: cd /data/mash/cche/azp-agent-regression-tests/web && git add . && git commit -m 'updated results' && git push
+    - script: cd /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
     - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
-    - publish: /home/bwibking/regression-tests/web
+    - publish: /data/mash/cche/azp-agent-regression-tests/web
       condition: succeededOrFailed()
       artifact: regressionHTMLOutput
       displayName: 'Upload results to Azure Pipelines'
-    - script: cd /home/bwibking/regression-tests/web && git add . && git commit -m 'updated results' && git push
+    - script: cd /data/mash/cche/azp-agent-regression-tests/web && git add . && git commit -m 'updated results' && git push
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'

--- a/.devcontainer/cuda-azp-agent-in-docker/Dockerfile
+++ b/.devcontainer/cuda-azp-agent-in-docker/Dockerfile
@@ -5,7 +5,7 @@ ENV TARGETARCH="linux/amd64"
 USER root
 RUN apt update && \
   apt upgrade -y && \
-  apt install -y curl git jq libicu74 python3-h5py
+  apt install -y curl git jq libicu74 python3-h5py gfortran
 
 # Install h5py
 # RUN pip3 install h5py 

--- a/.devcontainer/cuda-azp-agent-in-docker/build.sh
+++ b/.devcontainer/cuda-azp-agent-in-docker/build.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 export DOCKER_BUILDKIT=1
 docker buildx create --use
 

--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -35,7 +35,7 @@ derived_vars = pressure entropy nH temperature cooling_length \
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
 cooling.cooling_table_type = cloudy_cooling_tools
-cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
+cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
 temperature_floor = 100
 
 sharp_cloud_edge = 1

--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -35,7 +35,7 @@ derived_vars = pressure entropy nH temperature cooling_length \
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
 cooling.cooling_table_type = cloudy_cooling_tools
-cooling.hdf5_data_file = "/home/bwibking/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
+cooling.hdf5_data_file = "/data/mash/cche/azp-agent-regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
 temperature_floor = 100
 
 sharp_cloud_edge = 1

--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -35,7 +35,7 @@ derived_vars = pressure entropy nH temperature cooling_length \
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
 cooling.cooling_table_type = cloudy_cooling_tools
-cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
+cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
 temperature_floor = 100
 
 sharp_cloud_edge = 1

--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -35,7 +35,7 @@ derived_vars = pressure entropy nH temperature cooling_length \
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
 cooling.cooling_table_type = cloudy_cooling_tools
-cooling.hdf5_data_file = "/data/mash/cche/azp-agent-regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
+cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
 temperature_floor = 100
 
 sharp_cloud_edge = 1

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -53,7 +53,7 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/amrex
 branch = development
 
 [source]

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,6 +1,6 @@
 [main]
-testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
-webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
+testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests
+webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/web
 
 sourceTree = C_Src
 useCmake = 1
@@ -53,11 +53,11 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
+dir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/amrex
 branch = development
 
 [source]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka
+dir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/quokka
 branch = development
 
 # individual problems follow

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -53,7 +53,7 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/amrex
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
 branch = development
 
 [source]

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,6 +1,6 @@
 [main]
-testTopDir = /data/mash/cche/azp-agent-regression-tests
-webTopDir  = /data/mash/cche/azp-agent-regression-tests/web
+testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
+webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
 
 sourceTree = C_Src
 useCmake = 1
@@ -53,11 +53,11 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-regression-tests/amrex
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
 branch = development
 
 [source]
-dir = /data/mash/cche/azp-agent-regression-tests/quokka
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka
 branch = development
 
 # individual problems follow

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,6 +1,6 @@
 [main]
-testTopDir = /home/bwibking/regression-tests
-webTopDir  = /home/bwibking/regression-tests/web
+testTopDir = /data/mash/cche/azp-agent-regression-tests
+webTopDir  = /data/mash/cche/azp-agent-regression-tests/web
 
 sourceTree = C_Src
 useCmake = 1
@@ -25,7 +25,7 @@ default_branch = development
 
 # email
 sendEmailWhenFail = 0
-emailTo = wibkingb@msu.edu, benwibking+astro@gmail.com
+emailTo = chongchong.he@anu.edu.au, chongchonghe@outlook.com
 emailBody = quokka regression tests completed
 
 # some research groups use slack for communication.  If you setup a
@@ -36,7 +36,7 @@ emailBody = quokka regression tests completed
 # reasons, we don't put it in this inputs file, in case this is under
 # version control).
 slack_post = 1
-slack_webhookfile = /home/bwibking/.slack.webhook
+slack_webhookfile = /home/cche/quokka-azp-agents/.slack.webhook
 slack_channel = "#development"
 slack_username = "buildbot"
 
@@ -53,11 +53,11 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /home/bwibking/regression-tests/amrex
+dir = /data/mash/cche/azp-agent-regression-tests/amrex
 branch = development
 
 [source]
-dir = /home/bwibking/regression-tests/quokka
+dir = /data/mash/cche/azp-agent-regression-tests/quokka
 branch = development
 
 # individual problems follow

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,6 +1,6 @@
 [main]
-testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests
-webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/web
+testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
+webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
 
 sourceTree = C_Src
 useCmake = 1
@@ -53,11 +53,11 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/amrex
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
 branch = development
 
 [source]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/regression-tests/quokka
+dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka
 branch = development
 
 # individual problems follow


### PR DESCRIPTION
### Description

- Replace `/home/bwibking/regression-tests` with `/data/mash/cche/azp-agent-regression-tests`
- Add `gfortran` to cuda Dockerfile 

### Related issues
None. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
