### PR TITLE
Don't store face velocities in state_fc_

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1546,31 +1546,9 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	amrex::Gpu::streamSynchronizeAll();
 
 	// advect tracer particles using avgFaceVel
-#ifdef AMREX_PARTICLES
 	if (do_tracers != 0) {
-		// copy avgFaceVel to state_new_fc_[lev]
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::Copy(state_new_fc_[lev][idim], avgFaceVel[idim], Physics_Indices<problem_t>::velFirstIndex, 0,
-				    Physics_NumVars::numVelVars_per_dim, nghost_vel);
-		}
-
-		// fill ghost faces
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, time + 0.5 * dt_lev, quokka::centering::fc,
-					       quokka::direction{idim}, AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
-					       FillPatchType::fillpatch_function);
-		}
-
-		// copy state_new_fc_[lev] to avgFaceVel
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::Copy(avgFaceVel[idim], state_new_fc_[lev][idim], 0, Physics_Indices<problem_t>::velFirstIndex,
-				    Physics_NumVars::numVelVars_per_dim, nghost_vel);
-		}
-
-		// advect particles
 		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
 	}
-#endif
 
 	// do Strang split source terms (second half-step)
 	auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], lev, time + dt_lev, 0.5 * dt_lev);

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -56,11 +56,9 @@ template <typename problem_t> struct Physics_Indices {
 	static const int pscalarFirstIndex = Physics_NumVars::numHydroVars;
 	static const int radFirstIndex = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
 	// face-centered
-	static const int nvarPerDim_fc = Physics_NumVars::numVelVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled) +
-					 Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
+	static const int nvarPerDim_fc = Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
 	static const int nvarTotal_fc = AMREX_SPACEDIM * nvarPerDim_fc;
-	static const int velFirstIndex = 0;
-	static const int mhdFirstIndex = velFirstIndex + Physics_NumVars::numVelVars_per_dim;
+	static const int mhdFirstIndex = 0;
 };
 
 #endif // PHYSICS_INFO_HPP_

--- a/src/physics_numVars.hpp
+++ b/src/physics_numVars.hpp
@@ -9,9 +9,7 @@ struct Physics_NumVars {
 	static const int numRadVars = 4;
 	// face-centred
 	static const int numMHDVars_per_dim = 1;
-	static const int numVelVars_per_dim = 1;
 	static const int numMHDVars_tot = AMREX_SPACEDIM * numMHDVars_per_dim;
-	static const int numVelVars_tot = AMREX_SPACEDIM * numVelVars_per_dim;
 };
 
 #endif // PHYSICS_NUMVARS_HPP_

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -196,33 +196,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// constructor
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }
-
-	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) { initialize(); }
-
-	auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> &BCs_cc) -> amrex::Vector<amrex::BCRec>
-	{
-		amrex::Vector<amrex::BCRec> BCs_fc(Physics_Indices<problem_t>::nvarPerDim_fc);
-
-		if (Physics_Traits<problem_t>::is_hydro_enabled) {
-			AMREX_ALWAYS_ASSERT(Physics_Indices<problem_t>::nvarPerDim_fc == 1);
-			// set boundary conditions for face velocities (used ONLY for tracer particles)
-			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-				// lower boundary
-				if (BCs_cc[Physics_Indices<problem_t>::hydroFirstIndex].lo(i) == amrex::BCType::int_dir) {
-					BCs_fc[Physics_Indices<problem_t>::velFirstIndex].setLo(i, amrex::BCType::int_dir);
-				} else {
-					BCs_fc[Physics_Indices<problem_t>::velFirstIndex].setLo(i, amrex::BCType::foextrap);
-				}
-				// upper boundary
-				if (BCs_cc[Physics_Indices<problem_t>::hydroFirstIndex].hi(i) == amrex::BCType::int_dir) {
-					BCs_fc[Physics_Indices<problem_t>::velFirstIndex].setHi(i, amrex::BCType::int_dir);
-				} else {
-					BCs_fc[Physics_Indices<problem_t>::velFirstIndex].setHi(i, amrex::BCType::foextrap);
-				}
-			}
-		}
-		return BCs_fc;
-	}
+	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc) { initialize(); }
 
 	void initialize();
 	void PerformanceHints();


### PR DESCRIPTION
### Description
Since we now have 6 ghost cells, we don't need to store the face velocities as part of the global simulation state. We only need to store them temporarily during the hydro advance on a given level. This removes them to save memory and simplify the code.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/902.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
