### PR TITLE
Compute ghost wavespeeds and face velocities

### DIFF
--- a/inputs/hydro_wave.in
+++ b/inputs/hydro_wave.in
@@ -16,7 +16,9 @@ amr.v              = 0       # verbosity in Amr
 amr.n_cell          = 100 4 4
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
+amr.max_grid_size   = 28    # maximum grid size to create 4 FABs of 25 cells each
 
 do_reflux = 0
 do_subcycle = 0
+do_tracers = 1
 plotfile_interval = -1

--- a/scripts/python/plot_face_velocities.py
+++ b/scripts/python/plot_face_velocities.py
@@ -57,6 +57,26 @@ def parse_fab_file(filename):
                 else:
                     print(f"Warning: Could not parse box format: {box_str}")
                     box_info = None
+            elif line.startswith('# Valid box:'):
+                # Parse valid box bounds
+                valid_str = line.split(':', 1)[1].strip()
+                numbers = re.findall(r'-?\d+', valid_str)
+                numbers = [int(n) for n in numbers]
+                
+                comma_count = valid_str.count(',')
+                
+                if box_info is None:
+                    box_info = {}
+                
+                if comma_count == 0:  # 1D: ((0) (28) (1))
+                    box_info['valid_lo'] = [numbers[0]]
+                    box_info['valid_hi'] = [numbers[1]]
+                elif comma_count == 3:  # 2D: ((0,0) (17,16) (1,0))
+                    box_info['valid_lo'] = [numbers[0], numbers[1]]
+                    box_info['valid_hi'] = [numbers[2], numbers[3]]
+                elif comma_count == 5:  # 3D: ((lo_x,lo_y,lo_z) (hi_x,hi_y,hi_z))
+                    box_info['valid_lo'] = [numbers[0], numbers[1], numbers[2]]
+                    box_info['valid_hi'] = [numbers[3], numbers[4], numbers[5]]
             elif not line.startswith('#'):
                 parts = line.strip().split()
                 if parts:
@@ -105,6 +125,26 @@ def parse_reconstructed_fab_file(filename):
                 else:
                     print(f"Warning: Could not parse box format: {box_str}")
                     box_info = None
+            elif line.startswith('# Valid box:'):
+                # Parse valid box bounds
+                valid_str = line.split(':', 1)[1].strip()
+                numbers = re.findall(r'-?\d+', valid_str)
+                numbers = [int(n) for n in numbers]
+                
+                comma_count = valid_str.count(',')
+                
+                if box_info is None:
+                    box_info = {}
+                
+                if comma_count == 0:  # 1D: ((0) (28) (1))
+                    box_info['valid_lo'] = [numbers[0]]
+                    box_info['valid_hi'] = [numbers[1]]
+                elif comma_count == 3:  # 2D: ((0,0) (17,16) (1,0))
+                    box_info['valid_lo'] = [numbers[0], numbers[1]]
+                    box_info['valid_hi'] = [numbers[2], numbers[3]]
+                elif comma_count == 5:  # 3D: ((lo_x,lo_y,lo_z) (hi_x,hi_y,hi_z))
+                    box_info['valid_lo'] = [numbers[0], numbers[1], numbers[2]]
+                    box_info['valid_hi'] = [numbers[3], numbers[4], numbers[5]]
             elif not line.startswith('#'):
                 parts = line.strip().split()
                 if parts:
@@ -114,9 +154,10 @@ def parse_reconstructed_fab_file(filename):
 
 
 def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
-    """Check if ghost cells match valid cells from adjacent boxes"""
+    """Check if ghost cells match valid cells from adjacent boxes and list all ghost cells"""
     mismatches = []
     correct_matches = []
+    all_ghost_cells = []
     
     # Create a dictionary mapping indices to (box_id, value, is_ghost)
     index_map = {}
@@ -128,11 +169,34 @@ def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
         indices = data[:, 0].astype(int)
         values = data[:, 1] if data.shape[1] == 2 else data[:, 1:]  # Handle multi-component data
         
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
+        # Parse box bounds and valid box bounds from header
+        box_lo = box_info['lo'][0]
+        box_hi = box_info['hi'][0]
+        valid_lo = box_info.get('valid_lo', [box_lo])[0] if 'valid_lo' in box_info else box_lo
+        valid_hi = box_info.get('valid_hi', [box_hi])[0] if 'valid_hi' in box_info else box_hi
         
+        # Count ghost cells properly: any cell outside the valid region
         for idx, val in zip(indices, values):
-            is_ghost = (idx == lo_idx or idx == hi_idx)
+            is_ghost = (idx < valid_lo or idx > valid_hi)
+            is_boundary = (idx == box_lo or idx == box_hi)
+            
+            # Collect ALL ghost cells (outside valid region)
+            if is_ghost:
+                if idx < valid_lo:
+                    boundary_type = 'lo_ghost'
+                    ghost_layer = valid_lo - idx  # how many cells from valid boundary
+                else:
+                    boundary_type = 'hi_ghost'
+                    ghost_layer = idx - valid_hi  # how many cells from valid boundary
+                
+                all_ghost_cells.append({
+                    'index': idx,
+                    'box_id': box_id,
+                    'value': val,
+                    'boundary_type': boundary_type,
+                    'ghost_layer': ghost_layer,
+                    'is_boundary': is_boundary
+                })
             
             if idx not in index_map:
                 index_map[idx] = []
@@ -140,12 +204,12 @@ def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
             index_map[idx].append({
                 'box_id': box_id,
                 'value': val,
-                'is_ghost': is_ghost,
-                'lo': lo_idx,
-                'hi': hi_idx
+                'is_ghost': is_boundary,  # Keep this for interface checking
+                'lo': box_lo,
+                'hi': box_hi
             })
     
-    # Check for mismatches and correct matches
+    # Check for mismatches and correct matches (interface ghost cells only)
     for idx, entries in index_map.items():
         if len(entries) > 1:  # This index appears in multiple boxes
             # Find valid cell value(s)
@@ -180,7 +244,7 @@ def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
                     # Multiple valid entries for same index - this shouldn't happen
                     print(f"Warning: Multiple valid cells at index {idx}")
     
-    return mismatches, correct_matches
+    return mismatches, correct_matches, all_ghost_cells
 
 
 def plot_1d_face_velocities(dirname, timestep=0, level=0):
@@ -208,20 +272,27 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
             all_boxes.append(box_info)
     
     # Check ghost cell consistency
-    mismatches, correct_matches = check_ghost_cell_consistency(all_data, all_boxes)
+    mismatches, correct_matches, all_ghost_cells = check_ghost_cell_consistency(all_data, all_boxes)
     
-    print(f"\n📊 Face velocity ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(correct_matches)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(mismatches)}")
+    print(f"\n📊 All ghost cells in face velocity data:")
+    print(f"  👻 Total ghost cells found: {len(all_ghost_cells)}")
+    print(f"  ✅ Interface ghost cells (correctly matched): {len(correct_matches)}")
+    print(f"  ⚠️  Interface ghost cells (disagreeing): {len(mismatches)}")
+    
+    if all_ghost_cells:
+        print(f"\n👻 All {len(all_ghost_cells)} ghost cells:")
+        for ghost in sorted(all_ghost_cells, key=lambda x: (x['box_id'], x['index'])):
+            boundary_marker = " (boundary)" if ghost['is_boundary'] else ""
+            print(f"  Box {ghost['box_id']}, Index {ghost['index']} ({ghost['boundary_type']}, layer {ghost['ghost_layer']}){boundary_marker}: {ghost['value']:.6e}")
     
     if correct_matches:
-        print(f"\n✅ Details of {len(correct_matches)} correctly-filled ghost cells:")
+        print(f"\n✅ Details of {len(correct_matches)} correctly-filled interface ghost cells:")
         for m in correct_matches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
     
     if mismatches:
-        print(f"\n⚠️  Details of {len(mismatches)} ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(mismatches)} interface ghost cell mismatches:")
         for m in mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
@@ -239,12 +310,12 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
         indices = data[:, 0].astype(int)
         values = data[:, 1]
         
-        # Determine valid region (exclude first and last ghost cells)
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
+        # Determine valid region from header information
+        valid_lo = box_info.get('valid_lo', [box_info['lo'][0]])[0] if 'valid_lo' in box_info else box_info['lo'][0]
+        valid_hi = box_info.get('valid_hi', [box_info['hi'][0]])[0] if 'valid_hi' in box_info else box_info['hi'][0]
         
-        # Create masks for ghost and valid cells
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        # Create masks for ghost and valid cells (ghost = outside valid region)
+        is_ghost = np.logical_or(indices < valid_lo, indices > valid_hi)
         
         # Plot valid cells
         valid_mask = ~is_ghost
@@ -257,9 +328,10 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
                     color=colors[i], markersize=4, markerfacecolor='none',
                     markeredgewidth=1.5, label=f'Box {i} (ghost)')
         
-        # Add vertical lines at box boundaries
+        # Add vertical lines at shared face locations between adjacent boxes
         if i > 0:  # Don't draw line before first box
-            ax.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+            # The shared face is at the start of this box's valid region
+            ax.axvline(x=valid_lo, color='gray', linestyle='--', alpha=0.5)
     
     ax.set_xlabel('Face Index (i)')
     ax.set_ylabel('Face Velocity')
@@ -273,148 +345,13 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
     plt.show()
 
 
-def plot_2d_face_velocities(dirname, direction='x', timestep=0, level=0):
-    """Plot 2D face velocities from FAB files"""
-    fab_dir = Path(f"facevel_lev{level}_step{timestep}")
-    if not fab_dir.exists():
-        print(f"Directory {fab_dir} not found!")
-        return
-    
-    # Find all FAB files for the specified direction
-    fab_files = sorted(fab_dir.glob(f"facevel_{direction}_box_*.fab"))
-    
-    if not fab_files:
-        print(f"No FAB files found for direction {direction} in {fab_dir}")
-        return
-    
-    fig, ax = plt.subplots(figsize=(10, 8))
-    
-    # Collect all data to determine global bounds
-    all_data = []
-    all_boxes = []
-    
-    for fab_file in fab_files:
-        data, box_info = parse_fab_file(fab_file)
-        if data.size > 0:
-            all_data.append(data)
-            all_boxes.append(box_info)
-    
-    if not all_data:
-        print("No data found in FAB files")
-        return
-    
-    # For 2D data: columns are [i, j, value]
-    # Determine global bounds
-    i_min = min(int(data[:, 0].min()) for data in all_data)
-    i_max = max(int(data[:, 0].max()) for data in all_data)
-    j_min = min(int(data[:, 1].min()) for data in all_data)
-    j_max = max(int(data[:, 1].max()) for data in all_data)
-    
-    # Create a grid for plotting
-    grid = np.full((j_max - j_min + 1, i_max - i_min + 1), np.nan)
-    ghost_mask = np.zeros_like(grid, dtype=bool)
-    
-    # Fill the grid with data from each box
-    for data, box_info in zip(all_data, all_boxes):
-        indices_i = data[:, 0].astype(int)
-        indices_j = data[:, 1].astype(int)
-        values = data[:, 2]
-        
-        lo_i, lo_j = box_info['lo']
-        hi_i, hi_j = box_info['hi']
-        
-        for idx in range(len(indices_i)):
-            i = indices_i[idx]
-            j = indices_j[idx]
-            grid_i = i - i_min
-            grid_j = j - j_min
-            
-            grid[grid_j, grid_i] = values[idx]
-            
-            # Mark ghost cells
-            if i == lo_i or i == hi_i or j == lo_j or j == hi_j:
-                ghost_mask[grid_j, grid_i] = True
-    
-    # Create the plot - use scatter plot approach for better control
-    # Use a dictionary to avoid plotting the same face multiple times
-    face_data = {}  # (i,j) -> (value, is_ghost)
-    
-    # Collect all data points, handling duplicates
-    for data, box_info in zip(all_data, all_boxes):
-        indices_i = data[:, 0].astype(int)
-        indices_j = data[:, 1].astype(int)
-        values = data[:, 2]
-        
-        lo_i, lo_j = box_info['lo']
-        hi_i, hi_j = box_info['hi']
-        
-        for idx in range(len(indices_i)):
-            i = indices_i[idx]
-            j = indices_j[idx]
-            key = (i, j)
-            
-            # Mark ghost cells (at boundaries of this box)
-            is_ghost = (i == lo_i or i == hi_i or j == lo_j or j == hi_j)
-            
-            # If this face already exists, prefer non-ghost classification
-            if key in face_data:
-                existing_value, existing_is_ghost = face_data[key]
-                # Keep existing if it's not a ghost, or update if current is not ghost
-                if existing_is_ghost and not is_ghost:
-                    face_data[key] = (values[idx], is_ghost)
-            else:
-                face_data[key] = (values[idx], is_ghost)
-    
-    # Convert to arrays
-    all_i = np.array([pos[0] for pos in face_data.keys()])
-    all_j = np.array([pos[1] for pos in face_data.keys()])
-    all_values = np.array([data[0] for data in face_data.values()])
-    all_is_ghost = np.array([data[1] for data in face_data.values()])
-    
-    # Plot valid cells
-    valid_mask = ~all_is_ghost
-    if np.any(valid_mask):
-        scatter = ax.scatter(all_i[valid_mask], all_j[valid_mask], 
-                           c=all_values[valid_mask], s=15, cmap='viridis', 
-                           marker='o', edgecolors='black', linewidth=0.3)
-    
-    # Plot ghost cells with different style
-    if np.any(all_is_ghost):
-        ax.scatter(all_i[all_is_ghost], all_j[all_is_ghost], 
-                  c=all_values[all_is_ghost], s=25, cmap='viridis',
-                  marker='s', edgecolors='red', linewidth=1)
-    
-    # Draw box boundaries
-    for box_info in all_boxes:
-        lo_i, lo_j = box_info['lo']
-        hi_i, hi_j = box_info['hi']
-        
-        # Draw rectangle for each box (excluding ghost cells)
-        rect = plt.Rectangle((lo_i + 0.5, lo_j + 0.5), 
-                           hi_i - lo_i - 1, hi_j - lo_j - 1,
-                           fill=False, edgecolor='red', linewidth=2)
-        ax.add_patch(rect)
-    
-    ax.set_xlabel(f'Face Index i ({direction}-faces)')
-    ax.set_ylabel('Face Index j')
-    ax.set_title(f'{direction.upper()}-Face Velocities at Level {level}, Timestep {timestep}\n'
-                 f'Ghost cells shown as red squares, box boundaries in red')
-    
-    # Add colorbar if we have valid data
-    if np.any(valid_mask):
-        cbar = plt.colorbar(scatter, ax=ax)
-        cbar.set_label('Face Velocity')
-    
-    plt.tight_layout()
-    plt.savefig(f'face_velocities_2d_{direction}_lev{level}_step{timestep}.png', 
-                dpi=150, bbox_inches='tight')
-    plt.show()
 
 
 def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, tolerance=1e-10):
     """Check if ghost cells match valid cells from adjacent boxes for reconstructed states"""
     mismatches = []
     correct_matches = []
+    all_ghost_cells = []
     
     # Create a dictionary mapping indices to (box_id, value, is_ghost)
     index_map = {}
@@ -426,11 +363,33 @@ def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, toleran
         indices = data[:, 0].astype(int)
         values = data[:, var_col]  # Get the specific variable column
         
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
+        # Parse box bounds and valid box bounds from header
+        box_lo = box_info['lo'][0]
+        box_hi = box_info['hi'][0]
+        valid_lo = box_info.get('valid_lo', [box_lo])[0] if 'valid_lo' in box_info else box_lo
+        valid_hi = box_info.get('valid_hi', [box_hi])[0] if 'valid_hi' in box_info else box_hi
         
         for idx, val in zip(indices, values):
-            is_ghost = (idx == lo_idx or idx == hi_idx)
+            is_ghost = (idx < valid_lo or idx > valid_hi)
+            is_boundary = (idx == box_lo or idx == box_hi)
+            
+            # Collect ALL ghost cells (outside valid region)
+            if is_ghost:
+                if idx < valid_lo:
+                    boundary_type = 'lo_ghost'
+                    ghost_layer = valid_lo - idx  # how many cells from valid boundary
+                else:
+                    boundary_type = 'hi_ghost'
+                    ghost_layer = idx - valid_hi  # how many cells from valid boundary
+                
+                all_ghost_cells.append({
+                    'index': idx,
+                    'box_id': box_id,
+                    'value': val,
+                    'boundary_type': boundary_type,
+                    'ghost_layer': ghost_layer,
+                    'is_boundary': is_boundary
+                })
             
             if idx not in index_map:
                 index_map[idx] = []
@@ -438,12 +397,12 @@ def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, toleran
             index_map[idx].append({
                 'box_id': box_id,
                 'value': val,
-                'is_ghost': is_ghost,
-                'lo': lo_idx,
-                'hi': hi_idx
+                'is_ghost': is_boundary,  # Keep this for interface checking
+                'lo': box_lo,
+                'hi': box_hi
             })
     
-    # Check for mismatches and correct matches
+    # Check for mismatches and correct matches (interface ghost cells only)
     for idx, entries in index_map.items():
         if len(entries) > 1:  # This index appears in multiple boxes
             # Find valid cell value(s)
@@ -478,7 +437,7 @@ def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, toleran
                     # Multiple valid entries for same index - this shouldn't happen
                     print(f"Warning: Multiple valid cells at index {idx}")
     
-    return mismatches, correct_matches
+    return mismatches, correct_matches, all_ghost_cells
 
 
 def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density'):
@@ -533,37 +492,51 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
     # Check ghost cell consistency
     print(f"\nChecking ghost cell consistency for {variable}:")
     
-    left_mismatches, left_correct = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    left_mismatches, left_correct, left_all_ghosts = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
     print(f"\n📊 LEFT state ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(left_correct)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(left_mismatches)}")
+    print(f"  👻 Total ghost cells found: {len(left_all_ghosts)}")
+    print(f"  ✅ Interface ghost cells (correctly matched): {len(left_correct)}")
+    print(f"  ⚠️  Interface ghost cells (disagreeing): {len(left_mismatches)}")
+    
+    if left_all_ghosts:
+        print(f"\n👻 All {len(left_all_ghosts)} LEFT state ghost cells:")
+        for ghost in sorted(left_all_ghosts, key=lambda x: (x['box_id'], x['index'])):
+            boundary_marker = " (boundary)" if ghost['is_boundary'] else ""
+            print(f"  Box {ghost['box_id']}, Index {ghost['index']} ({ghost['boundary_type']}, layer {ghost['ghost_layer']}){boundary_marker}: {ghost['value']:.6e}")
     
     if left_correct:
