### PR TITLE
[WIP] compute emf using face velocities

### DIFF
--- a/.github/workflows/mhd.yml
+++ b/.github/workflows/mhd.yml
@@ -1,0 +1,82 @@
+name: MHD-WaveTests
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ development ]
+  merge_group:
+    branches: [ development ]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-mhd-wave-tests
+  cancel-in-progress: true
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        submodules: true
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
+
+    - name: Install Canary
+      run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3
+
+    - name: Get MHD test executables
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: |
+        # Find all CTestTestfile.cmake files that contain MHD label and extract executable names
+        grep -l "LABELS.*MHD" $(find . -name "CTestTestfile.cmake") | while read file; do
+          # Extract the executable path from add_test line
+          grep "add_test" "$file" | head -1 | sed 's/.*add_test([^"]*"//;s/".*//' | xargs basename
+        done | sort -u > mhd_executables.txt
+        echo "MHD test executables to build:"
+        cat mhd_executables.txt
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Build all MHD test targets
+      run: |
+        # Read the executables and build them
+        TARGETS=$(cat mhd_executables.txt | tr '\n' ' ')
+        echo "Building targets: $TARGETS"
+        cmake --build . --config $BUILD_TYPE --parallel 4 --target $TARGETS
+
+    - name: Create test output directory
+      run: cmake -E make_directory $GITHUB_WORKSPACE/tests
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute all tests with MHD in their name
+      run: canary run --output-on-failure --workers=2 -k MHD .
+
+    - name: Upload test output
+      if: always()
+      uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      with:
+        name: test-results
+        path: ${{github.workspace}}/tests

--- a/docs/markdown/parameters.md
+++ b/docs/markdown/parameters.md
@@ -60,3 +60,12 @@ These parameters are read in the ``RadhydroSimulation<problem_t>::readParmParse(
 | cooling.enabled | Integer | If set to 1, turns on optically-thin radiative cooling as a Strang-split source term. Default: 0 (disabled). |
 | cooling.read_tables_even_if_disabled | Integer | If set to 1, reads the cooling tables even if the cooling module is disabled. |
 | cooling.grackle_data_file | String | The path to the cooling tables in Grackle-compatible HDF5 format. |
+
+## MHD
+
+These parameters are read in the ``QuokkaSimulation<problem_t>::readParmParse()`` function in ``src/QuokkaSimulation.hpp``.
+
+| Parameter Name | Type | Description |
+|----|----|----|
+| mhd.emf_averaging_method | String | Determines the method used to average EMF at edges. Can be set to `BalsaraSpicer` or `LD04`. Default: `LD04`. |
+| mhd.emf_reconstruction_order | Integer | Determines the order of spatial reconstruction algorithm used for EMF computation. Can be set to 1 (piecewise constant), 2 (piecewise linear; PLM), 3 (piecewise parabolic; PPM), or 5 (extrema-preserving xPPM). Default: 5 (xPPM). |

--- a/inputs/alfven_wave_circular.in
+++ b/inputs/alfven_wave_circular.in
@@ -8,17 +8,33 @@ geometry.is_periodic =  1    1    1
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v              = 0       # verbosity in Amr
+amr.v              = 1       # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 12 8 4
-amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 4     # grid size must be divisible by this
+amr.n_cell          = 64 4 4
+amr.max_level       = 0
+amr.max_grid_size_x = 128
+amr.max_grid_size_y = 4
+amr.max_grid_size_z = 4
+amr.blocking_factor_x = 16
+amr.blocking_factor_y = 4
+amr.blocking_factor_z = 4
 
 do_reflux = 0
 do_subcycle = 0
 
 plotfile_interval = 100
-checkpoint_interval = 200
+plotfile_prefix = alfven_wave_circular_plt
+checkpoint_interval = -1
+cfl = 0.3
+stop_time = 5.0
+max_timesteps = 8000
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 5
+hydro.use_dual_energy = 0
+
+#mhd.emf_averaging_method = BalsaraSpicer
+mhd.emf_averaging_method = LD04

--- a/inputs/alfven_wave_linear.in
+++ b/inputs/alfven_wave_linear.in
@@ -8,17 +8,33 @@ geometry.is_periodic =  1    1    1
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v              = 0       # verbosity in Amr
+amr.v              = 1       # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 12 8 4
-amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 4     # grid size must be divisible by this
+amr.n_cell          = 64 4 4
+amr.max_level       = 0
+amr.max_grid_size_x = 128
+amr.max_grid_size_y = 4
+amr.max_grid_size_z = 4
+amr.blocking_factor_x = 16
+amr.blocking_factor_y = 4
+amr.blocking_factor_z = 4
 
 do_reflux = 0
 do_subcycle = 0
 
 plotfile_interval = 100
-checkpoint_interval = 200
+plotfile_prefix = alfven_wave_linear_plt
+checkpoint_interval = -1
+cfl = 0.3
+stop_time = 5.0
+max_timesteps = 8000
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 5
+hydro.use_dual_energy = 0
+
+#mhd.emf_averaging_method = BalsaraSpicer
+mhd.emf_averaging_method = LD04

--- a/inputs/current_sheet.in
+++ b/inputs/current_sheet.in
@@ -1,0 +1,42 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -0.5  -0.5  -0.5
+geometry.prob_hi     =  0.5   0.5   0.5
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 128 128 4
+amr.max_level       = 0 # number of levels = max_level + 1
+
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 64
+amr.max_grid_size_z = 4
+amr.blocking_factor_x = 16
+amr.blocking_factor_y = 16
+amr.blocking_factor_z = 4
+
+do_reflux = 0
+do_subcycle = 0
+
+plotfile_interval = 100
+checkpoint_interval = 1000
+cfl = 0.2
+stop_time = 10.0
+max_timesteps = 3e4
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 3
+hydro.artificial_viscosity_coefficient = 0.1
+hydro.use_dual_energy = 1
+
+# MHD parameters
+mhd.emf_reconstruction_order = 5  # xPPM for EMF
+mhd.emf_averaging_method = LD04

--- a/inputs/fast_wave.in
+++ b/inputs/fast_wave.in
@@ -8,17 +8,30 @@ geometry.is_periodic =  1    1    1
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v              = 0       # verbosity in Amr
+amr.v              = 1       # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 12 8 4
-amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 4     # grid size must be divisible by this
+amr.n_cell          = 8 8 8
+amr.max_level       = 0 # number of levels = max_level + 1
+
+amr.max_grid_size_x = 8
+amr.max_grid_size_y = 8
+amr.max_grid_size_z = 8
+amr.blocking_factor_x = 4
+amr.blocking_factor_y = 4
+amr.blocking_factor_z = 4
 
 do_reflux = 0
 do_subcycle = 0
 
-plotfile_interval = 100
-checkpoint_interval = 200
+plotfile_interval = 1
+checkpoint_interval = -1
+cfl = 0.3
+stop_time = 1.0
+max_timesteps = 2
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 5
+hydro.use_dual_energy = 0

--- a/inputs/field_loop.in
+++ b/inputs/field_loop.in
@@ -1,0 +1,41 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -1.0  -0.578125  -1.0
+geometry.prob_hi     =  1.0    0.578125   1.0
+geometry.is_periodic =  1      1     1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 256 148 4
+amr.max_level       = 0 # number of levels = max_level + 1
+
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 64
+amr.max_grid_size_z = 4
+amr.blocking_factor_x = 4
+amr.blocking_factor_y = 4
+amr.blocking_factor_z = 4
+
+do_reflux = 0
+do_subcycle = 0
+
+plotfile_interval = 100
+checkpoint_interval = 1000
+cfl = 0.2
+stop_time = 3.0
+max_timesteps = 3e4
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 3
+hydro.use_dual_energy = 0
+
+# MHD parameters
+mhd.emf_reconstruction_order = 5  # xPPM for EMF
+mhd.emf_averaging_method = LD04

--- a/inputs/orszag_tang.in
+++ b/inputs/orszag_tang.in
@@ -1,0 +1,41 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -0.5  -0.5  -0.5
+geometry.prob_hi     =  0.5   0.5   0.5
+geometry.is_periodic =  1    1    1
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 256 256 4
+amr.max_level       = 0 # number of levels = max_level + 1
+
+amr.max_grid_size_x = 64
+amr.max_grid_size_y = 64
+amr.max_grid_size_z = 4
+amr.blocking_factor_x = 16
+amr.blocking_factor_y = 16
+amr.blocking_factor_z = 4
+
+do_reflux = 0
+do_subcycle = 0
+
+plotfile_interval = 100
+checkpoint_interval = 1000
+cfl = 0.2
+stop_time = 1.0
+max_timesteps = 2e4
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 3
+hydro.use_dual_energy = 1
+
+# MHD parameters
+mhd.emf_reconstruction_order = 5  # xPPM for EMF
+mhd.emf_averaging_method = LD04

--- a/scripts/read_fc_print.py
+++ b/scripts/read_fc_print.py
@@ -1,0 +1,90 @@
+import numpy as np
+import sys
+
+def read_data_after_marker(filename, marker="DDEBUG", data_shape=(4, 4, 4), line_nums=None):
+    """
+    Read data from a file after a specific marker string.
+    
+    Args:
+        filename (str): Path to the input file
+        marker (str): The marker string to search for
+        num_of_lines (int): Number of lines to read after the marker
+        
+    Returns:
+        numpy.ndarray: Array containing the data after the marker
+    """
+    # Find the line number of the marker
+    if line_nums is None:
+        with open(filename, 'r') as f:
+            for i, line in enumerate(f):
+                if marker in line:
+                    start_lines = [i + 1]  # +1 because we want to start reading from the next line
+                    break
+            else:
+                raise ValueError(f"Marker '{marker}' not found in file")
+    else:
+        start_lines = line_nums
+    
+    # Use numpy.loadtxt to read the data
+    for start_line in start_lines:
+        try:
+            num_of_lines = np.prod(data_shape)
+            data = np.loadtxt(filename, skiprows=start_line, max_rows=num_of_lines)
+            print(f"Data loaded successfully starting with '{marker}'. Data size: {data.shape}")
+            check_data(data, data_shape)
+        except Exception as e:
+            raise Exception(f"Error loading data: {str(e)}")
+
+    return
+
+def check_data(data_raw, data_shape):
+
+    data = data_raw.reshape(data_shape)
+
+    # is there a nan?
+    print("Checking for nan in the data: ", end="")
+    if np.isnan(data).any():
+        print("fail")
+        # find the index of the nan
+        nan_index = np.where(np.isnan(data))
+        print(f"First nan found at index ({nan_index[0][0]}, {nan_index[1][0]}, {nan_index[2][0]})")
+    else:
+        print("pass")
+
+    # is there a inf?
+    print("Checking for inf in the data: ", end="")
+    if np.isinf(data).any():
+        print("fail")
+        # find the index of the inf
+        inf_index = np.where(np.isinf(data))
+        print(f"First Inf found at index ({inf_index[0][0]}, {inf_index[1][0]}, {inf_index[2][0]})")
+    elif np.any(data > 1e100):
+        print("fail")
+        # find the index of the inf
+        inf_index = np.where(data > 1e100)
+        print(f"First Inf found at index ({inf_index[0][0]}, {inf_index[1][0]}, {inf_index[2][0]})")
+    else:
+        print("pass")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: python read_fc_print.py <filename> [array_shape] [line_nums]")
+        print("Example: python read_fc_print.py LastTest.log 8 8 8 100,200,300")
+        sys.exit(1)
+    
+    filename = sys.argv[1]
+    data_shape = (int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4]))
+    # marker = sys.argv[2] if len(sys.argv) > 2 else "DDEBUG"
+    # line_num = [int(it) for it in sys.argv[5].split(",")]
+    
+    try:
+        marker = "DDEBUG fc at direction 0"
+        read_data_after_marker(filename, marker, data_shape)
+        marker = "DDEBUG fc at direction 1"
+        read_data_after_marker(filename, marker, data_shape)
+        marker = "DDEBUG fc at direction 2"
+        read_data_after_marker(filename, marker, data_shape)
+        # read_data_after_marker(filename, "", data_shape, line_num)
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -52,6 +52,7 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_PlotFileUtil.H"
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
+#include "AMReX_SPACE.H"
 #include "AMReX_YAFluxRegister.H"
 
 #ifdef AMREX_USE_ASCENT
@@ -67,6 +68,7 @@ namespace filesystem = experimental::filesystem;
 #include "cooling/TabulatedCooling.hpp"
 #include "eos.H"
 #include "hydro/hydro_system.hpp"
+#include "hydro/mhd_system.hpp"
 #include "hyperbolic_system.hpp"
 #include "physics_info.hpp"
 #include "physics_numVars.hpp"
@@ -86,6 +88,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	using AMRSimulation<problem_t>::particleRegister_;
 
 	using AMRSimulation<problem_t>::nghost_cc_;
+	using AMRSimulation<problem_t>::nghost_fc_;
 	using AMRSimulation<problem_t>::areInitialConditionsDefined_;
 	using AMRSimulation<problem_t>::BCs_cc_;
 	using AMRSimulation<problem_t>::BCs_fc_;
@@ -133,13 +136,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	quokka::GrackleLikeCooling::grackle_tables grackleTables_;
 	quokka::TabulatedCooling::cloudy_tables cloudyTables_;
 	quokka::ResampledCooling::resampled_tables resampledTables_;
-	std::string coolingTableType_{};
-	std::string coolingTableFilename_{};
+	std::string coolingTableType_;
+	std::string coolingTableFilename_;
 
 	static constexpr int nvarTotal_cc_ = Physics_Indices<problem_t>::nvarTotal_cc;
 	static constexpr int ncompHydro_ = HydroSystem<problem_t>::nvar_; // hydro
 	static constexpr int ncompHyperbolic_ = RadSystem<problem_t>::nvarHyperbolic_;
 	static constexpr int nstartHyperbolic_ = RadSystem<problem_t>::nstartHyperbolic_;
+	static constexpr int n_mhd_vars_per_dim_ = MHDSystem<problem_t>::nvar_per_dim_; // mhd
 
 	amrex::Real radiationCflNumber_ = 0.3;
 	int maxSubsteps_ = 10;				// maximum number of radiation subcycles per hydro step
@@ -156,10 +160,12 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	int integratorOrder_ = 2;		// 1 == forward Euler; 2 == RK2-SSP (default)
 	int reconstructionOrder_ = 3;		// 1 == donor cell; 2 == PLM; 3 == PPM (default); 5 == xPPM (extrema-preserving)
 	int radiationReconstructionOrder_ = 3;	// 1 == donor cell; 2 == PLM; 3 == PPM (default); 5 == xPPM
+	int emfReconstructionOrder_ = 5;	// 1 == donor cell; 2 == PLM; 3 == PPM; 5 == xPPM (extrema-preserving, default)
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
 	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
 	int nghost_vel_ = 2;			// number of ghost cells for face velocity computation (default == 2)
+	EMFAvgType emfAveragingType_ = EMFAvgType::LD04; // method to use to average EMF at edges
 
 	amrex::Long radiationCellUpdates_ = 0; // total number of radiation cell-updates
 
@@ -171,8 +177,17 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	explicit QuokkaSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { initialize(); }
 
-	inline void initialize()
+	void initialize()
 	{
+#if (AMREX_SPACEDIM != 3)
+		static_assert(!(Physics_Traits<problem_t>::is_mhd_enabled), "MHD is only supported in 3D.");
+#endif // (AMREX_SPACEDIM != 3)
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			if (max_level > 0) {
+				amrex::Error("MHD is only supported for uniform grids (max_level must be 0).");
+			}
+		}
+
 		defineComponentNames();
 		defineDefaultPlotfileVariables();
 		// read in runtime parameters
@@ -216,12 +231,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
 	void computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo);
+	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
 
 	// compute derived variables
 	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
 
 	// compute projected vars
-	[[nodiscard]] auto ComputeProjections(const amrex::Direction dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
+	[[nodiscard]] auto ComputeProjections(amrex::Direction dir) const -> std::unordered_map<std::string, amrex::BaseFab<amrex::Real>> override;
 
 	// compute statistics
 	auto ComputeStatistics() -> std::map<std::string, amrex::Real> override;
@@ -246,6 +263,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	// fill rhs for Poisson solve
 	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;
 
+	void print_multifab_fc(amrex::MultiFab &mf, std::string const &name, int lev, int idim);
+
 	// add gravitational acceleration to hydro state
 	void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) override;
 
@@ -260,8 +279,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 					    amrex::YAFluxRegister *fr_as_fine);
 
-	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev,
-				 amrex::Real time, amrex::Real dt_lev) -> bool;
+	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
+				 amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev);
 	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
@@ -269,7 +288,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	auto isCflViolated(int lev, amrex::Real time, amrex::Real dt_actual) -> bool;
 
 	// radiation subcycle
-	void swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew);
+	void swapRadiationState(amrex::MultiFab &stateOld_cc, amrex::MultiFab const &stateNew_cc);
 	auto computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int;
 	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps,
 					    amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
@@ -285,27 +304,34 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 	    -> std::tuple<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>;
 
-	auto computeHydroFluxes(amrex::MultiFab const &consVar, int nvars, int lev)
-	    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
+	auto computeHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int lev)
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
-	auto computeFOHydroFluxes(amrex::MultiFab const &consVar, int nvars, int lev)
-	    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
+	auto computeFOHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int lev)
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
-			       amrex::MultiFab &x1FaceVel, amrex::MultiFab const &x1Flat, amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat,
-			       int ng_reconstruct, int nvars);
+	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
+			       amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
+			       amrex::MultiFab const &x1Flat, amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total,
+			       int nvars);
 
 	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
-				 amrex::MultiFab &x1FaceVel, int ng_reconstruct, int nvars);
+	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
+				 amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf,
+				 int ng_reconstruct_total, int nvars);
 
 	void replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
 			   amrex::iMultiFab &redoFlag);
+
+	void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components,
+			 amrex::iMultiFab &redoFlag);
 
 	// void PrintRadEnergySource(amrex::MultiFab const &radEnergySource);
 };
@@ -353,11 +379,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::defineComponentN
 
 	// face-centred
 
-	// add face-centered velocities
-	for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-		componentNames_fc_flat_.push_back({quokka::face_dir_str[idim] + "-RiemannSolverVelocity"});  // rename to _fc_flatten_
-		componentNames_fc_[idim].push_back({quokka::face_dir_str[idim] + "-RiemannSolverVelocity"}); // array for fc_
-	}
 	// add mhd state variables
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; idim++) {
@@ -372,13 +393,11 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::defineDefaultPlo
 	// Initialize plotfileVarsToInclude_cc_ with all cell-centered variables
 	this->plotfileVarsToInclude_cc_.insert(this->plotfileVarsToInclude_cc_.end(), this->componentNames_cc_.begin(), this->componentNames_cc_.end());
 
-	// Add all face-centered variables except RiemannSolverVelocity
+	// Add all face-centered variables
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 		for (int icomp = 0; icomp < Physics_Indices<problem_t>::nvarTotal_fc; ++icomp) {
 			const std::string &varname = this->componentNames_fc_flat_[icomp];
-			if (varname.find("RiemannSolverVelocity") == std::string::npos) {
-				this->plotfileVarsToInclude_cc_.push_back(varname);
-			}
+			this->plotfileVarsToInclude_cc_.push_back(varname);
 		}
 	}
 
