### PR TITLE
A fix to the nvcc failure 

### DIFF
--- a/inputs/SN.in
+++ b/inputs/SN.in
@@ -35,8 +35,7 @@ problem.refine_half_domain = false
 problem.n_amb = 1.0
 problem.T_amb = 718.0
 problem.t_stop = 3.0e5
-particles.SN_scheme = SN_thermal_only
-# SN_thermal_or_thermal_momentum
+particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 10

--- a/inputs/SN.in
+++ b/inputs/SN.in
@@ -27,15 +27,16 @@ do_tracers = 0      # turn on tracer particles
 hydro.artificial_viscosity_coefficient = 0.1
 
 cooling.enabled = 1
-cooling.cooling_table_type = "grackle"
-cooling.hdf5_data_file = "../extern/grackle_data_files/input/CloudyData_UVB=HM2012.h5"
+cooling.cooling_table_type = "resampled"
+cooling.hdf5_data_file = "../extern/cooling/CloudyData_UVB=HM2012_resampled.h5"
 problem.SN_particles_file = "../inputs/SN.txt"
 problem.refine_half_domain = false
 
 problem.n_amb = 1.0
 problem.T_amb = 718.0
 problem.t_stop = 3.0e5
-particles.SN_scheme = SN_thermal_or_thermal_momentum
+particles.SN_scheme = SN_thermal_only
+# SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 10

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -124,7 +124,7 @@ class PhysicsParticleDescriptorBase
 
 	//----- Methods that are implemented for some but not all particle types, so they cannot be pure virtual -----
 
-	virtual void depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt)
+	virtual auto depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt) -> amrex::Real
 	{ /* Default empty implementation */ }
 
 	virtual void computeSinkAccretion(amrex::MultiFab &state, amrex::MultiFab &state_accretion_rate, int lev, amrex::Real time, amrex::Real dt)
@@ -765,8 +765,10 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 
 #if AMREX_SPACEDIM == 3
 	// Implementation of supernova energy and momentum deposition from particles to grid
-	void depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt) override
+	auto depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt) -> amrex::Real override
 	{
+		amrex::Real max_velocity = 0.0;
+
 		if (this->container_ != nullptr && this->getEvolutionStageIndex() >= 0) {
 			if (!quokka::disable_SN_feedback) {
 				// Requires CGS units
@@ -774,14 +776,16 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 								 "UnitSystem must be CGS for particleMeshInteraction");
 
 				// Deposit supernova energy and momentum from all particles. This also updates the evolution stage of the particles.
-				SNDeposition<ContainerType, problem_t>(this->container_, state, state_buffer, lev, time, dt, this->getMassIndex(),
-								       this->getEvolutionStageIndex(), this->getBirthTimeIndex());
+				max_velocity = SNDeposition<ContainerType, problem_t>(this->container_, state, state_buffer, lev, time, dt,
+												    this->getMassIndex(), this->getEvolutionStageIndex(), this->getBirthTimeIndex());
 			} else {
 				// Only update evolution stage but not deposit energy/momentum
 				SNFeedbackUtils::updateEvolutionStage(this->container_, lev, time + dt, this->getBirthTimeIndex(),
 								      this->getEvolutionStageIndex());
 			}
 		}
+
+		return max_velocity;
 	}
 
 	// compute accretion rate
@@ -956,16 +960,19 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Deposit supernova energy and momentum from all particles
-	void depositSN(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt)
+	auto depositSN(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt) -> amrex::Real
 	{
 		const BL_PROFILE("PhysicsParticleRegister::depositSN()");
+		amrex::Real max_velocity = 0.0;
 		amrex::MultiFab state_buffer(state.boxArray(), state.DistributionMap(), state.nComp(), state.nGrow());
 		// this function is only implemented for some particle types, so we specify the particle type manually here
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			if (descriptor->isStarParticle()) {
-				descriptor->depositSN(state, state_buffer, lev, time, dt);
+				const amrex::Real max_velocity_ = descriptor->depositSN(state, state_buffer, lev, time, dt);
+				max_velocity = std::max(max_velocity, max_velocity_);
 			}
 		}
+		return max_velocity;
 	}
 
 	// Implementation of computeSinkAccretion

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -124,7 +124,8 @@ class PhysicsParticleDescriptorBase
 
 	//----- Methods that are implemented for some but not all particle types, so they cannot be pure virtual -----
 
-	virtual auto depositSN(amrex::MultiFab & /*state*/, amrex::MultiFab & /*state_buffer*/, int  /*lev*/, amrex::Real  /*time*/, amrex::Real  /*dt*/) -> amrex::Real
+	virtual auto depositSN(amrex::MultiFab & /*state*/, amrex::MultiFab & /*state_buffer*/, int /*lev*/, amrex::Real /*time*/, amrex::Real /*dt*/)
+	    -> amrex::Real
 	{
 		return 0.0_rt;
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -125,7 +125,9 @@ class PhysicsParticleDescriptorBase
 	//----- Methods that are implemented for some but not all particle types, so they cannot be pure virtual -----
 
 	virtual auto depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt) -> amrex::Real