-        print(f"\n✅ Details of {len(left_correct)} correctly-filled LEFT state ghost cells:")
+        print(f"\n✅ Details of {len(left_correct)} correctly-filled LEFT state interface ghost cells:")
         for m in left_correct:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
     
     if left_mismatches:
-        print(f"\n⚠️  Details of {len(left_mismatches)} LEFT state ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(left_mismatches)} LEFT state interface ghost cell mismatches:")
         for m in left_mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
     
-    right_mismatches, right_correct = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    right_mismatches, right_correct, right_all_ghosts = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
     print(f"\n📊 RIGHT state ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(right_correct)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(right_mismatches)}")
+    print(f"  👻 Total ghost cells found: {len(right_all_ghosts)}")
+    print(f"  ✅ Interface ghost cells (correctly matched): {len(right_correct)}")
+    print(f"  ⚠️  Interface ghost cells (disagreeing): {len(right_mismatches)}")
+    
+    if right_all_ghosts:
+        print(f"\n👻 All {len(right_all_ghosts)} RIGHT state ghost cells:")
+        for ghost in sorted(right_all_ghosts, key=lambda x: (x['box_id'], x['index'])):
+            boundary_marker = " (boundary)" if ghost['is_boundary'] else ""
+            print(f"  Box {ghost['box_id']}, Index {ghost['index']} ({ghost['boundary_type']}, layer {ghost['ghost_layer']}){boundary_marker}: {ghost['value']:.6e}")
     
     if right_correct:
-        print(f"\n✅ Details of {len(right_correct)} correctly-filled RIGHT state ghost cells:")
+        print(f"\n✅ Details of {len(right_correct)} correctly-filled RIGHT state interface ghost cells:")
         for m in right_correct:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
     
     if right_mismatches:
-        print(f"\n⚠️  Details of {len(right_mismatches)} RIGHT state ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(right_mismatches)} RIGHT state interface ghost cell mismatches:")
         for m in right_mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
@@ -584,12 +557,12 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
         indices = data[:, 0].astype(int)
         values = data[:, var_col]
         
-        # Determine valid region (exclude first and last ghost cells)
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
+        # Determine valid region from header information
+        valid_lo = box_info.get('valid_lo', [box_info['lo'][0]])[0] if 'valid_lo' in box_info else box_info['lo'][0]
+        valid_hi = box_info.get('valid_hi', [box_info['hi'][0]])[0] if 'valid_hi' in box_info else box_info['hi'][0]
         
-        # Create masks for ghost and valid cells
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        # Create masks for ghost and valid cells (ghost = outside valid region)
+        is_ghost = np.logical_or(indices < valid_lo, indices > valid_hi)
         
         # Plot valid cells
         valid_mask = ~is_ghost
@@ -602,9 +575,9 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
                     color=colors[i], markersize=4, markerfacecolor='none',
                     markeredgewidth=1.5, label=f'Box {i} (ghost)')
         
-        # Add vertical lines at box boundaries
+        # Add vertical lines at shared face locations between adjacent boxes
         if i > 0:  # Don't draw line before first box
-            ax1.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+            ax1.axvline(x=valid_lo, color='gray', linestyle='--', alpha=0.5)
     
     # Plot right states
     for i, right_file in enumerate(right_files):
@@ -617,12 +590,12 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
         indices = data[:, 0].astype(int)
         values = data[:, var_col]
         
-        # Determine valid region (exclude first and last ghost cells)
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
+        # Determine valid region from header information
+        valid_lo = box_info.get('valid_lo', [box_info['lo'][0]])[0] if 'valid_lo' in box_info else box_info['lo'][0]
+        valid_hi = box_info.get('valid_hi', [box_info['hi'][0]])[0] if 'valid_hi' in box_info else box_info['hi'][0]
         
-        # Create masks for ghost and valid cells
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        # Create masks for ghost and valid cells (ghost = outside valid region)
+        is_ghost = np.logical_or(indices < valid_lo, indices > valid_hi)
         
         # Plot valid cells
         valid_mask = ~is_ghost
@@ -637,7 +610,7 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
         
         # Add vertical lines at box boundaries
         if i > 0:  # Don't draw line before first box
-            ax2.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+            ax2.axvline(x=valid_lo, color='gray', linestyle='--', alpha=0.5)
     
     # Configure plots
     ax1.set_xlabel('Face Index (i)')
@@ -659,256 +632,16 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
     plt.show()
 
 
-def plot_1d_combined(dirname, timestep=0, level=0, variable='xmom'):
-    """Plot 1D face velocities and reconstructed states together"""
-    # Check if both directories exist
-    facevel_dir = Path(f"facevel_lev{level}_step{timestep}")
-    reconst_dir = Path(f"reconst_lev{level}_step{timestep}")
-    
-    if not facevel_dir.exists():
-        print(f"Directory {facevel_dir} not found!")
-        return
-    if not reconst_dir.exists():
-        print(f"Directory {reconst_dir} not found!")
-        return
-    
-    # Find all files
-    facevel_files = sorted(facevel_dir.glob("facevel_x_box_*.fab"))
-    left_files = sorted(reconst_dir.glob("reconst_left_x_box_*.fab"))
-    right_files = sorted(reconst_dir.glob("reconst_right_x_box_*.fab"))
-    
-    if not facevel_files:
-        print(f"No face velocity files found in {facevel_dir}")
-        return
-    if not left_files or not right_files:
-        print(f"No reconstructed state files found in {reconst_dir}")
-        return
-    
-    # Variable mapping for reconstructed states
-    var_map = {
-        'density': 1,
-        'xmom': 2,
-        'ymom': 3,
-        'zmom': 4,
-        'energy': 5,
-        'intenergy': 6
-    }
-    
-    if variable not in var_map:
-        print(f"Unknown variable: {variable}. Available: {list(var_map.keys())}")
-        return
-    
-    var_col = var_map[variable]
-    
-    # Collect all data for ghost cell checking
-    all_facevel_data = []
-    all_facevel_boxes = []
-    all_left_data = []
-    all_left_boxes = []
-    all_right_data = []
-    all_right_boxes = []
-    
-    for fab_file in facevel_files:
-        data, box_info = parse_fab_file(fab_file)
-        if data.size > 0:
-            all_facevel_data.append(data)
-            all_facevel_boxes.append(box_info)
-    
-    for left_file in left_files:
-        data, box_info = parse_reconstructed_fab_file(left_file)
-        if data.size > 0:
-            all_left_data.append(data)
-            all_left_boxes.append(box_info)
-    
-    for right_file in right_files:
-        data, box_info = parse_reconstructed_fab_file(right_file)
-        if data.size > 0:
-            all_right_data.append(data)
-            all_right_boxes.append(box_info)
-    
-    # Check ghost cell consistency
-    print("\nChecking face velocity ghost cell consistency:")
-    facevel_mismatches, facevel_correct = check_ghost_cell_consistency(all_facevel_data, all_facevel_boxes)
-    print(f"📊 Face velocity ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(facevel_correct)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(facevel_mismatches)}")
-    
-    if facevel_correct:
-        print(f"\n✅ Details of {len(facevel_correct)} correctly-filled face velocity ghost cells:")
-        for m in facevel_correct:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
-    
-    if facevel_mismatches:
-        print(f"\n⚠️  Details of {len(facevel_mismatches)} face velocity ghost cell mismatches:")
-        for m in facevel_mismatches:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
-                  f"diff = {m['difference']:.6e}")
-    
-    print(f"\nChecking {variable} reconstructed state ghost cell consistency:")
-    
-    left_mismatches, left_correct = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
-    print(f"\n📊 LEFT state ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(left_correct)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(left_mismatches)}")
-    
-    if left_correct:
-        print(f"\n✅ Details of {len(left_correct)} correctly-filled LEFT state ghost cells:")
-        for m in left_correct:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
-    
-    if left_mismatches:
-        print(f"\n⚠️  Details of {len(left_mismatches)} LEFT state ghost cell mismatches:")
-        for m in left_mismatches:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
-                  f"diff = {m['difference']:.6e}")
-    
-    right_mismatches, right_correct = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
-    print(f"\n📊 RIGHT state ghost cell statistics:")
-    print(f"  ✅ Correctly-filled ghost cells: {len(right_correct)}")
-    print(f"  ⚠️  Disagreeing ghost cells: {len(right_mismatches)}")
-    
-    if right_correct:
-        print(f"\n✅ Details of {len(right_correct)} correctly-filled RIGHT state ghost cells:")
-        for m in right_correct:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
-    
-    if right_mismatches:
-        print(f"\n⚠️  Details of {len(right_mismatches)} RIGHT state ghost cell mismatches:")
-        for m in right_mismatches:
-            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
-                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
-                  f"diff = {m['difference']:.6e}")
-    
-    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(12, 15))
-    
-    colors = plt.cm.tab10(np.linspace(0, 1, max(len(facevel_files), len(left_files))))
-    
-    # Plot face velocities
-    for i, fab_file in enumerate(facevel_files):
-        data, box_info = parse_fab_file(fab_file)
-        
-        if data.size == 0:
-            continue
-            
-        # For 1D data: columns are [i, value]
-        indices = data[:, 0].astype(int)
-        values = data[:, 1]
-        
-        # Determine valid region (exclude first and last ghost cells)
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
-        
-        # Create masks for ghost and valid cells
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
-        
-        # Plot valid cells
-        valid_mask = ~is_ghost
-        ax1.plot(indices[valid_mask], values[valid_mask], 'o-', 
-                color=colors[i], label=f'Box {i} (valid)', markersize=3)
-        
-        # Plot ghost cells with different style
-        if np.any(is_ghost):
-            ax1.plot(indices[is_ghost], values[is_ghost], 's', 
-                    color=colors[i], markersize=4, markerfacecolor='none',
-                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
-        
-        # Add vertical lines at box boundaries
-        if i > 0:  # Don't draw line before first box
-            ax1.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
-    
-    # Plot left reconstructed states
-    for i, left_file in enumerate(left_files):
-        data, box_info = parse_reconstructed_fab_file(left_file)
-        
-        if data.size == 0:
-            continue
-            
-        indices = data[:, 0].astype(int)
-        values = data[:, var_col]
-        
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
-        
-        valid_mask = ~is_ghost
-        ax2.plot(indices[valid_mask], values[valid_mask], 'o-', 
-                color=colors[i], label=f'Box {i} (valid)', markersize=3)
-        
-        if np.any(is_ghost):
-            ax2.plot(indices[is_ghost], values[is_ghost], 's', 
-                    color=colors[i], markersize=4, markerfacecolor='none',
-                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
-        
-        if i > 0:
-            ax2.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
-    
-    # Plot right reconstructed states
-    for i, right_file in enumerate(right_files):
-        data, box_info = parse_reconstructed_fab_file(right_file)
-        
-        if data.size == 0:
-            continue
-            
-        indices = data[:, 0].astype(int)
-        values = data[:, var_col]
-        
-        lo_idx = box_info['lo'][0]
-        hi_idx = box_info['hi'][0]
-        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
-        
-        valid_mask = ~is_ghost
-        ax3.plot(indices[valid_mask], values[valid_mask], 'o-', 
-                color=colors[i], label=f'Box {i} (valid)', markersize=3)
-        
-        if np.any(is_ghost):
-            ax3.plot(indices[is_ghost], values[is_ghost], 's', 
-                    color=colors[i], markersize=4, markerfacecolor='none',
-                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
-        
-        if i > 0:
-            ax3.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
-    
-    # Configure plots
-    ax1.set_xlabel('Face Index (i)')
-    ax1.set_ylabel('Face Velocity')
-    ax1.set_title(f'Face Velocities at Level {level}, Timestep {timestep}')
-    ax1.grid(True, alpha=0.3)
-    ax1.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-    
-    ax2.set_xlabel('Face Index (i)')
-    ax2.set_ylabel(f'Left {variable}')
-    ax2.set_title(f'Left Reconstructed States ({variable})')
-    ax2.grid(True, alpha=0.3)
-    ax2.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-    
-    ax3.set_xlabel('Face Index (i)')
-    ax3.set_ylabel(f'Right {variable}')
-    ax3.set_title(f'Right Reconstructed States ({variable})')
-    ax3.grid(True, alpha=0.3)
-    ax3.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
-    
-    plt.tight_layout()
-    plt.savefig(f'combined_facevel_reconst_1d_{variable}_lev{level}_step{timestep}.png', dpi=150, bbox_inches='tight')
-    plt.show()
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Plot face velocity and reconstructed state FAB files')
-    parser.add_argument('--mode', type=str, default='facevel', choices=['facevel', 'reconst', 'combined'],
-                        help='Plotting mode: facevel (face velocities), reconst (reconstructed states), or combined')
-    parser.add_argument('--dim', type=int, default=1, choices=[1, 2],
-                        help='Dimensionality of the plot (1 or 2)')
+    parser = argparse.ArgumentParser(description='Plot 1D face velocity and reconstructed state FAB files')
+    parser.add_argument('--mode', type=str, default='facevel', choices=['facevel', 'reconst'],
+                        help='Plotting mode: facevel (face velocities) or reconst (reconstructed states)')
     parser.add_argument('--timestep', type=int, default=0,
                         help='Timestep to plot')
     parser.add_argument('--level', type=int, default=0,
                         help='AMR level to plot')
-    parser.add_argument('--direction', type=str, default='x', choices=['x', 'y', 'z'],
-                        help='Direction for face velocities (for 2D plots)')
     parser.add_argument('--variable', type=str, default='xmom', 
                         choices=['density', 'xmom', 'ymom', 'zmom', 'energy', 'intenergy'],
                         help='Variable to plot for reconstructed states')
@@ -922,20 +655,9 @@ def main():
         os.chdir(args.dir)
     
     if args.mode == 'facevel':
-        if args.dim == 1:
-            plot_1d_face_velocities(args.dir, args.timestep, args.level)
-        elif args.dim == 2:
-            plot_2d_face_velocities(args.dir, args.direction, args.timestep, args.level)
+        plot_1d_face_velocities(args.dir, args.timestep, args.level)
     elif args.mode == 'reconst':
-        if args.dim == 1:
-            plot_1d_reconstructed_states(args.dir, args.timestep, args.level, args.variable)
-        else:
-            print("2D reconstructed state plotting not yet implemented")
-    elif args.mode == 'combined':
-        if args.dim == 1:
-            plot_1d_combined(args.dir, args.timestep, args.level, args.variable)
-        else:
-            print("2D combined plotting not yet implemented")
+        plot_1d_reconstructed_states(args.dir, args.timestep, args.level, args.variable)
 
 
 if __name__ == '__main__':

--- a/scripts/python/plot_face_velocities.py
+++ b/scripts/python/plot_face_velocities.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
+# ABOUTME: Plot face velocities from FAB files with ghost cell validation
+# ABOUTME: Validates ghost cell consistency and outputs statistics for both correct and incorrect ghost cells
 """
-Plot face velocity and reconstructed state FAB files with ghost cells highlighted
+Plot face velocity and reconstructed state FAB files with ghost cells highlighted.
+Validates ghost cell consistency and outputs statistics for both correct and incorrect ghost cells.
 """
 
 import os
@@ -113,6 +116,7 @@ def parse_reconstructed_fab_file(filename):
 def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
     """Check if ghost cells match valid cells from adjacent boxes"""
     mismatches = []
+    correct_matches = []
     
     # Create a dictionary mapping indices to (box_id, value, is_ghost)
     index_map = {}
@@ -141,7 +145,7 @@ def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
                 'hi': hi_idx
             })
     
-    # Check for mismatches
+    # Check for mismatches and correct matches
     for idx, entries in index_map.items():
         if len(entries) > 1:  # This index appears in multiple boxes
             # Find valid cell value(s)
@@ -164,11 +168,19 @@ def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
                                 'ghost_value': ghost['value'],
                                 'difference': ghost['value'] - valid_val
                             })
+                        else:
+                            correct_matches.append({
+                                'index': idx,
+                                'valid_box': valid_entries[0]['box_id'],
+                                'valid_value': valid_val,
+                                'ghost_box': ghost['box_id'],
+                                'ghost_value': ghost['value']
+                            })
                 else:
                     # Multiple valid entries for same index - this shouldn't happen
                     print(f"Warning: Multiple valid cells at index {idx}")
     
-    return mismatches
+    return mismatches, correct_matches
 
 
 def plot_1d_face_velocities(dirname, timestep=0, level=0):
@@ -196,16 +208,24 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
             all_boxes.append(box_info)
     
     # Check ghost cell consistency
-    mismatches = check_ghost_cell_consistency(all_data, all_boxes)
+    mismatches, correct_matches = check_ghost_cell_consistency(all_data, all_boxes)
+    
+    print(f"\n📊 Face velocity ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(correct_matches)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(mismatches)}")
+    
+    if correct_matches:
+        print(f"\n✅ Details of {len(correct_matches)} correctly-filled ghost cells:")
+        for m in correct_matches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
     
     if mismatches:
-        print(f"\n⚠️  Found {len(mismatches)} ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(mismatches)} ghost cell mismatches:")
         for m in mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
-    else:
-        print("\n✅ All ghost cells match their corresponding valid cells!")
     
     fig, ax = plt.subplots(figsize=(12, 6))
     
@@ -394,6 +414,7 @@ def plot_2d_face_velocities(dirname, direction='x', timestep=0, level=0):
 def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, tolerance=1e-10):
     """Check if ghost cells match valid cells from adjacent boxes for reconstructed states"""
     mismatches = []
+    correct_matches = []
     
     # Create a dictionary mapping indices to (box_id, value, is_ghost)
     index_map = {}
@@ -422,7 +443,7 @@ def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, toleran
                 'hi': hi_idx
             })
     
-    # Check for mismatches
+    # Check for mismatches and correct matches
     for idx, entries in index_map.items():
         if len(entries) > 1:  # This index appears in multiple boxes
             # Find valid cell value(s)
@@ -445,11 +466,19 @@ def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, toleran
                                 'ghost_value': ghost['value'],
                                 'difference': ghost['value'] - valid_val
                             })
+                        else:
+                            correct_matches.append({
+                                'index': idx,
+                                'valid_box': valid_entries[0]['box_id'],
+                                'valid_value': valid_val,
+                                'ghost_box': ghost['box_id'],
+                                'ghost_value': ghost['value']
+                            })
                 else:
                     # Multiple valid entries for same index - this shouldn't happen
                     print(f"Warning: Multiple valid cells at index {idx}")
     
-    return mismatches
+    return mismatches, correct_matches
 
 
 def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density'):
@@ -504,25 +533,41 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
     # Check ghost cell consistency
     print(f"\nChecking ghost cell consistency for {variable}:")
     
