### PR TITLE
Control gravity with constexpr

### DIFF
--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -18,6 +18,7 @@ template <typename problem_t> struct Physics_Traits {
 	static constexpr int numMassScalars = 0;
 	static constexpr int numPassiveScalars = numMassScalars + 0;
 	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_self_gravity_enabled = false;
 	// face-centred
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int nGroups = 1; // number of radiation groups

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -31,6 +31,7 @@ struct SawtoothProblem {
 };
 
 template <> struct Physics_Traits<SawtoothProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -32,6 +32,7 @@ struct SquareProblem {
 };
 
 template <> struct Physics_Traits<SquareProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -31,6 +31,7 @@ struct SemiellipseProblem {
 };
 
 template <> struct Physics_Traits<SemiellipseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -48,6 +48,7 @@ template <> struct HydroSystem_Traits<BinaryOrbit> {
 
 template <> struct Physics_Traits<BinaryOrbit> {
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -184,7 +185,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<BinaryOrbit> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -31,6 +31,7 @@ template <> struct quokka::EOS_Traits<CoolingTest> {
 };
 
 template <> struct Physics_Traits<CoolingTest> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DiskGalaxy/galaxy.cpp
+++ b/src/problems/DiskGalaxy/galaxy.cpp
@@ -45,6 +45,7 @@ template <> struct HydroSystem_Traits<AgoraGalaxy> {
 template <> struct Physics_Traits<AgoraGalaxy> {
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -391,7 +392,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<AgoraGalaxy> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -33,6 +33,7 @@ template <> struct quokka::EOS_Traits<FCQuantities> {
 };
 
 template <> struct Physics_Traits<FCQuantities> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -47,6 +47,7 @@ template <> struct Physics_Traits<ParticleProblem> {
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int nGroups = nGroups_; // number of radiation groups
@@ -167,7 +168,6 @@ auto problem_main() -> int
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
-	sim.doPoissonSolve_ = 1;	       // enable self-gravity
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -37,6 +37,7 @@ template <> struct quokka::EOS_Traits<BlastProblem> {
 };
 
 template <> struct Physics_Traits<BlastProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -39,6 +39,7 @@ template <> struct HydroSystem_Traits<SedovProblem> {
 };
 
 template <> struct Physics_Traits<SedovProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -33,6 +33,7 @@ template <> struct quokka::EOS_Traits<ContactProblem> {
 };
 
 template <> struct Physics_Traits<ContactProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -40,6 +40,7 @@ template <> struct quokka::EOS_Traits<HighMachProblem> {
 };
 
 template <> struct Physics_Traits<HighMachProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -37,6 +37,7 @@ template <> struct HydroSystem_Traits<KelvinHelmholzProblem> {
 };
 
 template <> struct Physics_Traits<KelvinHelmholzProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -41,6 +41,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -52,6 +52,7 @@ template <> struct HydroSystem_Traits<QuirkProblem> {
 };
 
 template <> struct Physics_Traits<QuirkProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -35,6 +35,7 @@ template <> struct HydroSystem_Traits<RichtmeyerMeshkovProblem> {
 };
 
 template <> struct Physics_Traits<RichtmeyerMeshkovProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -33,6 +33,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -38,6 +38,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -43,6 +43,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 3;		     // number of mass scalars

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -35,6 +35,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -37,6 +37,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 };
 
 template <> struct Physics_Traits<ShocktubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -31,6 +31,7 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 };
 
 template <> struct Physics_Traits<WaveProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -54,6 +54,7 @@ template <> struct quokka::EOS_Traits<Channel> {
 };
 
 template <> struct Physics_Traits<Channel> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -51,6 +51,7 @@ template <> struct quokka::EOS_Traits<Vortex> {
 };
 
 template <> struct Physics_Traits<Vortex> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -60,6 +60,7 @@ template <> struct Physics_Traits<AccretionProblem> {
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_self_gravity_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int nGroups = 1; // number of radiation groups
@@ -295,7 +296,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<AccretionProblem> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1;      // enable self-gravity
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 	sim.initDt_ = 3.0e10;	      // ~1 kyr

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -51,6 +51,7 @@ template <> struct HydroSystem_Traits<TestParticle> {
 
 template <> struct Physics_Traits<TestParticle> {
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -268,7 +269,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<TestParticle> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 	sim.initDt_ = dt_;
 	sim.maxDt_ = dt_;
 

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -117,7 +117,6 @@ auto problem_main() -> int
 
 	// initialize
 	sim.maxTimesteps_ = 1;
-	// sim.doPoissonSolve_ = 1;
 	sim.setInitialConditions();
 
 	// get total gas mass

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -40,6 +40,7 @@ template <> struct HydroSystem_Traits<ParticleSFProblem> {
 };
 
 template <> struct Physics_Traits<ParticleSFProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/ParticleSink/test_particle_sink.cpp
+++ b/src/problems/ParticleSink/test_particle_sink.cpp
@@ -52,6 +52,7 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 template <> struct Physics_Traits<SinkProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;
@@ -155,7 +156,6 @@ auto problem_main() -> int
 	sim.stopTime_ = 10.0 * dt_init;
 	sim.initDt_ = dt_init;
 	sim.tempFloor_ = 10.0; // K
-	sim.doPoissonSolve_ = 1;
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -48,6 +48,7 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 template <> struct Physics_Traits<SinkProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;
@@ -147,7 +148,6 @@ auto problem_main() -> int
 	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 	sim.stopTime_ = 1.0e7 * year; // 1 Myr
 	sim.initDt_ = 1.0e5 * year;   // 0.1 Myr
-	sim.doPoissonSolve_ = 1;
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -35,6 +35,7 @@ template <> struct quokka::EOS_Traits<ScalarProblem> {
 };
 
 template <> struct Physics_Traits<ScalarProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -44,6 +44,7 @@ template <> struct HydroSystem_Traits<PopIII> {
 template <> struct Physics_Traits<PopIII> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr int numMassScalars = NumSpec;		     // number of chemical species
 	static constexpr int numPassiveScalars = numMassScalars + 0; // we only have mass scalars
 	static constexpr bool is_radiation_enabled = false;
@@ -450,7 +451,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<PopIII> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	sim.tempFloor_ = 2.73 * (30.0 + 1.0);
 	// sim.speedCeiling_ = 3e6;

--- a/src/problems/PrimordialChem/test_primordial_chem.cpp
+++ b/src/problems/PrimordialChem/test_primordial_chem.cpp
@@ -44,6 +44,7 @@ struct PrimordialChemTest {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
 template <> struct Physics_Traits<PrimordialChemTest> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = NumSpec;		     // number of chemical species

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -42,6 +42,7 @@ template <> struct RadSystem_Traits<BeamProblem> {
 };
 
 template <> struct Physics_Traits<BeamProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadDust/test_rad_dust.cpp
+++ b/src/problems/RadDust/test_rad_dust.cpp
@@ -63,6 +63,7 @@ template <> struct ISM_Traits<DustProblem> {
 };
 
 template <> struct Physics_Traits<DustProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadDustMG/test_rad_dust_MG.cpp
+++ b/src/problems/RadDustMG/test_rad_dust_MG.cpp
@@ -51,6 +51,7 @@ template <> struct quokka::EOS_Traits<DustProblem> {
 };
 
 template <> struct Physics_Traits<DustProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -56,6 +56,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 };
 
 template <> struct Physics_Traits<TubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -55,6 +55,7 @@ template <> struct quokka::EOS_Traits<CoolingProblem> {
 };
 
 template <> struct Physics_Traits<CoolingProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -60,6 +60,7 @@ template <> struct quokka::EOS_Traits<CoolingProblemMG> {
 };
 
 template <> struct Physics_Traits<CoolingProblemMG> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -49,6 +49,7 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -44,6 +44,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -51,6 +51,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -51,6 +51,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 };
 
 template <> struct Physics_Traits<MarshakProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -50,6 +50,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 };
 
 template <> struct Physics_Traits<MarshakProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -110,6 +110,7 @@ template <> struct quokka::EOS_Traits<SuOlsonProblemCgs> {
 };
 
 template <> struct Physics_Traits<SuOlsonProblemCgs> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -47,6 +47,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 };
 
 template <> struct Physics_Traits<CouplingProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -49,6 +49,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 };
 
 template <> struct Physics_Traits<CouplingProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadParticle/test_radparticle.cpp
+++ b/src/problems/RadParticle/test_radparticle.cpp
@@ -45,6 +45,7 @@ template <> struct Particle_Traits<ParticleProblem> {
 };
 
 template <> struct Physics_Traits<ParticleProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadParticle2D/test_radparticle_2D.cpp
+++ b/src/problems/RadParticle2D/test_radparticle_2D.cpp
@@ -34,6 +34,7 @@ template <> struct Particle_Traits<ParticleProblem> {
 };
 
 template <> struct Physics_Traits<ParticleProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -48,6 +48,7 @@ template <> struct RadSystem_Traits<ShadowProblem> {
 };
 
 template <> struct Physics_Traits<ShadowProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -33,6 +33,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 };
 
 template <> struct Physics_Traits<StreamingProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -36,6 +36,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 };
 
 template <> struct Physics_Traits<StreamingProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -62,6 +62,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 };
 
 template <> struct Physics_Traits<MarshakProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr bool is_chemistry_enabled = false;

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -54,6 +54,7 @@ template <> struct RadSystem_Traits<TophatProblem> {
 };
 
 template <> struct Physics_Traits<TophatProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -50,6 +50,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 };
 
 template <> struct Physics_Traits<TubeProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -111,6 +111,7 @@ template <> struct quokka::EOS_Traits<PulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -59,6 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -70,6 +71,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 template <> struct Physics_Traits<AdvPulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -59,6 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -70,6 +71,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 template <> struct Physics_Traits<AdvPulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -60,6 +60,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -71,6 +72,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 template <> struct Physics_Traits<AdvPulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -93,6 +93,7 @@ template <> struct quokka::EOS_Traits<SGProblem> {
 };
 
 template <> struct Physics_Traits<SGProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -156,6 +157,7 @@ template <> struct quokka::EOS_Traits<MGproblem> {
 };
 
 template <> struct Physics_Traits<MGproblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -103,6 +103,7 @@ template <> struct quokka::EOS_Traits<ExactProblem> {
 };
 
 template <> struct Physics_Traits<MGProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -114,6 +115,7 @@ template <> struct Physics_Traits<MGProblem> {
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 template <> struct Physics_Traits<ExactProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -53,6 +53,7 @@ template <> struct HydroSystem_Traits<ShellProblem> {
 };
 
 template <> struct Physics_Traits<ShellProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -74,6 +74,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 };
 
 template <> struct Physics_Traits<ShockProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -74,6 +74,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 };
 
 template <> struct Physics_Traits<ShockProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -52,6 +52,7 @@ constexpr double shock_position = 0.0130; // 0.0132; // cm (shock position drift
 constexpr double Lx = 0.01575;		  // cm
 
 template <> struct Physics_Traits<ShockProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -68,6 +68,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 };
 
 template <> struct Physics_Traits<PulseProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -40,6 +40,7 @@ constexpr double parsec_in_cm = 3.086e18;    // cm == 1 pc
 constexpr double m_H = C::m_p + C::m_e;	     // mass of hydrogen atom
 
 template <> struct Physics_Traits<RandomBlast> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -34,6 +34,7 @@ template <> struct HydroSystem_Traits<RTProblem> {
 };
 
 template <> struct Physics_Traits<RTProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -35,6 +35,7 @@ template <> struct HydroSystem_Traits<RTProblem> {
 };
 
 template <> struct Physics_Traits<RTProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