@@ -463,7 +482,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 {
 	// set hydro runtime parameters
 	{
-		amrex::ParmParse hpp("hydro");
+		amrex::ParmParse const hpp("hydro");
 		hpp.query("low_level_debugging_output", lowLevelDebuggingOutput_);
 		hpp.query("rk_integrator_order", integratorOrder_);
 		hpp.query("reconstruction_order", reconstructionOrder_);
@@ -472,9 +491,16 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		hpp.query("artificial_viscosity_coefficient", artificialViscosityK_);
 	}
 
+	// set MHD runtime parameters
+	{
+		amrex::ParmParse const hpp("mhd");
+		hpp.query("emf_averaging_method", emfAveragingType_);
+		hpp.query("emf_reconstruction_order", emfReconstructionOrder_);
+	}
+
 	// set cooling runtime parameters
 	{
-		amrex::ParmParse hpp("cooling");
+		amrex::ParmParse const hpp("cooling");
 		int alwaysReadTables = 0;
 		hpp.query("enabled", enableCooling_);
 		hpp.query("cooling_table_type", coolingTableType_);
@@ -502,7 +528,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 #ifdef CHEMISTRY
 	// set chemistry runtime parameters
 	{
-		amrex::ParmParse hpp("chemistry");
+		amrex::ParmParse const hpp("chemistry");
 		hpp.query("enabled", enableChemistry_);
 		hpp.query("max_density_allowed", max_density_allowed); // chemistry is not accurate for densities > 3e-6
 		hpp.query("min_density_allowed", min_density_allowed); // don't do chemistry in cells with densities below the minimum density specified
@@ -511,7 +537,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 
 	// set radiation runtime parameters
 	{
-		amrex::ParmParse rpp("radiation");
+		amrex::ParmParse const rpp("radiation");
 		rpp.query("reconstruction_order", radiationReconstructionOrder_);
 		rpp.query("cfl", radiationCflNumber_);
 		rpp.query("dust_gas_interaction_coeff", dustGasInteractionCoeff_);
@@ -541,30 +567,36 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfR
 	amrex::Real c_hat = RadSystem<problem_t>::c_hat_;
 	amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
 	amrex::Real dtrad_tmp = radiationCflNumber_ * (dx_min / c_hat);
-	int nsubSteps = std::ceil(dt_lev_hydro / dtrad_tmp);
+	int const nsubSteps = std::ceil(dt_lev_hydro / dtrad_tmp);
 	return nsubSteps;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignalLocal(int const level)
 {
-	BL_PROFILE("QuokkaSimulation::computeMaxSignalLocal()");
+	const BL_PROFILE("QuokkaSimulation::computeMaxSignalLocal()");
 
 	// hydro: loop over local grids, compute CFL timestep
 	for (amrex::MFIter iter(state_new_cc_[level]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateNew = state_new_cc_[level].const_array(iter);
+		auto const &stateNew_cc = state_new_cc_[level].const_array(iter);
+		std::array<amrex::Array4<const amrex::Real>, 3> stateNew_fc;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < 3; ++idim) {
+				stateNew_fc[idim] = state_new_fc_[level][idim].const_array(iter);
+			}
+		}
 		auto const &maxSignal = max_signal_speed_[level].array(iter);
 
 		if constexpr (Physics_Traits<problem_t>::is_hydro_enabled && !(Physics_Traits<problem_t>::is_radiation_enabled)) {
-			// hydro only
-			HydroSystem<problem_t>::ComputeMaxSignalSpeed(stateNew, maxSignal, indexRange);
+			// hydro/mhd
+			HydroSystem<problem_t>::ComputeMaxSignalSpeed(stateNew_cc, stateNew_fc, maxSignal, indexRange);
 		} else if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-			// radiation hydro, or radiation only
-			RadSystem<problem_t>::ComputeMaxSignalSpeed(stateNew, maxSignal, indexRange);
+			// radiation hydro/mhd, or radiation only
+			RadSystem<problem_t>::ComputeMaxSignalSpeed(stateNew_cc, maxSignal, indexRange);
 			if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
 				auto maxSignalHydroFAB = amrex::FArrayBox(indexRange);
 				auto const &maxSignalHydro = maxSignalHydroFAB.array();
-				HydroSystem<problem_t>::ComputeMaxSignalSpeed(stateNew, maxSignalHydro, indexRange);
+				HydroSystem<problem_t>::ComputeMaxSignalSpeed(stateNew_cc, stateNew_fc, maxSignalHydro, indexRange);
 				const int maxSubsteps = maxSubsteps_;
 				// ensure that we use the smaller of the two timesteps
 				amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
@@ -615,7 +647,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::checkHydroStates(amrex::MultiFab &mf, char const *file, int line)
 {
-	BL_PROFILE("QuokkaSimulation::checkHydroStates()");
+	const BL_PROFILE("QuokkaSimulation::checkHydroStates()");
 
 	bool validStates = HydroSystem<problem_t>::CheckStatesValid(mf);
 	amrex::ParallelDescriptor::ReduceBoolAnd(validStates);
@@ -801,6 +833,21 @@ void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref,
 	// user should implement
 }
 
+template <typename problem_t>
+void QuokkaSimulation<problem_t>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+{
+	// user should implement
+}
+
+template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_fc(amrex::MultiFab &mf, std::string const & /*name*/, int /*lev*/, int idim)
+{
+	amrex::Print() << "\nDDEBUG fc at direction " << idim << "\n";
+	auto mf_fc = mf.arrays();
+	amrex::ParallelFor(
+	    mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { printf("%f\n", mf_fc[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex)); });
+}
+
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
@@ -841,7 +888,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 	amrex::Print() << '\n';
 
 	if (computeReferenceSolution_) {
-		// compute reference solution
+		// compute cc-reference solution
+		amrex::Print() << "Checking cc-quantities\n";
 		const int ncomp = state_new_cc_[0].nComp();
 		amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 		computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
@@ -866,11 +914,14 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::Print() << "Relative rms L1 error norm = " << rel_error << '\n';
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+
 				amrex::Print() << "Checking fc-quantities in the " << idim << " direction\n";
 				const int ncomp = state_new_fc_[0][idim].nComp();
 				const int nghost = state_new_fc_[0][idim].nGrow();
 				amrex::MultiFab state_ref_level0(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0),
 								 ncomp, nghost);
+
+				computeReferenceSolution_fc(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
 
 				// compute error norm
 				amrex::MultiFab residual(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0), ncomp,
@@ -910,7 +961,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
 {
-	BL_PROFILE("QuokkaSimulation::advanceSingleTimestepAtLevel()");
+	const BL_PROFILE("QuokkaSimulation::advanceSingleTimestepAtLevel()");
 
 	// get flux registers
 	amrex::YAFluxRegister *fr_as_crse = nullptr;
@@ -981,50 +1032,52 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAt
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const amrex::Real dt)
 {
-	if constexpr (AMREX_SPACEDIM == 3) {
-		// apply Poisson gravity operator on level 'lev'
-		auto const &dx = geom[lev].CellSizeArray();
-		auto const &phi = phi_mf.const_arrays();
-		auto state = state_new_cc_[lev].arrays();
+#if (AMREX_SPACEDIM == 3)
+	// apply Poisson gravity operator on level 'lev'
+	auto const &dx = geom[lev].CellSizeArray();
+	auto const &phi = phi_mf.const_arrays();
+	auto state = state_new_cc_[lev].arrays();
 
-		amrex::ParallelFor(phi_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-			// add operator-split gravitational acceleration
-			const amrex::Real rho = state[bx](i, j, k, HydroSystem<problem_t>::density_index);
-			amrex::Real px = state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
-			amrex::Real py = state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
-			amrex::Real pz = state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
-			const amrex::Real KE_old = 0.5 * (px * px + py * py + pz * pz) / rho;
+	amrex::ParallelFor(phi_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		// add operator-split gravitational acceleration
+		const amrex::Real rho = state[bx](i, j, k, HydroSystem<problem_t>::density_index);
+		amrex::Real px = state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+		amrex::Real py = state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+		amrex::Real pz = state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+		const amrex::Real KE_old = 0.5 * (px * px + py * py + pz * pz) / rho;
 
-			// g = -grad \phi
-			amrex::Real gx = -0.5 * (phi[bx](i + 1, j, k) - phi[bx](i - 1, j, k)) / dx[0];
-			amrex::Real gy = -0.5 * (phi[bx](i, j + 1, k) - phi[bx](i, j - 1, k)) / dx[1];
-			amrex::Real gz = -0.5 * (phi[bx](i, j, k + 1) - phi[bx](i, j, k - 1)) / dx[2];
+		// g = -grad \phi
+		amrex::Real gx = -0.5 * (phi[bx](i + 1, j, k) - phi[bx](i - 1, j, k)) / dx[0];
+		amrex::Real gy = -0.5 * (phi[bx](i, j + 1, k) - phi[bx](i, j - 1, k)) / dx[1];
+		amrex::Real gz = -0.5 * (phi[bx](i, j, k + 1) - phi[bx](i, j, k - 1)) / dx[2];
 
-			px += dt * rho * gx;
-			py += dt * rho * gy;
-			pz += dt * rho * gz;
-			const amrex::Real KE_new = 0.5 * (px * px + py * py + pz * pz) / rho;
-			const amrex::Real dKE = KE_new - KE_old;
+		px += dt * rho * gx;
+		py += dt * rho * gy;
+		pz += dt * rho * gz;
+		const amrex::Real KE_new = 0.5 * (px * px + py * py + pz * pz) / rho;
+		const amrex::Real dKE = KE_new - KE_old;
 
-			state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index) = px;
-			state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index) = py;
-			state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index) = pz;
-			state[bx](i, j, k, HydroSystem<problem_t>::energy_index) += dKE;
-		});
-	}
+		state[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index) = px;
+		state[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index) = py;
+		state[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index) = pz;
+		state[bx](i, j, k, HydroSystem<problem_t>::energy_index) += dKE;
+	});
+#else
+	amrex::ignore_unused(phi_mf, lev, dt);
+#endif // (AMREX_SPACEDIM == 3)
 }
 
 // fix-up any unphysical states created by AMR operations
 // (e.g., caused by the flux register or from interpolation)
 template <typename problem_t> void QuokkaSimulation<problem_t>::FixupState(int lev)
 {
-	BL_PROFILE("QuokkaSimulation::FixupState()");
+	const BL_PROFILE("QuokkaSimulation::FixupState()");
 
 	// fix hydro state
 	HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, state_new_cc_[lev]);
 
 	// sync internal energy and total energy
-	HydroSystem<problem_t>::SyncDualEnergy(state_new_cc_[lev]);
+	HydroSystem<problem_t>::SyncDualEnergy(state_new_cc_[lev], state_new_fc_[lev]);
 }
 
 // Compute a new multifab 'mf' by copying in state from valid region and filling
@@ -1035,7 +1088,7 @@ template <typename problem_t>
 void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::MultiFab &mf, int icomp, int ncomp, quokka::centering cen, quokka::direction dir,
 					    FillPatchType fptype)
 {
-	BL_PROFILE("AMRSimulation::FillPatch()");
+	const BL_PROFILE("AMRSimulation::FillPatch()");
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::MultiFab *> fmf;
@@ -1061,7 +1114,7 @@ void QuokkaSimulation<problem_t>::FillPatch(int lev, amrex::Real time, amrex::Mu
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::PreInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
 {
-	BL_PROFILE("QuokkaSimulation::PreInterpState()");
+	const BL_PROFILE("QuokkaSimulation::PreInterpState()");
 
 	auto const &cons = mf.arrays();
 	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
@@ -1080,7 +1133,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::PreInterpState(a
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::PostInterpState(amrex::MultiFab &mf, int /*scomp*/, int /*ncomp*/)
 {
-	BL_PROFILE("QuokkaSimulation::PostInterpState()");
+	const BL_PROFILE("QuokkaSimulation::PostInterpState()");
 
 	auto const &cons = mf.arrays();
 	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
@@ -1103,7 +1156,7 @@ template <typename F>
 auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F const &user_f) -> amrex::Gpu::HostVector<amrex::Real>
 {
 	// compute a 1D profile of user_f(i, j, k, state) along the given axis.
-	BL_PROFILE("QuokkaSimulation::computeAxisAlignedProfile()");
+	const BL_PROFILE("QuokkaSimulation::computeAxisAlignedProfile()");
 
 	// allocate temporary multifabs
 	amrex::Vector<amrex::MultiFab> q;
@@ -1132,7 +1185,7 @@ auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F co
 	auto profile = amrex::sumToLine(q[0], 0, q[0].nComp(), domain, axis);
 
 	// normalize profile
-	amrex::Long numCells = domain.numPts() / domain.length(axis);
+	amrex::Long const numCells = domain.numPts() / domain.length(axis);
 	for (double &bin : profile) {
 		bin /= static_cast<amrex::Real>(numCells);
 	}
@@ -1144,7 +1197,7 @@ template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
 								 amrex::YAFluxRegister *fr_as_fine)
 {
-	BL_PROFILE_REGION("HydroSolver");
+	const BL_PROFILE_REGION("HydroSolver");
 	// timestep retries
 	const int max_retries = 6;
 	bool success = false;
@@ -1189,9 +1242,19 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 			}
 		}
 
-		// create temporary multifab for old state
+		// create temporary multifab for old cell-cenetered state
 		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 		amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+
+		// create temporary array (different faces) of multifabs for old face-centered state
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				state_old_fc_tmp[idim].define(amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim)), dmap[lev],
+							      Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+				amrex::Copy(state_old_fc_tmp[idim], state_old_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			}
+		}
 
 		// subcycle advanceHydroAtLevel, checking return value
 		for (int substep = 0; substep < nsubsteps; ++substep) {
@@ -1199,9 +1262,15 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 				// since we are starting a new substep, we need to copy hydro state from
 				//  the new state vector to old state vector
 				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+						amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
+							    nghost_fc_);
+					}
+				}
 			}
 
-			success = advanceHydroAtLevel(state_old_cc_tmp, fr_as_crse, fr_as_fine, lev, time, dt_step);
+			success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, time, dt_step);
 
 			if (!success) {
 				if (Verbose()) {
@@ -1284,10 +1353,11 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates
 }
 
 template <typename problem_t>
-auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      int lev, amrex::Real time, amrex::Real dt_lev) -> bool
+auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
+						      amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev, amrex::Real time,
+						      amrex::Real dt_lev) -> bool
 {
-	BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
+	const BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
 	amrex::Real fluxScaleFactor = NAN;
 	if (integratorOrder_ == 2) {
@@ -1296,6 +1366,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		fluxScaleFactor = 1.0;
 	}
 
+	auto ba_cc = grids[lev];
+	auto dm = dmap[lev];
 	auto dx = geom[lev].CellSizeArray();
 
 	// do Strang split source terms (first half-step)
@@ -1309,25 +1381,46 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	// create temporary multifab for intermediate state
 	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 	state_inter_cc_.setVal(0); // prevent assert in fillBoundaryConditions when radiation is enabled
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> state_inter_fc_;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_fc = amrex::convert(ba_cc, amrex::IntVect::TheDimensionVector(idim));
+			state_inter_fc_[idim].define(ba_fc, dm, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			state_inter_fc_[idim].setVal(0);
+		}
+	}
 
 	// create temporary multifabs for combined RK2 flux and time-average face velocity
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux_rk2;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> avgFaceVel;
 	const int nghost_vel = 2; // 2 ghost faces are needed for tracer particles
-	const auto ba = grids[lev];
-	const auto dm = dmap[lev];
+
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
+		auto ba_fc = amrex::convert(ba_cc, amrex::IntVect::TheDimensionVector(idim));
 		// initialize flux MultiFab
-		flux_rk2[idim] = amrex::MultiFab(ba_face, dm, ncompHydro_, 0);
+		flux_rk2[idim] = amrex::MultiFab(ba_fc, dm, ncompHydro_, 0);
 		flux_rk2[idim].setVal(0);
 		// initialize velocity MultiFab
-		avgFaceVel[idim] = amrex::MultiFab(ba_face, dm, 1, nghost_vel);
+		avgFaceVel[idim] = amrex::MultiFab(ba_fc, dm, 1, nghost_vel);
 		avgFaceVel[idim].setVal(0);
+	}
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_ave;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+			ec_emf_components_rk_ave[idim].define(ba_ec, dm, 1, 0);
+			ec_emf_components_rk_ave[idim].setVal(0.0);
+		}
 	}
 
 	// update ghost zones [old timestep]
 	fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState, PostInterpState);
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			fillBoundaryConditions(state_old_fc_tmp[idim], state_old_fc_tmp[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
+					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
+		}
+	}
 
 	// LOW LEVEL DEBUGGING: output state_old_cc_tmp (with ghost cells)
 	if (lowLevelDebuggingOutput_ == 1) {
@@ -1347,18 +1440,57 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
 
-	auto [FOfluxArrays, FOfaceVel] = computeFOHydroFluxes(state_old_cc_tmp, ncompHydro_, lev);
+	int nvars = ncompHydro_;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		// also create space to append the two magnetic field components orthogonal to the solving direction
+		nvars += 3; // add-hoc +3 because +1 (primScalar0_index) precedes +2 (x2Magnetic_index and x3Magnetic_index) at the end of the enum of
+			    // primitive quantities
+	}
+	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] = computeFOHydroFluxes(state_old_cc_tmp, state_old_fc_tmp, nvars, lev);
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
+		}
+		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, state_old_fc_tmp, FOfast_mhd_wavespeeds, emfReconstructionOrder_,
+						 emfAveragingType_);
+	}
 
 	// Stage 1 of RK2-SSP
 	{
-		// advance all grids on local processor (Stage 1 of integrator)
-		auto const &stateOld = state_old_cc_tmp;
-		auto &stateNew = state_inter_cc_;
-		auto [fluxArrays, faceVel] = computeHydroFluxes(stateOld, ncompHydro_, lev);
+		//  advance all grids on local processor (Stage 1 of integrator)
+		auto const &stateOld_cc = state_old_cc_tmp;
+		auto &stateNew_cc = state_inter_cc_;
+
+		auto const &stateOld_fc = state_old_fc_tmp;
+		auto &stateNew_fc = state_inter_fc_;
+
+		int nvars = ncompHydro_;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// also create space to append the two magnetic field components orthogonal to the solving direction
+			nvars += 3; // add-hoc +3 because +1 (primScalar0_index) precedes +2 (x2Magnetic_index and x3Magnetic_index) at the end of the enum of
+				    // primitive quantities
+		}
+		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateOld_cc, stateOld_fc, nvars, lev);
+
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage1;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+				ec_emf_components_rk_stage1[idim].define(ba_ec, dm, 1, 0);
+			}
+			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage1, stateOld_cc, stateOld_fc, fast_mhd_wavespeeds, emfReconstructionOrder_,
+							 emfAveragingType_);
+		}
 
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::MultiFab::Saxpy(flux_rk2[idim], 0.5, fluxArrays[idim], 0, 0, ncompHydro_, 0);
 			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, 0);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], 0.5, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
+			}
 		}
 
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
@@ -1366,8 +1498,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		redoFlag.setVal(quokka::redoFlag::none);
 
 		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, faceVel, redoFlag);
-		HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs, dt_lev, ncompHydro_, redoFlag);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, dx, faceVel, redoFlag);
+		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, ncompHydro_, redoFlag);
 
 		// LOW LEVEL DEBUGGING: output rhs
 		if (lowLevelDebuggingOutput_ == 1) {
@@ -1396,7 +1528,25 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 
 		// do first-order flux correction (FOFC)
-		amrex::Gpu::streamSynchronizeAll(); // just in case
+		amrex::Gpu::streamSynchronizeAll(); // ensure device-side ops are finished
+
+		// The following out commented section is for debugging, it forces some cells to have the redoFlag, remove before final merge!
+		//  int i = 0;
+		//  int k = 0;
+		//  int j_start = 0;
+		//  int j_end   = 7;
+
+		// for (amrex::MFIter mfi(redoFlag); mfi.isValid(); ++mfi) {
+		// 	const amrex::Box& bx = mfi.validbox();
+		// 	auto arr = redoFlag.array(mfi);  // IArray4<int>
+
+		// 	for (int j = j_start; i <= j_end; ++i) {
+		// 		if (bx.contains(amrex::IntVect(AMREX_D_DECL(i, j, k)))) {
+		// 			arr(i, j, k) = 1;
+		// 		}
+		// 	}
+		// }
+
 		amrex::Long const ncells_bad = redoFlag.sum(0);
 		if (ncells_bad > 0) {
 			if (Verbose()) {
@@ -1404,20 +1554,22 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
 				// Calculate the coordinates based on the cell index and cell size
 				printCoordinates(lev, cell_idx);
-				amrex::print_state(stateNew, cell_idx);
+				amrex::print_state(stateNew_cc, cell_idx);
 			}
 
 			// synchronize redoFlag across ranks
 			redoFlag.FillBoundary(geom[lev].periodicity());
 
-			// replace fluxes around troubled cells with Godunov fluxes
 			replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
 			replaceFluxes(faceVel, FOfaceVel, redoFlag); // needed for dual energy
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				replaceEMFs(ec_emf_components_rk_stage1, ec_emf_components_fo, redoFlag); // replace emf components
+			}
 
 			// re-do RK update
 			HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, ncompHydro_);
-			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, faceVel, redoFlag);
-			HydroSystem<problem_t>::PredictStep(stateOld, stateNew, rhs, dt_lev, ncompHydro_, redoFlag);
+			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, dx, faceVel, redoFlag);
+			HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, ncompHydro_, redoFlag);
 
 			amrex::Gpu::streamSynchronizeAll(); // just in case
 			amrex::Long const ncells_bad = static_cast<int>(redoFlag.sum(0));
@@ -1428,7 +1580,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 					// print cell state
 					amrex::Print() << "[FOFC-1] Flux correction failed:\n";
 					printCoordinates(lev, cell_idx);
-					amrex::print_state(stateNew, cell_idx);
+					amrex::print_state(stateNew_cc, cell_idx);
 					amrex::Print() << "[FOFC-1] failed for " << ncells_bad << " cells on level " << lev << "\n";
 				}
 				if (abortOnFofcFailure_ != 0) {
@@ -1437,12 +1589,17 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components_rk_stage1, dt_lev, geom[lev].CellSizeArray(),
+								geom[lev].ProbLoArray(), time);
+		}
+
 		// prevent vacuum
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateNew);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateNew_cc);
 
 		if (useDualEnergy_ == 1) {
 			// sync internal energy (requires positive density)
-			HydroSystem<problem_t>::SyncDualEnergy(stateNew);
+			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
 		}
 
 		if (do_reflux == 1) {
@@ -1454,25 +1611,52 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 
 	// Stage 2 of RK2-SSP
 	if (integratorOrder_ == 2) {
-		// update ghost zones [intermediate stage stored in state_inter_cc_]
+		//  update ghost zones [intermediate stage stored in state_inter_cc_]
 		fillBoundaryConditions(state_inter_cc_, state_inter_cc_, lev, time + dt_lev, quokka::centering::cc, quokka::direction::na, PreInterpState,
 				       PostInterpState);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				fillBoundaryConditions(state_inter_fc_[idim], state_inter_fc_[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
+						       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
+			}
+		}
 
 		// check intermediate state validity
 		AMREX_ASSERT(!state_inter_cc_.contains_nan(0, state_inter_cc_.nComp()));
 		AMREX_ASSERT(!state_inter_cc_.contains_nan()); // check ghost zones
 
-		// write out FABs with ghost zones
-		// amrex::writeFabs(state_inter_cc_, "state_inter_cc_" + std::to_string(istep[lev]));
+		auto const &stateOld_cc = state_old_cc_tmp;
+		auto const &stateInter_cc = state_inter_cc_;
+		auto &stateFinal_cc = state_new_cc_[lev];
 
-		auto const &stateOld = state_old_cc_tmp;
-		auto const &stateInter = state_inter_cc_;
-		auto &stateFinal = state_new_cc_[lev];
-		auto [fluxArrays, faceVel] = computeHydroFluxes(stateInter, ncompHydro_, lev);
+		auto const &stateOld_fc = state_old_fc_tmp;
+		auto const &stateInter_fc = state_inter_fc_;
+		auto &stateFinal_fc = state_new_fc_[lev];
+
+		int nvars = ncompHydro_;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// also create space to append the two magnetic field components orthogonal to the solving direction
+			nvars += 3; // add-hoc step: +3 because primScalar0_index precedes x2Magnetic_index and x3Magnetic_index at the end of the enum of
+				    // primitive quantities
+		}
+		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateInter_cc, stateInter_fc, nvars, lev);
+
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage2;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+				ec_emf_components_rk_stage2[idim].define(ba_ec, dm, 1, 0);
+			}
+			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage2, stateInter_cc, stateInter_fc, fast_mhd_wavespeeds,
+							 emfReconstructionOrder_, emfAveragingType_);
+		}
 
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::MultiFab::Saxpy(flux_rk2[idim], 0.5, fluxArrays[idim], 0, 0, ncompHydro_, 0);
 			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, 0);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], 0.5, ec_emf_components_rk_stage2[idim], 0, 0, 1, 0);
+			}
 		}
 
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
@@ -1480,8 +1664,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		redoFlag.setVal(quokka::redoFlag::none);
 
 		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, flux_rk2, dx, ncompHydro_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, avgFaceVel, redoFlag);
-		HydroSystem<problem_t>::PredictStep(stateOld, stateFinal, rhs, dt_lev, ncompHydro_, redoFlag);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, dx, avgFaceVel, redoFlag);
+		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateFinal_cc, rhs, dt_lev, ncompHydro_, redoFlag);
 
 		// do first-order flux correction (FOFC)
 		amrex::Gpu::streamSynchronizeAll(); // just in case
@@ -1491,23 +1675,25 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 				amrex::Print() << "[FOFC-2] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
 				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
 				printCoordinates(lev, cell_idx);
-				amrex::print_state(stateFinal, cell_idx);
+				amrex::print_state(stateFinal_cc, cell_idx);
 			}
 
 			// synchronize redoFlag across ranks
 			redoFlag.FillBoundary(geom[lev].periodicity());
 
-			// replace fluxes around troubled cells with Godunov fluxes
 			replaceFluxes(flux_rk2, FOfluxArrays, redoFlag);
 			replaceFluxes(avgFaceVel, FOfaceVel, redoFlag); // needed for dual energy
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				replaceEMFs(ec_emf_components_rk_ave, ec_emf_components_fo, redoFlag); // replaces EMF components
+			}
 
 			// re-do RK update
 			HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, flux_rk2, dx, ncompHydro_);
-			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld, dx, avgFaceVel, redoFlag);
-			HydroSystem<problem_t>::PredictStep(stateOld, stateFinal, rhs, dt_lev, ncompHydro_, redoFlag);
+			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, dx, avgFaceVel, redoFlag);
+			HydroSystem<problem_t>::PredictStep(stateOld_cc, stateFinal_cc, rhs, dt_lev, ncompHydro_, redoFlag);
 
 			amrex::Gpu::streamSynchronizeAll(); // just in case
-			amrex::Long ncells_bad = redoFlag.sum(0);
+			amrex::Long const ncells_bad = redoFlag.sum(0);
 			if (ncells_bad > 0) {
 				// FOFC failed
 				if (Verbose()) {
@@ -1515,7 +1701,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 					// print cell state
 					amrex::Print() << "[FOFC-2] Flux correction failed:\n";
 					printCoordinates(lev, cell_idx);
-					amrex::print_state(stateFinal, cell_idx);
+					amrex::print_state(stateFinal_cc, cell_idx);
 					amrex::Print() << "[FOFC-2] failed for " << ncells_bad << " cells on level " << lev << "\n";
 				}
 				if (abortOnFofcFailure_ != 0) {
@@ -1524,12 +1710,17 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateFinal_fc, ec_emf_components_rk_ave, dt_lev, geom[lev].CellSizeArray(),
+								geom[lev].ProbLoArray(), time);
+		}
+
 		// prevent vacuum
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateFinal);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateFinal_cc);
 
 		if (useDualEnergy_ == 1) {
 			// sync internal energy (requires positive density)
-			HydroSystem<problem_t>::SyncDualEnergy(stateFinal);
+			HydroSystem<problem_t>::SyncDualEnergy(stateFinal_cc, stateFinal_fc);
 		}
 
 		if (do_reflux == 1) {
@@ -1538,6 +1729,11 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 	} else { // we are only doing forward Euler
 		amrex::Copy(state_new_cc_[lev], state_inter_cc_, 0, 0, ncompHydro_, 0);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				amrex::Copy(state_new_fc_[lev][idim], state_inter_fc_[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, 0);
+			}
+		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
 
@@ -1557,7 +1753,7 @@ template <typename problem_t>
 void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
 						amrex::iMultiFab &redoFlag)
 {
-	BL_PROFILE("QuokkaSimulation::replaceFluxes()");
+	const BL_PROFILE("QuokkaSimulation::replaceFluxes()");
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) { // loop over dimension
 		// ensure that flux arrays have the same number of components
@@ -1600,10 +1796,69 @@ void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMRE
 }
 
 template <typename problem_t>