-    left_mismatches = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    left_mismatches, left_correct = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    print(f"\n📊 LEFT state ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(left_correct)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(left_mismatches)}")
+    
+    if left_correct:
+        print(f"\n✅ Details of {len(left_correct)} correctly-filled LEFT state ghost cells:")
+        for m in left_correct:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
+    
     if left_mismatches:
-        print(f"\n⚠️  Found {len(left_mismatches)} LEFT state ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(left_mismatches)} LEFT state ghost cell mismatches:")
         for m in left_mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
-    else:
-        print("✅ All LEFT state ghost cells match their corresponding valid cells!")
     
-    right_mismatches = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    right_mismatches, right_correct = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    print(f"\n📊 RIGHT state ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(right_correct)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(right_mismatches)}")
+    
+    if right_correct:
+        print(f"\n✅ Details of {len(right_correct)} correctly-filled RIGHT state ghost cells:")
+        for m in right_correct:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
+    
     if right_mismatches:
-        print(f"\n⚠️  Found {len(right_mismatches)} RIGHT state ghost cell mismatches:")
+        print(f"\n⚠️  Details of {len(right_mismatches)} RIGHT state ghost cell mismatches:")
         for m in right_mismatches:
             print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
-    else:
-        print("✅ All RIGHT state ghost cells match their corresponding valid cells!")
     
     fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
     
@@ -683,25 +728,61 @@ def plot_1d_combined(dirname, timestep=0, level=0, variable='xmom'):
     
     # Check ghost cell consistency
     print("\nChecking face velocity ghost cell consistency:")
-    facevel_mismatches = check_ghost_cell_consistency(all_facevel_data, all_facevel_boxes)
+    facevel_mismatches, facevel_correct = check_ghost_cell_consistency(all_facevel_data, all_facevel_boxes)
+    print(f"📊 Face velocity ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(facevel_correct)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(facevel_mismatches)}")
+    
+    if facevel_correct:
+        print(f"\n✅ Details of {len(facevel_correct)} correctly-filled face velocity ghost cells:")
+        for m in facevel_correct:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
+    
     if facevel_mismatches:
-        print(f"⚠️  Found {len(facevel_mismatches)} face velocity ghost cell mismatches")
-    else:
-        print("✅ All face velocity ghost cells match!")
+        print(f"\n⚠️  Details of {len(facevel_mismatches)} face velocity ghost cell mismatches:")
+        for m in facevel_mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
     
     print(f"\nChecking {variable} reconstructed state ghost cell consistency:")
     
-    left_mismatches = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
-    if left_mismatches:
-        print(f"⚠️  Found {len(left_mismatches)} LEFT state ghost cell mismatches")
-    else:
-        print("✅ All LEFT state ghost cells match!")
+    left_mismatches, left_correct = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    print(f"\n📊 LEFT state ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(left_correct)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(left_mismatches)}")
     
-    right_mismatches = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    if left_correct:
+        print(f"\n✅ Details of {len(left_correct)} correctly-filled LEFT state ghost cells:")
+        for m in left_correct:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
+    
+    if left_mismatches:
+        print(f"\n⚠️  Details of {len(left_mismatches)} LEFT state ghost cell mismatches:")
+        for m in left_mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
+    
+    right_mismatches, right_correct = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    print(f"\n📊 RIGHT state ghost cell statistics:")
+    print(f"  ✅ Correctly-filled ghost cells: {len(right_correct)}")
+    print(f"  ⚠️  Disagreeing ghost cells: {len(right_mismatches)}")
+    
+    if right_correct:
+        print(f"\n✅ Details of {len(right_correct)} correctly-filled RIGHT state ghost cells:")
+        for m in right_correct:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}")
+    
     if right_mismatches:
-        print(f"⚠️  Found {len(right_mismatches)} RIGHT state ghost cell mismatches")
-    else:
-        print("✅ All RIGHT state ghost cells match!")
+        print(f"\n⚠️  Details of {len(right_mismatches)} RIGHT state ghost cell mismatches:")
+        for m in right_mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
     
     fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(12, 15))
     

