### PR TITLE
Fix face-centered plotfile output failing when plotfile directory already exists

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2736,7 +2736,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 			amrex::UtilCreateDirectory(fc_vars_dir, 0755);
 		}
 		amrex::ParallelDescriptor::Barrier();
-		
+
 		std::array<amrex::Vector<amrex::MultiFab>, AMREX_SPACEDIM> mf_fc = PlotFileMF_fc(nghost_fc_);
 		std::vector<std::string> dimNames = {"x", "y", "z"};
 		auto varnames_fc = GetPlotfileVarNames_fc();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2730,6 +2730,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 
 	amrex::WriteMultiLevelPlotfile(plotfilename, finest_level + 1, mf_cc_ptr, varnames, Geom(), tNew_[0], istep, refRatio());
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
+		// Create fc_vars directory if it doesn't exist
+		const std::string fc_vars_dir = plotfilename + "/fc_vars";
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::UtilCreateDirectory(fc_vars_dir, 0755);
+		}
+		amrex::ParallelDescriptor::Barrier();
+		
 		std::array<amrex::Vector<amrex::MultiFab>, AMREX_SPACEDIM> mf_fc = PlotFileMF_fc(nghost_fc_);
 		std::vector<std::string> dimNames = {"x", "y", "z"};
 		auto varnames_fc = GetPlotfileVarNames_fc();


### PR DESCRIPTION
The face-centered plotfile output was failing when the plotfile directory already existed because it tried to create nested directories (e.g., plt00001/fc_vars/x00001/) without ensuring the intermediate /fc_vars/ directory was created first.

This fix adds the missing directory creation code before the face-centered plotfile output loop, following the same pattern used elsewhere in the codebase for directory creation.

The fix ensures thread-safe directory creation by using:
- amrex::ParallelDescriptor::IOProcessor() to prevent race conditions
- amrex::UtilCreateDirectory() with 0755 permissions
- amrex::ParallelDescriptor::Barrier() for synchronization

Fixes #1185

🤖 Generated with [Claude Code](https://claude.ai/code)