+void QuokkaSimulation<problem_t>::replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components,
+					      std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components, amrex::iMultiFab &redoFlag)
+{
+	const BL_PROFILE("QuokkaSimulation::replaceFluxes()");
+
+	for (int iedge = 0; iedge < 3; ++iedge) { // loop over edges
+		// ensure that flux arrays have the same number of components
+		AMREX_ASSERT(emf_components[iedge].nComp() == FO_emf_components[iedge].nComp());
+		int ncomp = emf_components[iedge].nComp();
+
+		auto const &FO_emf_components_arrs = FO_emf_components[iedge].const_arrays();
+		auto const &redoFlag_arrs = redoFlag.const_arrays();
+		auto emf_components_arrs = emf_components[iedge].arrays();
+
+		amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)}; // must include 1 ghost zone ?
+
+		amrex::ParallelFor(redoFlag, ng, ncomp, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
+			if (redoFlag_arrs[bx](i, j, k) == quokka::redoFlag::redo) {
+				// replace fluxes with first-order ones at the faces of cell (i,j,k)
+				if (emf_components_arrs[bx].contains(i, j, k)) {
+					emf_components_arrs[bx](i, j, k, n) = FO_emf_components_arrs[bx](i, j, k, n);
+				}
+				if (iedge == 0) { // x-dir fluxes
+					if (emf_components_arrs[bx].contains(i, j + 1, k)) {
+						emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
+					}
+					if (emf_components_arrs[bx].contains(i, j, k + 1)) {
+						emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
+					}
+					if (emf_components_arrs[bx].contains(i, j + 1, k + 1)) {
+						emf_components_arrs[bx](i, j + 1, k + 1, n) = FO_emf_components_arrs[bx](i, j + 1, k + 1, n);
+					}
+				} else if (iedge == 1) { // x-dir fluxes
+					if (emf_components_arrs[bx].contains(i + 1, j, k)) {
+						emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
+					}
+					if (emf_components_arrs[bx].contains(i, j, k + 1)) {
+						emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
+					}
+					if (emf_components_arrs[bx].contains(i + 1, j, k + 1)) {
+						emf_components_arrs[bx](i + 1, j, k + 1, n) = FO_emf_components_arrs[bx](i + 1, j, k + 1, n);
+					}
+				} else if (iedge == 2) { // x-dir fluxes
+					if (emf_components_arrs[bx].contains(i + 1, j, k)) {
+						emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
+					}
+					if (emf_components_arrs[bx].contains(i, j + 1, k)) {
+						emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
+					}
+					if (emf_components_arrs[bx].contains(i + 1, j + 1, k)) {
+						emf_components_arrs[bx](i + 1, j + 1, k, n) = FO_emf_components_arrs[bx](i + 1, j + 1, k, n);
+					}
+				}
+			}
+		});
+	}
+}
+
+template <typename problem_t>
 void QuokkaSimulation<problem_t>::addFluxArrays(std::array<amrex::MultiFab, AMREX_SPACEDIM> &dstfluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &srcfluxes,
 						const int srccomp, const int dstcomp)
 {
-	BL_PROFILE("QuokkaSimulation::addFluxArrays()");
+	const BL_PROFILE("QuokkaSimulation::addFluxArrays()");
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto const &srcflux = srcfluxes[idim];
@@ -1616,7 +1871,7 @@ template <typename problem_t>
 auto QuokkaSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxes, const int nstartNew, const int ncompNew)
     -> std::array<amrex::FArrayBox, AMREX_SPACEDIM>
 {
-	BL_PROFILE("QuokkaSimulation::expandFluxArrays()");
+	const BL_PROFILE("QuokkaSimulation::expandFluxArrays()");
 
 	// This is needed because reflux arrays must have the same number of components as
 	// state_new_cc_[lev]
@@ -1633,10 +1888,11 @@ auto QuokkaSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, 
 }
 
 template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
-    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
+						     const int nvars, const int lev)
+    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
-	BL_PROFILE("QuokkaSimulation::computeHydroFluxes()");
+	const BL_PROFILE("QuokkaSimulation::computeHydroFluxes()");
 
 	const auto ba = grids[lev];
 	const auto dm = dmap[lev];
@@ -1651,8 +1907,9 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
 
-	for (int idim = 0; idim < 3; ++idim) {
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		flatCoefs[idim] = amrex::MultiFab(ba, dm, 1, flatteningGhost);
 	}
 
@@ -1662,10 +1919,13 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost - 1);
 		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructGhost - 1);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost - 1);
+		}
 	}
 
 	// conserved to primitive variables
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar, nghost_cc_);
+	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flattening coefficients
 	AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(primVar, flatCoefs[0], flatteningGhost);
@@ -1673,12 +1933,12 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						    reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						      reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						      reconstructGhost, nvars);)
+	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0],
+						    flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+		     , hydroFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
+						      flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+		     , hydroFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
+						      flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -1725,45 +1985,81 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	}
 
 	// return flux and face-centered velocities
-	return std::make_pair(std::move(flux), std::move(facevel));
+	return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab const &x1Flat,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &flux,
+						    amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
+						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
+	amrex::MultiArray4<const amrex::Real> x2State_fc_in;
+	amrex::MultiArray4<const amrex::Real> x3State_fc_in;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		std::array<int, 3> delta_x2 = {0, 0, 0};
+		std::array<int, 3> delta_x3 = {0, 0, 0};
+		if constexpr (DIR == FluxDir::X1) {
+			delta_x2[1] = 1;
+			delta_x3[2] = 1;
+			x2State_fc_in = consVar_fc[1].const_arrays();
+			x3State_fc_in = consVar_fc[2].const_arrays();
+		} else if constexpr (DIR == FluxDir::X2) {
+			delta_x2[2] = 1;
+			delta_x3[0] = 1;
+			x2State_fc_in = consVar_fc[2].const_arrays();
+			x3State_fc_in = consVar_fc[0].const_arrays();
+		} else if constexpr (DIR == FluxDir::X3) {
+			delta_x2[0] = 1;
+			delta_x3[1] = 1;
+			x2State_fc_in = consVar_fc[0].const_arrays();
+			x3State_fc_in = consVar_fc[1].const_arrays();
+		}
+		auto primVar_in = primVar_mf.arrays();
+		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+		amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			const double bx2_m = x2State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p = x2State_fc_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x2Magnetic_index) = 0.5 * (bx2_m + bx2_p);
+
+			const double bx3_m = x3State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p = x3State_fc_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x3Magnetic_index) = 0.5 * (bx3_m + bx3_p);
+		});
+	}
+
 	if (reconstructionOrder_ == 5) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
+		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 3) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
+		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 2) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar, leftState, rightState, ng_reconstruct, nvars);
+		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	} else if (reconstructionOrder_ == 1) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
+		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
 	}
 
 	// cell-centered kernel
-	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
+	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar_mf, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
-											 nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(
+		    flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_, &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
-											 nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar_mf,
+											 artificialViscosityK_, nullptr, nullptr, nghost_vel_);
 	}
 }
 
 template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &consVar, const int nvars, const int lev)
-    -> std::pair<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
+						       const int nvars, const int lev)
+    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 {
-	BL_PROFILE("QuokkaSimulation::computeFOHydroFluxes()");
+	const BL_PROFILE("QuokkaSimulation::computeFOHydroFluxes()");
 
 	const auto ba = grids[lev];
 	const auto dm = dmap[lev];
@@ -1775,6 +2071,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
@@ -1782,38 +2079,91 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
 		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange - 1);
+		}
 	}
 
 	// conserved to primitive variables
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar, primVar, nghost_cc_);
+	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], reconstructRange, nvars);)
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
+						      reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
+							reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
+							reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
 
 	// return flux and face-centered velocities
-	return std::make_pair(std::move(flux), std::move(facevel));
+	return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab const &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, const int ng_reconstruct, const int nvars)
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
+						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
+						      const int nvars)
 {
+	amrex::MultiArray4<const amrex::Real> x2State_fc_in;
+	amrex::MultiArray4<const amrex::Real> x3State_fc_in;
+
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		std::array<int, 3> delta_x2 = {0, 0, 0};
+		std::array<int, 3> delta_x3 = {0, 0, 0};
+
+		if constexpr (DIR == FluxDir::X1) {
+			delta_x2[1] = 1;
+			delta_x3[2] = 1;
+			x2State_fc_in = x1ConsVar_fc_mf[1].const_arrays();
+			x3State_fc_in = x1ConsVar_fc_mf[2].const_arrays();
+		} else if constexpr (DIR == FluxDir::X2) {
+			delta_x2[2] = 1;
+			delta_x3[0] = 1;
+			x2State_fc_in = x1ConsVar_fc_mf[2].const_arrays();
+			x3State_fc_in = x1ConsVar_fc_mf[0].const_arrays();
+		} else if constexpr (DIR == FluxDir::X3) {
+			delta_x2[0] = 1;
+			delta_x3[1] = 1;
+			x2State_fc_in = x1ConsVar_fc_mf[0].const_arrays();
+			x3State_fc_in = x1ConsVar_fc_mf[1].const_arrays();
+		}
+
+		auto primVar_in = primVar_mf.arrays();
+		primVar_mf.arrays();
+		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+
+		amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			const double bx2_m = x2State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p = x2State_fc_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x2Magnetic_index) = 0.5 * (bx2_m + bx2_p);
+
+			const double bx3_m = x3State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p = x3State_fc_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x3Magnetic_index) = 0.5 * (bx3_m + bx3_p);
+		});
+	}
+
 	// donor-cell reconstruction
-	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar, leftState, rightState, ng_reconstruct, nvars);
+	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+
 	// LLF solver
-	HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar, artificialViscosityK_,
-										nghost_vel_);
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(
+		    flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_, &x1FSpds, &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_vel_);
+	} else {
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_,
+											nullptr, nullptr, nghost_vel_);
+	}
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)
 {
-	// copy radiation state variables from stateNew to stateOld
+	// copy radiation state variables from stateNew_cc to stateOld_cc
 	amrex::MultiFab::Copy(stateOld, stateNew, nstartHyperbolic_, nstartHyperbolic_, ncompHyperbolic_, 0);
 }
 
@@ -1896,7 +2246,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 				const amrex::Box &indexRange = iter.validbox();
-				auto const &stateNew = state_new_cc_[lev].array(iter);
+				auto const &stateNew_cc = state_new_cc_[lev].array(iter);
 				auto const &prob_lo = geom[lev].ProbLoArray();
 				auto const &prob_hi = geom[lev].ProbHiArray();
 
@@ -1907,11 +2257,11 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				// Note that only a fraction (IMEX_a32) of the matter-radiation exchange source terms are added to hydro. This ensures that the
 				// hydro properties get to t + IMEX_a32 dt in terms of matter-radiation exchange.
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew, radEnergySource_arr, indexRange, dt_radiation, 1,
+					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
 											dustGasInteractionCoeff_, p_iteration_counter,
 											p_iteration_failure_counter);
 				} else {
-					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew, radEnergySource_arr, indexRange, dt_radiation, 1,
+					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
 										       dustGasInteractionCoeff_, p_iteration_counter,
 										       p_iteration_failure_counter);
 				}
@@ -1932,7 +2282,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		// Add the matter-radiation exchange source terms to the radiation subsystem and evolve by (1 - IMEX_a32) * dt
 		for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
-			auto const &stateNew = state_new_cc_[lev].array(iter);
+			auto const &stateNew_cc = state_new_cc_[lev].array(iter);
 			auto const &prob_lo = geom[lev].ProbLoArray();
 			auto const &prob_hi = geom[lev].ProbHiArray();
 
@@ -1941,20 +2291,21 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// include cell-centered source terms; will update state_new_cc_[lev] in place (updates both radiation and hydro vars)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew, radEnergySource_arr, indexRange, dt_radiation, 2,
+				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
 										dustGasInteractionCoeff_, p_iteration_counter, p_iteration_failure_counter);
 			} else {
-				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew, radEnergySource_arr, indexRange, dt_radiation, 2,
+				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
 									       dustGasInteractionCoeff_, p_iteration_counter, p_iteration_failure_counter);
 			}
 		}
 
 		if (print_rad_counter_) {
-			auto h_iteration_counter = iteration_counter.copyToHost();
-			long global_solver_count = h_iteration_counter[0];	      // number of Newton-Raphson solvings
-			long global_iteration_sum = h_iteration_counter[1];	      // sum of Newton-Raphson iterations
-			int global_iteration_max = h_iteration_counter[2];	      // max number of Newton-Raphson iterations
-			long global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
+			auto *h_iteration_counter = iteration_counter.copyToHost();
+			long global_solver_count = h_iteration_counter[0];  // number of Newton-Raphson solvings, NOLINT(google-runtime-int)
+			long global_iteration_sum = h_iteration_counter[1]; // sum of Newton-Raphson iterations, NOLINT(google-runtime-int)
+			int global_iteration_max = h_iteration_counter[2];  // max number of Newton-Raphson iterations
+			long global_decoupled_iteration_sum =
+			    h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations, NOLINT(google-runtime-int)
 
 			amrex::ParallelDescriptor::ReduceLongSum(global_solver_count);
 			amrex::ParallelDescriptor::ReduceLongSum(global_iteration_sum);
@@ -1982,10 +2333,10 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			}
 		}
 
-		auto h_iteration_failure_counter = iteration_failure_counter.copyToHost();
-		long nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
-		long nf_dust = h_iteration_failure_counter[1];	   // number of dust temperature failures
-		long nf_outer = h_iteration_failure_counter[2];	   // number of outer iterations failures
+		auto *h_iteration_failure_counter = iteration_failure_counter.copyToHost();
+		long nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures, NOLINT(google-runtime-int)
+		long nf_dust = h_iteration_failure_counter[1];	   // number of dust temperature failures, NOLINT(google-runtime-int)
+		long nf_outer = h_iteration_failure_counter[2];	   // number of outer iterations failures, NOLINT(google-runtime-int)
 
 		amrex::ParallelDescriptor::ReduceLongSum(nf_coupling);
 		amrex::ParallelDescriptor::ReduceLongSum(nf_dust);