--- a/scripts/python/plot_face_velocities.py
+++ b/scripts/python/plot_face_velocities.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Plot face velocity FAB files with ghost cells highlighted
+Plot face velocity and reconstructed state FAB files with ghost cells highlighted
 """
 
 import os
@@ -62,6 +62,115 @@ def parse_fab_file(filename):
     return np.array(data), box_info
 
 
+def parse_reconstructed_fab_file(filename):
+    """Parse a reconstructed state FAB file and return the data and metadata"""
+    data = []
+    box_info = None
+    
+    with open(filename, 'r') as f:
+        for line in f:
+            if line.startswith('# Box:'):
+                # Parse box bounds like ((-2) (30) (1))
+                box_str = line.split(':', 1)[1].strip()
+                # Extract numbers from the box string
+                numbers = re.findall(r'-?\d+', box_str)
+                numbers = [int(n) for n in numbers]
+                
+                # Parse box format which can be:
+                # 1D: ((-2) (30) (1)) - single direction with placeholders
+                # 2D: ((-2,-2) (18,17) (1,0)) - two directions with placeholders  
+                
+                # Determine dimensionality from the data format
+                # Count commas to determine actual dimensions
+                comma_count = box_str.count(',')
+                
+                if comma_count == 0:  # 1D: ((-2) (30) (1))
+                    box_info = {
+                        'lo': [numbers[0]],
+                        'hi': [numbers[1]]
+                    }
+                elif comma_count == 3:  # 2D: ((-2,-2) (18,17) (1,0))
+                    box_info = {
+                        'lo': [numbers[0], numbers[1]], 
+                        'hi': [numbers[2], numbers[3]]
+                    }
+                elif comma_count == 5:  # 3D: ((lo_x,lo_y,lo_z) (hi_x,hi_y,hi_z))
+                    box_info = {
+                        'lo': [numbers[0], numbers[1], numbers[2]],
+                        'hi': [numbers[3], numbers[4], numbers[5]]
+                    }
+                else:
+                    print(f"Warning: Could not parse box format: {box_str}")
+                    box_info = None
+            elif not line.startswith('#'):
+                parts = line.strip().split()
+                if parts:
+                    data.append([float(x) for x in parts])
+    
+    return np.array(data), box_info
+
+
+def check_ghost_cell_consistency(all_data_list, all_boxes, tolerance=1e-10):
+    """Check if ghost cells match valid cells from adjacent boxes"""
+    mismatches = []
+    
+    # Create a dictionary mapping indices to (box_id, value, is_ghost)
+    index_map = {}
+    
+    for box_id, (data, box_info) in enumerate(zip(all_data_list, all_boxes)):
+        if data.size == 0:
+            continue
+            
+        indices = data[:, 0].astype(int)
+        values = data[:, 1] if data.shape[1] == 2 else data[:, 1:]  # Handle multi-component data
+        
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        for idx, val in zip(indices, values):
+            is_ghost = (idx == lo_idx or idx == hi_idx)
+            
+            if idx not in index_map:
+                index_map[idx] = []
+            
+            index_map[idx].append({
+                'box_id': box_id,
+                'value': val,
+                'is_ghost': is_ghost,
+                'lo': lo_idx,
+                'hi': hi_idx
+            })
+    
+    # Check for mismatches
+    for idx, entries in index_map.items():
+        if len(entries) > 1:  # This index appears in multiple boxes
+            # Find valid cell value(s)
+            valid_entries = [e for e in entries if not e['is_ghost']]
+            ghost_entries = [e for e in entries if e['is_ghost']]
+            
+            if valid_entries and ghost_entries:
+                # There should be exactly one valid value
+                if len(valid_entries) == 1:
+                    valid_val = valid_entries[0]['value']
+                    
+                    # Check all ghost cells against this valid value
+                    for ghost in ghost_entries:
+                        if np.any(np.abs(ghost['value'] - valid_val) > tolerance):
+                            mismatches.append({
+                                'index': idx,
+                                'valid_box': valid_entries[0]['box_id'],
+                                'valid_value': valid_val,
+                                'ghost_box': ghost['box_id'],
+                                'ghost_value': ghost['value'],
+                                'difference': ghost['value'] - valid_val
+                            })
+                else:
+                    # Multiple valid entries for same index - this shouldn't happen
+                    print(f"Warning: Multiple valid cells at index {idx}")
+    
+    return mismatches
+
+
 def plot_1d_face_velocities(dirname, timestep=0, level=0):
     """Plot 1D face velocities from FAB files"""
     fab_dir = Path(f"facevel_lev{level}_step{timestep}")
@@ -76,13 +185,33 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
         print(f"No FAB files found in {fab_dir}")
         return
     
+    # Collect all data for ghost cell checking
+    all_data = []
+    all_boxes = []
+    
+    for fab_file in fab_files:
+        data, box_info = parse_fab_file(fab_file)
+        if data.size > 0:
+            all_data.append(data)
+            all_boxes.append(box_info)
+    
+    # Check ghost cell consistency
+    mismatches = check_ghost_cell_consistency(all_data, all_boxes)
+    
+    if mismatches:
+        print(f"\n⚠️  Found {len(mismatches)} ghost cell mismatches:")
+        for m in mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
+    else:
+        print("\n✅ All ghost cells match their corresponding valid cells!")
+    
     fig, ax = plt.subplots(figsize=(12, 6))
     
     colors = plt.cm.tab10(np.linspace(0, 1, len(fab_files)))
     
-    for i, fab_file in enumerate(fab_files):
-        data, box_info = parse_fab_file(fab_file)
-        
+    for i, (data, box_info) in enumerate(zip(all_data, all_boxes)):
         if data.size == 0:
             continue
             
@@ -262,8 +391,435 @@ def plot_2d_face_velocities(dirname, direction='x', timestep=0, level=0):
     plt.show()
 
 
+def check_reconstructed_ghost_cells(all_data_list, all_boxes, var_col=1, tolerance=1e-10):
+    """Check if ghost cells match valid cells from adjacent boxes for reconstructed states"""
+    mismatches = []
+    
+    # Create a dictionary mapping indices to (box_id, value, is_ghost)
+    index_map = {}
+    
+    for box_id, (data, box_info) in enumerate(zip(all_data_list, all_boxes)):
+        if data.size == 0:
+            continue
+            
+        indices = data[:, 0].astype(int)
+        values = data[:, var_col]  # Get the specific variable column
+        
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        for idx, val in zip(indices, values):
+            is_ghost = (idx == lo_idx or idx == hi_idx)
+            
+            if idx not in index_map:
+                index_map[idx] = []
+            
+            index_map[idx].append({
+                'box_id': box_id,
+                'value': val,
+                'is_ghost': is_ghost,
+                'lo': lo_idx,
+                'hi': hi_idx
+            })
+    
+    # Check for mismatches
+    for idx, entries in index_map.items():
+        if len(entries) > 1:  # This index appears in multiple boxes
+            # Find valid cell value(s)
+            valid_entries = [e for e in entries if not e['is_ghost']]
+            ghost_entries = [e for e in entries if e['is_ghost']]
+            
+            if valid_entries and ghost_entries:
+                # There should be exactly one valid value
+                if len(valid_entries) == 1:
+                    valid_val = valid_entries[0]['value']
+                    
+                    # Check all ghost cells against this valid value
+                    for ghost in ghost_entries:
+                        if np.abs(ghost['value'] - valid_val) > tolerance:
+                            mismatches.append({
+                                'index': idx,
+                                'valid_box': valid_entries[0]['box_id'],
+                                'valid_value': valid_val,
+                                'ghost_box': ghost['box_id'],
+                                'ghost_value': ghost['value'],
+                                'difference': ghost['value'] - valid_val
+                            })
+                else:
+                    # Multiple valid entries for same index - this shouldn't happen
+                    print(f"Warning: Multiple valid cells at index {idx}")
+    
+    return mismatches
+
+
+def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density'):
+    """Plot 1D reconstructed states from FAB files"""
+    reconst_dir = Path(f"reconst_lev{level}_step{timestep}")
+    if not reconst_dir.exists():
+        print(f"Directory {reconst_dir} not found!")
+        return
+    
+    # Find all left and right state FAB files for x-direction
+    left_files = sorted(reconst_dir.glob("reconst_left_x_box_*.fab"))
+    right_files = sorted(reconst_dir.glob("reconst_right_x_box_*.fab"))
+    
+    if not left_files or not right_files:
+        print(f"No reconstructed state files found in {reconst_dir}")
+        return
+    
+    # Variable mapping: variable name -> column index
+    var_map = {
+        'density': 1,
+        'xmom': 2,
+        'ymom': 3,
+        'zmom': 4,
+        'energy': 5,
+        'intenergy': 6
+    }
+    
+    if variable not in var_map:
+        print(f"Unknown variable: {variable}. Available: {list(var_map.keys())}")
+        return
+    
+    var_col = var_map[variable]
+    
+    # Collect all data for ghost cell checking
+    all_left_data = []
+    all_left_boxes = []
+    all_right_data = []
+    all_right_boxes = []
+    
+    for left_file in left_files:
+        data, box_info = parse_reconstructed_fab_file(left_file)
+        if data.size > 0:
+            all_left_data.append(data)
+            all_left_boxes.append(box_info)
+    
+    for right_file in right_files:
+        data, box_info = parse_reconstructed_fab_file(right_file)
+        if data.size > 0:
+            all_right_data.append(data)
+            all_right_boxes.append(box_info)
+    
+    # Check ghost cell consistency
+    print(f"\nChecking ghost cell consistency for {variable}:")
+    
+    left_mismatches = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    if left_mismatches:
+        print(f"\n⚠️  Found {len(left_mismatches)} LEFT state ghost cell mismatches:")
+        for m in left_mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
+    else:
+        print("✅ All LEFT state ghost cells match their corresponding valid cells!")
+    
+    right_mismatches = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    if right_mismatches:
+        print(f"\n⚠️  Found {len(right_mismatches)} RIGHT state ghost cell mismatches:")
+        for m in right_mismatches:
+            print(f"  Index {m['index']}: Box {m['valid_box']} (valid) = {m['valid_value']:.6e}, "
+                  f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
+                  f"diff = {m['difference']:.6e}")
+    else:
+        print("✅ All RIGHT state ghost cells match their corresponding valid cells!")
+    
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
+    
+    colors = plt.cm.tab10(np.linspace(0, 1, max(len(left_files), len(right_files))))
+    
+    # Plot left states
+    for i, left_file in enumerate(left_files):
+        data, box_info = parse_reconstructed_fab_file(left_file)
+        
+        if data.size == 0:
+            continue
+            
+        # For reconstructed state data: columns are [i, density, xmom, ymom, zmom, energy, intenergy]
+        indices = data[:, 0].astype(int)
+        values = data[:, var_col]
+        
+        # Determine valid region (exclude first and last ghost cells)
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        # Create masks for ghost and valid cells
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        # Plot valid cells
+        valid_mask = ~is_ghost
+        ax1.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        # Plot ghost cells with different style
+        if np.any(is_ghost):
+            ax1.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        # Add vertical lines at box boundaries
+        if i > 0:  # Don't draw line before first box
+            ax1.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    # Plot right states
+    for i, right_file in enumerate(right_files):
+        data, box_info = parse_reconstructed_fab_file(right_file)
+        
+        if data.size == 0:
+            continue
+            
+        # For reconstructed state data: columns are [i, density, xmom, ymom, zmom, energy, intenergy]
+        indices = data[:, 0].astype(int)
+        values = data[:, var_col]
+        
+        # Determine valid region (exclude first and last ghost cells)
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        # Create masks for ghost and valid cells
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        # Plot valid cells
+        valid_mask = ~is_ghost
+        ax2.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        # Plot ghost cells with different style
+        if np.any(is_ghost):
+            ax2.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        # Add vertical lines at box boundaries
+        if i > 0:  # Don't draw line before first box
+            ax2.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    # Configure plots
+    ax1.set_xlabel('Face Index (i)')
+    ax1.set_ylabel(f'Left {variable}')
+    ax1.set_title(f'Left Reconstructed States ({variable}) at Level {level}, Timestep {timestep}\n'
+                  f'Ghost cells shown as squares')
+    ax1.grid(True, alpha=0.3)
+    ax1.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    ax2.set_xlabel('Face Index (i)')
+    ax2.set_ylabel(f'Right {variable}')
+    ax2.set_title(f'Right Reconstructed States ({variable}) at Level {level}, Timestep {timestep}\n'
+                  f'Ghost cells shown as squares')
+    ax2.grid(True, alpha=0.3)
+    ax2.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    plt.tight_layout()
+    plt.savefig(f'reconstructed_states_1d_{variable}_lev{level}_step{timestep}.png', dpi=150, bbox_inches='tight')
+    plt.show()
+
+
+def plot_1d_combined(dirname, timestep=0, level=0, variable='xmom'):
+    """Plot 1D face velocities and reconstructed states together"""
+    # Check if both directories exist
+    facevel_dir = Path(f"facevel_lev{level}_step{timestep}")
+    reconst_dir = Path(f"reconst_lev{level}_step{timestep}")
+    
+    if not facevel_dir.exists():
+        print(f"Directory {facevel_dir} not found!")
+        return
+    if not reconst_dir.exists():
+        print(f"Directory {reconst_dir} not found!")
+        return
+    
+    # Find all files
+    facevel_files = sorted(facevel_dir.glob("facevel_x_box_*.fab"))
+    left_files = sorted(reconst_dir.glob("reconst_left_x_box_*.fab"))
+    right_files = sorted(reconst_dir.glob("reconst_right_x_box_*.fab"))
+    
+    if not facevel_files:
+        print(f"No face velocity files found in {facevel_dir}")
+        return
+    if not left_files or not right_files:
+        print(f"No reconstructed state files found in {reconst_dir}")
+        return
+    
+    # Variable mapping for reconstructed states
+    var_map = {
+        'density': 1,
+        'xmom': 2,
+        'ymom': 3,
+        'zmom': 4,
+        'energy': 5,
+        'intenergy': 6
+    }
+    
+    if variable not in var_map:
+        print(f"Unknown variable: {variable}. Available: {list(var_map.keys())}")
+        return
+    
+    var_col = var_map[variable]
+    
+    # Collect all data for ghost cell checking
+    all_facevel_data = []
+    all_facevel_boxes = []
+    all_left_data = []
+    all_left_boxes = []
+    all_right_data = []
+    all_right_boxes = []
+    
+    for fab_file in facevel_files:
+        data, box_info = parse_fab_file(fab_file)
+        if data.size > 0:
+            all_facevel_data.append(data)
+            all_facevel_boxes.append(box_info)
+    
+    for left_file in left_files:
+        data, box_info = parse_reconstructed_fab_file(left_file)
+        if data.size > 0:
+            all_left_data.append(data)
+            all_left_boxes.append(box_info)
+    
+    for right_file in right_files:
+        data, box_info = parse_reconstructed_fab_file(right_file)
+        if data.size > 0:
+            all_right_data.append(data)
+            all_right_boxes.append(box_info)
+    
+    # Check ghost cell consistency
+    print("\nChecking face velocity ghost cell consistency:")
+    facevel_mismatches = check_ghost_cell_consistency(all_facevel_data, all_facevel_boxes)
+    if facevel_mismatches:
+        print(f"⚠️  Found {len(facevel_mismatches)} face velocity ghost cell mismatches")
+    else:
+        print("✅ All face velocity ghost cells match!")
+    
+    print(f"\nChecking {variable} reconstructed state ghost cell consistency:")
+    
+    left_mismatches = check_reconstructed_ghost_cells(all_left_data, all_left_boxes, var_col)
+    if left_mismatches:
+        print(f"⚠️  Found {len(left_mismatches)} LEFT state ghost cell mismatches")
+    else:
+        print("✅ All LEFT state ghost cells match!")
+    
+    right_mismatches = check_reconstructed_ghost_cells(all_right_data, all_right_boxes, var_col)
+    if right_mismatches:
+        print(f"⚠️  Found {len(right_mismatches)} RIGHT state ghost cell mismatches")
+    else:
+        print("✅ All RIGHT state ghost cells match!")
+    
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, figsize=(12, 15))
+    
+    colors = plt.cm.tab10(np.linspace(0, 1, max(len(facevel_files), len(left_files))))
+    
+    # Plot face velocities
+    for i, fab_file in enumerate(facevel_files):
+        data, box_info = parse_fab_file(fab_file)
+        
+        if data.size == 0:
+            continue
+            
+        # For 1D data: columns are [i, value]
+        indices = data[:, 0].astype(int)
+        values = data[:, 1]
+        
+        # Determine valid region (exclude first and last ghost cells)
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        # Create masks for ghost and valid cells
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        # Plot valid cells
+        valid_mask = ~is_ghost
+        ax1.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        # Plot ghost cells with different style
+        if np.any(is_ghost):
+            ax1.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        # Add vertical lines at box boundaries
+        if i > 0:  # Don't draw line before first box
+            ax1.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    # Plot left reconstructed states
+    for i, left_file in enumerate(left_files):
+        data, box_info = parse_reconstructed_fab_file(left_file)
+        
+        if data.size == 0:
+            continue
+            
+        indices = data[:, 0].astype(int)
+        values = data[:, var_col]
+        
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        valid_mask = ~is_ghost
+        ax2.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        if np.any(is_ghost):
+            ax2.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        if i > 0:
+            ax2.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    # Plot right reconstructed states
+    for i, right_file in enumerate(right_files):
+        data, box_info = parse_reconstructed_fab_file(right_file)
+        
+        if data.size == 0:
+            continue
+            
+        indices = data[:, 0].astype(int)
+        values = data[:, var_col]
+        
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        valid_mask = ~is_ghost
+        ax3.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        if np.any(is_ghost):
+            ax3.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        if i > 0:
+            ax3.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    # Configure plots
+    ax1.set_xlabel('Face Index (i)')
+    ax1.set_ylabel('Face Velocity')
+    ax1.set_title(f'Face Velocities at Level {level}, Timestep {timestep}')
+    ax1.grid(True, alpha=0.3)
+    ax1.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    ax2.set_xlabel('Face Index (i)')
+    ax2.set_ylabel(f'Left {variable}')
+    ax2.set_title(f'Left Reconstructed States ({variable})')
+    ax2.grid(True, alpha=0.3)
+    ax2.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    ax3.set_xlabel('Face Index (i)')
+    ax3.set_ylabel(f'Right {variable}')
+    ax3.set_title(f'Right Reconstructed States ({variable})')
+    ax3.grid(True, alpha=0.3)
+    ax3.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    plt.tight_layout()
+    plt.savefig(f'combined_facevel_reconst_1d_{variable}_lev{level}_step{timestep}.png', dpi=150, bbox_inches='tight')
+    plt.show()
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Plot face velocity FAB files')
+    parser = argparse.ArgumentParser(description='Plot face velocity and reconstructed state FAB files')
+    parser.add_argument('--mode', type=str, default='facevel', choices=['facevel', 'reconst', 'combined'],
+                        help='Plotting mode: facevel (face velocities), reconst (reconstructed states), or combined')
     parser.add_argument('--dim', type=int, default=1, choices=[1, 2],
                         help='Dimensionality of the plot (1 or 2)')
     parser.add_argument('--timestep', type=int, default=0,
@@ -272,8 +828,11 @@ def main():
                         help='AMR level to plot')
     parser.add_argument('--direction', type=str, default='x', choices=['x', 'y', 'z'],
                         help='Direction for face velocities (for 2D plots)')
+    parser.add_argument('--variable', type=str, default='xmom', 
+                        choices=['density', 'xmom', 'ymom', 'zmom', 'energy', 'intenergy'],
+                        help='Variable to plot for reconstructed states')
     parser.add_argument('--dir', type=str, default='.',
-                        help='Directory containing facevel_* subdirectories')
+                        help='Directory containing facevel_* and reconst_* subdirectories')
     
     args = parser.parse_args()
     
@@ -281,10 +840,21 @@ def main():
     if args.dir != '.':
         os.chdir(args.dir)
     
-    if args.dim == 1:
-        plot_1d_face_velocities(args.dir, args.timestep, args.level)
-    elif args.dim == 2:
-        plot_2d_face_velocities(args.dir, args.direction, args.timestep, args.level)
+    if args.mode == 'facevel':
+        if args.dim == 1:
+            plot_1d_face_velocities(args.dir, args.timestep, args.level)
+        elif args.dim == 2:
+            plot_2d_face_velocities(args.dir, args.direction, args.timestep, args.level)
+    elif args.mode == 'reconst':
+        if args.dim == 1:
+            plot_1d_reconstructed_states(args.dir, args.timestep, args.level, args.variable)
+        else:
+            print("2D reconstructed state plotting not yet implemented")
+    elif args.mode == 'combined':
+        if args.dim == 1:
+            plot_1d_combined(args.dir, args.timestep, args.level, args.variable)
+        else:
+            print("2D combined plotting not yet implemented")
 
 
 if __name__ == '__main__':

--- a/scripts/python/plot_face_velocities.py
+++ b/scripts/python/plot_face_velocities.py
@@ -298,7 +298,7 @@ def plot_1d_face_velocities(dirname, timestep=0, level=0):
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
     
-    fig, ax = plt.subplots(figsize=(12, 6))
+    _, ax = plt.subplots(figsize=(12, 6))
     
     colors = plt.cm.tab10(np.linspace(0, 1, len(fab_files)))
     
@@ -542,7 +542,7 @@ def plot_1d_reconstructed_states(dirname, timestep=0, level=0, variable='density
                   f"Box {m['ghost_box']} (ghost) = {m['ghost_value']:.6e}, "
                   f"diff = {m['difference']:.6e}")
     
-    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
+    _, (ax1, ax2) = plt.subplots(2, 1, figsize=(12, 10))
     
     colors = plt.cm.tab10(np.linspace(0, 1, max(len(left_files), len(right_files))))
     

--- a/scripts/python/plot_face_velocities.py
+++ b/scripts/python/plot_face_velocities.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Plot face velocity FAB files with ghost cells highlighted
+"""
+
+import os
+import re
+import numpy as np
+import matplotlib.pyplot as plt
+import argparse
+from pathlib import Path
+
+
+def parse_fab_file(filename):
+    """Parse a FAB file and return the data and metadata"""
+    data = []
+    box_info = None
+    
+    with open(filename, 'r') as f:
+        for line in f:
+            if line.startswith('# Box:'):
+                # Parse box bounds like ((-1) (113) (1)) or ((lo_x lo_y lo_z) (hi_x hi_y hi_z))
+                box_str = line.split(':', 1)[1].strip()
+                # Extract numbers from the box string
+                numbers = re.findall(r'-?\d+', box_str)
+                numbers = [int(n) for n in numbers]
+                
+                # Parse box format which can be:
+                # 1D: ((-1) (113) (1)) - single direction with placeholders
+                # 2D: ((-1,-1) (17,16) (1,0)) - two directions with placeholders  
+                # 3D: ((lo_x,lo_y,lo_z) (hi_x,hi_y,hi_z)) - full 3D
+                
+                # Determine dimensionality from the data format
+                # Count commas to determine actual dimensions
+                comma_count = box_str.count(',')
+                
+                if comma_count == 0:  # 1D: ((-1) (113) (1))
+                    box_info = {
+                        'lo': [numbers[0]],
+                        'hi': [numbers[1]]
+                    }
+                elif comma_count == 3:  # 2D: ((-1,-1) (17,16) (1,0))
+                    # For 2D, first 4 numbers are the actual bounds: lo_i, lo_j, hi_i, hi_j
+                    # The last 2 numbers (1,0) are stride/type indicators
+                    box_info = {
+                        'lo': [numbers[0], numbers[1]], 
+                        'hi': [numbers[2], numbers[3]]
+                    }
+                elif comma_count == 5:  # 3D: ((lo_x,lo_y,lo_z) (hi_x,hi_y,hi_z))
+                    box_info = {
+                        'lo': [numbers[0], numbers[1], numbers[2]],
+                        'hi': [numbers[3], numbers[4], numbers[5]]
+                    }
+                else:
+                    print(f"Warning: Could not parse box format: {box_str}")
+                    box_info = None
+            elif not line.startswith('#'):
+                parts = line.strip().split()
+                if parts:
+                    data.append([float(x) for x in parts])
+    
+    return np.array(data), box_info
+
+
+def plot_1d_face_velocities(dirname, timestep=0, level=0):
+    """Plot 1D face velocities from FAB files"""
+    fab_dir = Path(f"facevel_lev{level}_step{timestep}")
+    if not fab_dir.exists():
+        print(f"Directory {fab_dir} not found!")
+        return
+    
+    # Find all x-direction FAB files
+    fab_files = sorted(fab_dir.glob("facevel_x_box_*.fab"))
+    
+    if not fab_files:
+        print(f"No FAB files found in {fab_dir}")
+        return
+    
+    fig, ax = plt.subplots(figsize=(12, 6))
+    
+    colors = plt.cm.tab10(np.linspace(0, 1, len(fab_files)))
+    
+    for i, fab_file in enumerate(fab_files):
+        data, box_info = parse_fab_file(fab_file)
+        
+        if data.size == 0:
+            continue
+            
+        # For 1D data: columns are [i, value]
+        indices = data[:, 0].astype(int)
+        values = data[:, 1]
+        
+        # Determine valid region (exclude first and last ghost cells)
+        lo_idx = box_info['lo'][0]
+        hi_idx = box_info['hi'][0]
+        
+        # Create masks for ghost and valid cells
+        is_ghost = np.logical_or(indices == lo_idx, indices == hi_idx)
+        
+        # Plot valid cells
+        valid_mask = ~is_ghost
+        ax.plot(indices[valid_mask], values[valid_mask], 'o-', 
+                color=colors[i], label=f'Box {i} (valid)', markersize=3)
+        
+        # Plot ghost cells with different style
+        if np.any(is_ghost):
+            ax.plot(indices[is_ghost], values[is_ghost], 's', 
+                    color=colors[i], markersize=4, markerfacecolor='none',
+                    markeredgewidth=1.5, label=f'Box {i} (ghost)')
+        
+        # Add vertical lines at box boundaries
+        if i > 0:  # Don't draw line before first box
+            ax.axvline(x=lo_idx + 0.5, color='gray', linestyle='--', alpha=0.5)
+    
+    ax.set_xlabel('Face Index (i)')
+    ax.set_ylabel('Face Velocity')
+    ax.set_title(f'Face Velocities at Level {level}, Timestep {timestep}\n'
+                 f'Ghost cells shown as squares')
+    ax.grid(True, alpha=0.3)
+    ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left')
+    
+    plt.tight_layout()
+    plt.savefig(f'face_velocities_1d_lev{level}_step{timestep}.png', dpi=150, bbox_inches='tight')
+    plt.show()
+
+
+def plot_2d_face_velocities(dirname, direction='x', timestep=0, level=0):
+    """Plot 2D face velocities from FAB files"""
+    fab_dir = Path(f"facevel_lev{level}_step{timestep}")
+    if not fab_dir.exists():
+        print(f"Directory {fab_dir} not found!")
+        return
+    
+    # Find all FAB files for the specified direction
+    fab_files = sorted(fab_dir.glob(f"facevel_{direction}_box_*.fab"))
+    
+    if not fab_files:
+        print(f"No FAB files found for direction {direction} in {fab_dir}")
+        return
+    
+    fig, ax = plt.subplots(figsize=(10, 8))
+    
+    # Collect all data to determine global bounds
+    all_data = []
+    all_boxes = []
+    
+    for fab_file in fab_files:
+        data, box_info = parse_fab_file(fab_file)
+        if data.size > 0:
+            all_data.append(data)
+            all_boxes.append(box_info)
+    
+    if not all_data:
+        print("No data found in FAB files")
+        return
+    
+    # For 2D data: columns are [i, j, value]
+    # Determine global bounds
+    i_min = min(int(data[:, 0].min()) for data in all_data)
+    i_max = max(int(data[:, 0].max()) for data in all_data)
+    j_min = min(int(data[:, 1].min()) for data in all_data)
+    j_max = max(int(data[:, 1].max()) for data in all_data)
+    
+    # Create a grid for plotting
+    grid = np.full((j_max - j_min + 1, i_max - i_min + 1), np.nan)
+    ghost_mask = np.zeros_like(grid, dtype=bool)
+    
+    # Fill the grid with data from each box
+    for data, box_info in zip(all_data, all_boxes):
+        indices_i = data[:, 0].astype(int)
+        indices_j = data[:, 1].astype(int)
+        values = data[:, 2]
+        
+        lo_i, lo_j = box_info['lo']
+        hi_i, hi_j = box_info['hi']
+        
+        for idx in range(len(indices_i)):
+            i = indices_i[idx]
+            j = indices_j[idx]
+            grid_i = i - i_min
+            grid_j = j - j_min
+            
+            grid[grid_j, grid_i] = values[idx]
+            
+            # Mark ghost cells
+            if i == lo_i or i == hi_i or j == lo_j or j == hi_j:
+                ghost_mask[grid_j, grid_i] = True
+    
+    # Create the plot - use scatter plot approach for better control
+    # Use a dictionary to avoid plotting the same face multiple times
+    face_data = {}  # (i,j) -> (value, is_ghost)
+    
+    # Collect all data points, handling duplicates
+    for data, box_info in zip(all_data, all_boxes):
+        indices_i = data[:, 0].astype(int)
+        indices_j = data[:, 1].astype(int)
+        values = data[:, 2]
+        
+        lo_i, lo_j = box_info['lo']
+        hi_i, hi_j = box_info['hi']
+        
+        for idx in range(len(indices_i)):
+            i = indices_i[idx]
+            j = indices_j[idx]
+            key = (i, j)
+            
+            # Mark ghost cells (at boundaries of this box)
+            is_ghost = (i == lo_i or i == hi_i or j == lo_j or j == hi_j)
+            
+            # If this face already exists, prefer non-ghost classification
+            if key in face_data:
+                existing_value, existing_is_ghost = face_data[key]
+                # Keep existing if it's not a ghost, or update if current is not ghost
+                if existing_is_ghost and not is_ghost:
+                    face_data[key] = (values[idx], is_ghost)
+            else:
+                face_data[key] = (values[idx], is_ghost)
+    
+    # Convert to arrays
+    all_i = np.array([pos[0] for pos in face_data.keys()])
+    all_j = np.array([pos[1] for pos in face_data.keys()])
+    all_values = np.array([data[0] for data in face_data.values()])
+    all_is_ghost = np.array([data[1] for data in face_data.values()])
+    
+    # Plot valid cells
+    valid_mask = ~all_is_ghost
+    if np.any(valid_mask):
+        scatter = ax.scatter(all_i[valid_mask], all_j[valid_mask], 
+                           c=all_values[valid_mask], s=15, cmap='viridis', 
+                           marker='o', edgecolors='black', linewidth=0.3)
+    
+    # Plot ghost cells with different style
+    if np.any(all_is_ghost):
+        ax.scatter(all_i[all_is_ghost], all_j[all_is_ghost], 
+                  c=all_values[all_is_ghost], s=25, cmap='viridis',
+                  marker='s', edgecolors='red', linewidth=1)
+    
+    # Draw box boundaries
+    for box_info in all_boxes:
+        lo_i, lo_j = box_info['lo']
+        hi_i, hi_j = box_info['hi']
+        
+        # Draw rectangle for each box (excluding ghost cells)
+        rect = plt.Rectangle((lo_i + 0.5, lo_j + 0.5), 
+                           hi_i - lo_i - 1, hi_j - lo_j - 1,
+                           fill=False, edgecolor='red', linewidth=2)
+        ax.add_patch(rect)
+    
+    ax.set_xlabel(f'Face Index i ({direction}-faces)')
+    ax.set_ylabel('Face Index j')
+    ax.set_title(f'{direction.upper()}-Face Velocities at Level {level}, Timestep {timestep}\n'
+                 f'Ghost cells shown as red squares, box boundaries in red')
+    
+    # Add colorbar if we have valid data
+    if np.any(valid_mask):
+        cbar = plt.colorbar(scatter, ax=ax)
+        cbar.set_label('Face Velocity')
+    
+    plt.tight_layout()
+    plt.savefig(f'face_velocities_2d_{direction}_lev{level}_step{timestep}.png', 
+                dpi=150, bbox_inches='tight')
+    plt.show()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Plot face velocity FAB files')
+    parser.add_argument('--dim', type=int, default=1, choices=[1, 2],
+                        help='Dimensionality of the plot (1 or 2)')
+    parser.add_argument('--timestep', type=int, default=0,
+                        help='Timestep to plot')
+    parser.add_argument('--level', type=int, default=0,
+                        help='AMR level to plot')
+    parser.add_argument('--direction', type=str, default='x', choices=['x', 'y', 'z'],
+                        help='Direction for face velocities (for 2D plots)')
+    parser.add_argument('--dir', type=str, default='.',
+                        help='Directory containing facevel_* subdirectories')
+    
+    args = parser.parse_args()
+    
+    # Change to specified directory
+    if args.dir != '.':
+        os.chdir(args.dir)
+    
+    if args.dim == 1:
+        plot_1d_face_velocities(args.dir, args.timestep, args.level)
+    elif args.dim == 2:
+        plot_2d_face_velocities(args.dir, args.direction, args.timestep, args.level)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -159,6 +159,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
 	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
+	int nghost_vel_ = 2;			// number of ghost cells for face velocity computation (default == 2)
 
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
@@ -1774,9 +1775,9 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primV
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
 	}
 }
 
