### PR TITLE
Add a log message of maximum supernova remnant velocity 

### DIFF
--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -570,7 +570,7 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);
 
 	// Step 4: Check maximum velocity and print warning if needed
-	amrex::Real max_velocity = max_velocity_buffer.data()[0];
+	const amrex::Real max_velocity = max_velocity_buffer.data()[0];
 	constexpr amrex::Real c_light = C::c_light;
 	constexpr amrex::Real velocity_threshold = 0.03 * c_light;
 

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -546,7 +546,7 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	// Step 4: Check maximum velocity and print warning if needed
 	amrex::Real max_velocity = max_velocity_buffer.data()[0];
 	constexpr amrex::Real c_light = C::c_light;
-	constexpr amrex::Real velocity_threshold = 0.05 * c_light;
+	constexpr amrex::Real velocity_threshold = 0.03 * c_light;
 	
 	amrex::Print() << "SN remnant maximum velocity: " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
 	

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -317,7 +317,8 @@ void depositToBuffer(ContainerType *container, amrex::MultiFab &state, amrex::Mu
 
 template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state,
-								   amrex::Array4<amrex::Real> const &local_buffer, int i, int j, int k)
+								   amrex::Array4<amrex::Real> const &local_buffer, int i, int j, int k,
+								   amrex::Real *p_max_velocity)
 {
 	// For SN_thermal_or_thermal_momentum, SN_thermal_kinetic_or_thermal_momentum, and SN_pure_kinetic_or_thermal_momentum,
 	// the buffer contains mass, momentum, and energy. We need to add the buffer to the state in a way that guarantees
@@ -414,6 +415,13 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 	local_state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = e_int_new;
 	local_state(i, j, k, HydroSystem<problem_t>::energy_index) = e_tot_new;
 
+	// Compute velocity magnitude and track maximum
+	const Real vx = px_new / rho_new;
+	const Real vy = py_new / rho_new;
+	const Real vz = pz_new / rho_new;
+	const Real velocity_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
+	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude);
+
 	// // log the state, for debugging on CPU.
 	// if (d_rho / rho > 1.0e-12) {
 	// 	// print original rho, px, py, pz, e_int, e_tot; new rho_new, px_new, py_new, pz_new, e_int_new,
@@ -429,7 +437,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 
 template <typename problem_t>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Array4<amrex::Real> const &local_state,
-								     amrex::Array4<amrex::Real> const &local_buffer, int i, int j, int k)
+								     amrex::Array4<amrex::Real> const &local_buffer, int i, int j, int k,
+								     amrex::Real *p_max_velocity)
 {
 	// For SN_thermal_only, the buffer contains only mass and energy (and a small amount of momentum), so it's safe to add the
 	// buffer directly to the state.
@@ -446,9 +455,16 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 	local_state(i, j, k, HydroSystem<problem_t>::x3Momentum_index) = pz_new;
 	local_state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = e_int_new;
 	local_state(i, j, k, HydroSystem<problem_t>::energy_index) = e_new;
+
+	// Compute velocity magnitude and track maximum
+	const Real vx = px_new / rho_new;
+	const Real vy = py_new / rho_new;
+	const Real vz = pz_new / rho_new;
+	const Real velocity_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
+	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude);
 }
 
-template <typename problem_t> void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, const SNScheme SN_scheme_d)
+template <typename problem_t> void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, const SNScheme SN_scheme_d, amrex::Real *p_max_velocity)
 {
 	const BL_PROFILE("SNFeedbackUtils::addBufferToState()");
 	for (amrex::MFIter mfi(state); mfi.isValid(); ++mfi) {
@@ -459,9 +475,9 @@ template <typename problem_t> void addBufferToState(amrex::MultiFab &state, amre
 		// add buffer to state
 		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 			if (SN_scheme_d == SNScheme::SN_thermal_only) {
-				addThermalOnlyBufferToState<problem_t>(local_state, local_buffer, i, j, k);
+				addThermalOnlyBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity);
 			} else {
-				addCompositeBufferToState<problem_t>(local_state, local_buffer, i, j, k);
+				addCompositeBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity);
 			}
 		});
 	}
@@ -513,6 +529,10 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	// copy host variables to device
 	const SNScheme SN_scheme_d = SN_scheme;
 
+	// Initialize maximum velocity tracking
+	amrex::Gpu::Buffer<amrex::Real> max_velocity_buffer({0.0});
+	amrex::Real *p_max_velocity = max_velocity_buffer.data();
+
 	// Step 1: Local deposition within each box
 	SNFeedbackUtils::depositToBuffer<ContainerType, problem_t>(container, state, state_buffer, lev, time, dt, mass_index, evolutionStageIndex,
 								   birthTimeIndex, SN_scheme_d);