@@ -2034,13 +2385,13 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 	// advance all grids on local processor (Stage 1 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateOld = state_old_cc_[lev].const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateOld, indexRange, ncompHyperbolic_, dx);
+		auto const &stateOld_cc = state_old_cc_[lev].const_array(iter);
+		auto const &stateNew_cc = state_new_cc_[lev].array(iter);
+		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateOld_cc, indexRange, ncompHyperbolic_, dx);
 
 		// Stage 1 of RK2-SSP
 		RadSystem<problem_t>::PredictStep(
-		    stateOld, stateNew, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
+		    stateOld_cc, stateNew_cc, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
 		    {AMREX_D_DECL(fluxDiffusiveArrays[0].const_array(), fluxDiffusiveArrays[1].const_array(), fluxDiffusiveArrays[2].const_array())},
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
@@ -2059,14 +2410,14 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 	// advance all grids on local processor (Stage 2 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateOld = state_old_cc_[lev].const_array(iter);
-		auto const &stateInter = state_new_cc_[lev].const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateInter, indexRange, ncompHyperbolic_, dx);
+		auto const &stateOld_cc = state_old_cc_[lev].const_array(iter);
+		auto const &stateInter_cc = state_new_cc_[lev].const_array(iter);
+		auto const &stateNew_cc = state_new_cc_[lev].array(iter);
+		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateInter_cc, indexRange, ncompHyperbolic_, dx);
 
 		// Stage 2 of RK2-SSP
 		RadSystem<problem_t>::AddFluxesRK2(
-		    stateNew, stateOld, stateInter, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
+		    stateNew_cc, stateOld_cc, stateInter_cc, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
 		    {AMREX_D_DECL(fluxDiffusiveArrays[0].const_array(), fluxDiffusiveArrays[1].const_array(), fluxDiffusiveArrays[2].const_array())},
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
@@ -2093,13 +2444,13 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 	// advance all grids on local processor (Stage 1 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateOld = state_old_cc_[lev].const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateOld, indexRange, ncompHyperbolic_, dx);
+		auto const &stateOld_cc = state_old_cc_[lev].const_array(iter);
+		auto const &stateNew_cc = state_new_cc_[lev].array(iter);
+		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateOld_cc, indexRange, ncompHyperbolic_, dx);
 
 		// Stage 1 of RK2-SSP
 		RadSystem<problem_t>::PredictStep(
-		    stateOld, stateNew, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
+		    stateOld_cc, stateNew_cc, {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
 		    {AMREX_D_DECL(fluxDiffusiveArrays[0].const_array(), fluxDiffusiveArrays[1].const_array(), fluxDiffusiveArrays[2].const_array())},
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
@@ -2125,15 +2476,15 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 	// advance all grids on local processor (Stage 2 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
-		auto const &stateOld = state_old_cc_[lev].const_array(iter);
-		auto const &stateInter = state_new_cc_[lev].const_array(iter);
-		auto const &stateNew = state_new_cc_[lev].array(iter);
-		auto [fluxArraysOld, fluxDiffusiveArraysOld] = computeRadiationFluxes(stateOld, indexRange, ncompHyperbolic_, dx);
-		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateInter, indexRange, ncompHyperbolic_, dx);
+		auto const &stateOld_cc = state_old_cc_[lev].const_array(iter);
+		auto const &stateInter_cc = state_new_cc_[lev].const_array(iter);
+		auto const &stateNew_cc = state_new_cc_[lev].array(iter);
+		auto [fluxArraysOld, fluxDiffusiveArraysOld] = computeRadiationFluxes(stateOld_cc, indexRange, ncompHyperbolic_, dx);
+		auto [fluxArrays, fluxDiffusiveArrays] = computeRadiationFluxes(stateInter_cc, indexRange, ncompHyperbolic_, dx);
 
 		// Stage 2 of RK2-SSP
 		RadSystem<problem_t>::AddFluxesRK2(
-		    stateNew, stateOld, stateInter, {AMREX_D_DECL(fluxArraysOld[0].array(), fluxArraysOld[1].array(), fluxArraysOld[2].array())},
+		    stateNew_cc, stateOld_cc, stateInter_cc, {AMREX_D_DECL(fluxArraysOld[0].array(), fluxArraysOld[1].array(), fluxArraysOld[2].array())},
 		    {AMREX_D_DECL(fluxArrays[0].array(), fluxArrays[1].array(), fluxArrays[2].array())},
 		    {AMREX_D_DECL(fluxDiffusiveArraysOld[0].const_array(), fluxDiffusiveArraysOld[1].const_array(), fluxDiffusiveArraysOld[2].const_array())},
 		    {AMREX_D_DECL(fluxDiffusiveArrays[0].const_array(), fluxDiffusiveArrays[1].const_array(), fluxDiffusiveArrays[2].const_array())},

--- a/src/hydro/EOS.hpp
+++ b/src/hydro/EOS.hpp
@@ -39,7 +39,6 @@ template <typename problem_t> struct EOS_Traits {
 template <typename problem_t> class EOS
 {
       private:
-	static constexpr amrex::Real gamma_ = EOS_Traits<problem_t>::gamma;
 	static constexpr amrex::Real mean_molecular_weight_ = EOS_Traits<problem_t>::mean_molecular_weight;
 
       public:
@@ -68,6 +67,8 @@ template <typename problem_t> class EOS
 	ComputeSoundSpeed(amrex::Real rho, amrex::Real Pressure, std::optional<amrex::GpuArray<amrex::Real, nmscalars_>> const &massScalars = {})
 	    -> amrex::Real;
 
+	static constexpr amrex::Real gamma_ = EOS_Traits<problem_t>::gamma; // needed for HLLD solver
+
 	static constexpr amrex::Real boltzmann_constant_ = []() constexpr {
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			return C::k_B;
@@ -95,8 +96,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeTgasFromEin
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -139,8 +140,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromTga
 	amrex::Real const Tgas_value = Tgas;
 	chemstate.T = Tgas_value;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -180,8 +181,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeEintFromPre
 	chemstate.rho = rho;
 	chemstate.p = Pressure;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -217,13 +218,14 @@ EOS<problem_t>::ComputeEintTempDerivative(const amrex::Real rho, const amrex::Re
 	amrex::Real dEint_dT = NAN;
 
 #ifdef CHEMISTRY
+	amrex::ignore_unused(Tgas);
 	eos_t chemstate;
 	chemstate.rho = rho;
 	// we don't need Tgas to find chemstate.dedT, but we still need to initialize chemstate.T because we are using the 'rt' EOS mode
 	chemstate.T = NAN;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -270,8 +272,8 @@ EOS<problem_t>::ComputeOtherDerivatives(const amrex::Real rho, const amrex::Real
 	chemstate.rho = rho;
 	chemstate.p = P;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -319,8 +321,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputePressure(am
 	chemstate.rho = rho;
 	chemstate.e = Eint / rho;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {
@@ -365,8 +367,8 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto EOS<problem_t>::ComputeSoundSpeed(
 	chemstate.rho = rho;
 	chemstate.p = Pressure;
 	// initialize array of number densities
-	for (int ii = 0; ii < NumSpec; ++ii) {
-		chemstate.xn[ii] = -1.0;
+	for (double &ii : chemstate.xn) {
+		ii = -1.0;
 	}
 
 	if (massScalars) {

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -14,53 +14,28 @@ namespace quokka::Riemann
 {
 constexpr double DELTA = 1.0e-4;
 
-template <class T> constexpr auto SQUARE(const T x) -> T { return x * x; }
-
-// density, momentum, total energy, transverse magnetic field
-struct ConsHydro1D {
-	double rho; // density
-	double mx;  // x-momentum
-	double my;  // y-momentum
-	double mz;  // z-momentum
-	double E;   // total energy density
-	double by;  // y-magnetic field
-	double bz;  // z-magnetic field
-};
-
-template <int N_scalars, int N_mscalars>
-AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto FastMagnetoSonicSpeed(double gamma, quokka::HydroState<N_scalars, N_mscalars> const state, const double bx) -> double
-{
-	double gp = gamma * state.P;
-	double bx_sq = bx * bx;
-	double byz_sq = state.by * state.by + state.bz * state.bz;
-	double b_sq = bx_sq + byz_sq;
-	double bgp_p = b_sq + gp;
-	double bgp_m = b_sq - gp;
-	return std::sqrt(0.5 * (bgp_p + std::sqrt(bgp_m * bgp_m + 4.0 * gp * byz_sq)) / state.rho);
-}
-
 // HLLD solver following Miyoshi and Kusano (2005), hereafter MK5.
 template <typename problem_t, int N_scalars, int N_mscalars, int fluxdim>
 AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_mscalars> const &sL, quokka::HydroState<N_scalars, N_mscalars> const &sR,
-					      const double gamma, const double bx) -> quokka::valarray<double, fluxdim>
+					      const double gamma, const double bx) -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
 {
 	//--- Step 1. Compute L/R states
 
 	// initialize left and right conserved states
-	ConsHydro1D u_L{};
-	ConsHydro1D u_R{};
+	ConsHydro1D<N_scalars> u_L{};
+	ConsHydro1D<N_scalars> u_R{};
 	// initialize temporary container to store flux across interface
-	ConsHydro1D f_x{};
+	quokka::valarray<double, fluxdim> F_x = {};
 	// initialize fluxes at left and right side of the interface
-	ConsHydro1D f_L{};
-	ConsHydro1D f_R{};
+	ConsHydro1D<N_scalars> f_L{};
+	ConsHydro1D<N_scalars> f_R{};
 	// initialise signal speeds (left to right)
 	std::array<double, 5> spds{};
 	// initialise four intermediate conserved states
-	ConsHydro1D u_star_L{};
-	ConsHydro1D u_dstar_L{};
-	ConsHydro1D u_dstar_R{};
-	ConsHydro1D u_star_R{};
+	ConsHydro1D<N_scalars> u_star_L{};
+	ConsHydro1D<N_scalars> u_dstar_L{};
+	ConsHydro1D<N_scalars> u_dstar_R{};
+	ConsHydro1D<N_scalars> u_star_R{};
 
 	// frequently used term
 	double const bx_sq = SQUARE(bx);
@@ -79,6 +54,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	u_L.my = sL.v * u_L.rho;
 	u_L.mz = sL.w * u_L.rho;
 	u_L.E = ke_L + pb_L + sL.P / (gamma - 1.0); // TODO(neco): generalise EOS
+	u_L.Eint = sL.Eint;
 	u_L.by = sL.by;
 	u_L.bz = sL.bz;
 	// set right conserved states
@@ -87,15 +63,23 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	u_R.my = sR.v * u_R.rho;
 	u_R.mz = sR.w * u_R.rho;
 	u_R.E = ke_R + pb_R + sR.P / (gamma - 1.0);
+	u_R.Eint = sR.Eint;
 	u_R.by = sR.by;
 	u_R.bz = sR.bz;
 
+	for (int n = 0; n < N_scalars; ++n) {
+		u_L.scalar[n] = sL.scalar[n];
+		u_R.scalar[n] = sR.scalar[n];
+	}
+
 	//--- Step 2. Compute L & R wave speeds according to MK5, eqn. (67)
 
-	const double cfs_L = FastMagnetoSonicSpeed(gamma, sL, bx);
-	const double cfs_R = FastMagnetoSonicSpeed(gamma, sR, bx);
-	spds[0] = std::min(sL.u - cfs_L, sR.u - cfs_R);
-	spds[4] = std::max(sL.u + cfs_L, sR.u + cfs_R);
+	const double fspd_L = FastMagnetoSonicSpeed(gamma, sL, bx);
+	const double fspd_R = FastMagnetoSonicSpeed(gamma, sR, bx);
+	spds[0] = std::min(sL.u - fspd_L, sR.u - fspd_R);
+	spds[4] = std::max(sL.u + fspd_L, sR.u + fspd_R);
+	const double fspd_m = -std::min(0.0, spds[0]);
+	const double fspd_p = std::max(0.0, spds[4]);
 
 	//--- Step 3. Compute L/R fluxes
 
@@ -105,19 +89,27 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// fluxes on the left side of the interface
 	f_L.rho = u_L.mx;
 	f_L.mx = u_L.mx * sL.u + ptot_L - bx_sq;
-	f_L.my = u_L.my * sL.u + bx * u_L.by;
-	f_L.mz = u_L.mz * sL.u + bx * u_L.bz;
+	f_L.my = u_L.my * sL.u - bx * u_L.by;
+	f_L.mz = u_L.mz * sL.u - bx * u_L.bz;
 	f_L.E = sL.u * (u_L.E + ptot_L - bx_sq) - bx * (sL.v * u_L.by + sL.w * u_L.bz);
+	f_L.Eint = u_L.Eint * sL.u;
 	f_L.by = u_L.by * sL.u - bx * sL.v;
 	f_L.bz = u_L.bz * sL.u - bx * sL.w;
 	// fluxes on the right side of the interface
 	f_R.rho = u_R.mx;
 	f_R.mx = u_R.mx * sR.u + ptot_R - bx_sq;
-	f_R.my = u_R.my * sR.u + bx * u_R.by;
-	f_R.mz = u_R.mz * sR.u + bx * u_R.bz;
+	f_R.my = u_R.my * sR.u - bx * u_R.by;
+	f_R.mz = u_R.mz * sR.u - bx * u_R.bz;
 	f_R.E = sR.u * (u_R.E + ptot_R - bx_sq) - bx * (sR.v * u_R.by + sR.w * u_R.bz);
+	f_R.Eint = u_R.Eint * sR.u;
 	f_R.by = u_R.by * sR.u - bx * sR.v;
 	f_R.bz = u_R.bz * sR.u - bx * sR.w;
+
+	// passive scalar fluxes right and left
+	for (int n = 0; n < N_scalars; ++n) {
+		f_L.scalar[n] = u_L.scalar[n] * sL.u;
+		f_R.scalar[n] = u_R.scalar[n] * sR.u;
+	}
 
 	//--- Step 4. Compute middle and Alfven wave speeds
 
@@ -135,6 +127,13 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// MK5: rho_i from eqn (43)
 	u_star_L.rho = u_L.rho * siui_L * sism_inv_L;
 	u_star_R.rho = u_R.rho * siui_R * sism_inv_R;
+	u_star_L.Eint = u_L.Eint * siui_L * sism_inv_L;
+	u_star_R.Eint = u_R.Eint * siui_R * sism_inv_R;
+	for (int n = 0; n < N_scalars; ++n) {
+		u_star_L.scalar[n] = u_L.scalar[n] * siui_L * sism_inv_L;
+		u_star_R.scalar[n] = u_R.scalar[n] * siui_R * sism_inv_R;
+	}
+
 	double u_star_rho_inv_L = 1.0 / u_star_L.rho;
 	double u_star_rho_inv_R = 1.0 / u_star_R.rho;
 	double rho_sqrt_L = std::sqrt(u_star_L.rho);
@@ -147,13 +146,13 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 
 	// compute total pressure
 	// MK5: eqn (41) can be calculated (more explicitly) via eqn (23)
-	double ptot_star_L = ptot_L - u_L.rho * siui_L * (spds[2] - sL.u);
-	double ptot_star_R = ptot_R - u_R.rho * siui_R * (spds[2] - sR.u);
-	double ptot_star = 0.5 * (ptot_star_L + ptot_star_R);
+	double ptot_star_L = ptot_L + u_L.rho * siui_L * (spds[2] - sL.u);
+	double ptot_star_R = ptot_R + u_R.rho * siui_R * (spds[2] - sR.u);
+	double const ptot_star = 0.5 * (ptot_star_L + ptot_star_R);
 
 	// MK5: u_L^(star, dstar) from, eqn (39)
 	u_star_L.mx = u_star_L.rho * spds[2];
-	if (std::abs(u_L.rho * siui_L * sism_L - bx_sq) < (DELTA)*ptot_star) {
+	if (std::abs(u_L.rho * siui_L * sism_L - bx_sq) < DELTA * ptot_star) {
 		// degenerate case
 		u_star_L.my = u_star_L.rho * sL.v;
 		u_star_L.mz = u_star_L.rho * sL.w;
@@ -177,7 +176,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 
 	// MK5: u_R^(star, dstar) from, eqn (39)
 	u_star_R.mx = u_star_R.rho * spds[2];
-	if (std::abs(u_R.rho * siui_R * sism_R - bx_sq) < (DELTA)*ptot_star) {
+	if (std::abs(u_R.rho * siui_R * sism_R - bx_sq) < DELTA * ptot_star) {
 		// degenerate case
 		u_star_R.my = u_star_R.rho * sR.v;
 		u_star_R.mz = u_star_R.rho * sR.w;
@@ -200,7 +199,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	u_star_R.E = (siui_R * u_R.E - ptot_R * sR.u + ptot_star * spds[2] + bx * (sR.u * bx + (sR.v * u_R.by + sR.w * u_R.bz) - vb_star_R)) * sism_inv_R;
 
 	// if Bx is near zero, then u_i^dstar = u_i^star
-	if (0.5 * bx_sq < (DELTA)*ptot_star) {
+	if (0.5 * bx_sq < DELTA * ptot_star) {
 		u_dstar_L = u_star_L;
 		u_dstar_R = u_star_R;
 	} else {
@@ -210,6 +209,13 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 		u_dstar_R.rho = u_star_R.rho;
 		u_dstar_L.mx = u_star_L.mx;
 		u_dstar_R.mx = u_star_R.mx;
+		u_dstar_L.Eint = u_star_L.Eint;
+		u_dstar_R.Eint = u_star_R.Eint;
+		for (int n = 0; n < N_scalars; ++n) {
+			u_dstar_L.scalar[n] = u_star_L.scalar[n];
+			u_dstar_R.scalar[n] = u_star_R.scalar[n];
+		}
+
 		// MK5: eqn (59)
 		double tmp = rho_sum_inv * (rho_sqrt_L * (u_star_L.my * u_star_rho_inv_L) + rho_sqrt_R * (u_star_R.my * u_star_rho_inv_R) +
 					    bx_sign * (u_star_R.by - u_star_L.by));
@@ -236,99 +242,68 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 		u_dstar_R.E = u_star_R.E + rho_sqrt_R * bx_sign * (vb_star_R - tmp);
 	}
 
+	// Convert to arrays for simplified math
+
+	quokka::valarray<double, fluxdim> U_L_array = {u_L.rho, u_L.mx, u_L.my, u_L.mz, u_L.E, u_L.Eint};
+	quokka::valarray<double, fluxdim> U_R_array = {u_R.rho, u_R.mx, u_R.my, u_R.mz, u_R.E, u_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		U_L_array[nstart + n] = u_L.scalar[n];
+		U_R_array[nstart + n] = u_R.scalar[n];
+	}
+
+	quokka::valarray<double, fluxdim> U_star_L_array = {u_star_L.rho, u_star_L.mx, u_star_L.my, u_star_L.mz, u_star_L.E, u_star_L.Eint};
+	quokka::valarray<double, fluxdim> U_star_R_array = {u_star_R.rho, u_star_R.mx, u_star_R.my, u_star_R.mz, u_star_R.E, u_star_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		U_star_L_array[nstart + n] = u_star_L.scalar[n];
+		U_star_R_array[nstart + n] = u_star_R.scalar[n];
+	}
+
+	quokka::valarray<double, fluxdim> U_dstar_L_array = {u_dstar_L.rho, u_dstar_L.mx, u_dstar_L.my, u_dstar_L.mz, u_dstar_L.E, u_dstar_L.Eint};
+	quokka::valarray<double, fluxdim> U_dstar_R_array = {u_dstar_R.rho, u_dstar_R.mx, u_dstar_R.my, u_dstar_R.mz, u_dstar_R.E, u_dstar_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		U_dstar_L_array[nstart + n] = u_dstar_L.scalar[n];
+		U_dstar_R_array[nstart + n] = u_dstar_R.scalar[n];
+	}
+
+	quokka::valarray<double, fluxdim> F_L_array = {f_L.rho, f_L.mx, f_L.my, f_L.mz, f_L.E, f_L.Eint};
+	quokka::valarray<double, fluxdim> F_R_array = {f_R.rho, f_R.mx, f_R.my, f_R.mz, f_R.E, f_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		F_L_array[nstart + n] = f_L.scalar[n];
+		F_R_array[nstart + n] = f_R.scalar[n];
+	}
+
+	U_dstar_L_array = spds[1] * (U_dstar_L_array - U_star_L_array);
+	U_star_L_array = spds[0] * (U_star_L_array - U_L_array);
+	U_dstar_R_array = spds[3] * (U_dstar_R_array - U_star_R_array);
+	U_star_R_array = spds[4] * (U_star_R_array - U_R_array);
+
 	//--- Step 6. Compute fluxes
-
-	u_dstar_L.rho = spds[1] * (u_dstar_L.rho - u_star_L.rho);
-	u_dstar_L.mx = spds[1] * (u_dstar_L.mx - u_star_L.mx);
-	u_dstar_L.my = spds[1] * (u_dstar_L.my - u_star_L.my);
-	u_dstar_L.mz = spds[1] * (u_dstar_L.mz - u_star_L.mz);
-	u_dstar_L.E = spds[1] * (u_dstar_L.E - u_star_L.E);
-	u_dstar_L.by = spds[1] * (u_dstar_L.by - u_star_L.by);
-	u_dstar_L.bz = spds[1] * (u_dstar_L.bz - u_star_L.bz);
-
-	u_star_L.rho = spds[0] * (u_star_L.rho - u_L.rho);
-	u_star_L.mx = spds[0] * (u_star_L.mx - u_L.mx);
-	u_star_L.my = spds[0] * (u_star_L.my - u_L.my);
-	u_star_L.mz = spds[0] * (u_star_L.mz - u_L.mz);
-	u_star_L.E = spds[0] * (u_star_L.E - u_L.E);
-	u_star_L.by = spds[0] * (u_star_L.by - u_L.by);
-	u_star_L.bz = spds[0] * (u_star_L.bz - u_L.bz);
-
-	u_dstar_R.rho = spds[3] * (u_dstar_R.rho - u_star_R.rho);
-	u_dstar_R.mx = spds[3] * (u_dstar_R.mx - u_star_R.mx);
-	u_dstar_R.my = spds[3] * (u_dstar_R.my - u_star_R.my);
-	u_dstar_R.mz = spds[3] * (u_dstar_R.mz - u_star_R.mz);
-	u_dstar_R.E = spds[3] * (u_dstar_R.E - u_star_R.E);
-	u_dstar_R.by = spds[3] * (u_dstar_R.by - u_star_R.by);
-	u_dstar_R.bz = spds[3] * (u_dstar_R.bz - u_star_R.bz);
-
-	u_star_R.rho = spds[4] * (u_star_R.rho - u_R.rho);
-	u_star_R.mx = spds[4] * (u_star_R.mx - u_R.mx);
-	u_star_R.my = spds[4] * (u_star_R.my - u_R.my);
-	u_star_R.mz = spds[4] * (u_star_R.mz - u_R.mz);
-	u_star_R.E = spds[4] * (u_star_R.E - u_R.E);
-	u_star_R.by = spds[4] * (u_star_R.by - u_R.by);
-	u_star_R.bz = spds[4] * (u_star_R.bz - u_R.bz);
 
 	if (spds[0] >= 0.0) {
 		// return u_L if flow is supersonic
-		f_x.rho = f_L.rho;
-		f_x.mx = f_L.mx;
-		f_x.my = f_L.my;
-		f_x.mz = f_L.mz;
-		f_x.E = f_L.E;
-		f_x.by = f_L.by;
-		f_x.bz = f_L.bz;
+		F_x = F_L_array;
 	} else if (spds[4] <= 0.0) {
 		// return u_R if flow is supersonic
-		f_x.rho = f_R.rho;
-		f_x.mx = f_R.mx;
-		f_x.my = f_R.my;
-		f_x.mz = f_R.mz;
-		f_x.E = f_R.E;
-		f_x.by = f_R.by;
-		f_x.bz = f_R.bz;
+		F_x = F_R_array;
 	} else if (spds[1] >= 0.0) {
 		// return u_star_L
-		f_x.rho = f_L.rho + u_star_L.rho;
-		f_x.mx = f_L.mx + u_star_L.mx;
-		f_x.my = f_L.my + u_star_L.my;
-		f_x.mz = f_L.mz + u_star_L.mz;
-		f_x.E = f_L.E + u_star_L.E;
-		f_x.by = f_L.by + u_star_L.by;
-		f_x.bz = f_L.bz + u_star_L.bz;
+		F_x = F_L_array + U_star_L_array;
 	} else if (spds[2] >= 0.0) {
 		// return u_dstar_L
-		f_x.rho = f_L.rho + u_star_L.rho + u_dstar_L.rho;
-		f_x.mx = f_L.mx + u_star_L.mx + u_dstar_L.mx;
-		f_x.my = f_L.my + u_star_L.my + u_dstar_L.my;
-		f_x.mz = f_L.mz + u_star_L.mz + u_dstar_L.mz;
-		f_x.E = f_L.E + u_star_L.E + u_dstar_L.E;
-		f_x.by = f_L.by + u_star_L.by + u_dstar_L.by;
-		f_x.bz = f_L.bz + u_star_L.bz + u_dstar_L.bz;
+		F_x = F_L_array + U_star_L_array + U_dstar_L_array;
 	} else if (spds[3] > 0.0) {
 		// return u_dstar_R
-		f_x.rho = f_R.rho + u_star_R.rho + u_dstar_R.rho;
-		f_x.mx = f_R.mx + u_star_R.mx + u_dstar_R.mx;
-		f_x.my = f_R.my + u_star_R.my + u_dstar_R.my;
-		f_x.mz = f_R.mz + u_star_R.mz + u_dstar_R.mz;
-		f_x.E = f_R.E + u_star_R.E + u_dstar_R.E;
-		f_x.by = f_R.by + u_star_R.by + u_dstar_R.by;
-		f_x.bz = f_R.bz + u_star_R.bz + u_dstar_R.bz;
+		F_x = F_R_array + U_star_R_array + U_dstar_R_array;
 	} else {
 		// return u_star_R
-		f_x.rho = f_R.rho + u_star_R.rho;
-		f_x.mx = f_R.mx + u_star_R.mx;
-		f_x.my = f_R.my + u_star_R.my;
-		f_x.mz = f_R.mz + u_star_R.mz;
-		f_x.E = f_R.E + u_star_R.E;
-		f_x.by = f_R.by + u_star_R.by;
-		f_x.bz = f_R.bz + u_star_R.bz;
+		F_x = F_R_array + U_star_R_array;
 	}
 
-	// TODO(neco): Eint=0 for now; pscalars will also be needed in the future.
-	quokka::valarray<double, fluxdim> F_hydro = {f_x.rho, f_x.mx, f_x.my, f_x.mz, f_x.E, 0.0};
-	return F_hydro;
+	return std::make_tuple(std::move(F_x), fspd_m, fspd_p);
 }
 } // namespace quokka::Riemann
 

--- a/src/hydro/HydroState.hpp
+++ b/src/hydro/HydroState.hpp
@@ -2,6 +2,7 @@
 #define HYDROSTATE_HPP_
 
 #include "AMReX_Array.H"
+#include "util/valarray.hpp"
 
 namespace quokka
 {
@@ -21,5 +22,32 @@ template <int Nall, int Nmass> struct HydroState {
 };
 
 } // namespace quokka
+
+// density, momentum, total energy, transverse magnetic field
+template <int N_passiveScalars> struct ConsHydro1D {
+	double rho;					   // density
+	double mx;					   // x-momentum
+	double my;					   // y-momentum
+	double mz;					   // z-momentum
+	double E;					   // total energy density
+	double Eint;					   // specific internal energy
+	double by;					   // y-magnetic field
+	double bz;					   // z-magnetic field
+	quokka::valarray<double, N_passiveScalars> scalar; // passive scalars, problem defined
+};
+
+template <class T> constexpr auto SQUARE(const T x) -> T { return x * x; }
+
+template <int N_scalars, int N_mscalars>
+AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto FastMagnetoSonicSpeed(double gamma, quokka::HydroState<N_scalars, N_mscalars> const state, const double bx) -> double
+{
+	double gamma_pressure = gamma * state.P;
+	double byz_sq = SQUARE(state.by) + SQUARE(state.bz);
+	double const b_sq = SQUARE(bx) + byz_sq;
+	double const b_plus_gamma_pressure = b_sq + gamma_pressure;
+	double const b_minus_gamma_pressure = b_sq - gamma_pressure;
+	return std::sqrt(0.5 * (b_plus_gamma_pressure + std::sqrt(b_minus_gamma_pressure * b_minus_gamma_pressure + 4.0 * gamma_pressure * byz_sq)) /
+			 state.rho);
+}
 
 #endif // HYDROSTATE_HPP_

--- a/src/hydro/LLF_mhd.hpp
+++ b/src/hydro/LLF_mhd.hpp
@@ -1,0 +1,123 @@
+#ifndef LLF_MHD_HPP_ // NOLINT
+#define LLF_MHD_HPP_
+
+#include "AMReX_Extension.H"
+#include "AMReX_GpuQualifiers.H"
+#include <AMReX.H>
+#include <AMReX_REAL.H>
+
+#include "hydro/HydroState.hpp"
+#include "util/valarray.hpp"
+
+namespace quokka::Riemann
+{
+// Local Lax-Friedrichs (LLF) / Rusanov solver
+template <typename problem_t, int N_scalars, int N_mscalars, int fluxdim>
+AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto LLF_MHD(quokka::HydroState<N_scalars, N_mscalars> const &sL, quokka::HydroState<N_scalars, N_mscalars> const &sR,
+						 const double gamma, const double bx) -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
+{
+	// initialize left and right conserved states
+	ConsHydro1D<N_scalars> u_L{};
+	ConsHydro1D<N_scalars> u_R{};
+	// initialize fluxes at left and right side of the interface
+	ConsHydro1D<N_scalars> f_L{};
+	ConsHydro1D<N_scalars> f_R{};
+	quokka::valarray<double, fluxdim> Du = {};
+	quokka::valarray<double, fluxdim> F = {};
+
+	double const bx_sq = SQUARE(bx);
+
+	// compute L/R states for select conserved variables
+	// (group transverse vector components for floating-point associativity symmetry)
+	// magnetic pressure
+	double const pb_L = 0.5 * (bx_sq + (SQUARE(sL.by) + SQUARE(sL.bz)));
+	double const pb_R = 0.5 * (bx_sq + (SQUARE(sR.by) + SQUARE(sR.bz)));
+	// kinetic energy
+	double const ke_L = 0.5 * sL.rho * (SQUARE(sL.u) + (SQUARE(sL.v) + SQUARE(sL.w)));
+	double const ke_R = 0.5 * sR.rho * (SQUARE(sR.u) + (SQUARE(sR.v) + SQUARE(sR.w)));
+
+	double ptot_L = sL.P + pb_L;
+	double ptot_R = sR.P + pb_R;
+
+	const double fspd_L = FastMagnetoSonicSpeed(gamma, sL, bx);
+	const double fspd_R = FastMagnetoSonicSpeed(gamma, sR, bx);
+	const double fspd_m = -std::min(0.0, std::min(sL.u - fspd_L, sR.u - fspd_R));
+	const double fspd_p = std::max(0.0, std::max(sL.u + fspd_L, sR.u + fspd_R));
+
+	// set left conserved states
+	u_L.rho = sL.rho;
+	u_L.mx = sL.u * u_L.rho;
+	u_L.my = sL.v * u_L.rho;
+	u_L.mz = sL.w * u_L.rho;
+	u_L.E = ke_L + pb_L + sL.P / (gamma - 1.0);
+	u_L.Eint = sL.Eint;
+	u_L.by = sL.by;
+	u_L.bz = sL.bz;
+	// set right conserved states
+	u_R.rho = sR.rho;
+	u_R.mx = sR.u * u_R.rho;
+	u_R.my = sR.v * u_R.rho;
+	u_R.mz = sR.w * u_R.rho;
+	u_R.E = ke_R + pb_R + sR.P / (gamma - 1.0);
+	u_R.Eint = sR.Eint;
+	u_R.by = sR.by;
+	u_R.bz = sR.bz;
+
+	//--- Step 2.  Compute wave speeds in L,R states (see Toro eq. 10.43)
+
+	const amrex::Real a = 0.5 * std::max(std::abs(sL.u) + fspd_L, std::abs(sR.u) + fspd_R);
+	//--- Step 3.  Compute L/R fluxes
+	// fluxes on the left side of the interface, non-barotropic case
+	f_L.rho = u_L.mx;
+	f_L.mx = u_L.mx * sL.u + ptot_L - bx_sq;
+	f_L.my = u_L.my * sL.u - bx * u_L.by;
+	f_L.mz = u_L.mz * sL.u - bx * u_L.bz;
+	f_L.E = sL.u * (u_L.E + ptot_L - bx_sq) - bx * (sL.v * u_L.by + sL.w * u_L.bz);
+	f_L.Eint = u_L.Eint * sL.u;
+	f_L.by = u_L.by * sL.u - bx * sL.v;
+	f_L.bz = u_L.bz * sL.u - bx * sL.w;
+	// fluxes on the right side of the interface
+	f_R.rho = u_R.mx;
+	f_R.mx = u_R.mx * sR.u + ptot_R - bx_sq;
+	f_R.my = u_R.my * sR.u - bx * u_R.by;
+	f_R.mz = u_R.mz * sR.u - bx * u_R.bz;
+	f_R.E = sR.u * (u_R.E + ptot_R - bx_sq) - bx * (sR.v * u_R.by + sR.w * u_R.bz);
+	f_R.Eint = u_R.Eint * sR.u;
+	f_R.by = u_R.by * sR.u - bx * sR.v;
+	f_R.bz = u_R.bz * sR.u - bx * sR.w;
+
+	// passive scalar fluxes right and left
+	for (int n = 0; n < N_scalars; ++n) {
+		f_L.scalar[n] = u_L.scalar[n] * sL.u;
+		f_R.scalar[n] = u_R.scalar[n] * sR.u;
+	}
+
+	// convert to arrays for simplified math
+	quokka::valarray<double, fluxdim> U_L_array = {u_L.rho, u_L.mx, u_L.my, u_L.mz, u_L.E, u_L.Eint};
+	quokka::valarray<double, fluxdim> U_R_array = {u_R.rho, u_R.mx, u_R.my, u_R.mz, u_R.E, u_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		U_L_array[nstart + n] = u_L.scalar[n];
+		U_R_array[nstart + n] = u_R.scalar[n];
+	}
+	quokka::valarray<double, fluxdim> F_L_array = {f_L.rho, f_L.mx, f_L.my, f_L.mz, f_L.E, f_L.Eint};
+	quokka::valarray<double, fluxdim> F_R_array = {f_R.rho, f_R.mx, f_R.my, f_R.mz, f_R.E, f_R.Eint};
+	for (int n = 0; n < N_scalars; ++n) {
+		const int nstart = fluxdim - N_scalars;
+		F_L_array[nstart + n] = f_L.scalar[n];
+		F_R_array[nstart + n] = f_R.scalar[n];
+	}
+
+	//--- Step 4.  Compute difference in L/R states dU
+
+	Du = U_R_array - U_L_array;
+
+	//--- Step 5.  Compute the LLF flux at interface (see Toro eq. 10.42).
+
+	F = 0.5 * (F_L_array + F_R_array) - a * Du;
+
+	return std::make_tuple(std::move(F), fspd_m, fspd_p);
+}
+} // namespace quokka::Riemann
+
+#endif // LLF_MHD_HPP_

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -10,20 +10,25 @@
 ///
 
 // c++ headers
+#include <algorithm>
 #include <cmath>
 
 // library headers
 #include "AMReX.H"
 #include "AMReX_Array4.H"
 #include "AMReX_BLassert.H"
+#include "AMReX_MultiFabUtil.H"
+#include "AMReX_Print.H"
 #include "AMReX_REAL.H"
+#include "AMReX_SPACE.H"
 #include "AMReX_iMultiFab.H"
 
 // internal headers
+#include "EOS.hpp"
 #include "HLLC.hpp"
 #include "HLLD.hpp"
 #include "LLF.hpp"
-#include "hydro/EOS.hpp"
+#include "LLF_mhd.hpp"
 #include "hyperbolic_system.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
@@ -40,7 +45,7 @@ template <typename problem_t> struct HydroSystem_Traits {
 	static constexpr bool reconstruct_eint = true;
 };
 
-enum class RiemannSolver { HLLC, LLF, HLLD };
+enum class RiemannSolver { HLLC, LLF, LLF_MHD, HLLD };
 
 /// Class for the Euler equations of inviscid hydrodynamics
 ///
@@ -67,15 +72,21 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 		x2Velocity_index,
 		x3Velocity_index,
 		pressure_index,
-		primEint_index,	  // auxiliary internal energy (rho * e)
-		primScalar0_index // first passive scalar (only present if nscalars > 0!)
+		primEint_index,	   // auxiliary internal energy (rho * e)
+		primScalar0_index, // first passive scalar (only present if nscalars > 0!)
+		// TODO(benwibking): = check what is enabled
+		x2Magnetic_index, // when magnetic fields exist, then we also store cc-ave of the two orthogonal b-fields, so they can be reconstructed to the
+				  // solving face
+		x3Magnetic_index,
 	};
 
-	static void ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, int nghost);
+	static void ConservedToPrimitive(amrex::MultiFab const &cons_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf,
+					 amrex::MultiFab &primVar_mf, int nghost);
 
 	static auto maxSignalSpeedLocal(amrex::MultiFab const &cons) -> amrex::Real;
 
-	static void ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange);
+	static void ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons_cc, std::array<amrex::Array4<const amrex::Real>, 3> const &cons_fc,
+					  array_t &maxSignal, amrex::Box const &indexRange);
 
 	static auto CheckStatesValid(amrex::MultiFab const &cons_mf) -> bool;
 
@@ -111,11 +122,12 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &faceVelArray, amrex::iMultiFab const &redoFlag_mf);
 
-	static void SyncDualEnergy(amrex::MultiFab &consVar_mf);
+	static void SyncDualEnergy(amrex::MultiFab &consVar_mf, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &faceVar_mf);
 
 	template <RiemannSolver RIEMANN, FluxDir DIR>
 	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc, int nghost_vel = 2);
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc,
+				  amrex::MultiFab *x1FSpds_mf = nullptr, amrex::MultiFab const *x1ConsVar_fc_mf = nullptr, int nghost_vel = 2);
 
 	template <FluxDir DIR>
 	static void ComputeFirstOrderFluxes(amrex::Array4<const amrex::Real> const &consVar, array_t &x1FluxDiffusive, amrex::Box const &indexRange);
@@ -135,20 +147,39 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 	static constexpr bool reconstruct_eint = HydroSystem_Traits<problem_t>::reconstruct_eint;
 };
 
-template <typename problem_t> void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_mf, amrex::MultiFab &primVar_mf, const int nghost)
+template <typename problem_t>
+void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf,
+						  amrex::MultiFab &primVar_mf, const int nghost)
 {
 	// convert conserved to primitive variables
-	auto const &cons = cons_mf.const_arrays();
+	auto const &cons_fc_x0 = cons_fc_mf[0].const_arrays();
+#if AMREX_SPACEDIM >= 2
+	auto const &cons_fc_x1 = cons_fc_mf[1].const_arrays();
+#endif
+#if AMREX_SPACEDIM == 3
+	auto const &cons_fc_x2 = cons_fc_mf[2].const_arrays();
+#endif
+	auto const &cons_cc = cons_cc_mf.const_arrays();
 	auto const &primVar = primVar_mf.arrays();
 	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
 
-	amrex::ParallelFor(cons_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-		const auto rho = cons[bx](i, j, k, density_index);
-		const auto px = cons[bx](i, j, k, x1Momentum_index);
-		const auto py = cons[bx](i, j, k, x2Momentum_index);
-		const auto pz = cons[bx](i, j, k, x3Momentum_index);
-		const auto E = cons[bx](i, j, k, energy_index); // *total* gas energy per unit volume
-		const auto Eint_aux = cons[bx](i, j, k, internalEnergy_index);
+	amrex::ParallelFor(cons_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		// First-capture the magnetic field arrays by accessing them early
+		// This forces NVCC to capture them before the constexpr if block
+		[[maybe_unused]] auto fc_x0_ref = cons_fc_x0[bx];
+#if AMREX_SPACEDIM >= 2
+		[[maybe_unused]] auto fc_x1_ref = cons_fc_x1[bx];
+#endif
+#if AMREX_SPACEDIM == 3
+		[[maybe_unused]] auto fc_x2_ref = cons_fc_x2[bx];
+#endif
+
+		const amrex::Real rho = cons_cc[bx](i, j, k, density_index);
+		const amrex::Real px = cons_cc[bx](i, j, k, x1Momentum_index);
+		const amrex::Real py = cons_cc[bx](i, j, k, x2Momentum_index);
+		const amrex::Real pz = cons_cc[bx](i, j, k, x3Momentum_index);
+		const amrex::Real E = cons_cc[bx](i, j, k, energy_index); // *total* gas energy per unit volume
+		const amrex::Real Eint_aux = cons_cc[bx](i, j, k, internalEnergy_index);
 
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(px));
@@ -156,13 +187,32 @@ template <typename problem_t> void HydroSystem<problem_t>::ConservedToPrimitive(
 		AMREX_ASSERT(!std::isnan(pz));
 		AMREX_ASSERT(!std::isnan(E));
 
-		const auto vx = px / rho;
-		const auto vy = py / rho;
-		const auto vz = pz / rho;
-		const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
-		const auto Eint_cons = E - kinetic_energy;
+		const amrex::Real vx = px / rho;
+		const amrex::Real vy = py / rho;
+		const amrex::Real vz = pz / rho;
+		const amrex::Real kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+		amrex::Real magnetic_energy = 0.;
 
-		const amrex::Real Pgas = ComputePressure(cons[bx], i, j, k);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// note, bx is the box, and bxi is the magnetic-field component
+			const amrex::Real b_x0_m = fc_x0_ref(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x0_p = fc_x0_ref(i + 1, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x0 = 0.5 * (b_x0_m + b_x0_p);
+#if AMREX_SPACEDIM >= 2
+			const amrex::Real b_x1_m = fc_x1_ref(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x1_p = fc_x1_ref(i, j + 1, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x1 = 0.5 * (b_x1_m + b_x1_p);
+#endif
+#if AMREX_SPACEDIM == 3
+			const amrex::Real b_x2_m = fc_x2_ref(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x2_p = fc_x2_ref(i, j, k + 1, Physics_Indices<problem_t>::mhdFirstIndex);
+			const amrex::Real b_x2 = 0.5 * (b_x2_m + b_x2_p);
+#endif
+			magnetic_energy = 0.5 * (AMREX_D_TERM(b_x0 * b_x0, +b_x1 * b_x1, +b_x2 * b_x2));
+		}
+		const amrex::Real Eint_cons = E - kinetic_energy - magnetic_energy;
+
+		const amrex::Real Pgas = ComputePressure(cons_cc[bx], i, j, k);
 		const amrex::Real eint_cons = Eint_cons / rho;
 		const amrex::Real eint_aux = Eint_aux / rho;
 
@@ -190,7 +240,7 @@ template <typename problem_t> void HydroSystem<problem_t>::ConservedToPrimitive(
 
 		// copy any passive scalars
 		for (int nc = 0; nc < nscalars_; ++nc) {
-			primVar[bx](i, j, k, primScalar0_index + nc) = cons[bx](i, j, k, scalar0_index + nc);
+			primVar[bx](i, j, k, primScalar0_index + nc) = cons_cc[bx](i, j, k, scalar0_index + nc);
 		}
 	});
 }
@@ -221,13 +271,18 @@ template <typename problem_t> auto HydroSystem<problem_t>::maxSignalSpeedLocal(a
 }
 
 template <typename problem_t>
-void HydroSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons, array_t &maxSignal, amrex::Box const &indexRange)
+void HydroSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Real> const &cons_cc,
+						   std::array<amrex::Array4<const amrex::Real>, 3> const &cons_fc, array_t &maxSignal,
+						   amrex::Box const &indexRange)
 {
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-		const auto rho = cons(i, j, k, density_index);
-		const auto px = cons(i, j, k, x1Momentum_index);
-		const auto py = cons(i, j, k, x2Momentum_index);
-		const auto pz = cons(i, j, k, x3Momentum_index);
+		// First-capture by early access
+		[[maybe_unused]] const auto fc_ref = cons_fc;
+
+		const auto rho = cons_cc(i, j, k, density_index);
+		const auto px = cons_cc(i, j, k, x1Momentum_index);
+		const auto py = cons_cc(i, j, k, x2Momentum_index);
+		const auto pz = cons_cc(i, j, k, x3Momentum_index);
 		AMREX_ASSERT(!std::isnan(rho));
 		AMREX_ASSERT(!std::isnan(px));
 		AMREX_ASSERT(!std::isnan(py));
@@ -236,17 +291,44 @@ void HydroSystem<problem_t>::ComputeMaxSignalSpeed(amrex::Array4<const amrex::Re
 		const auto vx = px / rho;
 		const auto vy = py / rho;
 		const auto vz = pz / rho;
-		const double vel_mag = std::sqrt(vx * vx + vy * vy + vz * vz);
-		double cs = NAN;
+		const double vel_magnitude = std::sqrt(vx * vx + vy * vy + vz * vz);
+		double fastest_wavespeed = NAN;
 
-		if constexpr (is_eos_isothermal()) {
-			cs = cs_iso_;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			amrex::GpuArray<Real, nmscalars_> massScalars = RadSystem<problem_t>::ComputeMassScalars(cons_cc, i, j, k);
+			const auto total_energy = cons_cc(i, j, k, energy_index); // *total* gas energy per unit volume
+			const auto kinetic_energy = 0.5 * rho * (vx * vx + vy * vy + vz * vz);
+			const auto thermal_energy = total_energy - kinetic_energy;
+			const auto pressure = quokka::EOS<problem_t>::ComputePressure(rho, thermal_energy, massScalars);
+			double gp = quokka::EOS<problem_t>::gamma_ * pressure;
+
+			const auto bx1_m = fc_ref[0](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const auto bx1_p = fc_ref[0](i + 1, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const auto bx2_m = fc_ref[1](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const auto bx2_p = fc_ref[1](i, j + 1, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const auto bx3_m = fc_ref[2](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const auto bx3_p = fc_ref[2](i, j, k + 1, Physics_Indices<problem_t>::mhdFirstIndex);
+
+			const auto bx1 = 0.5 * (bx1_m + bx1_p);
+			const auto bx2 = 0.5 * (bx2_m + bx2_p);
+			const auto bx3 = 0.5 * (bx3_m + bx3_p);
+			double b_sq = bx1 * bx1 + bx2 * bx2 + bx3 * bx3;
+
+			double bgp_p = b_sq + gp;
+			double const bgp_m = b_sq - gp;
+			fastest_wavespeed = std::max({std::sqrt(0.5 * (bgp_p + std::sqrt(bgp_m * bgp_m + 4.0 * gp * (bx2 * bx2 + bx3 * bx3))) / rho),
+						      std::sqrt(0.5 * (bgp_p + std::sqrt(bgp_m * bgp_m + 4.0 * gp * (bx1 * bx1 + bx3 * bx3))) / rho),
+						      std::sqrt(0.5 * (bgp_p + std::sqrt(bgp_m * bgp_m + 4.0 * gp * (bx1 * bx1 + bx2 * bx2))) / rho)});
 		} else {
-			cs = ComputeSoundSpeed(cons, i, j, k);
+			if constexpr (is_eos_isothermal()) {
+				fastest_wavespeed = cs_iso_;
+			} else {
+				fastest_wavespeed = ComputeSoundSpeed(cons_cc, i, j, k);
+			}
+			AMREX_ASSERT(fastest_wavespeed > 0.);
 		}
-		AMREX_ASSERT(cs > 0.);
 
-		const double signal_max = cs + vel_mag;
+		const double signal_max = fastest_wavespeed + vel_magnitude;
 		maxSignal(i, j, k) = signal_max;
 	});
 }
@@ -272,7 +354,7 @@ template <typename problem_t> auto HydroSystem<problem_t>::CheckStatesValid(amre
 					const auto P = ComputePressure(cons[bx], i, j, k);
 
 					bool negativeDensity = (rho <= 0.);
-					bool negativePressure = (P <= 0.);
+					bool const negativePressure = (P <= 0.);
 
 					if constexpr (is_eos_isothermal()) {
 						if (negativeDensity) {
@@ -425,7 +507,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(am
 {
 	// check if cons(i, j, k) is a valid state
 	const amrex::Real rho = cons(i, j, k, density_index);
-	bool isDensityPositive = (rho > 0.);
+	bool const isDensityPositive = (rho > 0.);
 
 	bool isMassScalarPositive = true;
 	if constexpr (nmscalars_ > 0) {
@@ -457,10 +539,10 @@ void HydroSystem<problem_t>::ComputeRhsFromFluxes(amrex::MultiFab &rhs_mf, std::
 	// the interface on the right of zone i.
 
 	auto const x1Flux = fluxArray[0].const_arrays();
-#if AMREX_SPACEDIM >= 2
+#if (AMREX_SPACEDIM >= 2)
 	auto const x2Flux = fluxArray[1].const_arrays();
 #endif
-#if AMREX_SPACEDIM == 3
+#if (AMREX_SPACEDIM == 3)
 	auto const x3Flux = fluxArray[2].const_arrays();
 #endif
 	auto rhs = rhs_mf.arrays();
@@ -476,7 +558,7 @@ template <typename problem_t>
 void HydroSystem<problem_t>::PredictStep(amrex::MultiFab const &consVarOld_mf, amrex::MultiFab &consVarNew_mf, amrex::MultiFab const &rhs_mf, const double dt,
 					 const int nvars, amrex::iMultiFab &redoFlag_mf)
 {
-	BL_PROFILE("HydroSystem::PredictStep()");
+	const BL_PROFILE("HydroSystem::PredictStep()");
 
 	auto const &consVarOld = consVarOld_mf.const_arrays();
 	auto const &rhs = rhs_mf.const_arrays();
@@ -500,7 +582,7 @@ template <typename problem_t>
 void HydroSystem<problem_t>::AddFluxesRK2(amrex::MultiFab &Unew_mf, amrex::MultiFab const &U0_mf, amrex::MultiFab const &U1_mf, amrex::MultiFab const &rhs_mf,
 					  const double dt, const int nvars, amrex::iMultiFab &redoFlag_mf)
 {
-	BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
+	const BL_PROFILE("HydroSystem::AddFluxesRK2()");
 
 	auto const &U0 = U0_mf.const_arrays();
 	auto const &U1 = U1_mf.const_arrays();
@@ -652,7 +734,7 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 		// compute coefficient as the minimum from adjacent cells along *each
 		// axis*
 		//  (Eq. 86 of Miller & Colella 2001; Eq. 78 of Miller & Colella 2002)
-		double chi_ijk = std::min({
+		double const chi_ijk = std::min({
 		    x1Chi_in[bx](i_in - 1, j_in, k_in),
 		    x1Chi_in[bx](i_in, j_in, k_in),
 		    x1Chi_in[bx](i_in + 1, j_in, k_in),
@@ -685,12 +767,12 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 		x1LeftState(i + 1, j, k, n) = new_a_plus;
 	});
 
-	if constexpr (AMREX_SPACEDIM < 2) {
-		amrex::ignore_unused(x2Chi_in);
-	}
-	if constexpr (AMREX_SPACEDIM < 3) {
-		amrex::ignore_unused(x3Chi_in);
-	}
+#if (AMREX_SPACEDIM < 2)
+	amrex::ignore_unused(x2Chi_in);
+#endif
+#if (AMREX_SPACEDIM < 3)
+	amrex::ignore_unused(x3Chi_in);
+#endif
 }
 
 // to ensure that physical quantities are within reasonable
@@ -813,7 +895,8 @@ void HydroSystem<problem_t>::AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex
 	});
 }
 
-template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf)
+template <typename problem_t>
+void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &faceVar_mf)
 {
 	// sync internal energy and total energy
 	// this step must be done as an operator-split step after *each* RK stage
@@ -821,6 +904,13 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 	const amrex::Real eta = 1.0e-3; // dual energy parameter 'eta'
 
 	auto consVar = consVar_mf.arrays();
+	auto faceVar_x = faceVar_mf[0].const_arrays();
+#if AMREX_SPACEDIM >= 2
+	auto faceVar_y = faceVar_mf[1].const_arrays();
+#if AMREX_SPACEDIM == 3
+	auto faceVar_z = faceVar_mf[2].const_arrays();
+#endif
+#endif
 
 	amrex::ParallelFor(consVar_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 		amrex::Real const rho = consVar[bx](i, j, k, density_index);
@@ -835,8 +925,25 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 			amrex::Abort("density is negative in SyncDualEnergy! abort!!");
 		}
 
+		// compute kinetic energy
 		amrex::Real const Ekin = (px * px + py * py + pz * pz) / (2.0 * rho);
-		amrex::Real const Eint_cons = Etot - Ekin;
+
+		// compute magnetic energy
+		amrex::Real Emag = 0;
+		if (Physics_Traits<problem_t>::is_mhd_enabled) { // cannot be 'if constexpr' due to CUDA limitation
+			constexpr int mhd_idx = Physics_Indices<problem_t>::mhdFirstIndex;
+			amrex::Real const Bx = 0.5 * (faceVar_x[bx](i, j, k, mhd_idx) + faceVar_x[bx](i + 1, j, k, mhd_idx));
+#if AMREX_SPACEDIM >= 2
+			amrex::Real const By = 0.5 * (faceVar_y[bx](i, j, k, mhd_idx) + faceVar_y[bx](i, j + 1, k, mhd_idx));
+#endif
+#if AMREX_SPACEDIM == 3
+			amrex::Real const Bz = 0.5 * (faceVar_z[bx](i, j, k, mhd_idx) + faceVar_z[bx](i, j, k + 1, mhd_idx));
+#endif
+			Emag = 0.5 * (AMREX_D_TERM(Bx * Bx, +By * By, +Bz * Bz));
+		}
+
+		// compute internal energy from conserved vars
+		amrex::Real const Eint_cons = Etot - Ekin - Emag;
 
 		// Li et al. sync method
 		// replace Eint with Eint_cons == (Etot - Ekin) if (Eint_cons / E) > eta
@@ -844,7 +951,7 @@ template <typename problem_t> void HydroSystem<problem_t>::SyncDualEnergy(amrex:
 			consVar[bx](i, j, k, internalEnergy_index) = Eint_cons;
 		} else { // non-conservative sync
 			consVar[bx](i, j, k, internalEnergy_index) = Eint_aux;
-			consVar[bx](i, j, k, energy_index) = Eint_aux + Ekin;
+			consVar[bx](i, j, k, energy_index) = Eint_aux + Ekin + Emag;
 		}
 	});
 }
@@ -853,7 +960,7 @@ template <typename problem_t>
 template <RiemannSolver RIEMANN, FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
 					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
-					   const int nghost_vel)
+					   amrex::MultiFab *x1FSpds_mf, amrex::MultiFab const *x1ConsVar_fc_mf, const int nghost_vel)
 {
 
 	// By convention, the interfaces are defined on the left edge of each
@@ -868,14 +975,27 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	auto x1Flux_in = x1Flux_mf.arrays();
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
 
+	amrex::MultiArray4<double> x1FSpds_in;
+	amrex::MultiArray4<const double> x1ConsVar_fc_in;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		if (RIEMANN == RiemannSolver::HLLD || RIEMANN == RiemannSolver::LLF_MHD) {
+			x1FSpds_in = (*x1FSpds_mf).arrays();
+		}
+		x1ConsVar_fc_in = (*x1ConsVar_fc_mf).const_arrays();
+	}
+
 	// Include ghost cells when computing face velocities
 	amrex::IntVect ng{AMREX_D_DECL(nghost_vel, nghost_vel, nghost_vel)};
 	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
+		// first capture
+		[[maybe_unused]] const auto x1ConsVar_fc_ref = x1ConsVar_fc_in[bx];
+		[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
+
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
+		quokka::Array4View<const amrex::Real, DIR> q(primVar_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1FaceVel(x1FaceVel_in[bx]);
-		quokka::Array4View<const amrex::Real, DIR> q(primVar_in[bx]);
 
 		auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
@@ -910,6 +1030,24 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		double cs_L = NAN;
 		double cs_R = NAN;
 
+		double bx1 = 0.0;
+		double by_L = 0.0;
+		double bz_L = 0.0;
+		double by_R = 0.0;
+		double bz_R = 0.0;
+		double magnetic_energy_L = 0.0;
+		double magnetic_energy_R = 0.0;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			quokka::Array4View<const amrex::Real, DIR> x1ConsVar_fc(x1ConsVar_fc_ref);
+			bx1 = x1ConsVar_fc(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			by_L = x1LeftState(i, j, k, x2Magnetic_index);
+			bz_L = x1LeftState(i, j, k, x3Magnetic_index);
+			by_R = x1RightState(i, j, k, x2Magnetic_index);
+			bz_R = x1RightState(i, j, k, x3Magnetic_index);
+			magnetic_energy_L = 0.5 * (bx1 * bx1 + by_L * by_L + bz_L * bz_L);
+			magnetic_energy_R = 0.5 * (bx1 * bx1 + by_R * by_R + bz_R * bz_R);
+		}
+
 		if constexpr (is_eos_isothermal()) {
 			P_L = rho_L * (cs_iso_ * cs_iso_);
 			P_R = rho_R * (cs_iso_ * cs_iso_);
@@ -942,11 +1080,11 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 
 			amrex::GpuArray<Real, nmscalars_> massScalars_L = RadSystem<problem_t>::ComputeMassScalars(x1LeftState, i, j, k);
 			cs_L = quokka::EOS<problem_t>::ComputeSoundSpeed(rho_L, P_L, massScalars_L);
-			E_L = quokka::EOS<problem_t>::ComputeEintFromPres(rho_L, P_L, massScalars_L) + ke_L;
+			E_L = quokka::EOS<problem_t>::ComputeEintFromPres(rho_L, P_L, massScalars_L) + ke_L + magnetic_energy_L;
 
 			amrex::GpuArray<Real, nmscalars_> massScalars_R = RadSystem<problem_t>::ComputeMassScalars(x1RightState, i, j, k);
 			cs_R = quokka::EOS<problem_t>::ComputeSoundSpeed(rho_R, P_R, massScalars_R);
-			E_R = quokka::EOS<problem_t>::ComputeEintFromPres(rho_R, P_R, massScalars_R) + ke_R;
+			E_R = quokka::EOS<problem_t>::ComputeEintFromPres(rho_R, P_R, massScalars_R) + ke_R + magnetic_energy_R;
 		}
 
 		AMREX_ASSERT(cs_L > 0.0);
@@ -963,15 +1101,16 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 			velV_index = x2Velocity_index;
 			velW_index = x3Velocity_index;
 		} else if constexpr (DIR == FluxDir::X2) {
-			if constexpr (AMREX_SPACEDIM == 2) {
-				velN_index = x2Velocity_index;
-				velV_index = x1Velocity_index;
-				velW_index = x3Velocity_index; // unchanged in 2D
-			} else if constexpr (AMREX_SPACEDIM == 3) {
-				velN_index = x2Velocity_index;
-				velV_index = x3Velocity_index;
-				velW_index = x1Velocity_index;
-			}
+#if (AMREX_SPACEDIM == 2)
+			velN_index = x2Velocity_index;
+			velV_index = x1Velocity_index;
+			velW_index = x3Velocity_index; // unchanged in 2D
+#endif
+#if (AMREX_SPACEDIM == 3)
+			velN_index = x2Velocity_index;
+			velV_index = x3Velocity_index;
+			velW_index = x1Velocity_index;
+#endif
 		} else if constexpr (DIR == FluxDir::X3) {
 			velN_index = x3Velocity_index;
 			velV_index = x1Velocity_index;
@@ -987,10 +1126,8 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		sL.cs = cs_L;
 		sL.E = E_L;
 		sL.Eint = Eint_L;
-		// the following has been set to zero to test that the HLLD solver works with hydro only
-		// TODO(Neco): set correct magnetic field values once magnetic fields are enabled
-		sL.by = 0.0;
-		sL.bz = 0.0;
+		sL.by = by_L;
+		sL.bz = bz_L;
 
 		quokka::HydroState<nscalars_, nmscalars_> sR{};
 		sR.rho = rho_R;
@@ -1001,9 +1138,8 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		sR.cs = cs_R;
 		sR.E = E_R;
 		sR.Eint = Eint_R;
-		// as above, set to zero for testing purposes
-		sR.by = 0.0;
-		sR.bz = 0.0;
+		sR.by = by_R;
+		sR.bz = bz_R;
 
 		// The remaining components are mass scalars and passive scalars, so just copy them from
 		// x1LeftState and x1RightState into the (left, right) state vectors U_L and
@@ -1033,7 +1169,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		amrex::Real dwl =
 		    std::min(q(i - 1, j, k + 1, velW_index) - q(i - 1, j, k, velW_index), q(i - 1, j, k, velW_index) - q(i - 1, j, k - 1, velW_index));
 		amrex::Real dwr = std::min(q(i, j, k + 1, velW_index) - q(i, j, k, velW_index), q(i, j, k, velW_index) - q(i, j, k - 1, velW_index));
-		dw = std::min(std::min(dwl, dwr), dw);
+		dw = std::min({dwl, dwr, dw});
 #endif
 
 		// solve the Riemann problem in canonical form (i.e., where the x-dir is the normal direction)
@@ -1044,10 +1180,18 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 			F_canonical = quokka::Riemann::HLLC<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, du, dw);
 		} else if constexpr (RIEMANN == RiemannSolver::LLF) {
 			F_canonical = quokka::Riemann::LLF<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR);
+		} else if constexpr (RIEMANN == RiemannSolver::LLF_MHD) {
+			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
+			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::LLF_MHD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
+			F_canonical = F_canonical_tmp;
+			x1FSpds(i, j, k, 0) = fspd_m;
+			x1FSpds(i, j, k, 1) = fspd_p;
 		} else if constexpr (RIEMANN == RiemannSolver::HLLD) {
-			// bx = 0 for testing purposes
-			// TODO(Neco): pass correct bx value once magnetic fields are enabled
-			F_canonical = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, 0.0);
+			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
+			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
+			F_canonical = F_canonical_tmp;
+			x1FSpds(i, j, k, 0) = fspd_m;
+			x1FSpds(i, j, k, 1) = fspd_p;
 		}
 
 		quokka::valarray<double, nvar_> F = F_canonical;

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -13,11 +13,18 @@
 // library headers
 
 // internal headers
+#include "AMReX_BLProfiler.H"
+#include "AMReX_GpuControl.H"
+#include "AMReX_ParmParse.H"
+#include "hydro_system.hpp"
+#include "hyperbolic_system.hpp"
 #include "physics_info.hpp"
 #include "physics_numVars.hpp"
 
+AMREX_ENUM(EMFAvgType, BalsaraSpicer, LD04); // NOLINT
+
 /// Class for a MHD system of conservation laws
-template <typename problem_t> class MHDSystem
+template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_t>
 {
       public:
 	static constexpr int nvar_per_dim_ = Physics_NumVars::numMHDVars_per_dim;
@@ -26,6 +33,418 @@ template <typename problem_t> class MHDSystem
 	enum varIndex_perDim {
 		bfield_index = Physics_Indices<problem_t>::mhdFirstIndex,
 	};
+
+	static void ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
+			       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds,
+			       int reconstructionOrder, EMFAvgType emf_avg_type);
+
+	static void ReconstructTo(FluxDir dir, arrayconst_t &cState, array_t &lState, array_t &rState, const amrex::Box &box_cValid, int reconstructionOrder);
+
+	static void SolveInductionEqn(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fc_consVarOld_mf,
+				      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fc_consVarNew_mf,
+				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &ec_emf_mf, double dt, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
+				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo, double time);
 };
+
+template <typename problem_t>
+void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
+				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
+				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, EMFAvgType emf_avg_type)
+{
+	const BL_PROFILE("MHDSystem::ComputeEMF()");
+	const int nghost_cc = 4; // we only need 4 cc ghost cells when reconstructing cc->fc->ec using PPM
+	// note: all the different centerings still have the same distribution mapping, so it is fine for us to attach our looping to cc FArrayBox
+	// note: cell-centered (cc), face-centered (fc), and edge-centered (ec) data all have a different number of cells
+
+	// In this function we distinguish between world (w:3), array (i:2), quandrant (q:4), and component (x:3) index-ing by using prefixes. We will
+	// use the prefix x- when the w- and i- indexes are the same. We also choose to minimise the storage footprint by only computing and holding
+	// onto the quantities required for calculating the EMF in the w-direction. This inadvertently leads to duplicate computation, but allows us to
+	// significantly reduces the total memory used, which is a much bigger bottleneck.
+
+	// loop over each box-array on this level
+	for (amrex::MFIter mfi(cc_mf_cVars); mfi.isValid(); ++mfi) {
+		const amrex::Box &box_cc = mfi.validbox();
+
+		// extract cell-centered velocity fields
+		// indexing: field[3: x-component]
+		std::array<amrex::FArrayBox, 3> cc_fabs_Ux;
+		{
+			const amrex::Box &box_cc_U = amrex::grow(box_cc, nghost_cc);
+			cc_fabs_Ux[0].resize(box_cc_U, 1);
+			cc_fabs_Ux[1].resize(box_cc_U, 1);
+			cc_fabs_Ux[2].resize(box_cc_U, 1);
+			const auto &cc_a4_Ux0 = cc_fabs_Ux[0].array();
+			const auto &cc_a4_Ux1 = cc_fabs_Ux[1].array();
+			const auto &cc_a4_Ux2 = cc_fabs_Ux[2].array();
+			const auto &cc_a4_cVars = cc_mf_cVars[mfi].const_array();
+
+			amrex::ParallelFor(box_cc_U, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+				const auto rho = cc_a4_cVars(i, j, k, HydroSystem<problem_t>::density_index);
+				const auto px1 = cc_a4_cVars(i, j, k, HydroSystem<problem_t>::x1Momentum_index);
+				const auto px2 = cc_a4_cVars(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
+				const auto px3 = cc_a4_cVars(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
+				cc_a4_Ux0(i, j, k) = px1 / rho;
+				cc_a4_Ux1(i, j, k) = px2 / rho;
+				cc_a4_Ux2(i, j, k) = px3 / rho;
+			});
+		}
+
+		// indexing: field[3: x-component/x-face]
+		// create a view of all the b-field data (+ghost cells; do not make another copy)
+		std::array<amrex::FArrayBox, 3> fc_fabs_Bx = {
+		    amrex::FArrayBox(fcx_mf_cVars[0][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		    amrex::FArrayBox(fcx_mf_cVars[1][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		    amrex::FArrayBox(fcx_mf_cVars[2][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		};
+
+		// compute the magnetic flux through each cell-face
+		for (int iedge = 0; iedge < 3; ++iedge) {
+			// for each of the two cell-edges on the cell-face
+			// we are doing redundant compute. only need to look at one edge for each face: there is a one-to-one mapping.
+
+			// define the two directions we need to extrapolate cell-centered velocity fields to get them to the cell-edge
+			// we will want to compute E2 = (U0 * B1 - U1 * B0) along the cell-edge
+			std::array<int, 2> extrap_dirs = {(iedge + 1) % 3, (iedge + 2) % 3};
+			std::array<amrex::IntVect, 2> vecs_cc2ec = {amrex::IntVect::TheDimensionVector(extrap_dirs[0]),
+								    amrex::IntVect::TheDimensionVector(extrap_dirs[1])};
+			const amrex::IntVect vec_cc2ec = vecs_cc2ec[0] + vecs_cc2ec[1];
+			const amrex::Box box_ec = amrex::convert(box_cc, vec_cc2ec);
+			const amrex::Box box_ec_r = amrex::grow(box_ec, 1);
+
+			// initialise FArrayBox for storing the temporary edge-centered velocity fields created in each permutation of reconstructing from the
+			// cell-face indexing: field[2: i-side of edge]
+			std::array<amrex::FArrayBox, 2> ec_fabs_U_ieside;
+
+			// define the four possible velocity field quantities that could be reconstructed at the cell-edge
+			// also define the temporary velocity field quantities that will be used for computing the extrapolation
+			ec_fabs_U_ieside[0].resize(box_ec_r, 1);
+			ec_fabs_U_ieside[1].resize(box_ec_r, 1);
+
+			// indexing: field[2: i-compnent][2: i-side of edge]
+			// note: magnetic field components cannot be discontinuous along themselves (i.e., either side of the face where they are
+			// stored), so there are only two possible values (sides), rather than four (quadrants of) possible reconstructed values
+			std::array<std::array<amrex::FArrayBox, 2>, 2> ec_fabs_Bi_ieside;
+
+			// initialise FArrayBox for storing the edge-centered velocity fields averaged across the two extrapolation permutations
+			// indexing: field[2: i-compnent][4: quadrant around edge]
+			std::array<std::array<amrex::FArrayBox, 4>, 2> ec_fabs_Ui_q;
+
+			// define quantities
+			for (int icomp = 0; icomp < 2; ++icomp) {
+				ec_fabs_Bi_ieside[icomp][0].resize(box_ec_r, 1);
+				ec_fabs_Bi_ieside[icomp][1].resize(box_ec_r, 1);
+				for (int iquad = 0; iquad < 4; ++iquad) {
+					ec_fabs_Ui_q[icomp][iquad].resize(box_ec_r, 1);
+					ec_fabs_Ui_q[icomp][iquad].setVal<amrex::RunOn::Device>(0.0);
+				}
+			}
+
+			// extrapolate the two required cell-centered velocity field components to the cell-edge
+			// there are two possible permutations for doing this: getting cell-centered quanties to a cell-edge
+			// first is cc->fc[dir-0]->ec and second is cc->fc[dir-1]->ec
+			for (int iperm = 0; iperm < 2; ++iperm) {
+				// for each permutation of extrapolating cc->fc->ec
+
+				// define quantities
+				const int extrap_dir2face = extrap_dirs[iperm];
+				const int extrap_dir2edge = extrap_dirs[(iperm + 1) % 2];
+				const auto dir2face = static_cast<FluxDir>(extrap_dir2face);
+				const auto dir2edge = static_cast<FluxDir>(extrap_dir2edge);
+				const amrex::IntVect vec_cc2fc = amrex::IntVect::TheDimensionVector(extrap_dir2face);
+				const amrex::IntVect vec_fc2ec = amrex::IntVect::TheDimensionVector(extrap_dir2edge);
+				const amrex::Box box_fc = amrex::convert(box_cc, vec_cc2fc);
+				// we expand the domain of cc-data, so that when we reconstruct cc->fc (we include enough ghost cells in the fc->ec dimension),
+				// we get as an output (from reconstructing fc->ec) data only in the valid domain
+				const amrex::Box box_cc_U =
+				    amrex::grow(box_cc, (nghost_cc - 1) * vec_fc2ec); // note, the reconstruct function will uniformly grow the bounds by 1
+				const amrex::Box box_fc_U = amrex::grow(box_fc, (nghost_cc - 1) * vec_fc2ec + 1);
+
+				// extrapolate both required cell-centered velocity fields to the cell-edge
+				for (int icomp = 0; icomp < 2; ++icomp) {
+					// create temporary FArrayBox for storing the face-centered velocity field reconstructed from the cell-center
+					// indexing: field[2: i-side of face]
+					std::array<amrex::FArrayBox, 2> fc_fabs_U_ifside;
+					const int wcomp = extrap_dirs[icomp];
+					fc_fabs_U_ifside[0].resize(box_fc_U, 1);
+					fc_fabs_U_ifside[1].resize(box_fc_U, 1);
+
+					// extrapolate cell-centered velocity components to the cell-face
+					MHDSystem<problem_t>::ReconstructTo(dir2face, cc_fabs_Ux[wcomp].array(), fc_fabs_U_ifside[0].array(),
+									    fc_fabs_U_ifside[1].array(), box_cc_U, reconstructionOrder);
+
+					// extrapolate face-centered velocity components to the cell-edge
+					for (int iface = 0; iface < 2; ++iface) {
+						// reset values in temporary FArrayBox
+						ec_fabs_U_ieside[0].setVal<amrex::RunOn::Device>(0.0);
+						ec_fabs_U_ieside[1].setVal<amrex::RunOn::Device>(0.0);
+
+						// extrapolate face-centered velocity component to the cell-edge
+						MHDSystem<problem_t>::ReconstructTo(dir2edge, fc_fabs_U_ifside[iface].array(), ec_fabs_U_ieside[0].array(),
+										    ec_fabs_U_ieside[1].array(), box_fc, reconstructionOrder);
+
+						// figure out which quadrant of the cell-edge this extrapolated velocity component corresponds with
+						int iquad0 = -1;
+						int iquad1 = -1;
+
+						// note: quadrants are defined based on where the quantity sits relative to the edge (dir-0, dir-1):
+						// (-,+) | (+,+)
+						//   1   |   2
+						// ------+------
+						//   0   |   3
+						// (-,-) | (+,-)
+						if (iperm == 0) {
+							iquad0 = (iface == 0) ? 0 : 3;
+							iquad1 = (iface == 0) ? 1 : 2;
+						} else {
+							iquad0 = (iface == 0) ? 0 : 1;
+							iquad1 = (iface == 0) ? 3 : 2;
+						}
+
+						ec_fabs_Ui_q[icomp][iquad0].plus<amrex::RunOn::Device>(ec_fabs_U_ieside[0], 0, 0, 1);
+						ec_fabs_Ui_q[icomp][iquad1].plus<amrex::RunOn::Device>(ec_fabs_U_ieside[1], 0, 0, 1);
+					}
+				}
+			}
+
+			// finish averaging the two different ways for extrapolating velocity fields: cc->fc->ec
+			for (int icomp = 0; icomp < 2; ++icomp) {
+				for (int iquad = 0; iquad < 4; ++iquad) {
+					ec_fabs_Ui_q[icomp][iquad].mult<amrex::RunOn::Device>(0.5, 0, 1);
+				}
+			}
+
+			// extrapolate the two required face-centered magnetic field components to the cell-edge
+			for (int icomp = 0; icomp < 2; ++icomp) {
+				const int extrap_dir2edge = extrap_dirs[(icomp + 1) % 2];
+				const auto dir2edge = static_cast<FluxDir>(extrap_dir2edge);
+				const int wcomp = extrap_dirs[icomp];
+				const amrex::IntVect vec_cc2fc = amrex::IntVect::TheDimensionVector(wcomp);
+				const amrex::Box box_fc = amrex::convert(box_cc, vec_cc2fc);
+				// extrapolate face-centered magnetic components to the cell-edge
+				MHDSystem<problem_t>::ReconstructTo(dir2edge, fc_fabs_Bx[wcomp].array(), ec_fabs_Bi_ieside[icomp][0].array(),
+								    ec_fabs_Bi_ieside[icomp][1].array(), box_fc, reconstructionOrder);
+			}
+
+			// indexing: field[4: quadrant around edge]
+			std::array<amrex::FArrayBox, 4> ec_fabs_E_q;
+
+			// compute the EMF along the cell-edge
+			for (int iquad = 0; iquad < 4; ++iquad) {
+				// extract relevant velocity and magnetic field components
+				const auto &U0_qi = ec_fabs_Ui_q[0][iquad].const_array();
+				const auto &U1_qi = ec_fabs_Ui_q[1][iquad].const_array();
+				const auto &B0_qi = ec_fabs_Bi_ieside[0][(iquad == 0 || iquad == 3) ? 0 : 1].const_array();
+				const auto &B1_qi = ec_fabs_Bi_ieside[1][(iquad < 2) ? 0 : 1].const_array();
+
+				// compute electric field in the quadrant about the cell-edge: cross product between velocity and magnetic field in that
+				// define EMF FArrayBox
+				ec_fabs_E_q[iquad].resize(box_ec, 1);
+				const auto &E2_qi = ec_fabs_E_q[iquad].array();
+
+				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+					const double u0 = U0_qi(i, j, k);
+					const double u1 = U1_qi(i, j, k);
+					const double b0 = B0_qi(i, j, k);
+					const double b1 = B1_qi(i, j, k);
+					double const uxb = u0 * b1 - u1 * b0;
+					E2_qi(i, j, k) = uxb;
+				});
+			}
+
+			// extract wavespeeds
+			int const w0_comp = extrap_dirs[0];
+			int const w1_comp = extrap_dirs[1];
+			std::array<int, 3> delta_w0 = {0, 0, 0};
+			std::array<int, 3> delta_w1 = {0, 0, 0};
+			delta_w0[w0_comp] = 1;
+			delta_w1[w1_comp] = 1;
+			const auto &fspd_x0 = fcx_mf_fspds[w0_comp][mfi].const_array();
+			const auto &fspd_x1 = fcx_mf_fspds[w1_comp][mfi].const_array();
+
+			// extract both components of magnetic field either side of the cell-edge
+			const auto &B0_m = ec_fabs_Bi_ieside[0][0].const_array();
+			const auto &B0_p = ec_fabs_Bi_ieside[0][1].const_array();
+			const auto &B1_m = ec_fabs_Bi_ieside[1][0].const_array();
+			const auto &B1_p = ec_fabs_Bi_ieside[1][1].const_array();
+
+			// extract all four quadrants of the electric field about the cell-edge
+			const auto &E2_q0 = ec_fabs_E_q[0].const_array();
+			const auto &E2_q1 = ec_fabs_E_q[1].const_array();
+			const auto &E2_q2 = ec_fabs_E_q[2].const_array();
+			const auto &E2_q3 = ec_fabs_E_q[3].const_array();
+
+			// compute electric field on the cell-edge
+			const auto &E2_ave = ec_mf_emf_components[iedge][mfi].array();
+
+			if (emf_avg_type == EMFAvgType::BalsaraSpicer) {
+				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+					const double E2_q0_ = E2_q0(i, j, k);
+					const double E2_q1_ = E2_q1(i, j, k);
+					const double E2_q2_ = E2_q2(i, j, k);
+					const double E2_q3_ = E2_q3(i, j, k);
+					// Balsara & Spicer averaging scheme:
+					E2_ave(i, j, k) = 0.25 * (E2_q0_ + E2_q1_ + E2_q2_ + E2_q3_);
+				});
+			} else if (emf_avg_type == EMFAvgType::LD04) {
+				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+					const double E2_q0_ = E2_q0(i, j, k);
+					const double E2_q1_ = E2_q1(i, j, k);
+					const double E2_q2_ = E2_q2(i, j, k);
+					const double E2_q3_ = E2_q3(i, j, k);
+
+					const double B0_p_ = B0_p(i, j, k);
+					const double B0_m_ = B0_m(i, j, k);
+					const double B1_p_ = B1_p(i, j, k);
+					const double B1_m_ = B1_m(i, j, k);
+
+					// LD04 scheme:
+					const double a0_m = std::max(fspd_x0(i, j, k, 0), fspd_x0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 0));
+					const double a0_p = std::max(fspd_x0(i, j, k, 1), fspd_x0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 1));
+					const double a1_m = std::max(fspd_x1(i, j, k, 0), fspd_x1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 0));
+					const double a1_p = std::max(fspd_x1(i, j, k, 1), fspd_x1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 1));
+
+					// note: quadrants are defined based on where the quantity sits relative to the edge (dir-0, dir-1):
+					// (-,+) | (+,+)
+					//   1   |   2
+					// ------+------
+					//   0   |   3
+					// (-,-) | (+,-)
+
+					const double num1 =
+					    ((a0_p * a1_p) * E2_q0_ + (a0_m * a1_p) * E2_q3_) + ((a0_p * a1_m) * E2_q1_ + (a0_m * a1_m) * E2_q2_);
+					const double num2 =
+					    ((a0_p * a1_p) * E2_q0_ + (a0_p * a1_m) * E2_q1_) + ((a0_m * a1_p) * E2_q3_ + (a0_m * a1_m) * E2_q2_);
+
+					// must be averaged for exact floating-point symmetry
+					const double numerator = 0.5 * (num1 + num2);
+					const double denominator = (a0_m + a0_p) * (a1_m + a1_p);
+
+					// NOTE: there is a sign error in Equation 56 of Felker & Stone
+					const double term2 =
+					    ((a1_m * a1_p) / (a1_m + a1_p)) * (B0_p_ - B0_m_) - ((a0_m * a0_p) / (a0_m + a0_p)) * (B1_p_ - B1_m_);
+
+					E2_ave(i, j, k) = (numerator / denominator) + term2;
+				});
+			}
+		}
+	}
+}
+
+template <typename problem_t>
+void MHDSystem<problem_t>::ReconstructTo(FluxDir dir, arrayconst_t &cState, array_t &lState, array_t &rState, const amrex::Box &box_cValid,
+					 int reconstructionOrder)
+{
+	const BL_PROFILE("MHDSystem::ReconstructTo()");
+	amrex::Box const &box_r = amrex::grow(box_cValid, 1);
+	amrex::Box const &box_r_x1 = amrex::surroundingNodes(box_r, static_cast<int>(dir));
+	if (reconstructionOrder == 5) {
+		// note: only box_r is used. box_r_x1 is unused.
+		switch (dir) {
+			case FluxDir::X1:
+				MHDSystem<problem_t>::template ReconstructStatesPPM_EP<FluxDir::X1>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+			case FluxDir::X2:
+				MHDSystem<problem_t>::template ReconstructStatesPPM_EP<FluxDir::X2>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+			case FluxDir::X3:
+				MHDSystem<problem_t>::template ReconstructStatesPPM_EP<FluxDir::X3>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+		}
+	} else if (reconstructionOrder == 3) {
+		switch (dir) {
+			case FluxDir::X1:
+				MHDSystem<problem_t>::template ReconstructStatesPPM<FluxDir::X1>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+			case FluxDir::X2:
+				MHDSystem<problem_t>::template ReconstructStatesPPM<FluxDir::X2>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+			case FluxDir::X3:
+				MHDSystem<problem_t>::template ReconstructStatesPPM<FluxDir::X3>(cState, lState, rState, box_r, box_r_x1, 1);
+				break;
+		}
+	} else if (reconstructionOrder == 2) {
+		switch (dir) {
+			case FluxDir::X1:
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X1, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				break;
+			case FluxDir::X2:
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X2, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				break;
+			case FluxDir::X3:
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X3, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				break;
+		}
+	} else if (reconstructionOrder == 1) {
+		switch (dir) {
+			case FluxDir::X1:
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X1>(cState, lState, rState, box_r_x1, 1);
+				break;
+			case FluxDir::X2:
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X2>(cState, lState, rState, box_r_x1, 1);
+				break;
+			case FluxDir::X3:
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X3>(cState, lState, rState, box_r_x1, 1);
+				break;
+		}
+	} else {
+		amrex::Abort("Invalid reconstruction order specified! Supported orders: 1 (constant), 2 (PLM), 3 (PPM), 5 (xPPM).");
+	}
+}
+
+template <typename problem_t>
+void MHDSystem<problem_t>::SolveInductionEqn(std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fc_consVarOld_mf,
+					     std::array<amrex::MultiFab, AMREX_SPACEDIM> &fc_consVarNew_mf,
+					     std::array<amrex::MultiFab, AMREX_SPACEDIM> const &ec_emf_mf, double dt,
+					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> /*prob_lo*/,
+					     double /*time*/)
+{
+	const BL_PROFILE("MHDSystem::SolveInductionEqn()");
+	// compute the total right-hand-side for the MOL integration
+
+	// By convention, the fluxes are defined on the left edge of each zone,
+	// i.e. flux_(i) is the flux *into* zone i through the interface on the
+	// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
+	// the interface on the right of zone i.
+
+	// loop over faces pointing in the w0-direction
+	for (int w0 = 0; w0 < 3; ++w0) {
+		// you have two edges on the perimeter of this face
+		const int w1 = (w0 + 1) % 3; // vec_fc(w0) + vec_fc(w1)
+		const int w2 = (w0 + 2) % 3; // vec_fc(w0) + vec_fc(w2)
+
+		// direction to find the edges either side of the face. this depends on the direction the face points
+		std::array<int, 3> delta_w1 = {0, 0, 0};
+		std::array<int, 3> delta_w2 = {0, 0, 0};
+		if (w0 == 0) {
+			delta_w1[1] = 1;
+			delta_w2[2] = 1;
+		} else if (w0 == 1) {
+			delta_w1[2] = 1;
+			delta_w2[0] = 1;
+		} else if (w0 == 2) {
+			delta_w1[0] = 1;
+			delta_w2[1] = 1;
+		}
+
+		auto const dx1 = dx[w1];
+		auto const dx2 = dx[w2];
+		auto const ec_emf_w1 = ec_emf_mf[w1].const_arrays();
+		auto const ec_emf_w2 = ec_emf_mf[w2].const_arrays();
+		auto const fc_consVarOld = fc_consVarOld_mf[w0].const_arrays();
+		auto fc_consVarNew = fc_consVarNew_mf[w0].arrays();
+
+		amrex::ParallelFor(fc_consVarNew_mf[w0], [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+			// the ec emfs sit in the opposite fc directions relative to the face
+			const double emf_w1_m = ec_emf_w1[bx](i, j, k);
+			const double emf_w2_m = ec_emf_w2[bx](i, j, k);
+			const double emf_w1_p = ec_emf_w1[bx](i + delta_w2[0], j + delta_w2[1], k + delta_w2[2]);
+			const double emf_w2_p = ec_emf_w2[bx](i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
+			const double db_dt = (dx1 * (emf_w1_m - emf_w1_p) + dx2 * (emf_w2_p - emf_w2_m)) / (dx1 * dx2);
+
+			fc_consVarNew[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex) =
+			    fc_consVarOld[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex) + dt * db_dt;
+		});
+	}
+}
 
 #endif // HYDRO_SYSTEM_HPP_

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -14,6 +14,7 @@
 ///
 
 // c++ headers
+#include <algorithm>
 #include <cmath>
 
 // library headers
@@ -57,7 +58,7 @@ template <typename problem_t> class HyperbolicSystem
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(double a, double b) -> double
 	{
-		return 0.5 * (sgn(a) + sgn(b)) * std::min(0.5 * std::abs(a + b), std::min(2.0 * std::abs(a), 2.0 * std::abs(b)));
+		return 0.5 * (sgn(a) + sgn(b)) * std::min({0.5 * std::abs(a + b), 2.0 * std::abs(a), 2.0 * std::abs(b)});
 	}
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod(double a, double b) -> double
@@ -69,9 +70,6 @@ template <typename problem_t> class HyperbolicSystem
 	{
 		return std::max(std::min(a, b), std::min(std::max(a, b), c));
 	}
-
-	[[nodiscard]] AMREX_GPU_DEVICE AMREX_FORCE_INLINE static auto GetMinmaxSurroundingCell(arrayconst_t &q, int i, int j, int k, int n)
-	    -> std::pair<double, double>;
 
 	template <FluxDir DIR>
 	static void ReconstructStatesConstant(amrex::MultiFab const &q, amrex::MultiFab &leftState, amrex::MultiFab &rightState, int nghost, int nvars);
@@ -348,6 +346,7 @@ AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM(quo
 	const std::pair<double, double> bounds = std::minmax({q(i, j, k, iReadFrom + n), q(i - 1, j, k, iReadFrom + n), q(i + 1, j, k, iReadFrom + n)});
 
 	// get interfaces
+
 	// PPM reconstruction following Colella & Woodward (1984), with
 	// some modifications following Mignone (2014), as implemented in
 	// Athena++.
@@ -409,7 +408,6 @@ AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM(quo
 			new_a_plus = a + 2.0 * dq_minus;
 		}
 	}
-
 	rightState(i, j, k, iWriteFrom + n) = new_a_minus;
 	leftState(i + 1, j, k, iWriteFrom + n) = new_a_plus;
 }
@@ -625,7 +623,7 @@ void HyperbolicSystem<problem_t>::PredictStep(arrayconst_t &consVarOld, array_t 
 					      const double dt_in, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
 					      const int nvars, F &&isStateValid, amrex::Array4<int> const &redoFlag)
 {
-	BL_PROFILE("HyperbolicSystem::PredictStep()");
+	const BL_PROFILE("HyperbolicSystem::PredictStep()");
 
 	// By convention, the fluxes are defined on the left edge of each zone,
 	// i.e. flux_(i) is the flux *into* zone i through the interface on the
@@ -652,7 +650,7 @@ void HyperbolicSystem<problem_t>::PredictStep(arrayconst_t &consVarOld, array_t 
 		}
 
 		// check if state is valid -- flag for re-do if not
-		if (!isStateValid(consVarNew, i, j, k)) {
+		if (!std::forward<F>(isStateValid)(consVarNew, i, j, k)) {
 			redoFlag(i, j, k) = quokka::redoFlag::redo;
 		} else {
 			redoFlag(i, j, k) = quokka::redoFlag::none;
@@ -666,7 +664,7 @@ void HyperbolicSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0,
 					       const double dt_in, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx_in, amrex::Box const &indexRange,
 					       const int nvars, F &&isStateValid, amrex::Array4<int> const &redoFlag)
 {
-	BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
+	const BL_PROFILE("HyperbolicSystem::AddFluxesRK2()");
 
 	// By convention, the fluxes are defined on the left edge of each zone,
 	// i.e. flux_(i) is the flux *into* zone i through the interface on the
@@ -704,7 +702,7 @@ void HyperbolicSystem<problem_t>::AddFluxesRK2(array_t &U_new, arrayconst_t &U0,
 		}
 
 		// check if state is valid -- flag for re-do if not
-		if (!isStateValid(U_new, i, j, k)) {
+		if (!std::forward<F>(isStateValid)(U_new, i, j, k)) {
 			redoFlag(i, j, k) = quokka::redoFlag::redo;
 		} else {
 			redoFlag(i, j, k) = quokka::redoFlag::none;

--- a/src/problems/AlfvenWaveCircular/CMakeLists.txt
+++ b/src/problems/AlfvenWaveCircular/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_alfven_wave_circular test_alfven_wave_circular.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_alfven_wave_circular)
+    endif()
+
+    add_test(NAME AlfvenWaveCircular COMMAND test_alfven_wave_circular ../inputs/alfven_wave_circular.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    set_tests_properties(AlfvenWaveCircular PROPERTIES LABELS "MHD")
+endif()

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -1,0 +1,252 @@
+//==============================================================================
+// Copyright 2022 Neco Kriel.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_fc_quantities.cpp
+/// \brief Defines a test problem to make sure face-centred quantities are created correctly.
+///
+
+#include <cassert>
+#include <cmath>
+#include <gcem.hpp>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "physics_info.hpp"
+
+struct AlfvenWaveCircular {
+};
+
+template <> struct quokka::EOS_Traits<AlfvenWaveCircular> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<AlfvenWaveCircular> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+// constants
+constexpr double sound_speed = 1.0;
+constexpr double gamma_gas = quokka::EOS_Traits<AlfvenWaveCircular>::gamma;
+
+// we have set up the problem so that the direction of wave propagation, vec(k), is aligned with the x1-direction, and the background magnetic field sits in the
+// x1-x2 plane
+
+// k = 2 pi / wave_length. note: wave_length should be an integer, because of periodic BCs + the requirement that the magnetic field be continuous. also, the
+// box length = 1, so |k| in [1, inf)
+constexpr double num_modes = 1;
+constexpr double k_amplitude = 2.0 * M_PI * num_modes;
+
+// background states
+constexpr double bg_density = 1.0;
+constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
+constexpr double bg_mag_amplitude = 1.0;
+
+// magnetic field properties
+constexpr double delta_b = 1e-6;
+constexpr double alfven_speed = bg_mag_amplitude / gcem::sqrt(bg_density);
+
+constexpr double omega = gcem::sqrt(gcem::pow(alfven_speed, 2.0) * gcem::pow(k_amplitude, 2.0));
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_x(double x1, double /*x2*/, double x3, double time) -> double
+{
+	return bg_mag_amplitude * delta_b * x3 * std::sin(omega * time - k_amplitude * x1);
+}
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_y(double x1, double /*x2*/, double /*x3*/, double time) -> double
+{
+	return -bg_mag_amplitude * delta_b / k_amplitude * std::sin(omega * time - k_amplitude * x1);
+}
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_z(double /*x1*/, double x2, double /*x3*/, double /*time*/) -> double { return bg_mag_amplitude * x2; }
+
+AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::centering cen, quokka::direction dir,
+					  double time)
+{
+	const amrex::Real x1_L = prob_lo[0] + i * dx[0];
+	const amrex::Real x2_L = prob_lo[1] + j * dx[1];
+	const amrex::Real x3_L = prob_lo[2] + k * dx[2];
+
+	const amrex::Real x1_C = x1_L + static_cast<amrex::Real>(0.5) * dx[0];
+
+	if (cen == quokka::centering::cc) {
+		const double sin_wave_C = std::sin(omega * time - k_amplitude * x1_C);
+		const double cos_wave_C = std::cos(omega * time - k_amplitude * x1_C);
+
+		const double density = bg_density;
+		const double pressure = bg_pressure;
+		const double x1vel = 0.0;
+		const double x2vel = -omega * delta_b / (sound_speed * k_amplitude) * sin_wave_C;
+		const double x3vel = -omega * delta_b / (sound_speed * k_amplitude) * cos_wave_C;
+
+		// magnetic field at the center of the cell
+		const double x1mag = bg_mag_amplitude;
+		const double x2mag = bg_mag_amplitude * delta_b * sin_wave_C;
+		const double x3mag = bg_mag_amplitude * delta_b * cos_wave_C;
+
+		const double velocity_magnitude = std::sqrt(std::pow(x1vel, 2) + std::pow(x2vel, 2) + std::pow(x3vel, 2));
+		const double momentum = density * velocity_magnitude;
+		const double Ekin = 0.5 * std::pow(momentum, 2.0) / density;
+		const double Emag = 0.5 * (x1mag * x1mag + x2mag * x2mag + x3mag * x3mag);
+		const double Eint = pressure / (gamma_gas - 1);
+		const double Etot = Ekin + Emag + Eint;
+
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::density_index) = density;
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x1Momentum_index) = x1vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x2Momentum_index) = x2vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x3Momentum_index) = x3vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<AlfvenWaveCircular>::internalEnergy_index) = Eint;
+	} else if (cen == quokka::centering::fc) {
+		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2.0, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2.0, time)) /
+					 dx[1] -
+				     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L, time)) /
+					 dx[2];
+		const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L, time)) /
+					 dx[2] -
+				     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2.0, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2.0, time)) /
+					 dx[0];
+		const double x3mag = (computeMagneticVectorPotential_y(x1_L + dx[0], x2_L + dx[1] / 2.0, x3_L, time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L, time)) /
+					 dx[0] -
+				     (computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L + dx[1], x3_L, time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L, time)) /
+					 dx[1];
+		if (dir == quokka::direction::x) {
+			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x1mag;
+		} else if (dir == quokka::direction::y) {
+			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x2mag;
+		} else if (dir == quokka::direction::z) {
+			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x3mag;
+		}
+	}
+}
+
+template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_cc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_cc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_cc; ++n) {
+			state_cc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_cc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_fc = Physics_Indices<AlfvenWaveCircular>::nvarPerDim_fc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_fc; ++n) {
+			state_fc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_fc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <>
+void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, 0);
+		});
+	}
+}
+
+template <>
+void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, 0);
+		});
+	}
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+	sim.computeReferenceSolution_ = true;
+	sim.setInitialConditions();
+	sim.evolve();
+
+	// Compute test success condition
+	int status = 0;
+	const double error_tol = 0.002;
+	if (sim.errorNorm_ > error_tol) {
+		status = 1;
+	}
+
+	return status;
+}