@@ -1828,7 +1829,7 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &pri
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	// LLF solver
-	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_);
+	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1665,9 +1665,9 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	const auto ba = grids[lev];
 	const auto dm = dmap[lev];
-	const int flatteningGhost = 2;
 	const int reconstructGhost = 3; // reconstruct *two* additional cells outside valid region
 	// we need two additional ghost cells in order to compute two ghost face velocities
+	const int flatteningGhost = reconstructGhost + 1;
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -1692,12 +1692,10 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	// conserved to primitive variables
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar, nghost_cc_);
 
-#if 0
 	// compute flattening coefficients
 	AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(primVar, flatCoefs[0], flatteningGhost);
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X2>(primVar, flatCoefs[1], flatteningGhost);
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
-#endif
 
 	// compute flux functions
 	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], flatCoefs[0], flatCoefs[1], flatCoefs[2],
@@ -1772,7 +1770,7 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primV
 	}
 
 	// cell-centered kernel
-	// HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
+	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -256,6 +256,9 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
+	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVel, int lev, int step);
+	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int step);
+
 	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 					    amrex::YAFluxRegister *fr_as_fine);
 
@@ -1666,7 +1669,7 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
 	const int flatteningGhost = 2;
-	const int reconstructGhost = 1;
+	const int reconstructGhost = 2; // increased from 1 to 2 to reconstruct one additional cell outside valid region
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -1684,17 +1687,19 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
-		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
-		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, 0);
+		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost - 1);
+		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructGhost - 1);
 	}
 
 	// conserved to primitive variables
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar, nghost_cc_);
 
+#if 0
 	// compute flattening coefficients
 	AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(primVar, flatCoefs[0], flatteningGhost);
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X2>(primVar, flatCoefs[1], flatteningGhost);
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
+#endif
 
 	// compute flux functions
 	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], flatCoefs[0], flatCoefs[1], flatCoefs[2],
@@ -1706,6 +1711,12 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
+
+	// write reconstructed states to disk for analysis (includes ghost zones)
+	writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
+
+	// write face velocities to disk for analysis
+	writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// LOW LEVEL DEBUGGING: output all of the temporary MultiFabs
 	if (lowLevelDebuggingOutput_ == 1) {
@@ -1763,7 +1774,7 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primV
 	}
 
 	// cell-centered kernel
-	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
+	// HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1781,7 +1792,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
-	const int reconstructRange = 1;
+	const int reconstructRange = 2; // increased from 1 to 2 to reconstruct one additional cell outside valid region
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -1794,8 +1805,8 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
-		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
-		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, 0);
+		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
+		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
 	}
 
 	// conserved to primitive variables
@@ -1806,8 +1817,14 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 		     , hydroFOFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], reconstructRange, nvars);
 		     , hydroFOFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], reconstructRange, nvars);)
 
+	// write reconstructed states to disk for analysis (includes ghost zones)
+	writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
+
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
+
+	// write face velocities to disk for analysis
+	writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// return flux and face-centered velocities
 	return std::make_pair(std::move(flux), std::move(facevel));
@@ -2242,6 +2259,152 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 	amrex::Box const &x1FluxRange = amrex::surroundingNodes(indexRange, dir);
 	RadSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux.array(), x1FluxDiffusive.array(), x1LeftState.array(), x1RightState.array(), x1FluxRange,
 							  consState, dx, use_wavespeed_correction_); // watch out for argument order!!
+}
+
+template <typename problem_t>
+void QuokkaSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep)
+{
+	// Create directory for face velocity outputs if it doesn't exist
+	std::string dirname = fmt::format("facevel_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's face velocities
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write each FAB in the MultiFab
+		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
+			
+			// Create filename for this FAB
+			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write FAB to disk in ASCII format
+			std::ofstream ofs(filename, std::ios::out);
+			if (ofs.is_open()) {
+				// Write box information
+				ofs << "# Face velocity FAB for direction " << dimname << "\n";
+				ofs << "# Box: " << bx << "\n";
+#if AMREX_SPACEDIM == 1
+				ofs << "# Format: i value\n";
+#elif AMREX_SPACEDIM == 2
+				ofs << "# Format: i j value\n";
+#elif AMREX_SPACEDIM == 3
+				ofs << "# Format: i j k value\n";
+#endif
+				
+				// Write data
+				auto const& arr = fab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					ofs << i << " " << arr(i,j,k,0) << "\n";
+#elif AMREX_SPACEDIM == 2
+					ofs << i << " " << j << " " << arr(i,j,k,0) << "\n";
+#elif AMREX_SPACEDIM == 3
+					ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
+#endif
+				});
+				ofs.close();
+			}
+		}
+	}
+}
+
+template <typename problem_t>
+void QuokkaSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int timestep)
+{
+	// Create directory for reconstructed state outputs if it doesn't exist
+	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's reconstructed states
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write left and right states for each FAB in the MultiFab
+		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& leftFab = leftState[idim][mfi];
+			const amrex::FArrayBox& rightFab = rightState[idim][mfi];
+			
+			// Create filenames for this FAB's left and right states
+			std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
+			std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write left state FAB to disk
+			std::ofstream leftOfs(leftFilename, std::ios::out);
+			if (leftOfs.is_open()) {
+				// Write box information
+				leftOfs << "# Left reconstructed state FAB for direction " << dimname << "\n";
+				leftOfs << "# Box: " << bx << "\n";
+#if AMREX_SPACEDIM == 1
+				leftOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 2
+				leftOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 3
+				leftOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
+#endif
+				
+				// Write data (all hydro variables)
+				auto const& leftArr = leftFab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					leftOfs << i;
+#elif AMREX_SPACEDIM == 2
+					leftOfs << i << " " << j;
+#elif AMREX_SPACEDIM == 3
+					leftOfs << i << " " << j << " " << k;
+#endif
+					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
+					for (int ivar = 0; ivar < leftFab.nComp(); ++ivar) {
+						leftOfs << " " << leftArr(i,j,k,ivar);
+					}
+					leftOfs << "\n";
+				});
+				leftOfs.close();
+			}
+			
+			// Write right state FAB to disk
+			std::ofstream rightOfs(rightFilename, std::ios::out);
+			if (rightOfs.is_open()) {
+				// Write box information
+				rightOfs << "# Right reconstructed state FAB for direction " << dimname << "\n";
+				rightOfs << "# Box: " << bx << "\n";
+#if AMREX_SPACEDIM == 1
+				rightOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 2
+				rightOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 3
+				rightOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
+#endif
+				
+				// Write data (all hydro variables)
+				auto const& rightArr = rightFab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					rightOfs << i;
+#elif AMREX_SPACEDIM == 2
+					rightOfs << i << " " << j;
+#elif AMREX_SPACEDIM == 3
+					rightOfs << i << " " << j << " " << k;
+#endif
+					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
+					for (int ivar = 0; ivar < rightFab.nComp(); ++ivar) {
+						rightOfs << " " << rightArr(i,j,k,ivar);
+					}
+					rightOfs << "\n";
+				});
+				rightOfs.close();
+			}
+		}
+	}
 }
 
 #endif // RADIATION_SIMULATION_HPP_

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2253,6 +2253,4 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 							  consState, dx, use_wavespeed_correction_); // watch out for argument order!!
 }
 
-
-
 #endif // RADIATION_SIMULATION_HPP_

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1317,8 +1317,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux_rk2;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> avgFaceVel;
 	const int nghost_vel = 2; // 2 ghost faces are needed for tracer particles
-	auto ba = grids[lev];
-	auto dm = dmap[lev];
+	const auto ba = grids[lev];
+	const auto dm = dmap[lev];
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		// initialize flux MultiFab
@@ -1663,8 +1663,8 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 {
 	BL_PROFILE("QuokkaSimulation::computeHydroFluxes()");
 
-	auto ba = grids[lev];
-	auto dm = dmap[lev];
+	const auto ba = grids[lev];
+	const auto dm = dmap[lev];
 	const int flatteningGhost = 2;
 	const int reconstructGhost = 3; // reconstruct *two* additional cells outside valid region
 	// we need two additional ghost cells in order to compute two ghost face velocities
@@ -1788,8 +1788,8 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 {
 	BL_PROFILE("QuokkaSimulation::computeFOHydroFluxes()");
 
-	auto ba = grids[lev];
-	auto dm = dmap[lev];
+	const auto ba = grids[lev];
+	const auto dm = dmap[lev];
 	const int reconstructRange = 3; // reconstruct *two* additional cells outside valid region
 
 	// allocate temporary MultiFabs

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1669,7 +1669,8 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
 	const int flatteningGhost = 2;
-	const int reconstructGhost = 2; // increased from 1 to 2 to reconstruct one additional cell outside valid region
+	const int reconstructGhost = 3; // reconstruct *two* additional cells outside valid region
+	// we need two additional ghost cells in order to compute two ghost face velocities
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -1792,7 +1793,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
-	const int reconstructRange = 2; // increased from 1 to 2 to reconstruct one additional cell outside valid region
+	const int reconstructRange = 3; // reconstruct *two* additional cells outside valid region
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -1817,14 +1818,8 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 		     , hydroFOFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], reconstructRange, nvars);
 		     , hydroFOFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], reconstructRange, nvars);)
 
-	// write reconstructed states to disk for analysis (includes ghost zones)
-	writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
-
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
-
-	// write face velocities to disk for analysis
-	writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// return flux and face-centered velocities
 	return std::make_pair(std::move(flux), std::move(facevel));

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -256,9 +256,6 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVel, int lev, int step);
-	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int step);
-
 	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 					    amrex::YAFluxRegister *fr_as_fine);
 
@@ -1714,10 +1711,10 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	amrex::Gpu::streamSynchronizeAll();
 
 	// write reconstructed states to disk for analysis (includes ghost zones)
-	writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
+	this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
 
 	// write face velocities to disk for analysis
-	writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
+	this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// LOW LEVEL DEBUGGING: output all of the temporary MultiFabs
 	if (lowLevelDebuggingOutput_ == 1) {
@@ -2256,156 +2253,6 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 							  consState, dx, use_wavespeed_correction_); // watch out for argument order!!
 }
 
-template <typename problem_t>
-void QuokkaSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep)
-{
-	// Create directory for face velocity outputs if it doesn't exist
-	std::string dirname = fmt::format("facevel_lev{}_step{}", lev, timestep);
-	if (amrex::ParallelDescriptor::IOProcessor()) {
-		amrex::UtilCreateDirectory(dirname, 0755);
-	}
-	amrex::ParallelDescriptor::Barrier();
 
-	// Write each direction's face velocities
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
-		// Write each FAB in the MultiFab
-		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
-			
-			// Create filename for this FAB
-			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
-			// Write FAB to disk in ASCII format
-			std::ofstream ofs(filename, std::ios::out);
-			if (ofs.is_open()) {
-				// Write box information
-				ofs << "# Face velocity FAB for direction " << dimname << "\n";
-				ofs << "# Box: " << bx << "\n";
-				ofs << "# Valid box: " << mfi.validbox() << "\n";
-				ofs << "# MultiFab ghost cells: " << faceVelArrays[idim].nGrow() << "\n";
-#if AMREX_SPACEDIM == 1
-				ofs << "# Format: i value\n";
-#elif AMREX_SPACEDIM == 2
-				ofs << "# Format: i j value\n";
-#elif AMREX_SPACEDIM == 3
-				ofs << "# Format: i j k value\n";
-#endif
-				
-				// Write data
-				auto const& arr = fab.const_array();
-				amrex::Loop(bx, [&](int i, int j, int k) {
-#if AMREX_SPACEDIM == 1
-					ofs << i << " " << arr(i,j,k,0) << "\n";
-#elif AMREX_SPACEDIM == 2
-					ofs << i << " " << j << " " << arr(i,j,k,0) << "\n";
-#elif AMREX_SPACEDIM == 3
-					ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
-#endif
-				});
-				ofs.close();
-			}
-		}
-	}
-}
-
-template <typename problem_t>
-void QuokkaSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int timestep)
-{
-	// Create directory for reconstructed state outputs if it doesn't exist
-	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
-	if (amrex::ParallelDescriptor::IOProcessor()) {
-		amrex::UtilCreateDirectory(dirname, 0755);
-	}
-	amrex::ParallelDescriptor::Barrier();
-
-	// Write each direction's reconstructed states
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
-		// Write left and right states for each FAB in the MultiFab
-		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& leftFab = leftState[idim][mfi];
-			const amrex::FArrayBox& rightFab = rightState[idim][mfi];
-			
-			// Create filenames for this FAB's left and right states
-			std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
-			std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
-			// Write left state FAB to disk
-			std::ofstream leftOfs(leftFilename, std::ios::out);
-			if (leftOfs.is_open()) {
-				// Write box information
-				leftOfs << "# Left reconstructed state FAB for direction " << dimname << "\n";
-				leftOfs << "# Box: " << bx << "\n";
-				leftOfs << "# Valid box: " << mfi.validbox() << "\n";
-				leftOfs << "# MultiFab ghost cells: " << leftState[idim].nGrow() << "\n";
-#if AMREX_SPACEDIM == 1
-				leftOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
-#elif AMREX_SPACEDIM == 2
-				leftOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
-#elif AMREX_SPACEDIM == 3
-				leftOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
-#endif
-				
-				// Write data (all hydro variables)
-				auto const& leftArr = leftFab.const_array();
-				amrex::Loop(bx, [&](int i, int j, int k) {
-#if AMREX_SPACEDIM == 1
-					leftOfs << i;
-#elif AMREX_SPACEDIM == 2
-					leftOfs << i << " " << j;
-#elif AMREX_SPACEDIM == 3
-					leftOfs << i << " " << j << " " << k;
-#endif
-					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
-					for (int ivar = 0; ivar < leftFab.nComp(); ++ivar) {
-						leftOfs << " " << leftArr(i,j,k,ivar);
-					}
-					leftOfs << "\n";
-				});
-				leftOfs.close();
-			}
-			
-			// Write right state FAB to disk
-			std::ofstream rightOfs(rightFilename, std::ios::out);
-			if (rightOfs.is_open()) {
-				// Write box information
-				rightOfs << "# Right reconstructed state FAB for direction " << dimname << "\n";
-				rightOfs << "# Box: " << bx << "\n";
-				rightOfs << "# Valid box: " << mfi.validbox() << "\n";
-				rightOfs << "# MultiFab ghost cells: " << rightState[idim].nGrow() << "\n";
-#if AMREX_SPACEDIM == 1
-				rightOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
-#elif AMREX_SPACEDIM == 2
-				rightOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
-#elif AMREX_SPACEDIM == 3
-				rightOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
-#endif
-				
-				// Write data (all hydro variables)
-				auto const& rightArr = rightFab.const_array();
-				amrex::Loop(bx, [&](int i, int j, int k) {
-#if AMREX_SPACEDIM == 1
-					rightOfs << i;
-#elif AMREX_SPACEDIM == 2
-					rightOfs << i << " " << j;
-#elif AMREX_SPACEDIM == 3
-					rightOfs << i << " " << j << " " << k;
-#endif
-					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
-					for (int ivar = 0; ivar < rightFab.nComp(); ++ivar) {
-						rightOfs << " " << rightArr(i,j,k,ivar);
-					}
-					rightOfs << "\n";
-				});
-				rightOfs.close();
-			}
-		}
-	}
-}
 
 #endif // RADIATION_SIMULATION_HPP_

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1709,10 +1709,10 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	amrex::Gpu::streamSynchronizeAll();
 
 	// write reconstructed states to disk for analysis (includes ghost zones)
-	this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
+	//this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
 
 	// write face velocities to disk for analysis
-	this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
+	//this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// LOW LEVEL DEBUGGING: output all of the temporary MultiFabs
 	if (lowLevelDebuggingOutput_ == 1) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1775,9 +1775,11 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primV
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
+											 nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
+											 nghost_vel_);
 	}
 }
 
@@ -1829,7 +1831,8 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &pri
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
 	// LLF solver
-	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_, nghost_vel_);
+	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
+										nghost_vel_);
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2284,6 +2284,8 @@ void QuokkaSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Mu
 				// Write box information
 				ofs << "# Face velocity FAB for direction " << dimname << "\n";
 				ofs << "# Box: " << bx << "\n";
+				ofs << "# Valid box: " << mfi.validbox() << "\n";
+				ofs << "# MultiFab ghost cells: " << faceVelArrays[idim].nGrow() << "\n";
 #if AMREX_SPACEDIM == 1
 				ofs << "# Format: i value\n";
 #elif AMREX_SPACEDIM == 2
@@ -2339,6 +2341,8 @@ void QuokkaSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amre
 				// Write box information
 				leftOfs << "# Left reconstructed state FAB for direction " << dimname << "\n";
 				leftOfs << "# Box: " << bx << "\n";
+				leftOfs << "# Valid box: " << mfi.validbox() << "\n";
+				leftOfs << "# MultiFab ghost cells: " << leftState[idim].nGrow() << "\n";
 #if AMREX_SPACEDIM == 1
 				leftOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
 #elif AMREX_SPACEDIM == 2
@@ -2372,6 +2376,8 @@ void QuokkaSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amre
 				// Write box information
 				rightOfs << "# Right reconstructed state FAB for direction " << dimname << "\n";
 				rightOfs << "# Box: " << bx << "\n";
+				rightOfs << "# Valid box: " << mfi.validbox() << "\n";
+				rightOfs << "# MultiFab ghost cells: " << rightState[idim].nGrow() << "\n";
 #if AMREX_SPACEDIM == 1
 				rightOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
 #elif AMREX_SPACEDIM == 2

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1709,10 +1709,10 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	amrex::Gpu::streamSynchronizeAll();
 
 	// write reconstructed states to disk for analysis (includes ghost zones)
-	//this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
+	// this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
 
 	// write face velocities to disk for analysis
-	//this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
+	// this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
 
 	// LOW LEVEL DEBUGGING: output all of the temporary MultiFabs
 	if (lowLevelDebuggingOutput_ == 1) {

--- a/src/hydro/NSCBC_inflow.hpp
+++ b/src/hydro/NSCBC_inflow.hpp
@@ -133,6 +133,9 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setInflowX1Lower(const amrex::IntVect &
 	quokka::valarray<amrex::Real, N> const Q_im2 = -2.0 * Q_ip1 - 3.0 * Q_i + 6.0 * Q_im1 + 6.0 * dx * dQ_dx;
 	quokka::valarray<amrex::Real, N> const Q_im3 = 3.0 * Q_ip1 + 10.0 * Q_i - 18.0 * Q_im1 + 6.0 * Q_im2 - 12.0 * dx * dQ_dx;
 	quokka::valarray<amrex::Real, N> const Q_im4 = -2.0 * Q_ip1 - 13.0 * Q_i + 24.0 * Q_im1 - 12.0 * Q_im2 + 4.0 * Q_im3 + 12.0 * dx * dQ_dx;
+	// TODO(bwibking): update these values with higher-order extrapolated values
+	quokka::valarray<amrex::Real, N> const Q_im5 = Q_im4;
+	quokka::valarray<amrex::Real, N> const Q_im6 = Q_im4;
 
 	// set cell values
 	quokka::valarray<amrex::Real, N> consCell{};
@@ -144,6 +147,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setInflowX1Lower(const amrex::IntVect &
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_im3);
 	} else if (i == ilo - 4) {
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_im4);
+	} else if (i == ilo - 5) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_im5);
+	} else if (i == ilo - 6) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_im6);
 	}
 
 	consVar(i, j, k, HydroSystem<problem_t>::density_index) = consCell[0];

