### PR TITLE
Fix fextract function for MPI-parallel runs

### DIFF
--- a/src/util/fextract.cpp
+++ b/src/util/fextract.cpp
@@ -155,13 +155,13 @@ auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coo
 		// Use a dummy Real value when vectors are empty to avoid passing null pointers
 		Real dummy_pos = 0.0;
 		Real dummy_data = 0.0;
-		const Real* pos_ptr = pos.empty() ? &dummy_pos : pos.data();
-		Real* allpos_ptr = allpos.empty() ? &dummy_data : allpos.data();
-		
+		const Real *pos_ptr = pos.empty() ? &dummy_pos : pos.data();
+		Real *allpos_ptr = allpos.empty() ? &dummy_data : allpos.data();
+
 		ParallelDescriptor::Gatherv(pos_ptr, numpts, allpos_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		for (int i = 0; i < data.size(); ++i) {
-			const Real* data_ptr = data[i].empty() ? &dummy_data : data[i].data();
-			Real* alldata_ptr = alldata[i].empty() ? &dummy_data : alldata[i].data();
+			const Real *data_ptr = data[i].empty() ? &dummy_data : data[i].data();
+			Real *alldata_ptr = alldata[i].empty() ? &dummy_data : alldata[i].data();
 			ParallelDescriptor::Gatherv(data_ptr, numpts, alldata_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		}
 		if (ParallelDescriptor::IOProcessor()) {

--- a/src/util/fextract.cpp
+++ b/src/util/fextract.cpp
@@ -151,9 +151,18 @@ auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coo
 				v.resize(1);
 			}
 		}
-		ParallelDescriptor::Gatherv(pos.data(), numpts, allpos.data(), recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
+		// Handle empty vectors to avoid null pointer issues in MPI gather operations
+		// Use a dummy Real value when vectors are empty to avoid passing null pointers
+		Real dummy_pos = 0.0;
+		Real dummy_data = 0.0;
+		const Real* pos_ptr = pos.empty() ? &dummy_pos : pos.data();
+		Real* allpos_ptr = allpos.empty() ? &dummy_data : allpos.data();
+		
+		ParallelDescriptor::Gatherv(pos_ptr, numpts, allpos_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		for (int i = 0; i < data.size(); ++i) {
-			ParallelDescriptor::Gatherv(data[i].data(), numpts, alldata[i].data(), recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
+			const Real* data_ptr = data[i].empty() ? &dummy_data : data[i].data();
+			Real* alldata_ptr = alldata[i].empty() ? &dummy_data : alldata[i].data();
+			ParallelDescriptor::Gatherv(data_ptr, numpts, alldata_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		}
 		if (ParallelDescriptor::IOProcessor()) {
 			pos = std::move(allpos);

--- a/src/util/fextract.cpp
+++ b/src/util/fextract.cpp
@@ -152,16 +152,16 @@ auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coo
 			}
 		}
 		// Handle empty vectors to avoid null pointer issues in MPI gather operations
-		// Use a dummy Real value when vectors are empty to avoid passing null pointers
-		Real dummy_pos = 0.0;
-		Real dummy_data = 0.0;
-		const Real *pos_ptr = pos.empty() ? &dummy_pos : pos.data();
-		Real *allpos_ptr = allpos.empty() ? &dummy_data : allpos.data();
+		// Use static Real addresses when vectors are empty to provide non-null pointers
+		// MPI won't read from these addresses when numpts is 0
+		static Real static_real = 0.0;
+		const Real *pos_ptr = pos.empty() ? &static_real : pos.data();
+		Real *allpos_ptr = allpos.empty() ? &static_real : allpos.data();
 
 		ParallelDescriptor::Gatherv(pos_ptr, numpts, allpos_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		for (int i = 0; i < data.size(); ++i) {
-			const Real *data_ptr = data[i].empty() ? &dummy_data : data[i].data();
-			Real *alldata_ptr = alldata[i].empty() ? &dummy_data : alldata[i].data();
+			const Real *data_ptr = data[i].empty() ? &static_real : data[i].data();
+			Real *alldata_ptr = alldata[i].empty() ? &static_real : alldata[i].data();
 			ParallelDescriptor::Gatherv(data_ptr, numpts, alldata_ptr, recvcnt, disp, ParallelDescriptor::IOProcessorNumber());
 		}
 		if (ParallelDescriptor::IOProcessor()) {


### PR DESCRIPTION
The fextract function was causing SIGABRT when running with multiple MPI processes due to null pointer issues in ParallelDescriptor::Gatherv operations. When some processes had no data for the slice, their vectors were empty, causing data() to return null pointers.

This fix uses dummy Real values when vectors are empty to ensure we never pass null pointers to MPI gather operations, while the numpts parameter correctly indicates the actual number of elements to gather.

Fixes #1101

Generated with [Claude Code](https://claude.ai/code)