--- a/src/problems/AlfvenWaveLinear/CMakeLists.txt
+++ b/src/problems/AlfvenWaveLinear/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_alfven_wave_linear test_alfven_wave_linear.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_alfven_wave_linear)
+    endif()
+
+    add_test(NAME AlfvenWaveLinear COMMAND test_alfven_wave_linear ../inputs/alfven_wave_linear.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    set_tests_properties(AlfvenWaveLinear PROPERTIES LABELS "MHD")
+endif()

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -1,0 +1,299 @@
+//==============================================================================
+// Copyright 2022 Neco Kriel.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_fc_quantities.cpp
+/// \brief Defines a test problem to make sure face-centred quantities are created correctly.
+///
+
+#include <cassert>
+#include <cmath>
+#include <gcem.hpp>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "hydro/EOS.hpp"
+#include "physics_info.hpp"
+#include "util/fextract.hpp"
+#ifdef HAVE_PYTHON
+#include "util/matplotlibcpp.h"
+#endif
+
+struct AlfvenWaveLinear {
+};
+
+template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<AlfvenWaveLinear> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+// constants
+constexpr double sound_speed = 1.0;
+constexpr double gamma_gas = quokka::EOS_Traits<AlfvenWaveLinear>::gamma;
+
+// we have set up the problem so that:
+// the direction of wave propagation, vec(k), is aligned with the x1-direction
+// the background magnetic field sits in the x1-x2 plane
+
+// k = 2 pi / wave_length. note: wave_length should be an integer, because of periodic BCs + the requirement that the magnetic field be continuous. also, the
+// box length = 1, so |k| in [1, inf)
+constexpr double num_modes = 1;
+constexpr double k_amplitude = 2.0 * M_PI * num_modes;
+
+// alignment between the background magnetic field and the direction of wave propagation (in the x1-x2 plane). recall that hat(k) = (1, 0, 0) and hat(delta_u) =
+// (0, 1, 0)
+constexpr double theta_degrees = 0.0; // degrees
+constexpr double cos_theta = gcem::cos(theta_degrees * M_PI / 180.0);
+constexpr double sin_theta = gcem::sin(theta_degrees * M_PI / 180.0);
+
+// background states
+constexpr double bg_density = 1.0;
+constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
+constexpr double bg_mag_amplitude = 1.0;
+
+// magnetic field properties
+constexpr double delta_b = 1e-6;
+constexpr double alfven_speed = bg_mag_amplitude / gcem::sqrt(bg_density);
+constexpr double bg_mag_x1 = bg_mag_amplitude * cos_theta;
+constexpr double bg_mag_x2 = bg_mag_amplitude * sin_theta;
+
+constexpr double omega = gcem::sqrt(alfven_speed * alfven_speed * k_amplitude * k_amplitude * cos_theta * cos_theta);
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_x(double /*x1*/, double /*x2*/, double /*x3*/, double /*time*/) -> double { return 0.0; }
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_y(double x1, double /*x2*/, double /*x3*/, double time) -> double
+{
+	return -bg_mag_amplitude * delta_b / k_amplitude * std::sin(omega * time - k_amplitude * x1);
+}
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_z(double /*x1*/, double x2, double /*x3*/, double /*time*/) -> double { return bg_mag_amplitude * x2; }
+
+AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::centering cen, quokka::direction dir,
+					  double time)
+{
+	const amrex::Real x1_L = prob_lo[0] + i * dx[0];
+	const amrex::Real x2_L = prob_lo[1] + j * dx[1];
+	const amrex::Real x3_L = prob_lo[2] + k * dx[2];
+
+	const amrex::Real x1_C = x1_L + static_cast<amrex::Real>(0.5) * dx[0];
+
+	if (cen == quokka::centering::cc) {
+		const double cos_wave_C = std::cos(omega * time - k_amplitude * x1_C);
+
+		const double density = bg_density;
+		const double pressure = bg_pressure;
+		const double x1vel = 0.0;
+		const double x2vel = 0.0;
+		const double x3vel = -omega * delta_b / (sound_speed * k_amplitude * cos_theta) * cos_wave_C;
+
+		// magnetic field at the center of the cell
+		const double x1mag = bg_mag_x1;
+		const double x2mag = bg_mag_x2;
+		const double x3mag = bg_mag_amplitude * delta_b * cos_wave_C;
+
+		const double velocity_magnitude = std::sqrt(std::pow(x1vel, 2) + std::pow(x2vel, 2) + std::pow(x3vel, 2));
+		const double momentum = density * velocity_magnitude;
+		const double Ekin = 0.5 * std::pow(momentum, 2) / density;
+		const double Emag = 0.5 * (x1mag * x1mag + x2mag * x2mag + x3mag * x3mag);
+		const double Eint = pressure / (gamma_gas - 1);
+		const double Etot = Ekin + Emag + Eint;
+
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::density_index) = density;
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x1Momentum_index) = x1vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x2Momentum_index) = x2vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x3Momentum_index) = x3vel * density;
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<AlfvenWaveLinear>::internalEnergy_index) = Eint;
+	} else if (cen == quokka::centering::fc) {
+		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2.0, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2.0, time)) /
+					 dx[1] -
+				     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L, time)) /
+					 dx[2];
+		const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L, time)) /
+					 dx[2] -
+				     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2.0, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2.0, time)) /
+					 dx[0];
+		const double x3mag = (computeMagneticVectorPotential_y(x1_L + dx[0], x2_L + dx[1] / 2.0, x3_L, time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2.0, x3_L, time)) /
+					 dx[0] -
+				     (computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L + dx[1], x3_L, time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L, time)) /
+					 dx[1];
+		if (dir == quokka::direction::x) {
+			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = x1mag;
+		} else if (dir == quokka::direction::y) {
+			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = x2mag;
+		} else if (dir == quokka::direction::z) {
+			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = x3mag;
+		}
+	}
+}
+
+// void ComputeExactSolution(double x, double time)
+// {
+
+// }
+
+template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_cc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_cc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_cc; ++n) {
+			state_cc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_cc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_fc = Physics_Indices<AlfvenWaveLinear>::nvarPerDim_fc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_fc; ++n) {
+			state_fc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_fc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <>
+void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, 0);
+		});
+	}
+}
+
+template <>
+void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, 0);
+		});
+	}
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
+	sim.computeReferenceSolution_ = true;
+	sim.setInitialConditions();
+	sim.evolve();
+
+	// 	const int idim = 0;
+	// 	const int ncomp = sim.state_new_fc_[0][idim].nComp();
+	// 	const int nghost = sim.state_new_fc_[0][idim].nGrow();
+	// 	amrex::MultiFab state_ref_level0(amrex::convert(sim.boxArray(0), amrex::IntVect::TheDimensionVector(idim)), sim.DistributionMap(0), ncomp,
+	// nghost); 	sim.computeReferenceSolution_fc(state_ref_level0, sim.geom[0].CellSizeArray(), sim.geom[0].ProbLoArray(), quokka::direction{1});
+
+	// 	// extract the exact solution at y = z = 0
+	// 	auto [position, values] = fextract(state_ref_level0, sim.geom[0], 0, 0.0);
+
+	// 	// plot the exact solution
+	// 	if (amrex::ParallelDescriptor::IOProcessor()) {
+	// 		std::vector<double> xs(position.size());
+	// 		std::vector<double> bfield(position.size());
+	// 		for (int i = 0; i < position.size(); ++i) {
+	// 			xs[i] = position[i];
+	// 			bfield[i] = values[MHDSystem<AlfvenWaveLinear>::bfield_index + 1][i];
+	// 			amrex::Print() << "x = " << xs[i] << ", bfield = " << bfield[i] << "\n";
+	// 		}
+
+	// #ifdef HAVE_PYTHON
+	// 		matplotlibcpp::plot(xs, bfield);
+	// 		matplotlibcpp::xlabel("x");
+	// 		matplotlibcpp::ylabel("B");
+	// 		matplotlibcpp::save("./bfield.pdf");
+	// #endif
+	// 	}
+
+	// Compute test success condition
+	int status = 1;
+	const double error_tol = 0.002;
+	if (sim.errorNorm_ < error_tol) {
+		status = 0;
+		amrex::Print() << "Error norm = " << sim.errorNorm_ << "\n";
+		amrex::Print() << "test passed\n";
+	} else {
+		amrex::Print() << "Error norm = " << sim.errorNorm_ << "\n";
+		amrex::Print() << "test failed\n";
+	}
+
+	return status;
+}