--- a/src/hydro/NSCBC_outflow.hpp
+++ b/src/hydro/NSCBC_outflow.hpp
@@ -326,12 +326,17 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundary(const amrex::IntVect
 	quokka::valarray<amrex::Real, N> Q_ip2 = -2.0 * Q_im1 - 3.0 * Q_i + 6.0 * Q_ip1 - 6.0 * dx * dQ_dx;
 	quokka::valarray<amrex::Real, N> Q_ip3 = 3.0 * Q_im1 + 10.0 * Q_i - 18.0 * Q_ip1 + 6.0 * Q_ip2 + 12.0 * dx * dQ_dx;
 	quokka::valarray<amrex::Real, N> Q_ip4 = -2.0 * Q_im1 - 13.0 * Q_i + 24.0 * Q_ip1 - 12.0 * Q_ip2 + 4.0 * Q_ip3 - 12.0 * dx * dQ_dx;
+	// TODO(bwibking): update these values with higher-order extrapolated values
+	quokka::valarray<amrex::Real, N> Q_ip5 = Q_ip4;
+	quokka::valarray<amrex::Real, N> Q_ip6 = Q_ip4;
 
 	// set cell values
 	const int ip1 = (SIDE == BoundarySide::Lower) ? ibr - 1 : ibr + 1;
 	const int ip2 = (SIDE == BoundarySide::Lower) ? ibr - 2 : ibr + 2;
 	const int ip3 = (SIDE == BoundarySide::Lower) ? ibr - 3 : ibr + 3;
 	const int ip4 = (SIDE == BoundarySide::Lower) ? ibr - 4 : ibr + 4;
+	const int ip5 = (SIDE == BoundarySide::Lower) ? ibr - 5 : ibr + 5;
+	const int ip6 = (SIDE == BoundarySide::Lower) ? ibr - 6 : ibr + 6;
 
 	quokka::valarray<amrex::Real, N> consCell{};
 	if (idx[static_cast<int>(DIR)] == ip1) {
@@ -342,6 +347,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundary(const amrex::IntVect
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip3);
 	} else if (idx[static_cast<int>(DIR)] == ip4) {
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip4);
+	} else if (idx[static_cast<int>(DIR)] == ip5) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip5);
+	} else if (idx[static_cast<int>(DIR)] == ip6) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip6);
 	}
 
 	consVar(i, j, k, HydroSystem<problem_t>::density_index) = consCell[0];
@@ -371,6 +380,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 	const int im1 = (SIDE == BoundarySide::Lower) ? ibr + 1 : ibr - 1;
 	const int im2 = (SIDE == BoundarySide::Lower) ? ibr + 2 : ibr - 2;
 	const int im3 = (SIDE == BoundarySide::Lower) ? ibr + 3 : ibr - 3;
+	const int im4 = (SIDE == BoundarySide::Lower) ? ibr + 4 : ibr - 4;
+	const int im5 = (SIDE == BoundarySide::Lower) ? ibr + 5 : ibr - 5;
 
 	// compute primitive vars
 	quokka::valarray<amrex::Real, N> Q_i{};
@@ -386,6 +397,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 	quokka::valarray<amrex::Real, N> Q_ip2{};
 	quokka::valarray<amrex::Real, N> Q_ip3{};
 	quokka::valarray<amrex::Real, N> Q_ip4{};
+	quokka::valarray<amrex::Real, N> Q_ip5{};
+	quokka::valarray<amrex::Real, N> Q_ip6{};
 
 	// if gas is inflowing, change to reflecting B.C.
 	quokka::valarray<amrex::Real, N> Qr_im0 = detail::permute_vel<problem_t, DIR>(Q_i);
@@ -396,35 +409,49 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 		quokka::valarray<amrex::Real, N> Q_im1{};
 		quokka::valarray<amrex::Real, N> Q_im2{};
 		quokka::valarray<amrex::Real, N> Q_im3{};
+		quokka::valarray<amrex::Real, N> Q_im4{};
+		quokka::valarray<amrex::Real, N> Q_im5{};
 
 		if constexpr (DIR == FluxDir::X1) {
 			Q_im1 = HydroSystem<problem_t>::ComputePrimVars(consVar, im1, j, k);
 			Q_im2 = HydroSystem<problem_t>::ComputePrimVars(consVar, im2, j, k);
 			Q_im3 = HydroSystem<problem_t>::ComputePrimVars(consVar, im3, j, k);
+			Q_im4 = HydroSystem<problem_t>::ComputePrimVars(consVar, im4, j, k);
+			Q_im5 = HydroSystem<problem_t>::ComputePrimVars(consVar, im5, j, k);
 		} else if constexpr (DIR == FluxDir::X2) {
 			Q_im1 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, im1, k);
 			Q_im2 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, im2, k);
 			Q_im3 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, im3, k);
+			Q_im4 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, im4, k);
+			Q_im5 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, im5, k);
 		} else if constexpr (DIR == FluxDir::X3) {
 			Q_im1 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im1);
 			Q_im2 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im2);
 			Q_im3 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im3);
+			Q_im3 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im4);
+			Q_im3 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im5);
 		}
 
 		// reflect velocities
 		quokka::valarray<amrex::Real, N> Qr_im1 = detail::permute_vel<problem_t, DIR>(Q_im1);
 		quokka::valarray<amrex::Real, N> Qr_im2 = detail::permute_vel<problem_t, DIR>(Q_im2);
 		quokka::valarray<amrex::Real, N> Qr_im3 = detail::permute_vel<problem_t, DIR>(Q_im3);
+		quokka::valarray<amrex::Real, N> Qr_im4 = detail::permute_vel<problem_t, DIR>(Q_im4);
+		quokka::valarray<amrex::Real, N> Qr_im5 = detail::permute_vel<problem_t, DIR>(Q_im5);
 
 		Qr_im0[1] *= -1.0;
 		Qr_im1[1] *= -1.0;
 		Qr_im2[1] *= -1.0;
 		Qr_im3[1] *= -1.0;
+		Qr_im4[1] *= -1.0;
+		Qr_im5[1] *= -1.0;
 
 		Q_ip1 = detail::unpermute_vel<problem_t, DIR>(Qr_im0);
 		Q_ip2 = detail::unpermute_vel<problem_t, DIR>(Qr_im1);
 		Q_ip3 = detail::unpermute_vel<problem_t, DIR>(Qr_im2);
 		Q_ip4 = detail::unpermute_vel<problem_t, DIR>(Qr_im3);
+		Q_ip5 = detail::unpermute_vel<problem_t, DIR>(Qr_im4);
+		Q_ip6 = detail::unpermute_vel<problem_t, DIR>(Qr_im5);
 	} else {
 		// specify pressure at boundary
 		Q_i[4] = P_outflow;
@@ -432,6 +459,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 		Q_ip2 = Q_i;
 		Q_ip3 = Q_i;
 		Q_ip4 = Q_i;
+		Q_ip5 = Q_i;
+		Q_ip6 = Q_i;
 	}
 
 	// set cell values
@@ -439,6 +468,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 	const int ip2 = (SIDE == BoundarySide::Lower) ? ibr - 2 : ibr + 2;
 	const int ip3 = (SIDE == BoundarySide::Lower) ? ibr - 3 : ibr + 3;
 	const int ip4 = (SIDE == BoundarySide::Lower) ? ibr - 4 : ibr + 4;
+	const int ip5 = (SIDE == BoundarySide::Lower) ? ibr - 5 : ibr + 5;
+	const int ip6 = (SIDE == BoundarySide::Lower) ? ibr - 6 : ibr + 6;
 
 	quokka::valarray<amrex::Real, N> consCell{};
 	if (idx[static_cast<int>(DIR)] == ip1) {
@@ -449,6 +480,10 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundaryLowOrder(const amrex:
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip3);
 	} else if (idx[static_cast<int>(DIR)] == ip4) {
 		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip4);
+	} else if (idx[static_cast<int>(DIR)] == ip5) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip5);
+	} else if (idx[static_cast<int>(DIR)] == ip6) {
+		consCell = HydroSystem<problem_t>::ComputeConsVars(Q_ip6);
 	}
 
 	consVar(i, j, k, HydroSystem<problem_t>::density_index) = consCell[0];

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -115,7 +115,7 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	template <RiemannSolver RIEMANN, FluxDir DIR>
 	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc);
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc, int nghost_vel = 2);
 
 	template <FluxDir DIR>
 	static void ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar, array_t &x1FluxDiffusive, amrex::Box const &indexRange);
@@ -852,7 +852,7 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 template <typename problem_t>
 template <RiemannSolver RIEMANN, FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc)
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc, const int nghost_vel)
 {
 
 	// By convention, the interfaces are defined on the left edge of each
@@ -868,7 +868,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
 
 	// Include ghost cells when computing face velocities
-	amrex::IntVect ng{AMREX_D_DECL(2, 2, 2)};
+	amrex::IntVect ng{AMREX_D_DECL(nghost_vel, nghost_vel, nghost_vel)};
 	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -852,7 +852,8 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 template <typename problem_t>
 template <RiemannSolver RIEMANN, FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc, const int nghost_vel)
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
+					   const int nghost_vel)
 {
 
 	// By convention, the interfaces are defined on the left edge of each

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1090,19 +1090,36 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		}
 
 		// compute face-centered normal velocity
-		const double v_norm = (F[density_index] >= 0.) ? (F[density_index] / rho_R) : (F[density_index] / rho_L);
+		double v_norm = 0.0;
+		if (F[density_index] >= 0.) {
+			if (rho_R > 0.) {
+				v_norm = F[density_index] / rho_R;
+			}
+		} else {
+			if (rho_L > 0.) {
+				v_norm = F[density_index] / rho_L;
+			}
+		}
 		x1FaceVel(i, j, k) = v_norm;
 
 		// use the same logic as above to scale and conserve specie fluxes
 		if (F[density_index] >= 0.) {
 			for (int n = 0; n < nmscalars_; ++n) {
 				const int nstart = nvar_ - nscalars_;
-				F[nstart + n] = F[density_index] * U_L[nstart + n] / fluxSum_U_L;
+				if (fluxSum_U_L > 0.) {
+					F[nstart + n] = F[density_index] * U_L[nstart + n] / fluxSum_U_L;
+				} else {
+					F[nstart + n] = 0.;
+				}
 			}
 		} else {
 			for (int n = 0; n < nmscalars_; ++n) {
 				const int nstart = nvar_ - nscalars_;
-				F[nstart + n] = F[density_index] * U_R[nstart + n] / fluxSum_U_R;
+				if (fluxSum_U_R > 0.) {
+					F[nstart + n] = F[density_index] * U_R[nstart + n] / fluxSum_U_R;
+				} else {
+					F[nstart + n] = 0.;
+				}
 			}
 		}
 

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -868,7 +868,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
 
 	// Include ghost cells when computing face velocities
-	amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
+	amrex::IntVect ng{AMREX_D_DECL(2, 2, 2)};
 	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -867,7 +867,9 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	auto x1Flux_in = x1Flux_mf.arrays();
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
 
-	amrex::ParallelFor(x1Flux_mf, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
+	// Include ghost cells when computing face velocities
+	amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
+	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -102,13 +102,17 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
-	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev) -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
+	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev) -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, 
+													     std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
 	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1LeftState,
 			  amrex::MultiFab &x1RightState, int ng_reconstruct, int nvars);
 
 	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep);
+
+	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftStateArrays, 
+					    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightStateArrays, int lev, int timestep);
 
 	double advectionVx_ = 1.0; // default
 	double advectionVy_ = 0.0; // default
@@ -362,10 +366,13 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 	{
 		auto const &stateOld = state_old_cc_[lev];
 		auto &stateNew = state_new_cc_[lev];
-		auto [fluxArrays, faceVelArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
 		writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
+		
+		// Write reconstructed states to disk
+		writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
 
 		// Stage 1 of RK2-SSP
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -393,7 +400,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 			auto const &stateInOld = state_old_cc_[lev];
 			auto const &stateInStar = state_new_cc_[lev];
 			auto &stateOut = state_new_cc_[lev];
-			auto [fluxArrays, faceVelArrays] = computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 			// Stage 2 of RK2-SSP
 			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -441,7 +448,8 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 
 template <typename problem_t>
 auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
-    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, 
+		  std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
@@ -468,7 +476,7 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
-	return std::make_pair(std::move(flux), std::move(facevel));
+	return std::make_tuple(std::move(flux), std::move(facevel), std::move(leftState), std::move(rightState));
 }
 
 template <typename problem_t>
@@ -555,6 +563,151 @@ void AdvectionSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex:
 					for (int j = lo[1]; j <= hi[1]; ++j) {
 						for (int i = lo[0]; i <= hi[0]; ++i) {
 							ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
+						}
+					}
+				}
+#endif
+				ofs.close();
+			}
+		}
+	}
+}
+
+template <typename problem_t>
+void AdvectionSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftStateArrays,
+								    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightStateArrays, int lev, int timestep)
+{
+	// Create directory for reconstructed states outputs if it doesn't exist
+	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's left and right states
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write left states
+		for (amrex::MFIter mfi(leftStateArrays[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& fab = leftStateArrays[idim][mfi];
+			
+			// Create filename for this FAB
+			std::string filename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write FAB to disk in ASCII format
+			std::ofstream ofs(filename, std::ios::out);
+			if (ofs.is_open()) {
+				// Write box information
+				ofs << "# Left reconstructed states for direction " << dimname << "\n";
+				ofs << "# Box: " << bx << "\n";
+				ofs << "# Number of components: " << fab.nComp() << "\n";
+#if AMREX_SPACEDIM == 1
+				ofs << "# Format: i comp0 comp1 ... compN\n";
+#elif AMREX_SPACEDIM == 2
+				ofs << "# Format: i j comp0 comp1 ... compN\n";
+#elif AMREX_SPACEDIM == 3
+				ofs << "# Format: i j k comp0 comp1 ... compN\n";
+#endif
+				
+				// Write data including ghost cells
+				const auto& arr = fab.array();
+				const auto lo = bx.smallEnd();
+				const auto hi = bx.bigEnd();
+				const int ncomp = fab.nComp();
+				
+#if AMREX_SPACEDIM == 1
+				for (int i = lo[0]; i <= hi[0]; ++i) {
+					ofs << i;
+					for (int n = 0; n < ncomp; ++n) {
+						ofs << " " << arr(i,0,0,n);
+					}
+					ofs << "\n";
+				}
+#elif AMREX_SPACEDIM == 2
+				for (int j = lo[1]; j <= hi[1]; ++j) {
+					for (int i = lo[0]; i <= hi[0]; ++i) {
+						ofs << i << " " << j;
+						for (int n = 0; n < ncomp; ++n) {
+							ofs << " " << arr(i,j,0,n);
+						}
+						ofs << "\n";
+					}
+				}
+#elif AMREX_SPACEDIM == 3
+				for (int k = lo[2]; k <= hi[2]; ++k) {
+					for (int j = lo[1]; j <= hi[1]; ++j) {
+						for (int i = lo[0]; i <= hi[0]; ++i) {
+							ofs << i << " " << j << " " << k;
+							for (int n = 0; n < ncomp; ++n) {
+								ofs << " " << arr(i,j,k,n);
+							}
+							ofs << "\n";
+						}
+					}
+				}
+#endif
+				ofs.close();
+			}
+		}
+		
+		// Write right states
+		for (amrex::MFIter mfi(rightStateArrays[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& fab = rightStateArrays[idim][mfi];
+			
+			// Create filename for this FAB
+			std::string filename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write FAB to disk in ASCII format
+			std::ofstream ofs(filename, std::ios::out);
+			if (ofs.is_open()) {
+				// Write box information
+				ofs << "# Right reconstructed states for direction " << dimname << "\n";
+				ofs << "# Box: " << bx << "\n";
+				ofs << "# Number of components: " << fab.nComp() << "\n";
+#if AMREX_SPACEDIM == 1
+				ofs << "# Format: i comp0 comp1 ... compN\n";
+#elif AMREX_SPACEDIM == 2
+				ofs << "# Format: i j comp0 comp1 ... compN\n";
+#elif AMREX_SPACEDIM == 3
+				ofs << "# Format: i j k comp0 comp1 ... compN\n";
+#endif
+				
+				// Write data including ghost cells
+				const auto& arr = fab.array();
+				const auto lo = bx.smallEnd();
+				const auto hi = bx.bigEnd();
+				const int ncomp = fab.nComp();
+				
+#if AMREX_SPACEDIM == 1
+				for (int i = lo[0]; i <= hi[0]; ++i) {
+					ofs << i;
+					for (int n = 0; n < ncomp; ++n) {
+						ofs << " " << arr(i,0,0,n);
+					}
+					ofs << "\n";
+				}
+#elif AMREX_SPACEDIM == 2
+				for (int j = lo[1]; j <= hi[1]; ++j) {
+					for (int i = lo[0]; i <= hi[0]; ++i) {
+						ofs << i << " " << j;
+						for (int n = 0; n < ncomp; ++n) {
+							ofs << " " << arr(i,j,0,n);
+						}
+						ofs << "\n";
+					}
+				}
+#elif AMREX_SPACEDIM == 3
+				for (int k = lo[2]; k <= hi[2]; ++k) {
+					for (int j = lo[1]; j <= hi[1]; ++j) {
+						for (int i = lo[0]; i <= hi[0]; ++i) {
+							ofs << i << " " << j << " " << k;
+							for (int n = 0; n < ncomp; ++n) {
+								ofs << " " << arr(i,j,k,n);
+							}
+							ofs << "\n";
 						}
 					}
 				}

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -365,10 +365,10 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
-		this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
+		//this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
 
 		// Write reconstructed states to disk
-		this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
+		//this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
 
 		// Stage 1 of RK2-SSP
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -453,7 +453,10 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 {
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
-	const int reconstructRange = 1;
+	const int reconstructRange = 2; // fully reconstruct a parabola within *two* cells outside the valid region
+	// NOTE: one cell is needed to get L/R states at the FAB boundaries.
+	//   The extra cell is needed to get L/R states (and therefore the face velocity) for one ghost face.
+	//   (For hydro, we need *two* ghost face velocities!)
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
@@ -466,8 +469,8 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
-		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
-		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, 1);
+		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
+		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
 	}
 
 	AMREX_D_TERM(fluxFunction<FluxDir::X1>(consVar, primVar, flux[0], facevel[0], leftState[0], rightState[0], reconstructRange, nvars);
@@ -497,14 +500,7 @@ void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consSta
 
 	LinearAdvectionSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, x1LeftState, x1RightState, ng_reconstruct, nvars);
 
-	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux, x1LeftState, x1RightState, advectionVel, nvars);
-
-	// Fill face velocities with the advection velocity (including ghost cells)
-	const amrex::IntVect ngrowVec(AMREX_D_DECL(1, 1, 1));
-	auto x1FaceVel_in = x1FaceVel.arrays();
-	amrex::ParallelFor(x1FaceVel, ngrowVec, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-		x1FaceVel_in[bx](i, j, k) = advectionVel;
-	});
+	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux, x1LeftState, x1RightState, x1FaceVel, advectionVel, nvars);
 }
 
 template <typename problem_t>

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -102,12 +102,13 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
-	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev) -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, 
-													     std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
+	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev)
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
-	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1LeftState,
-			  amrex::MultiFab &x1RightState, int ng_reconstruct, int nvars);
+	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
+			  amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState, int ng_reconstruct, int nvars);
 
 	double advectionVx_ = 1.0; // default
 	double advectionVy_ = 0.0; // default