@@ -521,7 +541,22 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	state_buffer.SumBoundary(container->Geom(lev).periodicity());
 
 	// Step 3: Add the buffer to the state
-	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d);
+	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);
+
+	// Step 4: Check maximum velocity and print warning if needed
+	amrex::Real max_velocity = max_velocity_buffer.data()[0];
+	constexpr amrex::Real c_light = C::c_light;
+	constexpr amrex::Real velocity_threshold = 0.05 * c_light;
+	
+	if (max_velocity > 0.0) {
+		amrex::Print() << "SN feedback maximum velocity: " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
+		
+		if (max_velocity > velocity_threshold) {
+			amrex::Print() << "WARNING: SN feedback produced velocity (" << max_velocity / c_light << " c) greater than 0.05 c threshold!"
+				       << "\n";
+		}
+		amrex::Print() << "\n";
+	}
 }
 
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -331,6 +331,12 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 	const double e_tot = local_state(i, j, k, HydroSystem<problem_t>::energy_index);
 
 	const double d_rho = local_buffer(i, j, k, HydroSystem<problem_t>::density_index);
+
+	// Skip if there is no SN feedback
+	if (d_rho < 10. * std::numeric_limits<Real>::min()) {
+		return;
+	}
+
 	const double d_px = local_buffer(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
 	const double d_py = local_buffer(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
 	const double d_pz = local_buffer(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
@@ -449,9 +455,16 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 								     amrex::Array4<amrex::Real> const &local_buffer, int i, int j, int k,
 								     amrex::Real *p_max_velocity)
 {
+	const Real d_rho = local_buffer(i, j, k, HydroSystem<problem_t>::density_index);
+
+	// Skip if there is no SN feedback
+	if (d_rho < 10. * std::numeric_limits<Real>::min()) {
+		return;
+	}
+
 	// For SN_thermal_only, the buffer contains only mass and energy (and a small amount of momentum), so it's safe to add the
 	// buffer directly to the state.
-	const double rho_new = local_state(i, j, k, HydroSystem<problem_t>::density_index) + local_buffer(i, j, k, HydroSystem<problem_t>::density_index);
+	const double rho_new = local_state(i, j, k, HydroSystem<problem_t>::density_index) + d_rho;
 	const double px_new = local_state(i, j, k, HydroSystem<problem_t>::x1Momentum_index) + local_buffer(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
 	const double py_new = local_state(i, j, k, HydroSystem<problem_t>::x2Momentum_index) + local_buffer(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
 	const double pz_new = local_state(i, j, k, HydroSystem<problem_t>::x3Momentum_index) + local_buffer(i, j, k, HydroSystem<problem_t>::x3Momentum_index);

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -415,12 +415,21 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 	local_state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = e_int_new;
 	local_state(i, j, k, HydroSystem<problem_t>::energy_index) = e_tot_new;
 
+	// Compute sound speed
+	Real cs = NAN;
+	if constexpr (HydroSystem<problem_t>::is_eos_isothermal()) {
+		cs = quokka::EOS_Traits<problem_t>::cs_isothermal;
+	} else {
+		cs = HydroSystem<problem_t>::ComputeSoundSpeed(local_state, i, j, k);
+	}
+
 	// Compute velocity magnitude and track maximum
 	const Real vx = px_new / rho_new;
 	const Real vy = py_new / rho_new;
 	const Real vz = pz_new / rho_new;
 	const Real velocity_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
-	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude);
+
+	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude + cs);
 
 	// // log the state, for debugging on CPU.
 	// if (d_rho / rho > 1.0e-12) {
@@ -456,12 +465,15 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 	local_state(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = e_int_new;
 	local_state(i, j, k, HydroSystem<problem_t>::energy_index) = e_new;
 
-	// Compute velocity magnitude and track maximum
-	const Real vx = px_new / rho_new;
-	const Real vy = py_new / rho_new;
-	const Real vz = pz_new / rho_new;
-	const Real velocity_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
-	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude);
+	// Compute sound speed. For thermal-only feedback, the gas velocity stays unchanged, so we only report sound speed.
+	Real cs = NAN;
+	if constexpr (HydroSystem<problem_t>::is_eos_isothermal()) {
+		cs = quokka::EOS_Traits<problem_t>::cs_isothermal;
+	} else {
+		cs = HydroSystem<problem_t>::ComputeSoundSpeed(local_state, i, j, k);
+	}
+
+	amrex::Gpu::Atomic::Max(p_max_velocity, cs);
 }
 
 template <typename problem_t> void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, const SNScheme SN_scheme_d, amrex::Real *p_max_velocity)
@@ -548,10 +560,10 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	constexpr amrex::Real c_light = C::c_light;
 	constexpr amrex::Real velocity_threshold = 0.03 * c_light;
 	
-	amrex::Print() << "SN remnant maximum velocity: " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
+	amrex::Print() << "SN remnant maximum net velocity (v_max + cs): " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
 	
 	if (max_velocity > velocity_threshold) {
-		amrex::Print() << "WARNING: SN remnant velocity (" << max_velocity / c_light << " c) greater than 0.05 c threshold!" << "\n";
+		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / c_light << " c) greater than 0.03 c threshold!" << "\n";
 	}
 	amrex::Print() << "\n";
 }

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -548,15 +548,12 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	constexpr amrex::Real c_light = C::c_light;
 	constexpr amrex::Real velocity_threshold = 0.05 * c_light;
 	