--- a/src/problems/CMakeLists.txt
+++ b/src/problems/CMakeLists.txt
@@ -62,6 +62,13 @@ add_subdirectory(RadhydroPulseMGconst)
 add_subdirectory(RadhydroPulseMGint)
 add_subdirectory(RadhydroBB)
 
+add_subdirectory(AlfvenWaveLinear)
+add_subdirectory(AlfvenWaveCircular)
+add_subdirectory(CurrentSheet)
+add_subdirectory(OrszagTang)
+add_subdirectory(FastWave)
+add_subdirectory(FieldLoop)
+
 add_subdirectory(DiskGalaxy)
 add_subdirectory(BinaryOrbitCIC)
 add_subdirectory(Cooling)

--- a/src/problems/CurrentSheet/CMakeLists.txt
+++ b/src/problems/CurrentSheet/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_current_sheet test_current_sheet.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_current_sheet)
+    endif()
+
+    add_test(NAME CurrentSheet COMMAND test_current_sheet ../inputs/current_sheet.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -1,0 +1,130 @@
+//==============================================================================
+// Copyright 2022 Neco Kriel and Ben Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_current_sheet.cpp
+/// \brief Defines a test problem to test magnetic reconnection in a current sheet.
+///   This problem is based on the description here:
+///	  https://www.astro.princeton.edu/~jstone/Athena/tests/current-sheet/current-sheet.html
+///
+
+#include <cmath>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "hydro/EOS.hpp"
+#include "hydro/hydro_system.hpp"
+#include "physics_info.hpp"
+
+struct CurrentSheet {
+};
+
+template <> struct quokka::EOS_Traits<CurrentSheet> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<CurrentSheet> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+// constants
+constexpr double gamma_gas = quokka::EOS_Traits<CurrentSheet>::gamma;
+constexpr double beta = 0.1;
+constexpr double A = 0.1;
+
+// background states
+constexpr double rho0 = 1.0;
+constexpr double P0 = 0.5 * beta;
+
+template <> void QuokkaSimulation<CurrentSheet>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
+		const double vx = A * std::sin(2.0 * M_PI * y);
+
+		const double Ekin = 0.5 * rho0 * (vx * vx);
+		const double Eint = P0 / (gamma_gas - 1.0);
+		const double Emag = 0.5;
+
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::density_index) = rho0;
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::x1Momentum_index) = rho0 * vx;
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::x2Momentum_index) = 0;
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::x3Momentum_index) = 0;
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::internalEnergy_index) = Eint;
+		state_cc(i, j, k, HydroSystem<CurrentSheet>::energy_index) = Eint + Ekin + Emag;
+	});
+}
+
+template <> void QuokkaSimulation<CurrentSheet>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
+
+		double by = NAN;
+		if (std::abs(x) > 0.25) {
+			by = 1.;
+		} else {
+			by = -1.;
+		}
+
+		// somehow this does not work -- the outputs show that x-BField is nonzero...
+		if (dir == quokka::direction::x) {
+			state_fc(i, j, k, Physics_Indices<CurrentSheet>::mhdFirstIndex) = 0;
+		} else if (dir == quokka::direction::y) {
+			state_fc(i, j, k, Physics_Indices<CurrentSheet>::mhdFirstIndex) = by;
+		} else if (dir == quokka::direction::z) {
+			state_fc(i, j, k, Physics_Indices<CurrentSheet>::mhdFirstIndex) = 0;
+		}
+	});
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<CurrentSheet>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<CurrentSheet>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<CurrentSheet> sim(BCs_cc, BCs_fc);
+	sim.setInitialConditions();
+	sim.evolve();
+	return 0;
+}

