### PR TITLE
Make stellar velocity limit a runtime parameter

### DIFF
--- a/inputs/ParticleSF.in
+++ b/inputs/ParticleSF.in
@@ -29,6 +29,8 @@ hydro.artificial_viscosity_coefficient = 0.1
 particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 0
 particles.eps_ff = 0.5
+# Maximum velocity limit for stellar particles (cm/s), default: 1.0e8 (1000 km/s)
+particles.stellar_velocity_limit = 1.0e8
 
 tiny_profiler.enabled = 0
 

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -409,6 +409,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
 		amrex::Real eps_ff_ = eps_ff;
+		amrex::Real stellar_velocity_limit_ = stellar_velocity_limit;
 
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int processor_id, amrex::Long particle_id_start, int evolution_stage_index,
@@ -543,7 +544,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 						// Enforce maximum speed limit for stellar particles
 						{
 							const double speed = std::sqrt(vx_new * vx_new + vy_new * vy_new + vz_new * vz_new);
-							const double max_speed = quokka::stellar_velocity_limit; // cm s^{-1}
+							const double max_speed = stellar_velocity_limit_; // cm s^{-1}
 							if (speed > max_speed) {
 								double const scale = max_speed / speed;
 								vx_new *= scale;

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -540,10 +540,10 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 						double vy_new = signy * amrex::RandomNormal(std::abs(vy), std::sqrt(sigma_sq_y), engine);
 						double vz_new = signz * amrex::RandomNormal(std::abs(vz), std::sqrt(sigma_sq_z), engine);
 
-						// Enforce maximum speed limit of 1000 km/s
+						// Enforce maximum speed limit for stellar particles
 						{
 							const double speed = std::sqrt(vx_new * vx_new + vy_new * vy_new + vz_new * vz_new);
-							constexpr double max_speed = 1.0e8; // cm s^{-1}
+							const double max_speed = quokka::stellar_velocity_limit; // cm s^{-1}
 							if (speed > max_speed) {
 								double const scale = max_speed / speed;
 								vx_new *= scale;

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -314,6 +314,9 @@ inline bool sink_particle_use_uniform_kernel = false; // NOLINT. If true, use un
 // Verbosity for particle operations
 inline int particle_verbose = 0; // NOLINT print particle logistics
 
+// Maximum velocity limit for stellar particles in cm/s (default: 1000 km/s)
+inline amrex::Real stellar_velocity_limit = 1.0e8; // NOLINT
+
 // Function to parse particle parameters from input file
 // The 'inline' keyword allows this function to be defined in a header file without
 // causing multiple definition errors when the header is included in multiple source files.
@@ -335,6 +338,9 @@ inline void particleParmParse()
 
 	// Handle integer verbose flag
 	pp.query("verbose", particle_verbose);
+
+	// Stellar velocity limit parameter
+	pp.query("stellar_velocity_limit", stellar_velocity_limit);
 
 	// Placeholder parameters for particles
 	pp.query("param1", particle_param1);


### PR DESCRIPTION
Convert hardcoded velocity limit in stellar particle creation from 1000 km/s to configurable runtime parameter `particles.stellar_velocity_limit`.

**Changes:**
- Add stellar_velocity_limit parameter to particle_types.hpp (default: 1.0e8 cm/s)
- Add parameter parsing in particleParmParse() function
- Replace hardcoded max_speed in particle_creation.hpp with runtime parameter
- Update ParticleSF.in input file to demonstrate new parameter

Resolves #1116

Generated with [Claude Code](https://claude.ai/code)