### PR TITLE
use ResampledCooling module for ShockCloud regression test

### DIFF
--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -34,8 +34,8 @@ derived_vars = pressure entropy nH temperature cooling_length \
 
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
-cooling.cooling_table_type = cloudy_cooling_tools
-cooling.hdf5_data_file = "/data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka/extern/cooling/isrf_1000Go_grains.h5"
+cooling.cooling_table_type = resampled
+cooling.hdf5_data_file = "./CloudyData_UVB=HM2012_resampled.h5"
 temperature_floor = 100
 
 sharp_cloud_edge = 1

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -83,6 +83,7 @@ ignore_return_code = 1
 buildDir = .
 target = shock_cloud
 inputFile = inputs/ShockCloud_64_regression.in
+link1File = extern/cooling/CloudyData_UVB=HM2012_resampled.h5
 dim = 3
 cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
 restartTest = 0


### PR DESCRIPTION
### Description
This switches the ShockCloud nightly regression test to use the ResampledCooling module. This is to ensure that ResampledCooling is bitwise reproducible. If it isn't, the nightly tests will fail.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
