### PR TITLE
[WIP] Replace ext_dir with ext_dir_cc for correct AMR interpolation

### DIFF
--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -189,8 +189,8 @@ auto problem_main() -> int
 	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-		BCs_cc[n].setLo(1, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(1, amrex::BCType::ext_dir_cc);  // Dirichlet
+		BCs_cc[n].setLo(1, amrex::BCType::foextrap);   // extrapolate
+		BCs_cc[n].setHi(1, amrex::BCType::ext_dir_cc); // Dirichlet
 #if AMREX_SPACEDIM == 3
 		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(2, amrex::BCType::int_dir);

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -190,7 +190,7 @@ auto problem_main() -> int
 		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
 		BCs_cc[n].setLo(1, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(1, amrex::BCType::ext_dir);  // Dirichlet
+		BCs_cc[n].setHi(1, amrex::BCType::ext_dir_cc);  // Dirichlet
 #if AMREX_SPACEDIM == 3
 		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(2, amrex::BCType::int_dir);

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -257,8 +257,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		// outflow
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::ext_dir_cc);
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			// periodic
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir);

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -273,8 +273,8 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::ext_dir_cc);
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -359,8 +359,8 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -252,8 +252,8 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -294,7 +294,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -319,8 +319,8 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir_cc);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -126,8 +126,8 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<Channel>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // NSCBC inflow
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir); // NSCBC outflow
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // NSCBC inflow
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc); // NSCBC outflow
 
 #if (AMREX_SPACEDIM >= 2)
 		BCs_cc[n].setLo(1, amrex::BCType::int_dir); // periodic

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -156,15 +156,15 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		if constexpr (outflow_boundary_along_x_axis) {
-			BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // x- NSCBC outflow
-			BCs_cc[n].setHi(0, amrex::BCType::ext_dir);
+			BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // x- NSCBC outflow
+			BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc);
 			BCs_cc[n].setLo(1, amrex::BCType::int_dir); // y- periodic
 			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 		} else {
 			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // x- periodic
 			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::ext_dir); // y- NSCBC outflow
-			BCs_cc[n].setHi(1, amrex::BCType::ext_dir);
+			BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc); // y- NSCBC outflow
+			BCs_cc[n].setHi(1, amrex::BCType::ext_dir_cc);
 		}
 #if (AMREX_SPACEDIM == 3)
 		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // z- periodic

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -278,10 +278,10 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<BeamProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- inflow
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
-		BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc);  // left x2 -- inflow
-		BCs_cc[n].setHi(1, amrex::BCType::foextrap); // right x2 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // left x1 -- inflow
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // right x1 -- extrapolate
+		BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc); // left x2 -- inflow
+		BCs_cc[n].setHi(1, amrex::BCType::foextrap);   // right x2 -- extrapolate
 #if (AMREX_SPACEDIM == 3)
 		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
 		BCs_cc[n].setHi(2, amrex::BCType::int_dir);

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -278,9 +278,9 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<BeamProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- inflow
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- inflow
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
-		BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // left x2 -- inflow
+		BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc);  // left x2 -- inflow
 		BCs_cc[n].setHi(1, amrex::BCType::foextrap); // right x2 -- extrapolate
 #if (AMREX_SPACEDIM == 3)
 		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -183,7 +183,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		// for x-axis:
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
 		// for y-, z- axes:
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -115,7 +115,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 							   amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/, const amrex::BCRec *bcr,
 							   int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != amrex::BCType::ext_dir_cc) && (bcr->hi(0) != amrex::BCType::ext_dir_cc)) {
 		return;
 	}
 
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -214,8 +214,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir);     // custom (Marshak) x1
+				amrex::BCType::ext_dir_cc);     // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir_cc);     // custom (Marshak) x1
+				amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -224,8 +224,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblemCgs>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -113,7 +113,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 							      int /*numcomp*/, amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/,
 							      const amrex::BCRec *bcr, int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != amrex::BCType::ext_dir_cc) && (bcr->hi(0) != amrex::BCType::ext_dir_cc)) {
 		return;
 	}
 