-	{ /* Default empty implementation */ }
+	{
+		return 0.0_rt;
+	}
 
 	virtual void computeSinkAccretion(amrex::MultiFab &state, amrex::MultiFab &state_accretion_rate, int lev, amrex::Real time, amrex::Real dt)
 	{ /* Default empty implementation */ }

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -124,7 +124,7 @@ class PhysicsParticleDescriptorBase
 
 	//----- Methods that are implemented for some but not all particle types, so they cannot be pure virtual -----
 
-	virtual auto depositSN(amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt) -> amrex::Real
+	virtual auto depositSN(amrex::MultiFab & /*state*/, amrex::MultiFab & /*state_buffer*/, int  /*lev*/, amrex::Real  /*time*/, amrex::Real  /*dt*/) -> amrex::Real
 	{
 		return 0.0_rt;
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -776,8 +776,9 @@ class StarParticleDescriptor : public PhysicsParticleDescriptor<ContainerType, p
 								 "UnitSystem must be CGS for particleMeshInteraction");
 
 				// Deposit supernova energy and momentum from all particles. This also updates the evolution stage of the particles.
-				max_velocity = SNDeposition<ContainerType, problem_t>(this->container_, state, state_buffer, lev, time, dt,
-												    this->getMassIndex(), this->getEvolutionStageIndex(), this->getBirthTimeIndex());
+				max_velocity =
+				    SNDeposition<ContainerType, problem_t>(this->container_, state, state_buffer, lev, time, dt, this->getMassIndex(),
+									   this->getEvolutionStageIndex(), this->getBirthTimeIndex());
 			} else {
 				// Only update evolution stage but not deposit energy/momentum
 				SNFeedbackUtils::updateEvolutionStage(this->container_, lev, time + dt, this->getBirthTimeIndex(),

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -501,10 +501,11 @@ void addBufferToState(amrex::MultiFab &state, amrex::MultiFab &state_buffer, con
 
 		// add buffer to state
 		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+			auto p_max_velocity_local = p_max_velocity; // NOLINT
 			if (SN_scheme_d == SNScheme::SN_thermal_only) {
-				addThermalOnlyBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity);
+				addThermalOnlyBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity_local);
 			} else {
-				addCompositeBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity);
+				addCompositeBufferToState<problem_t>(local_state, local_buffer, i, j, k, p_max_velocity_local);
 			}
 		});
 	}
@@ -543,8 +544,8 @@ void updateEvolutionStage(ContainerType *container, int lev_min, amrex::Real ste
 } // namespace SNFeedbackUtils
 
 template <typename ContainerType, typename problem_t>
-void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt, int mass_index,
-		  int evolutionStageIndex, int birthTimeIndex)
+auto SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &state_buffer, int lev, amrex::Real time, amrex::Real dt, int mass_index,
+		  int evolutionStageIndex, int birthTimeIndex) -> Real
 {
 	const BL_PROFILE("[particle_deposition] SNDeposition()");
 	static_assert(SN_stencil_size <= 3,
@@ -572,15 +573,18 @@ void SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 
 	// Step 4: Check maximum velocity and print warning if needed
 	const amrex::Real max_velocity = max_velocity_buffer.data()[0];
-	constexpr amrex::Real c_light = C::c_light;
-	constexpr amrex::Real velocity_threshold = 0.03 * c_light;
 
-	amrex::Print() << "SN remnant maximum net velocity (v_max + cs): " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
+	return max_velocity;
 
-	if (max_velocity > velocity_threshold) {
-		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / c_light << " c) greater than 0.03 c threshold!" << "\n";
-	}
-	amrex::Print() << "\n";
+	// constexpr amrex::Real c_light = C::c_light;
+	// constexpr amrex::Real velocity_threshold = 0.03 * c_light;
+
+	// amrex::Print() << "SN remnant maximum net velocity (v_max + cs): " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
+
+	// if (max_velocity > velocity_threshold) {
+	// 	amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / c_light << " c) greater than 0.03 c threshold!" << "\n";
+	// }
+	// amrex::Print() << "\n";
 }
 
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -572,7 +572,7 @@ auto SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);
 
 	// Step 4: Check maximum velocity and print warning if needed
