### PR TITLE
Add timestep drop detector (dt_cutoff parameter)

### DIFF
--- a/docs/markdown/parameters.md
+++ b/docs/markdown/parameters.md
@@ -28,6 +28,7 @@ These parameters are read in the ``AMRSimulation<problem_t>::readParameters()`` 
 | density_floor | Float | The minimum density value allowed in the simulation. Enforced through EnforceLimits. |
 | temperature_floor | Float | The minimum temperature value allowed in the simulation. Enforced through EnforceLimits. |
 | max_walltime | String | The maximum walltime for the simulation in the format DD:HH:SS (days/hours/seconds). After 90% of this walltime elapses, the simulation will automatically stop and exit. |
+| dt_cutoff | Float | Timestep drop detector threshold. If the timestep drops below dt_cutoff * current_time, the simulation aborts with an error message. This helps detect numerical instabilities early. Default: 0.0 (disabled). |
 
 ## Hydrodynamics
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -168,6 +168,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real cflNumber_ = 0.3;	      // default
 	amrex::Real particleCflNumber_ = 0.5; // default
 	amrex::Real dtToleranceFactor_ = 1.1; // default
+	amrex::Real dtCutoff_ = 0.0; // default: no cutoff (disabled when 0)
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;				     // default: don't print
 	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit
@@ -686,6 +687,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default stopping time
 	pp.query("stop_time", stopTime_);
 
+	// Default timestep cutoff (safety feature)
+	pp.query("dt_cutoff", dtCutoff_);
+
 	// Default ascent render interval
 	pp.query("ascent_interval", ascentInterval_);
 
@@ -1061,6 +1065,20 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		}
 
 		computeTimestep();
+
+		// Check for timestep drop (safety feature)
+		if (dtCutoff_ > 0.0) {
+			const amrex::Real dt_min_allowed = dtCutoff_ * cur_time;
+			if ((cur_time > 0.0) && (dt_[0] < dt_min_allowed)) {
+				amrex::Print() << "ERROR: Timestep has dropped below cutoff threshold!\n";
+				amrex::Print() << "Current time: " << cur_time << "\n";
+				amrex::Print() << "Current timestep: " << dt_[0] << "\n";
+				amrex::Print() << "Minimum allowed timestep: " << dt_min_allowed << "\n";
+				amrex::Print() << "dt_cutoff parameter: " << dtCutoff_ << "\n";
+				amrex::Print() << "This may indicate a stability issue in the simulation.\n";
+				amrex::Abort("Timestep drop detected - aborting simulation for safety");
+			}
+		}
 
 		// do user-specified calculations before the level update
 		computeBeforeTimestep();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -168,7 +168,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real cflNumber_ = 0.3;	      // default
 	amrex::Real particleCflNumber_ = 0.5; // default
 	amrex::Real dtToleranceFactor_ = 1.1; // default
-	amrex::Real dtCutoff_ = 0.0; // default: no cutoff (disabled when 0)
+	amrex::Real dtCutoff_ = 0.0;	      // default: no cutoff (disabled when 0)
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;				     // default: don't print
 	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit


### PR DESCRIPTION
This PR implements a timestep drop detector feature similar to Castro's `dt_cutoff` parameter.

## Changes
- Add `dtCutoff_` member variable to AMRSimulation class
- Add `dt_cutoff` parameter reading in readParameters()
- Implement timestep drop detection in main simulation loop
- Abort simulation with detailed error if dt < dt_cutoff * current_time

## Usage
Add to input file:
```
dt_cutoff = 1.0e-12  # Abort if timestep drops below 1e-12 * current_time
```

Feature is disabled by default (dt_cutoff = 0.0) and only activates when explicitly set.

Fixes #533

Generated with [Claude Code](https://claude.ai/code)