@@ -224,7 +224,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblemCgs>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -202,8 +202,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -202,7 +202,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -203,8 +203,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -203,7 +203,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -268,7 +268,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir);     // custom (Marshak) x1
+				amrex::BCType::ext_dir_cc);     // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -268,7 +268,7 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir_cc);     // custom (Marshak) x1
+				amrex::BCType::ext_dir_cc);  // custom (Marshak) x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -218,8 +218,8 @@ auto problem_main() -> int
 
 	amrex::Vector<amrex::BCRec> BCs_cc(Physics_Indices<ShadowProblem>::nvarTotal_cc);
 	for (int n = 0; n < Physics_Indices<ShadowProblem>::nvarTotal_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- streaming
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // left x1 -- streaming
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
 				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -218,7 +218,7 @@ auto problem_main() -> int
 
 	amrex::Vector<amrex::BCRec> BCs_cc(Physics_Indices<ShadowProblem>::nvarTotal_cc);
 	for (int n = 0; n < Physics_Indices<ShadowProblem>::nvarTotal_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- streaming
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- streaming
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -174,8 +174,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<StreamingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -174,7 +174,7 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<StreamingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -180,14 +180,14 @@ auto problem_main() -> int
 	for (int n = 0; n < nvars; ++n) {
 		// assert at compile time
 		if constexpr (direction == 0) {
-			BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
 			BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 			BCs_cc[n].setLo(1, amrex::BCType::int_dir);  // periodic
 			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 		} else {
 			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc);  // Dirichlet x1
 			BCs_cc[n].setHi(1, amrex::BCType::foextrap); // extrapolate x1
 		}
 	}

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -180,15 +180,15 @@ auto problem_main() -> int
 	for (int n = 0; n < nvars; ++n) {
 		// assert at compile time
 		if constexpr (direction == 0) {
-			BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // Dirichlet x1
-			BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
-			BCs_cc[n].setLo(1, amrex::BCType::int_dir);  // periodic
+			BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
+			BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // extrapolate x1
+			BCs_cc[n].setLo(1, amrex::BCType::int_dir);    // periodic
 			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 		} else {
 			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc);  // Dirichlet x1
-			BCs_cc[n].setHi(1, amrex::BCType::foextrap); // extrapolate x1
+			BCs_cc[n].setLo(1, amrex::BCType::ext_dir_cc); // Dirichlet x1
+			BCs_cc[n].setHi(1, amrex::BCType::foextrap);   // extrapolate x1
 		}
 	}
 

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -266,8 +266,8 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<TophatProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- Marshak
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // left x1 -- Marshak
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);   // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
 				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -266,7 +266,7 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<TophatProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- Marshak
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);  // left x1 -- Marshak
 		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -270,8 +270,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<TubeProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir); // Dirichlet x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc); // Dirichlet x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -111,7 +111,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != amrex::BCType::ext_dir_cc) && (bcr->hi(0) != amrex::BCType::ext_dir_cc)) {
 		return;
 	}
 
@@ -242,8 +242,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);	    // custom x1
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc);	    // custom x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -112,7 +112,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != amrex::BCType::ext_dir_cc) && (bcr->hi(0) != amrex::BCType::ext_dir_cc)) {
 		return;
 	}
 
@@ -243,8 +243,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);	    // custom x1
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc);	    // custom x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -105,7 +105,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if (!((bcr->lo(0) == amrex::BCType::ext_dir) || (bcr->hi(0) == amrex::BCType::ext_dir))) { // NOLINT
+	if (!((bcr->lo(0) == amrex::BCType::ext_dir_cc) || (bcr->hi(0) == amrex::BCType::ext_dir_cc))) { // NOLINT
 		return;
 	}
 
@@ -238,8 +238,8 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir_cc);	    // custom x1
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir_cc);	    // custom x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -900,8 +900,8 @@ auto problem_main() -> int
 	constexpr int nvars = QuokkaSimulation<ShockCloud>::nvarTotal_cc_;
 	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		boundaryConditions[n].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		boundaryConditions[n].setHi(0, amrex::BCType::ext_dir); // NSCBC outflow
+		boundaryConditions[n].setLo(0, amrex::BCType::ext_dir_cc); // Dirichlet
+		boundaryConditions[n].setHi(0, amrex::BCType::ext_dir_cc); // NSCBC outflow
 
 		boundaryConditions[n].setLo(1, amrex::BCType::int_dir); // periodic
 		boundaryConditions[n].setHi(1, amrex::BCType::int_dir);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1803,7 +1803,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setCustomBoun
 											       int orig_comp)
 {
 	// user should implement if needed using template specialization
-	// (This is only called when amrex::BCType::ext_dir is set for a given
+	// (This is only called when amrex::BCType::ext_dir_cc is set for a given
 	// boundary.)
 
 	// set boundary condition for cell 'iv'
@@ -1816,7 +1816,7 @@ AMRSimulation<problem_t>::setCustomBoundaryConditionsFaceVar(const amrex::IntVec
 							     int orig_comp)
 {
 	// user should implement if needed using template specialization
-	// (This is only called when amrex::BCType::ext_dir is set for a given
+	// (This is only called when amrex::BCType::ext_dir_cc is set for a given
 	// boundary.)
 
 	// set boundary condition for cell 'iv'


### PR DESCRIPTION
Fixes #418

This PR replaces all uses of `amrex::BCType::ext_dir` with `amrex::BCType::ext_dir_cc` to properly handle cell-centered boundary conditions for AMR interpolation.

## Summary
- Replaced `ext_dir` with `ext_dir_cc` in 27 files
- Fixes AMR interpolation behavior when refined levels are adjacent to physical boundaries
- Addresses AMReX assumption that `ext_dir` values are at cell faces vs cell centers

## Changes
- 26 problem files in `src/problems/*/`
- 1 header file: `src/simulation.hpp`

Generated with [Claude Code](https://claude.ai/code)