--- a/src/problems/FCQuantities/CMakeLists.txt
+++ b/src/problems/FCQuantities/CMakeLists.txt
@@ -1,7 +1,10 @@
-add_executable(test_fc_quantities test_fc_quantities.cpp ${QuokkaObjSources})
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_fc_quantities test_fc_quantities.cpp ${QuokkaObjSources})
 
-if(AMReX_GPU_BACKEND MATCHES "CUDA")
-    setup_target_for_cuda_compilation(test_fc_quantities)
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_fc_quantities)
+    endif()
+
+    add_test(NAME FCQuantities COMMAND test_fc_quantities ../inputs/fc_hydro_wave.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    set_tests_properties(FCQuantities PROPERTIES LABELS "MHD")
 endif()
-
-add_test(NAME FCQuantities COMMAND test_fc_quantities ../inputs/fc_hydro_wave.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/problems/FastWave/CMakeLists.txt
+++ b/src/problems/FastWave/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_fast_wave test_fast_wave.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_fast_wave)
+    endif()
+
+    add_test(NAME FastWave COMMAND test_fast_wave ../inputs/fast_wave.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    set_tests_properties(FastWave PROPERTIES LABELS "MHD")
+endif()

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -1,0 +1,264 @@
+//==============================================================================
+// Copyright 2025 Neco Elizabeth Cole-Kodikara.
+// Credit to Nico Kriel for creating the MHD module and Alfven wave test
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_fast_wave.cpp
+/// \brief Defines a test problem for magnetosonic waves of the fast type.
+///
+
+#include <bitset>
+#include <cassert>
+#include <cmath>
+#include <gcem.hpp>
+#include <iostream>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "physics_info.hpp"
+#include "test_fast_wave.hpp"
+#include "util/fextract.hpp"
+
+struct FastWave {
+};
+
+template <> struct quokka::EOS_Traits<FastWave> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<FastWave> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+// constants
+constexpr double sound_speed = 1.0;
+constexpr double gamma_gas = quokka::EOS_Traits<FastWave>::gamma;
+
+// background states
+constexpr double bg_density = 1.0;
+constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
+constexpr double bg_mag_amplitude = 1.;
+
+// theta is the angle between k and background magnetic field bg_mag
+constexpr double theta_degrees = 90.0; // degrees
+constexpr double cos_theta = gcem::cos(theta_degrees * M_PI / 180.0);
+
+// k = 2 pi / wave length
+// box length = 1, so |k| in [1, inf)
+constexpr double num_modes = 1;
+constexpr double k_amplitude = 2 * M_PI * num_modes;
+
+// input perturbation: choose to do this via the relative density field in [0, 1]. remember, the linear regime is valid when this perturbation is small
+constexpr double delta_b = 1e-4;
+
+constexpr double alfven_speed = bg_mag_amplitude / gcem::sqrt(bg_density);
+constexpr double magnetosonic_speed = gcem::sqrt(alfven_speed * alfven_speed + sound_speed * sound_speed);
+constexpr double bg_mag_x3 = bg_mag_amplitude;
+
+constexpr double omega =
+    gcem::sqrt(gcem::pow(k_amplitude, 2) / 2.0 *
+	       (gcem::pow(magnetosonic_speed, 2) + gcem::sqrt(gcem::pow(magnetosonic_speed, 4) - 4.0 * gcem::pow(alfven_speed, 2) * gcem::pow(sound_speed, 2) *
+												     gcem::pow(cos_theta, 2)))); // NOLINT(cert-err58-cpp)
+
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_x(double x1, double x2, double /*x3*/, double time)
+{
+	return -x2 / 2.0 * (bg_mag_amplitude + delta_b * std::cos(omega * time - k_amplitude * x1));
+}
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_y(double x1, double /*x2*/, double /*x3*/, double time) -> double
+{
+	return bg_mag_amplitude * x1 / 2.0 + ((delta_b)*std::sin(omega * time - k_amplitude * x1) / (-2.0 * k_amplitude));
+}
+AMREX_GPU_DEVICE auto computeMagneticVectorPotential_z(double /*x1*/, double /*x2*/, double /*x3*/, double /*time*/) -> double { return 0.0; }
+
+////////////////////////////////////
+AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::centering cen, quokka::direction dir,
+					  double time)
+{
+	const amrex::Real x1_L = prob_lo[0] + i * dx[0];
+	const amrex::Real x2_L = prob_lo[1] + j * dx[1];
+	const amrex::Real x3_L = prob_lo[2] + k * dx[2];
+
+	const amrex::Real x1_C = x1_L + static_cast<amrex::Real>(0.5) * dx[0];
+
+	if (cen == quokka::centering::cc) {
+		const double cos_wave_C = std::cos(omega * time - k_amplitude * x1_C);
+
+		// magnetic field at the center of the cell
+		const double x1mag = 0.0;
+		const double x2mag = 0.0;
+		const double x3mag = bg_mag_amplitude + delta_b * cos_wave_C;
+
+		const double density = bg_density + bg_density * delta_b / bg_mag_amplitude * cos_wave_C;
+		const double pressure = bg_pressure + bg_pressure * gamma_gas * delta_b / bg_mag_amplitude * cos_wave_C;
+		const double x1vel = magnetosonic_speed * delta_b / bg_mag_amplitude * cos_wave_C;
+		const double x2vel = 0.0;
+		const double x3vel = 0.0;
+
+		const double velocity_magnitude = std::sqrt(std::pow(x1vel, 2) + std::pow(x2vel, 2) + std::pow(x3vel, 2));
+		const double momentum = density * velocity_magnitude;
+		const double Ekin = 0.5 * std::pow(momentum, 2) / density;
+		const double Emag = 0.5 * (x1mag * x1mag + x2mag * x2mag + x3mag * x3mag);
+		const double Eint = pressure / (gamma_gas - 1);
+		const double Etot = Ekin + Emag + Eint;
+
+		state(i, j, k, HydroSystem<FastWave>::density_index) = density;
+		state(i, j, k, HydroSystem<FastWave>::x1Momentum_index) = x1vel * density;
+		state(i, j, k, HydroSystem<FastWave>::x2Momentum_index) = x2vel * density;
+		state(i, j, k, HydroSystem<FastWave>::x3Momentum_index) = x3vel * density;
+		state(i, j, k, HydroSystem<FastWave>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<FastWave>::internalEnergy_index) = Eint;
+	} else if (cen == quokka::centering::fc) {
+		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+					 dx[1] -
+				     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L, time)) /
+					 dx[2];
+		const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L, time)) /
+					 dx[2] -
+				     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+					 dx[0];
+
+		const double x3mag = ((computeMagneticVectorPotential_y(x1_L + dx[0], x2_L + (dx[1] / 2), x3_L, time) -
+				       computeMagneticVectorPotential_y(x1_L, x2_L + (dx[1] / 2), x3_L, time)) /
+				      dx[0]) -
+				     ((computeMagneticVectorPotential_x(x1_L + (dx[0] / 2), x2_L + dx[1], x3_L, time) -
+				       computeMagneticVectorPotential_x(x1_L + (dx[0] / 2), x2_L, x3_L, time)) /
+				      dx[1]);
+
+		if (dir == quokka::direction::x) {
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
+		} else if (dir == quokka::direction::y) {
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
+		} else if (dir == quokka::direction::z) {
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x3mag;
+		}
+	}
+}
+
+template <> void QuokkaSimulation<FastWave>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_cc = Physics_Indices<FastWave>::nvarTotal_cc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_cc; ++n) {
+			state_cc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_cc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <> void QuokkaSimulation<FastWave>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_fc = Physics_Indices<FastWave>::nvarPerDim_fc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_fc; ++n) {
+			state_fc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+		computeWaveSolution(i, j, k, state_fc, dx, prob_lo, cen, dir, 0);
+	});
+}
+
+template <>
+void QuokkaSimulation<FastWave>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+							  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, 0);
+		});
+	}
+}
+
+template <>
+void QuokkaSimulation<FastWave>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+{
+	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &stateExact = ref.array(iter);
+		auto const ncomp = ref.nComp();
+
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			for (int n = 0; n < ncomp; ++n) {
+				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
+			}
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, 0);
+		});
+	}
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<FastWave>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<FastWave>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<FastWave> sim(BCs_cc, BCs_fc);
+	sim.computeReferenceSolution_ = true;
+	sim.setInitialConditions();
+	sim.evolve();
+
+	// Compute test success condition
+	int status = 0;
+	const double error_tol = 0.002;
+	if (sim.errorNorm_ > error_tol) {
+		status = 1;
+	}
+
+	return status;
+}