-	if (max_velocity > 0.0) {
-		amrex::Print() << "SN feedback maximum velocity: " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
-		
-		if (max_velocity > velocity_threshold) {
-			amrex::Print() << "WARNING: SN feedback produced velocity (" << max_velocity / c_light << " c) greater than 0.05 c threshold!"
-				       << "\n";
-		}
-		amrex::Print() << "\n";
+	amrex::Print() << "SN remnant maximum velocity: " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
+	
+	if (max_velocity > velocity_threshold) {
+		amrex::Print() << "WARNING: SN remnant velocity (" << max_velocity / c_light << " c) greater than 0.05 c threshold!" << "\n";
 	}
+	amrex::Print() << "\n";
 }
 
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 
+#include "AMReX_Algorithm.H"
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
 #include "AMReX_BLProfiler.H"
@@ -333,7 +334,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 	const double d_rho = local_buffer(i, j, k, HydroSystem<problem_t>::density_index);
 
 	// Skip if there is no SN feedback
-	if (d_rho < 10. * std::numeric_limits<Real>::min()) {
+	if (d_rho == 0.0) {
 		return;
 	}
 
@@ -458,7 +459,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 	const Real d_rho = local_buffer(i, j, k, HydroSystem<problem_t>::density_index);
 
 	// Skip if there is no SN feedback
-	if (d_rho < 10. * std::numeric_limits<Real>::min()) {
+	if (d_rho == 0.0) {
 		return;
 	}
 

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -476,7 +476,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 	amrex::Gpu::Atomic::Max(p_max_velocity, cs);
 }
 
-template <typename problem_t> void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, const SNScheme SN_scheme_d, amrex::Real *p_max_velocity)
+template <typename problem_t>
+void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, const SNScheme SN_scheme_d, amrex::Real *p_max_velocity)
 {
 	const BL_PROFILE("SNFeedbackUtils::addBufferToState()");
 	for (amrex::MFIter mfi(state); mfi.isValid(); ++mfi) {
@@ -559,9 +560,9 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	amrex::Real max_velocity = max_velocity_buffer.data()[0];
 	constexpr amrex::Real c_light = C::c_light;
 	constexpr amrex::Real velocity_threshold = 0.03 * c_light;
-	
+
 	amrex::Print() << "SN remnant maximum net velocity (v_max + cs): " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
-	
+
 	if (max_velocity > velocity_threshold) {
 		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / c_light << " c) greater than 0.03 c threshold!" << "\n";
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1471,7 +1471,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 
 	// Fill boundary before computing accretion rate. This is necessary because the computation of accretion rate uses 3 ghost cells, but the
 	// boundaries are not filled at this point.
-	// TODO(cch): we can fill the hydro variables only if no other variables are used in accretion rate computation
+	// TODO(cch): fill the hydro variables but not radiation variables, since radiation variables are used in accretion
 	state_new_cc_[lev].FillBoundary(geom[lev].periodicity());
 
 	// Create a MultiFab to hold the change of states (density, 3 x momentum, internal energy, energy) during particle-mesh interaction
@@ -1489,7 +1489,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	particleRegister_.createParticlesFromState(state_new_cc_[lev], accretion_rate_at_level, lev, time, dt);
 
 	// Deposit the SN particles into the MultiFab
-	// TODO(cch): put accretion_rate_at_level inside depositSN
 	particleRegister_.depositSN(state_new_cc_[lev], lev, time, dt);
 }
 #endif // AMREX_SPACEDIM == 3


### PR DESCRIPTION
### Description

Print the maximum net velocity (speed + c_s) in supernova remnant regions at each step. Print a WARNING when net velocity > 0.03 c (equivalent to T = 1e10 K). 

### Related issues
None. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