-	auto h_max_velocity = max_velocity_buffer.copyToHost();
+	auto *h_max_velocity = max_velocity_buffer.copyToHost();
 	Real max_velocity = h_max_velocity[0];
 	amrex::ParallelDescriptor::ReduceRealMax(max_velocity);
 

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -572,19 +572,11 @@ auto SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);
 
 	// Step 4: Check maximum velocity and print warning if needed
-	const amrex::Real max_velocity = max_velocity_buffer.data()[0];
+	const auto h_max_velocity = max_velocity_buffer.copyToHost();
+	const Real max_velocity = h_max_velocity[0];
+	amrex::ParallelDescriptor::ReduceRealMax(max_velocity);
 
 	return max_velocity;
-
-	// constexpr amrex::Real c_light = C::c_light;
-	// constexpr amrex::Real velocity_threshold = 0.03 * c_light;
-
-	// amrex::Print() << "SN remnant maximum net velocity (v_max + cs): " << max_velocity << " cm/s (" << max_velocity / c_light << " c)" << "\n";
-
-	// if (max_velocity > velocity_threshold) {
-	// 	amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / c_light << " c) greater than 0.03 c threshold!" << "\n";
-	// }
-	// amrex::Print() << "\n";
 }
 
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -436,7 +436,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addCompositeBufferToState(amrex::Array4
 	const Real vz = pz_new / rho_new;
 	const Real velocity_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
 
-	amrex::Gpu::Atomic::Max(p_max_velocity, velocity_magnitude + cs);
+	amrex::Gpu::Atomic::Max(&p_max_velocity[0], velocity_magnitude + cs);
 
 	// // log the state, for debugging on CPU.
 	// if (d_rho / rho > 1.0e-12) {
@@ -487,7 +487,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void addThermalOnlyBufferToState(amrex::Arra
 		cs = HydroSystem<problem_t>::ComputeSoundSpeed(local_state, i, j, k);
 	}
 
-	amrex::Gpu::Atomic::Max(p_max_velocity, cs);
+	amrex::Gpu::Atomic::Max(&p_max_velocity[0], cs);
 }
 
 template <typename problem_t>

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -572,8 +572,8 @@ auto SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);
 
 	// Step 4: Check maximum velocity and print warning if needed
-	const auto h_max_velocity = max_velocity_buffer.copyToHost();
-	const Real max_velocity = h_max_velocity[0];
+	auto h_max_velocity = max_velocity_buffer.copyToHost();
+	Real max_velocity = h_max_velocity[0];
 	amrex::ParallelDescriptor::ReduceRealMax(max_velocity);
 
 	return max_velocity;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1489,7 +1489,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	particleRegister_.createParticlesFromState(state_new_cc_[lev], accretion_rate_at_level, lev, time, dt);
 
 	// Deposit the SN particles into the MultiFab
-	particleRegister_.depositSN(state_new_cc_[lev], lev, time, dt);
+	const amrex::Real max_velocity = particleRegister_.depositSN(state_new_cc_[lev], lev, time, dt);
+
+	// Check if the maximum velocity is greater than the threshold
+	// constexpr amrex::Real v_over_c_threshold = 0.03;
+	// if (max_velocity > v_over_c_threshold * C::c_light) {
+	// 	amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / C::c_light << " c) greater than " << v_over_c_threshold << " c threshold!" << "\n";
+	// }
 }
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1494,7 +1494,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	// Check if the maximum velocity is greater than the threshold
 	constexpr amrex::Real v_over_c_threshold = 0.03;
 	if (max_velocity > v_over_c_threshold * C::c_light) {
-		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / C::c_light << " c) greater than " << v_over_c_threshold << " c threshold!" << "\n";
+		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / C::c_light << " c) greater than " << v_over_c_threshold
+			       << " c threshold!" << "\n";
 	}
 }
 #endif // AMREX_SPACEDIM == 3

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1492,10 +1492,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	const amrex::Real max_velocity = particleRegister_.depositSN(state_new_cc_[lev], lev, time, dt);
 
 	// Check if the maximum velocity is greater than the threshold
-	// constexpr amrex::Real v_over_c_threshold = 0.03;
-	// if (max_velocity > v_over_c_threshold * C::c_light) {
-	// 	amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / C::c_light << " c) greater than " << v_over_c_threshold << " c threshold!" << "\n";
-	// }
+	constexpr amrex::Real v_over_c_threshold = 0.03;
+	if (max_velocity > v_over_c_threshold * C::c_light) {
+		amrex::Print() << "WARNING: SN remnant net velocity (" << max_velocity / C::c_light << " c) greater than " << v_over_c_threshold << " c threshold!" << "\n";
+	}
 }
 #endif // AMREX_SPACEDIM == 3
 


### PR DESCRIPTION
### Description
This fixes the nvcc failure brought by #1175 . This mistake was that I forgot to run `copyToHost` after parallel deduction. 

### Related issues
Closes #1178 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