@@ -365,7 +366,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 
 		// Write face velocities to disk
 		this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
-		
+
 		// Write reconstructed states to disk
 		this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
 
@@ -395,7 +396,8 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 			auto const &stateInOld = state_old_cc_[lev];
 			auto const &stateInStar = state_new_cc_[lev];
 			auto &stateOut = state_new_cc_[lev];
-			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] =
+			    computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 			// Stage 2 of RK2-SSP
 			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -443,8 +445,8 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 
 template <typename problem_t>
 auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
-    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, 
-		  std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+		  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
@@ -479,8 +481,9 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 
 template <typename problem_t>
 template <FluxDir DIR>
-void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
-						  amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState, const int ng_reconstruct, const int nvars)
+void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux,
+						  amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState,
+						  const int ng_reconstruct, const int nvars)
 {
 	amrex::Real advectionVel = NAN;
 	if constexpr (DIR == FluxDir::X1) {
@@ -497,7 +500,5 @@ void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consSta
 
 	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux, x1LeftState, x1RightState, x1FaceVel, advectionVel, nvars);
 }
-
-
 
 #endif // ADVECTION_SIMULATION_HPP_

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -10,6 +10,7 @@
 /// timestepping, solving, and I/O of a simulation for linear advection.
 
 #include <array>
+#include <fstream>
 
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
@@ -26,6 +27,7 @@
 #include "linear_advection/linear_advection.hpp"
 #include "simulation.hpp"
 #include "util/ArrayView.hpp"
+#include <fmt/format.h>
 
 // Simulation class should be initialized only once per program (i.e., is a singleton)
 template <typename problem_t> class AdvectionSimulation : public AMRSimulation<problem_t>
@@ -100,11 +102,13 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
-	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev) -> std::array<amrex::MultiFab, AMREX_SPACEDIM>;
+	auto computeFluxes(amrex::MultiFab const &consVar, int nvars, int lev) -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
-	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1LeftState,
+	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1LeftState,
 			  amrex::MultiFab &x1RightState, int ng_reconstruct, int nvars);
+
+	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep);
 
 	double advectionVx_ = 1.0; // default
 	double advectionVy_ = 0.0; // default
@@ -358,7 +362,10 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 	{
 		auto const &stateOld = state_old_cc_[lev];
 		auto &stateNew = state_new_cc_[lev];
-		auto fluxArrays = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+		auto [fluxArrays, faceVelArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+
+		// Write face velocities to disk
+		writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
 
 		// Stage 1 of RK2-SSP
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -386,7 +393,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 			auto const &stateInOld = state_old_cc_[lev];
 			auto const &stateInStar = state_new_cc_[lev];
 			auto &stateOut = state_new_cc_[lev];
-			auto fluxArrays = computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+			auto [fluxArrays, faceVelArrays] = computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 			// Stage 2 of RK2-SSP
 			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -434,7 +441,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 
 template <typename problem_t>
 auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
-    -> std::array<amrex::MultiFab, AMREX_SPACEDIM>
+    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
@@ -443,6 +450,7 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
 
@@ -451,20 +459,21 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, 0);
+		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, 1);
 	}
 
-	AMREX_D_TERM(fluxFunction<FluxDir::X1>(consVar, primVar, flux[0], leftState[0], rightState[0], reconstructRange, nvars);
-		     , fluxFunction<FluxDir::X2>(consVar, primVar, flux[1], leftState[1], rightState[1], reconstructRange, nvars);
-		     , fluxFunction<FluxDir::X3>(consVar, primVar, flux[2], leftState[2], rightState[2], reconstructRange, nvars);)
+	AMREX_D_TERM(fluxFunction<FluxDir::X1>(consVar, primVar, flux[0], facevel[0], leftState[0], rightState[0], reconstructRange, nvars);
+		     , fluxFunction<FluxDir::X2>(consVar, primVar, flux[1], facevel[1], leftState[1], rightState[1], reconstructRange, nvars);
+		     , fluxFunction<FluxDir::X3>(consVar, primVar, flux[2], facevel[2], leftState[2], rightState[2], reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
-	return flux;
+	return std::make_pair(std::move(flux), std::move(facevel));
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux,
+void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
 						  amrex::MultiFab &x1LeftState, amrex::MultiFab &x1RightState, const int ng_reconstruct, const int nvars)
 {
 	amrex::Real advectionVel = NAN;
@@ -476,14 +485,84 @@ void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consSta
 		advectionVel = advectionVz_;
 	}
 
-	// amrex::Box const &reconstructRange = amrex::grow(indexRange, 1);
-	// amrex::Box const &x1ReconstructRange = amrex::surroundingNodes(reconstructRange, dim);
-
 	LinearAdvectionSystem<problem_t>::ConservedToPrimitive(consState, primVar, nghost_cc_, nvars);
 
 	LinearAdvectionSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, x1LeftState, x1RightState, ng_reconstruct, nvars);
 
 	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux, x1LeftState, x1RightState, advectionVel, nvars);
+
+	// Fill face velocities with the advection velocity (including ghost cells)
+	const amrex::IntVect ngrowVec(AMREX_D_DECL(1, 1, 1));
+	auto x1FaceVel_in = x1FaceVel.arrays();
+	amrex::ParallelFor(x1FaceVel, ngrowVec, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		x1FaceVel_in[bx](i, j, k) = advectionVel;
+	});
+}
+
+template <typename problem_t>
+void AdvectionSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep)
+{
+	// Create directory for face velocity outputs if it doesn't exist
+	std::string dirname = fmt::format("facevel_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's face velocities
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write each FAB in the MultiFab
+		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
+			
+			// Create filename for this FAB
+			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write FAB to disk in ASCII format
+			std::ofstream ofs(filename, std::ios::out);
+			if (ofs.is_open()) {
+				// Write box information
+				ofs << "# Face velocity FAB for direction " << dimname << "\n";
+				ofs << "# Box: " << bx << "\n";
+#if AMREX_SPACEDIM == 1
+				ofs << "# Format: i value\n";
+#elif AMREX_SPACEDIM == 2
+				ofs << "# Format: i j value\n";
+#elif AMREX_SPACEDIM == 3
+				ofs << "# Format: i j k value\n";
+#endif
+				
+				// Write data including ghost cells
+				const auto& arr = fab.array();
+				const auto lo = bx.smallEnd();
+				const auto hi = bx.bigEnd();
+				
+#if AMREX_SPACEDIM == 1
+				for (int i = lo[0]; i <= hi[0]; ++i) {
+					ofs << i << " " << arr(i,0,0,0) << "\n";
+				}
+#elif AMREX_SPACEDIM == 2
+				for (int j = lo[1]; j <= hi[1]; ++j) {
+					for (int i = lo[0]; i <= hi[0]; ++i) {
+						ofs << i << " " << j << " " << arr(i,j,0,0) << "\n";
+					}
+				}
+#elif AMREX_SPACEDIM == 3
+				for (int k = lo[2]; k <= hi[2]; ++k) {
+					for (int j = lo[1]; j <= hi[1]; ++j) {
+						for (int i = lo[0]; i <= hi[0]; ++i) {
+							ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
+						}
+					}
+				}
+#endif
+				ofs.close();
+			}
+		}
+	}
 }
 
 #endif // ADVECTION_SIMULATION_HPP_

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -365,10 +365,10 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
-		//this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
+		// this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
 
 		// Write reconstructed states to disk
-		//this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
+		// this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
 
 		// Stage 1 of RK2-SSP
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -453,10 +453,10 @@ auto AdvectionSimulation<problem_t>::computeFluxes(amrex::MultiFab const &consVa
 {
 	auto ba = grids[lev];
 	auto dm = dmap[lev];
-	const int reconstructRange = 2; // fully reconstruct a parabola within *two* cells outside the valid region
+	const int reconstructRange = 3; // fully reconstruct a parabola within *three* cells outside the valid region
 	// NOTE: one cell is needed to get L/R states at the FAB boundaries.
-	//   The extra cell is needed to get L/R states (and therefore the face velocity) for one ghost face.
-	//   (For hydro, we need *two* ghost face velocities!)
+	//   The extra cells are needed to get L/R states (and therefore the face velocity) for *two* ghost faces.
+	//   (For hydro, we need *two* ghost face velocities in order to do particle MAC advection.)
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -109,11 +109,6 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void fluxFunction(amrex::MultiFab const &consState, amrex::MultiFab &primVar, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1LeftState,
 			  amrex::MultiFab &x1RightState, int ng_reconstruct, int nvars);
 
-	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep);
-
-	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftStateArrays, 
-					    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightStateArrays, int lev, int timestep);
-
 	double advectionVx_ = 1.0; // default
 	double advectionVy_ = 0.0; // default
 	double advectionVz_ = 0.0; // default
@@ -369,10 +364,10 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
-		writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
+		this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
 		
 		// Write reconstructed states to disk
-		writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
+		this->writeReconstructedStatesToDisk(leftStateArrays, rightStateArrays, lev, cycleCount_);
 
 		// Stage 1 of RK2-SSP
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
@@ -503,215 +498,6 @@ void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consSta
 	LinearAdvectionSystem<problem_t>::template ComputeFluxes<DIR>(x1Flux, x1LeftState, x1RightState, x1FaceVel, advectionVel, nvars);
 }
 
-template <typename problem_t>
-void AdvectionSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep)
-{
-	// Create directory for face velocity outputs if it doesn't exist
-	std::string dirname = fmt::format("facevel_lev{}_step{}", lev, timestep);
-	if (amrex::ParallelDescriptor::IOProcessor()) {
-		amrex::UtilCreateDirectory(dirname, 0755);
-	}
-	amrex::ParallelDescriptor::Barrier();
 
-	// Write each direction's face velocities
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
-		// Write each FAB in the MultiFab
-		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
-			
-			// Create filename for this FAB
-			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
-			// Write FAB to disk in ASCII format
-			std::ofstream ofs(filename, std::ios::out);
-			if (ofs.is_open()) {
-				// Write box information
-				ofs << "# Face velocity FAB for direction " << dimname << "\n";
-				ofs << "# Box: " << bx << "\n";
-#if AMREX_SPACEDIM == 1
-				ofs << "# Format: i value\n";
-#elif AMREX_SPACEDIM == 2
-				ofs << "# Format: i j value\n";
-#elif AMREX_SPACEDIM == 3
-				ofs << "# Format: i j k value\n";
-#endif
-				
-				// Write data including ghost cells
-				const auto& arr = fab.array();
-				const auto lo = bx.smallEnd();
-				const auto hi = bx.bigEnd();
-				
-#if AMREX_SPACEDIM == 1
-				for (int i = lo[0]; i <= hi[0]; ++i) {
-					ofs << i << " " << arr(i,0,0,0) << "\n";
-				}
-#elif AMREX_SPACEDIM == 2
-				for (int j = lo[1]; j <= hi[1]; ++j) {
-					for (int i = lo[0]; i <= hi[0]; ++i) {
-						ofs << i << " " << j << " " << arr(i,j,0,0) << "\n";
-					}
-				}
-#elif AMREX_SPACEDIM == 3
-				for (int k = lo[2]; k <= hi[2]; ++k) {
-					for (int j = lo[1]; j <= hi[1]; ++j) {
-						for (int i = lo[0]; i <= hi[0]; ++i) {
-							ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
-						}
-					}
-				}
-#endif
-				ofs.close();
-			}
-		}
-	}
-}
-
-template <typename problem_t>
-void AdvectionSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftStateArrays,
-								    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightStateArrays, int lev, int timestep)
-{
-	// Create directory for reconstructed states outputs if it doesn't exist
-	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
-	if (amrex::ParallelDescriptor::IOProcessor()) {
-		amrex::UtilCreateDirectory(dirname, 0755);
-	}
-	amrex::ParallelDescriptor::Barrier();
-
-	// Write each direction's left and right states
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
-		// Write left states
-		for (amrex::MFIter mfi(leftStateArrays[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& fab = leftStateArrays[idim][mfi];
-			
-			// Create filename for this FAB
-			std::string filename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
-			// Write FAB to disk in ASCII format
-			std::ofstream ofs(filename, std::ios::out);
-			if (ofs.is_open()) {
-				// Write box information
-				ofs << "# Left reconstructed states for direction " << dimname << "\n";
-				ofs << "# Box: " << bx << "\n";
-				ofs << "# Number of components: " << fab.nComp() << "\n";
-#if AMREX_SPACEDIM == 1
-				ofs << "# Format: i comp0 comp1 ... compN\n";
-#elif AMREX_SPACEDIM == 2
-				ofs << "# Format: i j comp0 comp1 ... compN\n";
-#elif AMREX_SPACEDIM == 3
-				ofs << "# Format: i j k comp0 comp1 ... compN\n";
-#endif
-				
-				// Write data including ghost cells
-				const auto& arr = fab.array();
-				const auto lo = bx.smallEnd();
-				const auto hi = bx.bigEnd();
-				const int ncomp = fab.nComp();
-				
-#if AMREX_SPACEDIM == 1
-				for (int i = lo[0]; i <= hi[0]; ++i) {
-					ofs << i;
-					for (int n = 0; n < ncomp; ++n) {
-						ofs << " " << arr(i,0,0,n);
-					}
-					ofs << "\n";
-				}
-#elif AMREX_SPACEDIM == 2
-				for (int j = lo[1]; j <= hi[1]; ++j) {
-					for (int i = lo[0]; i <= hi[0]; ++i) {
-						ofs << i << " " << j;
-						for (int n = 0; n < ncomp; ++n) {
-							ofs << " " << arr(i,j,0,n);
-						}
-						ofs << "\n";
-					}
-				}
-#elif AMREX_SPACEDIM == 3
-				for (int k = lo[2]; k <= hi[2]; ++k) {
-					for (int j = lo[1]; j <= hi[1]; ++j) {
-						for (int i = lo[0]; i <= hi[0]; ++i) {
-							ofs << i << " " << j << " " << k;
-							for (int n = 0; n < ncomp; ++n) {
-								ofs << " " << arr(i,j,k,n);
-							}
-							ofs << "\n";
-						}
-					}
-				}
-#endif
-				ofs.close();
-			}
-		}
-		
-		// Write right states
-		for (amrex::MFIter mfi(rightStateArrays[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& fab = rightStateArrays[idim][mfi];
-			
-			// Create filename for this FAB
-			std::string filename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
-			// Write FAB to disk in ASCII format
-			std::ofstream ofs(filename, std::ios::out);
-			if (ofs.is_open()) {
-				// Write box information
-				ofs << "# Right reconstructed states for direction " << dimname << "\n";
-				ofs << "# Box: " << bx << "\n";
-				ofs << "# Number of components: " << fab.nComp() << "\n";
-#if AMREX_SPACEDIM == 1
-				ofs << "# Format: i comp0 comp1 ... compN\n";
-#elif AMREX_SPACEDIM == 2
-				ofs << "# Format: i j comp0 comp1 ... compN\n";
-#elif AMREX_SPACEDIM == 3
-				ofs << "# Format: i j k comp0 comp1 ... compN\n";
-#endif
-				
-				// Write data including ghost cells
-				const auto& arr = fab.array();
-				const auto lo = bx.smallEnd();
-				const auto hi = bx.bigEnd();
-				const int ncomp = fab.nComp();
-				
-#if AMREX_SPACEDIM == 1
-				for (int i = lo[0]; i <= hi[0]; ++i) {
-					ofs << i;
-					for (int n = 0; n < ncomp; ++n) {
-						ofs << " " << arr(i,0,0,n);
-					}
-					ofs << "\n";
-				}
-#elif AMREX_SPACEDIM == 2
-				for (int j = lo[1]; j <= hi[1]; ++j) {
-					for (int i = lo[0]; i <= hi[0]; ++i) {
-						ofs << i << " " << j;
-						for (int n = 0; n < ncomp; ++n) {
-							ofs << " " << arr(i,j,0,n);
-						}
-						ofs << "\n";
-					}
-				}
-#elif AMREX_SPACEDIM == 3
-				for (int k = lo[2]; k <= hi[2]; ++k) {
-					for (int j = lo[1]; j <= hi[1]; ++j) {
-						for (int i = lo[0]; i <= hi[0]; ++i) {
-							ofs << i << " " << j << " " << k;
-							for (int n = 0; n < ncomp; ++n) {
-								ofs << " " << arr(i,j,k,n);
-							}
-							ofs << "\n";
-						}
-					}
-				}
-#endif
-				ofs.close();
-			}
-		}
-	}
-}
 
 #endif // ADVECTION_SIMULATION_HPP_

--- a/src/linear_advection/linear_advection.hpp
+++ b/src/linear_advection/linear_advection.hpp
@@ -43,8 +43,8 @@ template <typename problem_t> class LinearAdvectionSystem : public HyperbolicSys
 				 int nvars);
 
 	template <FluxDir DIR>
-	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf, amrex::MultiFab &x1FaceVel_mf, double advectionVx,
-				  int nvars);
+	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf,
+				  amrex::MultiFab &x1FaceVel_mf, double advectionVx, int nvars);
 };
 
 template <typename problem_t>