+++ b/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
@@ -91,6 +91,7 @@ template <> struct quokka::EOS_Traits<ResampledCoolingTest> {
 };
 
 template <> struct Physics_Traits<ResampledCoolingTest> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars

--- a/src/problems/SN/test_SN.cpp
+++ b/src/problems/SN/test_SN.cpp
@@ -57,6 +57,7 @@ template <> struct HydroSystem_Traits<SNProblem> {
 };
 
 template <> struct Physics_Traits<SNProblem> {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -47,6 +47,7 @@ constexpr double keV_in_ergs = 1.60218e-9;   // ergs == 1 keV
 constexpr double m_H = C::m_p + C::m_e;	     // mass of hydrogen atom
 
 template <> struct Physics_Traits<ShockCloud> {
+	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -44,6 +44,7 @@ template <> struct HydroSystem_Traits<CollapseProblem> {
 template <> struct Physics_Traits<CollapseProblem> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;
@@ -168,7 +169,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<CollapseProblem> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -49,6 +49,7 @@ template <> struct HydroSystem_Traits<StarCluster> {
 template <> struct Physics_Traits<StarCluster> {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
 	static constexpr bool is_radiation_enabled = false;
@@ -234,7 +235,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<StarCluster> sim(BCs_cc);
-	sim.doPoissonSolve_ = 1; // enable self-gravity
 	sim.densityFloor_ = 0.01;
 
 	sim.userData_.R_sphere = R_sphere;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -186,7 +186,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int restartRefineFactor_ = 1;				     // 1 == don't refine, >1 == refine by this factor on restart
 	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
 	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
-	int doPoissonSolve_ = 0;				     // 1 == self-gravity enabled, 0 == disabled
 	int poissonSupercycleInterval_ = 1;			     // number of coarse steps between Poisson solves (default: 1)
 	amrex::Vector<amrex::MultiFab> phi;
 
@@ -1097,7 +1096,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 #if AMREX_SPACEDIM == 3
 		// do particle leapfrog (first kick at time t)
-		if (doPoissonSolve_ != 0) {
+		if constexpr (Physics_Traits<problem_t>::is_self_gravity_enabled) {
 			kickParticlesAllLevels(dt_[0]);
 		}
 #endif
@@ -1120,7 +1119,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 		// do particle leapfrog (second kick at t + dt)
 #if AMREX_SPACEDIM == 3
-		if (doPoissonSolve_ != 0) {
+		if constexpr (Physics_Traits<problem_t>::is_self_gravity_enabled) {
 			kickParticlesAllLevels(dt_[0]);
 		}
 
@@ -1275,7 +1274,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLevels()
 {
 #if AMREX_SPACEDIM == 3
-	if (doPoissonSolve_ != 0) {
+	if constexpr (Physics_Traits<problem_t>::is_self_gravity_enabled) {
 		if (do_subcycle == 1) { // not supported
 			amrex::Abort("Poisson solve is not support when AMR subcycling is enabled! You must set do_subcycle = 0.");
 		}
@@ -1339,7 +1338,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(const amrex::Real dt)
 {
 #if AMREX_SPACEDIM == 3
-	if (doPoissonSolve_ != 0) {
+	if constexpr (Physics_Traits<problem_t>::is_self_gravity_enabled) {
 
 		BL_PROFILE_REGION("GravitySolver"); // NOLINT(misc-const-correctness)
 
@@ -1354,7 +1353,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::gravAccelAllLevels(
 template <typename problem_t> void AMRSimulation<problem_t>::ellipticSolveAllLevels(const amrex::Real dt)
 {
 #if AMREX_SPACEDIM == 3
-	if (doPoissonSolve_ != 0) {
+	if constexpr (Physics_Traits<problem_t>::is_self_gravity_enabled) {
 		if (poissonSupercycleInterval_ > 1) {
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(regrid_int <= 0, "Poisson supercycling is only allowed for static meshes!");
 		}


### PR DESCRIPTION
### Description
Replace runtime parameter `doPoissonSolve_` with constexpr `is_self_gravity_enabled` in Particle_Traits. This makes gravity more consistent with other physics traits, and also reduces compile time for problems without gravity. 

### Related issues
Closes #977 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