--- a/src/problems/FastWave/test_fast_wave.hpp
+++ b/src/problems/FastWave/test_fast_wave.hpp
@@ -1,0 +1,20 @@
+#ifndef TEST_FAST_WAVE_HPP_ // NOLINT
+#define TEST_FAST_WAVE_HPP_
+//==============================================================================
+// Copyright 2025 Neco Elizabeth Cole-Kodikara.
+// Credit to Nico Kriel for creating the MHD module and Alfven wave test
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_fast_wave.hpp
+/// \brief Defines a test problem for magnetosonic waves of the fast type.
+///
+
+// external headers
+#include <fmt/format.h>
+
+// internal headers
+#include "hydro/mhd_system.hpp"
+
+// function definitions
+
+#endif // TEST_FAST_WAVE_HPP_

--- a/src/problems/FieldLoop/CMakeLists.txt
+++ b/src/problems/FieldLoop/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_field_loop test_field_loop.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_field_loop)
+    endif()
+
+    add_test(NAME FieldLoop COMMAND test_field_loop ../inputs/field_loop.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -1,0 +1,146 @@
+//==============================================================================
+// Copyright 2025 Ben Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_field_loop.cpp
+/// \brief
+///   This problem is based on the test described here:
+///   https://www.astro.princeton.edu/~jstone/Athena/tests/field-loop/Field-loop.html
+///
+
+#include <cmath>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "hydro/EOS.hpp"
+#include "hydro/hydro_system.hpp"
+#include "physics_info.hpp"
+
+struct FieldLoop {
+};
+
+template <> struct quokka::EOS_Traits<FieldLoop> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<FieldLoop> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+constexpr double A = 1.0e-3;
+constexpr double R_0 = 0.3;
+
+template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+
+	constexpr double gamma_gas = quokka::EOS_Traits<FieldLoop>::gamma;
+	constexpr double rho0 = 1.0;
+	constexpr double P0 = 1.0;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
+		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
+
+		//  Vx=sin(60 degrees) and Vy=cos(60 degrees)
+		const double vx = std::sin(M_PI / 3.0);
+		const double vy = std::cos(M_PI / 3.0);
+		const double vz = 1.0; // this should not affect the solution!
+
+		const double Ekin = 0.5 * rho0 * (vx * vx + vy * vy);
+		const double Eint = P0 / (gamma_gas - 1.0);
+
+		// Az = MAX([A ( R0 - r )],0)
+		auto A_z = [=](double x, double y) {
+			const double R = std::sqrt(x * x + y * y);
+			return std::max(A * (R_0 - R), 0.);
+		};
+		auto B_x = [=](double xL, double yL) { return (A_z(xL, yL + dx[1]) - A_z(xL, yL)) / dx[1]; };
+		auto B_y = [=](double xL, double yL) { return -(A_z(xL + dx[0], yL) - A_z(xL, yL)) / dx[0]; };
+		const double bx = 0.5 * (B_x(x - 0.5 * dx[0], y - 0.5 * dx[1]) + B_x(x + 0.5 * dx[0], y - 0.5 * dx[1]));
+		const double by = 0.5 * (B_y(x - 0.5 * dx[0], y - 0.5 * dx[1]) + B_y(x - 0.5 * dx[0], y + 0.5 * dx[1]));
+		const double Emag = 0.5 * (bx * bx + by * by);
+
+		state_cc(i, j, k, HydroSystem<FieldLoop>::density_index) = rho0;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x1Momentum_index) = rho0 * vx;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x2Momentum_index) = rho0 * vy;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x3Momentum_index) = rho0 * vz;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::internalEnergy_index) = Eint;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::energy_index) = Eint + Ekin + Emag;
+	});
+}
+
+template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double xL = prob_lo[0] + (i * dx[0]);
+		const double yL = prob_lo[1] + (j * dx[1]);
+
+		// Az = MAX([A ( R0 - r )],0)
+		auto A_z = [=](double x, double y) {
+			const double R = std::sqrt(x * x + y * y);
+			return std::max(A * (R_0 - R), 0.);
+		};
+		auto B_x = [=](double xL, double yL) { return (A_z(xL, yL + dx[1]) - A_z(xL, yL)) / dx[1]; };
+		auto B_y = [=](double xL, double yL) { return -(A_z(xL + dx[0], yL) - A_z(xL, yL)) / dx[0]; };
+		const double bx = B_x(xL, yL);
+		const double by = B_y(xL, yL);
+
+		if (dir == quokka::direction::x) {
+			state_fc(i, j, k, Physics_Indices<FieldLoop>::mhdFirstIndex) = bx;
+		} else if (dir == quokka::direction::y) {
+			state_fc(i, j, k, Physics_Indices<FieldLoop>::mhdFirstIndex) = by;
+		} else if (dir == quokka::direction::z) {
+			state_fc(i, j, k, Physics_Indices<FieldLoop>::mhdFirstIndex) = 0;
+		}
+	});
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<FieldLoop>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<FieldLoop>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<FieldLoop> sim(BCs_cc, BCs_fc);
+	sim.setInitialConditions();
+	sim.evolve();
+	return 0;
+}

--- a/src/problems/OrszagTang/CMakeLists.txt
+++ b/src/problems/OrszagTang/CMakeLists.txt
@@ -1,0 +1,9 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_orszag_tang test_orszag_tang.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_orszag_tang)
+    endif()
+
+    add_test(NAME OrszagTang COMMAND test_orszag_tang ../inputs/orszag_tang.in WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -1,0 +1,144 @@
+//==============================================================================
+// Copyright 2025 Ben Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_orszag_tang.cpp
+/// \brief
+///   This problem is based on the implementation here:
+///   https://github.com/PrincetonUniversity/athena/blob/master/src/pgen/orszag_tang.cpp.
+///	  (Phil Hopkins made several typos on this page, do not use:
+///	  https://www.astro.princeton.edu/~jstone/Athena/tests/orszag-tang/pagesource.html)
+///
+
+#include <cmath>
+
+#include "AMReX_Array.H"
+#include "AMReX_Array4.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "grid.hpp"
+#include "hydro/EOS.hpp"
+#include "hydro/hydro_system.hpp"
+#include "physics_info.hpp"
+
+struct OrszagTang {
+};
+
+template <> struct quokka::EOS_Traits<OrszagTang> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+	static constexpr double boltzmann_constant = C::k_B;
+};
+
+template <> struct Physics_Traits<OrszagTang> {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_self_gravity_enabled = false;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+constexpr double B0 = 1.0 / gcem::sqrt(4.0 * PI);
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto A_z(double x, double y) -> double
+{
+	return B0 / (4.0 * M_PI) * (std::cos(4.0 * M_PI * x) - 2.0 * std::cos(2.0 * M_PI * y));
+};
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto B_x(double xL, double yL, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx) -> double
+{
+	return (A_z(xL, yL + dx[1]) - A_z(xL, yL)) / dx[1];
+};
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto B_y(double xL, double yL, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx) -> double
+{
+	return -(A_z(xL + dx[0], yL) - A_z(xL, yL)) / dx[0];
+};
+
+template <> void QuokkaSimulation<OrszagTang>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+
+	constexpr double gamma_gas = quokka::EOS_Traits<OrszagTang>::gamma;
+	constexpr double rho0 = 25. / (36. * M_PI);
+	constexpr double P0 = 5. / (12. * M_PI);
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
+		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
+
+		const double vx = std::sin(2 * M_PI * y);
+		const double vy = -std::sin(2 * M_PI * x);
+
+		const double Bx = 0.5 * (B_x(x - 0.5 * dx[0], y - 0.5 * dx[1], dx) + B_x(x + 0.5 * dx[0], y - 0.5 * dx[1], dx));
+		const double By = 0.5 * (B_y(x - 0.5 * dx[0], y - 0.5 * dx[1], dx) + B_y(x - 0.5 * dx[0], y + 0.5 * dx[1], dx));
+
+		const double Ekin = 0.5 * rho0 * (vx * vx + vy * vy);
+		const double Eint = P0 / (gamma_gas - 1.0);
+		const double Emag = 0.5 * (Bx * Bx + By * By);
+
+		state_cc(i, j, k, HydroSystem<OrszagTang>::density_index) = rho0;
+		state_cc(i, j, k, HydroSystem<OrszagTang>::x1Momentum_index) = rho0 * vx;
+		state_cc(i, j, k, HydroSystem<OrszagTang>::x2Momentum_index) = rho0 * vy;
+		state_cc(i, j, k, HydroSystem<OrszagTang>::x3Momentum_index) = 0;
+		state_cc(i, j, k, HydroSystem<OrszagTang>::internalEnergy_index) = Eint;
+		state_cc(i, j, k, HydroSystem<OrszagTang>::energy_index) = Eint + Ekin + Emag;
+	});
+}
+
+template <> void QuokkaSimulation<OrszagTang>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const double xL = prob_lo[0] + (i * dx[0]);
+		const double yL = prob_lo[1] + (j * dx[1]);
+
+		if (dir == quokka::direction::x) {
+			state_fc(i, j, k, Physics_Indices<OrszagTang>::mhdFirstIndex) = B_x(xL, yL, dx);
+		} else if (dir == quokka::direction::y) {
+			state_fc(i, j, k, Physics_Indices<OrszagTang>::mhdFirstIndex) = B_y(xL, yL, dx);
+		} else if (dir == quokka::direction::z) {
+			state_fc(i, j, k, Physics_Indices<OrszagTang>::mhdFirstIndex) = 0;
+		}
+	});
+}
+
+auto problem_main() -> int
+{
+	const int nvars_cc = Physics_Indices<OrszagTang>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
+	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	const int nvars_fc = Physics_Indices<OrszagTang>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	QuokkaSimulation<OrszagTang> sim(BCs_cc, BCs_fc);
+	sim.setInitialConditions();
+	sim.evolve();
+	return 0;
+}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -194,7 +194,15 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// constructor
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }
-	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc) { initialize(); }
+
+	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) { initialize(); }
+
+	auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> & /*BCs_cc*/) -> amrex::Vector<amrex::BCRec>
+	{
+		static_assert(!(Physics_Traits<problem_t>::is_mhd_enabled), "You are required to explicitly define the face-centered BCs when MHD is enabled.");
+		amrex::Vector<amrex::BCRec> BCs_fc(0);
+		return BCs_fc;
+	}
 
 	void initialize();
 	void PerformanceHints();
@@ -403,7 +411,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// Nghost = number of ghost cells for each array
 	int nghost_cc_ = 6; // PPM needs nghost >= 3, PPM+flattening needs nghost >= 4, +2 for face velocity ghost cells
-	int nghost_fc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 4 : 2; // 4 needed for MHD, otherwise only 2 for tracer particles
+	int nghost_fc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 6 : 2; // 6 needed for MHD, otherwise only 2 for tracer particles
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;
 	std::array<amrex::Vector<std::string>, AMREX_SPACEDIM> componentNames_fc_;
@@ -565,10 +573,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	dt_.resize(nlevs_max, 1.e100);
 	state_new_cc_.resize(nlevs_max);
 	state_old_cc_.resize(nlevs_max);
-	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
-		state_new_fc_.resize(nlevs_max);
-		state_old_fc_.resize(nlevs_max);
-	}
+	state_new_fc_.resize(nlevs_max);
+	state_old_fc_.resize(nlevs_max);
 	max_signal_speed_.resize(nlevs_max);
 	flux_reg_.resize(nlevs_max + 1);
 	fillpatcher_.resize(nlevs_max + 1);
@@ -2401,13 +2407,13 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 		// Fill ghost zones for state_new_cc_
 		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
 				       InterpHookNone, FillPatchType::fillpatch_function);
-	}
 
-	// Fill ghost zones for state_new_fc_
-	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
-					       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		// Fill ghost zones for state_new_fc_
+		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
+						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+			}
 		}
 	}
 
@@ -2465,7 +2471,6 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_f
 	const int ncomp_plotMF_fc = nvar_dim_tot_fc;
 
 	amrex::MultiFab plotMF_fc(amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim)), dmap[lev], ncomp_plotMF_fc, nghost_fc_);
-
 	// Fill ghost zones for state_new_fc_
 	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
 		fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,


### PR DESCRIPTION
### Description
Compute the emf using the face velocities returned from the Riemann solver.

Reference: https://scixplorer.org/abs/2021JCoPh.42409748M/abstract

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