@@ -189,7 +189,7 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 
 		// For advection, simply choose upwind side of the interface.
 		const double upwind_density = (vx < 0.0) ? x1RightState(i, j, k, density_index) : x1LeftState(i, j, k, density_index);
-		
+
 		if (vx < 0.0) { // upwind switch
 			// upwind direction is the right-side of the interface
 			x1Flux(i, j, k, n) = vx * x1RightState(i, j, k, n);
@@ -198,7 +198,7 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 			// upwind direction is the left-side of the interface
 			x1Flux(i, j, k, n) = vx * x1LeftState(i, j, k, n);
 		}
-		
+
 		// Compute face velocity as flux divided by upwind density (only for density component)
 		if (n == density_index) {
 			x1FaceVel(i, j, k) = x1Flux(i, j, k, n) / upwind_density;

--- a/src/linear_advection/linear_advection.hpp
+++ b/src/linear_advection/linear_advection.hpp
@@ -201,7 +201,11 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 
 		// Compute face velocity as flux divided by upwind density (only for density component)
 		if (n == density_index) {
-			x1FaceVel(i, j, k) = x1Flux(i, j, k, n) / upwind_density;
+			if (upwind_density != 0.0) {
+				x1FaceVel(i, j, k) = x1Flux(i, j, k, n) / upwind_density;
+			} else {
+				x1FaceVel(i, j, k) = 0.0;
+			}
 		}
 	});
 }

--- a/src/linear_advection/linear_advection.hpp
+++ b/src/linear_advection/linear_advection.hpp
@@ -43,7 +43,7 @@ template <typename problem_t> class LinearAdvectionSystem : public HyperbolicSys
 				 int nvars);
 
 	template <FluxDir DIR>
-	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf, double advectionVx,
+	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf, amrex::MultiFab &x1FaceVel_mf, double advectionVx,
 				  int nvars);
 };
 
@@ -165,7 +165,7 @@ void LinearAdvectionSystem<problem_t>::AddFluxesRK2(amrex::MultiFab &U_new_mf, a
 template <typename problem_t>
 template <FluxDir DIR>
 void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab const &x1LeftState_mf, amrex::MultiFab const &x1RightState_mf,
-						     const double vx, const int nvars)
+						     amrex::MultiFab &x1FaceVel_mf, const double vx, const int nvars)
 {
 	// By convention, the interfaces are defined on the left edge of each zone, i.e.
 	// xinterface_(i) is the solution to the Riemann problem at the left edge of zone i.
@@ -174,18 +174,22 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 	auto const &x1LeftState_in = x1LeftState_mf.const_arrays();
 	auto const &x1RightState_in = x1RightState_mf.const_arrays();
 	auto x1Flux_in = x1Flux_mf.arrays();
-	amrex::IntVect ng{AMREX_D_DECL(0, 0, 0)};
+	auto x1FaceVel_in = x1FaceVel_mf.arrays();
+	amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
 
 	amrex::ParallelFor(x1Flux_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
 		// construct ArrayViews for permuted indices
 		quokka::Array4View<amrex::Real const, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<amrex::Real const, DIR> x1RightState(x1RightState_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
+		quokka::Array4View<amrex::Real, DIR> x1FaceVel(x1FaceVel_in[bx]);
 
 		// permute array indices according to dir
 		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
 		// For advection, simply choose upwind side of the interface.
+		const double upwind_density = (vx < 0.0) ? x1RightState(i, j, k, density_index) : x1LeftState(i, j, k, density_index);
+		
 		if (vx < 0.0) { // upwind switch
 			// upwind direction is the right-side of the interface
 			x1Flux(i, j, k, n) = vx * x1RightState(i, j, k, n);
@@ -193,6 +197,11 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 		} else {
 			// upwind direction is the left-side of the interface
 			x1Flux(i, j, k, n) = vx * x1LeftState(i, j, k, n);
+		}
+		
+		// Compute face velocity as flux divided by upwind density (only for density component)
+		if (n == density_index) {
+			x1FaceVel(i, j, k) = x1Flux(i, j, k, n) / upwind_density;
 		}
 	});
 }

--- a/src/linear_advection/linear_advection.hpp
+++ b/src/linear_advection/linear_advection.hpp
@@ -175,7 +175,7 @@ void LinearAdvectionSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf,
 	auto const &x1RightState_in = x1RightState_mf.const_arrays();
 	auto x1Flux_in = x1Flux_mf.arrays();
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
-	amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
+	amrex::IntVect ng{AMREX_D_DECL(2, 2, 2)}; // add two ghost faces for velocities
 
 	amrex::ParallelFor(x1Flux_mf, ng, nvars, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in, int n) noexcept {
 		// construct ArrayViews for permuted indices

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -428,7 +428,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
 
 	// Nghost = number of ghost cells for each array
-	int nghost_cc_ = 4;						    // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4
+	int nghost_cc_ = 5;						    // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +1 for face velocity ghost cells
 	int nghost_fc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 4 : 2; // 4 needed for MHD, otherwise only 2 for tracer particles
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -428,7 +428,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
 
 	// Nghost = number of ghost cells for each array
-	int nghost_cc_ = 5;						    // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +1 for face velocity ghost cells
+	int nghost_cc_ = 6;						    // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +2 for face velocity ghost cells
 	int nghost_fc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 4 : 2; // 4 needed for MHD, otherwise only 2 for tracer particles
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -359,6 +359,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void WriteProjectionPlotfile() const;
 	void WriteCheckpointFile() const;
 	void SetLastCheckpointSymlink(std::string const &checkpointname) const;
+	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVel, int lev, int step);
+	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int step);
 
 	// ABOUTME: Used to handle universal refinement during checkpoint restart operations
 	struct RefinementContext {
@@ -3459,6 +3461,158 @@ void AMRSimulation<problem_t>::initializeParticleContainerFromCheckpoint(std::un
 		}
 	}
 #endif
+}
+
+template <typename problem_t>
+void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArrays, int lev, int timestep)
+{
+	// Create directory for face velocity outputs if it doesn't exist
+	std::string dirname = fmt::format("facevel_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's face velocities
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write each FAB in the MultiFab
+		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
+			
+			// Create filename for this FAB
+			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write FAB to disk in ASCII format
+			std::ofstream ofs(filename, std::ios::out);
+			if (ofs.is_open()) {
+				// Write box information
+				ofs << "# Face velocity FAB for direction " << dimname << "\n";
+				ofs << "# Box: " << bx << "\n";
+				ofs << "# Valid box: " << mfi.validbox() << "\n";
+				ofs << "# MultiFab ghost cells: " << faceVelArrays[idim].nGrow() << "\n";
+#if AMREX_SPACEDIM == 1
+				ofs << "# Format: i value\n";
+#elif AMREX_SPACEDIM == 2
+				ofs << "# Format: i j value\n";
+#elif AMREX_SPACEDIM == 3
+				ofs << "# Format: i j k value\n";
+#endif
+				
+				// Write data
+				auto const& arr = fab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					ofs << i << " " << arr(i,j,k,0) << "\n";
+#elif AMREX_SPACEDIM == 2
+					ofs << i << " " << j << " " << arr(i,j,k,0) << "\n";
+#elif AMREX_SPACEDIM == 3
+					ofs << i << " " << j << " " << k << " " << arr(i,j,k,0) << "\n";
+#endif
+				});
+				ofs.close();
+			}
+		}
+	}
+}
+
+template <typename problem_t>
+void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int timestep)
+{
+	// Create directory for reconstructed state outputs if it doesn't exist
+	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::UtilCreateDirectory(dirname, 0755);
+	}
+	amrex::ParallelDescriptor::Barrier();
+
+	// Write each direction's reconstructed states
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		
+		// Write left and right states for each FAB in the MultiFab
+		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
+			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox& leftFab = leftState[idim][mfi];
+			const amrex::FArrayBox& rightFab = rightState[idim][mfi];
+			
+			// Create filenames for this FAB's left and right states
+			std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
+			std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
+			
+			// Write left state FAB to disk
+			std::ofstream leftOfs(leftFilename, std::ios::out);
+			if (leftOfs.is_open()) {
+				// Write box information
+				leftOfs << "# Left reconstructed state FAB for direction " << dimname << "\n";
+				leftOfs << "# Box: " << bx << "\n";
+				leftOfs << "# Valid box: " << mfi.validbox() << "\n";
+				leftOfs << "# MultiFab ghost cells: " << leftState[idim].nGrow() << "\n";
+#if AMREX_SPACEDIM == 1
+				leftOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 2
+				leftOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 3
+				leftOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
+#endif
+				
+				// Write data (all hydro variables)
+				auto const& leftArr = leftFab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					leftOfs << i;
+#elif AMREX_SPACEDIM == 2
+					leftOfs << i << " " << j;
+#elif AMREX_SPACEDIM == 3
+					leftOfs << i << " " << j << " " << k;
+#endif
+					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
+					for (int ivar = 0; ivar < leftFab.nComp(); ++ivar) {
+						leftOfs << " " << leftArr(i,j,k,ivar);
+					}
+					leftOfs << "\n";
+				});
+				leftOfs.close();
+			}
+			
+			// Write right state FAB to disk
+			std::ofstream rightOfs(rightFilename, std::ios::out);
+			if (rightOfs.is_open()) {
+				// Write box information
+				rightOfs << "# Right reconstructed state FAB for direction " << dimname << "\n";
+				rightOfs << "# Box: " << bx << "\n";
+				rightOfs << "# Valid box: " << mfi.validbox() << "\n";
+				rightOfs << "# MultiFab ghost cells: " << rightState[idim].nGrow() << "\n";
+#if AMREX_SPACEDIM == 1
+				rightOfs << "# Format: i density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 2
+				rightOfs << "# Format: i j density xmom ymom zmom energy intenergy\n";
+#elif AMREX_SPACEDIM == 3
+				rightOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
+#endif
+				
+				// Write data (all hydro variables)
+				auto const& rightArr = rightFab.const_array();
+				amrex::Loop(bx, [&](int i, int j, int k) {
+#if AMREX_SPACEDIM == 1
+					rightOfs << i;
+#elif AMREX_SPACEDIM == 2
+					rightOfs << i << " " << j;
+#elif AMREX_SPACEDIM == 3
+					rightOfs << i << " " << j << " " << k;
+#endif
+					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
+					for (int ivar = 0; ivar < rightFab.nComp(); ++ivar) {
+						rightOfs << " " << rightArr(i,j,k,ivar);
+					}
+					rightOfs << "\n";
+				});
+				rightOfs.close();
+			}
+		}
+	}
 }
 
 #endif // SIMULATION_HPP_

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3475,7 +3475,14 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 
 	// Write each direction's face velocities
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		std::string dimname;
+		if (idim == 0) {
+			dimname = "x";
+		} else if (idim == 1) {
+			dimname = "y";
+		} else {
+			dimname = "z";
+		}
 		
 		// Write each FAB in the MultiFab
 		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
@@ -3483,7 +3490,7 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
 			
 			// Create filename for this FAB
-			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
+			const std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
 			
 			// Write FAB to disk in ASCII format
 			std::ofstream ofs(filename, std::ios::out);
@@ -3530,7 +3537,14 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 
 	// Write each direction's reconstructed states
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
+		std::string dimname;
+		if (idim == 0) {
+			dimname = "x";
+		} else if (idim == 1) {
+			dimname = "y";
+		} else {
+			dimname = "z";
+		}
 		
 		// Write left and right states for each FAB in the MultiFab
 		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
@@ -3539,8 +3553,8 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 			const amrex::FArrayBox& rightFab = rightState[idim][mfi];
 			
 			// Create filenames for this FAB's left and right states
-			std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
-			std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
+			const std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
+			const std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
 			
 			// Write left state FAB to disk
 			std::ofstream leftOfs(leftFilename, std::ios::out);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3484,7 +3484,7 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 		} else {
 			dimname = "z";
 		}
-		
+
 		// Write each FAB in the MultiFab
 		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
 			const amrex::Box &bx = mfi.fabbox(); // This includes ghost cells
@@ -3492,7 +3492,7 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 
 			// Create filename for this FAB
 			const std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
+
 			// Write FAB to disk in ASCII format
 			std::ofstream ofs(filename, std::ios::out);
 			if (ofs.is_open()) {
@@ -3547,7 +3547,7 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 		} else {
 			dimname = "z";
 		}
-		
+
 		// Write left and right states for each FAB in the MultiFab
 		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
 			const amrex::Box &bx = mfi.fabbox(); // This includes ghost cells
@@ -3557,7 +3557,7 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 			// Create filenames for this FAB's left and right states
 			const std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
 			const std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
+
 			// Write left state FAB to disk
 			std::ofstream leftOfs(leftFilename, std::ios::out);
 			if (leftOfs.is_open()) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -360,7 +360,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void WriteCheckpointFile() const;
 	void SetLastCheckpointSymlink(std::string const &checkpointname) const;
 	void writeFaceVelocitiesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVel, int lev, int step);
-	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int step);
+	void writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState,
+					    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int step);
 
 	// ABOUTME: Used to handle universal refinement during checkpoint restart operations
 	struct RefinementContext {
@@ -430,7 +431,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
 
 	// Nghost = number of ghost cells for each array
-	int nghost_cc_ = 6;						    // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +2 for face velocity ghost cells
+	int nghost_cc_ = 6; // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +2 for face velocity ghost cells
 	int nghost_fc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 4 : 2; // 4 needed for MHD, otherwise only 2 for tracer particles
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;
@@ -3476,15 +3477,15 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 	// Write each direction's face velocities
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
+
 		// Write each FAB in the MultiFab
 		for (amrex::MFIter mfi(faceVelArrays[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& fab = faceVelArrays[idim][mfi];
-			
+			const amrex::Box &bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox &fab = faceVelArrays[idim][mfi];
+
 			// Create filename for this FAB
 			std::string filename = fmt::format("{}/facevel_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
+
 			// Write FAB to disk in ASCII format
 			std::ofstream ofs(filename, std::ios::out);
 			if (ofs.is_open()) {
@@ -3500,12 +3501,12 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 #elif AMREX_SPACEDIM == 3
 				ofs << "# Format: i j k value\n";
 #endif
-				
+
 				// Write data
-				auto const& arr = fab.const_array();
+				auto const &arr = fab.const_array();
 				amrex::Loop(bx, [&](int i, int j, int k) {
 #if AMREX_SPACEDIM == 1
-					ofs << i << " " << arr(i,j,k,0) << "\n";
+					ofs << i << " " << arr(i, j, k, 0) << "\n";
 #elif AMREX_SPACEDIM == 2
 					ofs << i << " " << j << " " << arr(i,j,k,0) << "\n";
 #elif AMREX_SPACEDIM == 3
@@ -3519,7 +3520,8 @@ void AMRSimulation<problem_t>::writeFaceVelocitiesToDisk(std::array<amrex::Multi
 }
 
 template <typename problem_t>
-void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int timestep)
+void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &leftState,
+							      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &rightState, int lev, int timestep)
 {
 	// Create directory for reconstructed state outputs if it doesn't exist
 	std::string dirname = fmt::format("reconst_lev{}_step{}", lev, timestep);
@@ -3531,17 +3533,17 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 	// Write each direction's reconstructed states
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		std::string dimname = (idim == 0) ? "x" : (idim == 1) ? "y" : "z";
-		
+
 		// Write left and right states for each FAB in the MultiFab
 		for (amrex::MFIter mfi(leftState[idim]); mfi.isValid(); ++mfi) {
-			const amrex::Box& bx = mfi.fabbox(); // This includes ghost cells
-			const amrex::FArrayBox& leftFab = leftState[idim][mfi];
-			const amrex::FArrayBox& rightFab = rightState[idim][mfi];
-			
+			const amrex::Box &bx = mfi.fabbox(); // This includes ghost cells
+			const amrex::FArrayBox &leftFab = leftState[idim][mfi];
+			const amrex::FArrayBox &rightFab = rightState[idim][mfi];
+
 			// Create filenames for this FAB's left and right states
 			std::string leftFilename = fmt::format("{}/reconst_left_{}_box_{}.fab", dirname, dimname, mfi.index());
 			std::string rightFilename = fmt::format("{}/reconst_right_{}_box_{}.fab", dirname, dimname, mfi.index());
-			
+
 			// Write left state FAB to disk
 			std::ofstream leftOfs(leftFilename, std::ios::out);
 			if (leftOfs.is_open()) {
@@ -3557,9 +3559,9 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 #elif AMREX_SPACEDIM == 3
 				leftOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
 #endif
-				
+
 				// Write data (all hydro variables)
-				auto const& leftArr = leftFab.const_array();
+				auto const &leftArr = leftFab.const_array();
 				amrex::Loop(bx, [&](int i, int j, int k) {
 #if AMREX_SPACEDIM == 1
 					leftOfs << i;
@@ -3570,13 +3572,13 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 #endif
 					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
 					for (int ivar = 0; ivar < leftFab.nComp(); ++ivar) {
-						leftOfs << " " << leftArr(i,j,k,ivar);
+						leftOfs << " " << leftArr(i, j, k, ivar);
 					}
 					leftOfs << "\n";
 				});
 				leftOfs.close();
 			}
-			
+
 			// Write right state FAB to disk
 			std::ofstream rightOfs(rightFilename, std::ios::out);
 			if (rightOfs.is_open()) {
@@ -3592,9 +3594,9 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 #elif AMREX_SPACEDIM == 3
 				rightOfs << "# Format: i j k density xmom ymom zmom energy intenergy\n";
 #endif
-				
+
 				// Write data (all hydro variables)
-				auto const& rightArr = rightFab.const_array();
+				auto const &rightArr = rightFab.const_array();
 				amrex::Loop(bx, [&](int i, int j, int k) {
 #if AMREX_SPACEDIM == 1
 					rightOfs << i;
@@ -3605,7 +3607,7 @@ void AMRSimulation<problem_t>::writeReconstructedStatesToDisk(std::array<amrex::
 #endif
 					// Write all hydro variables (density, xmom, ymom, zmom, energy, intenergy)
 					for (int ivar = 0; ivar < rightFab.nComp(); ++ivar) {
-						rightOfs << " " << rightArr(i,j,k,ivar);
+						rightOfs << " " << rightArr(i, j, k, ivar);
 					}
 					rightOfs << "\n";
 				});


### PR DESCRIPTION
### Description
This computes 2 ghost face-centered velocities and wavespeeds (as returned from the Riemann solver). This requires increasing `nghost_cc_` by two additional cells (from 4 to 6).

This is required for MHD with AMR.

![face_velocities_1d_lev0_step0](https://github.com/user-attachments/assets/0fa70eeb-7310-4da4-8327-7cfce3ac99a6)

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
