### PR TITLE
Remove all AMREX_PARTICLES ifdef blocks

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1157,14 +1157,12 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		amrex::Copy(originalFineData, fineData, 0, 0, fineData.nComp(), 0);
 	}
 
-#ifdef AMREX_PARTICLES
 	amrex::AmrTracerParticleContainer::ContainerLike<amrex::DefaultAllocator> originalTracerPC;
 	if (do_tracers != 0) {
 		// save the pre-advance tracer particles
 		originalTracerPC = TracerPC->make_alike();	 // create empty particle container
 		originalTracerPC.copyParticles(*TracerPC, true); // do local copy of particles
 	}
-#endif
 
 	for (int retry_count = 0; retry_count <= max_retries; ++retry_count) {
 		// reduce timestep by a factor of 2^retry_count
@@ -1185,12 +1183,10 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 				amrex::Copy(fr_as_fine->getFineData(), originalFineData, 0, 0, originalFineData.nComp(), 0);
 			}
 
-#ifdef AMREX_PARTICLES
 			if (do_tracers != 0) {
 				// reset the tracer particles to their pre-advance state
 				TracerPC->copyParticles(originalTracerPC, true);
 			}
-#endif
 		}
 
 		// create temporary multifab for old state
@@ -1881,7 +1877,6 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			radEnergySource.setVal(0.0); // Initialize the MultiFab to zero
 
-#ifdef AMREX_PARTICLES
 			// for debugging, print the radEnergySource array
 			// if (i == 0) {
 			// 	amrex::Print() << "Initial,              ";
@@ -1898,7 +1893,6 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			// 	PrintRadEnergySource(radEnergySource);
 			// 	amrex::Print() << "\n";
 			// }
-#endif
 
 			for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 				const amrex::Box &indexRange = iter.validbox();
@@ -1932,10 +1926,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		radEnergySource.setVal(0.0); // Initialize the MultiFab to zero
 
-#ifdef AMREX_PARTICLES
 		// Deposit radiation from particles into radEnergySource. When there are no particles with luminosity, this will do nothing.
 		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
-#endif
 
 		// Add the matter-radiation exchange source terms to the radiation subsystem and evolve by (1 - IMEX_a32) * dt
 		for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -72,10 +72,8 @@ namespace filesystem = experimental::filesystem;
 #include <fmt/ranges.h>
 #include <yaml-cpp/yaml.h>
 
-#ifdef AMREX_PARTICLES
 #include "AMReX_AmrParticles.H"
 #include "particles/PhysicsParticles.hpp"
-#endif
 
 #if AMREX_SPACEDIM == 3
 #include "AMReX_OpenBC.H"
@@ -489,7 +487,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	}();
 
 	// tracer particles
-#ifdef AMREX_PARTICLES
       public:
 	int do_tracers = 0;
 
@@ -505,7 +502,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	std::unique_ptr<quokka::SinkParticleContainer> SinkParticles;
 	std::unique_ptr<quokka::TestParticleContainer<problem_t>> TestParticles;
 #endif // AMREX_SPACEDIM == 3
-#endif
 
 	// external objects
 #ifdef AMREX_USE_ASCENT
@@ -795,13 +791,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 		InitFromScratch(time);
 		AverageDown();
 
-#ifdef AMREX_PARTICLES
 		if (do_tracers != 0) {
 			InitParticles();
 		}
 
 		InitPhyParticles();
-#endif
 
 		if (checkpointInterval_ > 0) {
 			WriteCheckpointFile();
@@ -1288,10 +1282,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			rhs_min = std::min(rhs_min, rhs[lev].min(0));
 		}
 
-#ifdef AMREX_PARTICLES
 		// deposit particle mass from all particles that have mass into rhs by accumulation
 		particleRegister_.depositMass(amrex::GetVecOfPtrs(rhs), finest_level, Gconst_);
-#endif
 
 		// check for NaN
 		for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1512,7 +1504,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 					}
 				}
 
-#ifdef AMREX_PARTICLES
 				// redistribute particles
 				if (do_tracers != 0) {
 					TracerPC->Redistribute(lev);
@@ -1520,7 +1511,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 
 				// redistribute all particles in particleRegister_
 				particleRegister_.redistribute(lev);
-#endif
 
 				// do fix-up on all levels that have been re-gridded
 				for (int k = lev; k <= finest_level; ++k) {
@@ -1575,7 +1565,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 		fillpatcher_[lev + 1].reset(); // because the data on lev have changed.
 	}
 
-#ifdef AMREX_PARTICLES
 	// redistribute tracer particles
 	if (do_tracers != 0) {
 		int redistribute_ngrow = 0;
@@ -1600,7 +1589,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 		// redistribute all particles in particleRegister_
 		particleRegister_.redistribute(lev, redistribute_ngrow);
 	}
-#endif
 }
 
 template <typename problem_t>
@@ -2251,7 +2239,6 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 	return result;
 }
 
-#ifdef AMREX_PARTICLES
 template <typename problem_t> void AMRSimulation<problem_t>::InitParticles()
 {
 	const BL_PROFILE("AMRSimulation::InitParticles()");
@@ -2365,7 +2352,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 
 	particleRegister_.redistribute(0);
 }
-#endif
 
 // get plotfile name
 template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileName(int lev) const -> std::string { return amrex::Concatenate(plot_file, lev, 5); }
@@ -2744,7 +2730,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	}
 	WriteMetadataFile(plotfilename + "/metadata.yaml");
 
-#ifdef AMREX_PARTICLES
 	// write particles
 	if (do_tracers != 0) {
 		TracerPC->WritePlotFile(plotfilename, "tracer_particles");
@@ -2752,7 +2737,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 
 	// write all particles in particleRegister_ to plotfile
 	particleRegister_.writePlotFile(plotfilename);
-#endif // AMREX_PARTICLES
 #endif
 }
 
@@ -2995,14 +2979,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	}
 
 	// write particle data
-#ifdef AMREX_PARTICLES
 	if (do_tracers != 0) {
 		TracerPC->Checkpoint(checkpointname, "tracer_particles", true);
 	}
 
 	// write all particles in particleRegister_ to checkpoint file
 	particleRegister_.writeCheckpoint(checkpointname, true);
-#endif
 
 	// create symlink and point it at this checkpoint dir
 	SetLastCheckpointSymlink(checkpointname);
@@ -3273,7 +3255,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	// 5. Load MultiFab data with refinement handling
 	loadMultiFabData(refinement_context);
 
-#ifdef AMREX_PARTICLES
 	// read particle data
 	if (do_tracers != 0) {
 		AMREX_ASSERT(TracerPC == nullptr);
@@ -3308,7 +3289,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		initializeParticleContainerFromCheckpoint(TestParticles, quokka::ParticleType::Test, header_box_arrays, true);
 	}
 #endif // AMREX_SPACEDIM == 3
-#endif
 
 	areInitialConditionsDefined_ = true;
 }


### PR DESCRIPTION
Remove all conditional compilation blocks for AMREX_PARTICLES while preserving the particle functionality code inside them. This makes particle support always available instead of being conditionally compiled.

Changes:
- Remove all #ifdef AMREX_PARTICLES and corresponding #endif blocks
- Keep all particle-related code that was previously conditional
- Affects 13 locations across simulation.hpp and QuokkaSimulation.hpp

Resolves #1099

Generated with [Claude Code](https://claude.ai/code)