### PR TITLE
[WIP] Replace `long` with `amrex::Long`

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1952,9 +1952,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		if (print_rad_counter_) {
 			auto h_iteration_counter = iteration_counter.copyToHost();
-			int64_t global_solver_count = h_iteration_counter[0];	      // number of Newton-Raphson solvings
-			int64_t global_iteration_sum = h_iteration_counter[1];	      // sum of Newton-Raphson iterations
-			int global_iteration_max = h_iteration_counter[2];	      // max number of Newton-Raphson iterations
+			int64_t global_solver_count = h_iteration_counter[0];		 // number of Newton-Raphson solvings
+			int64_t global_iteration_sum = h_iteration_counter[1];		 // sum of Newton-Raphson iterations
+			int global_iteration_max = h_iteration_counter[2];		 // max number of Newton-Raphson iterations
 			int64_t global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
 
 			amrex::ParallelDescriptor::ReduceLongSum(global_solver_count);
@@ -1985,8 +1985,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		auto h_iteration_failure_counter = iteration_failure_counter.copyToHost();
 		int64_t nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
-		int64_t nf_dust = h_iteration_failure_counter[1];	   // number of dust temperature failures
-		int64_t nf_outer = h_iteration_failure_counter[2];	   // number of outer iterations failures
+		int64_t nf_dust = h_iteration_failure_counter[1];     // number of dust temperature failures
+		int64_t nf_outer = h_iteration_failure_counter[2];    // number of outer iterations failures
 
 		amrex::ParallelDescriptor::ReduceLongSum(nf_coupling);
 		amrex::ParallelDescriptor::ReduceLongSum(nf_dust);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -12,7 +12,6 @@
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include <array>
-#include <cstdint>
 #include <iostream>
 #include <set>
 #if __has_include(<filesystem>)
@@ -1952,10 +1951,10 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		if (print_rad_counter_) {
 			auto h_iteration_counter = iteration_counter.copyToHost();
-			int64_t global_solver_count = h_iteration_counter[0];		 // number of Newton-Raphson solvings
-			int64_t global_iteration_sum = h_iteration_counter[1];		 // sum of Newton-Raphson iterations
+			amrex::Long global_solver_count = h_iteration_counter[0];		 // number of Newton-Raphson solvings
+			amrex::Long global_iteration_sum = h_iteration_counter[1];		 // sum of Newton-Raphson iterations
 			int global_iteration_max = h_iteration_counter[2];		 // max number of Newton-Raphson iterations
-			int64_t global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
+			amrex::Long global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
 
 			amrex::ParallelDescriptor::ReduceLongSum(global_solver_count);
 			amrex::ParallelDescriptor::ReduceLongSum(global_iteration_sum);
@@ -1984,9 +1983,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		}
 
 		auto h_iteration_failure_counter = iteration_failure_counter.copyToHost();
-		int64_t nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
-		int64_t nf_dust = h_iteration_failure_counter[1];     // number of dust temperature failures
-		int64_t nf_outer = h_iteration_failure_counter[2];    // number of outer iterations failures
+		amrex::Long nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
+		amrex::Long nf_dust = h_iteration_failure_counter[1];     // number of dust temperature failures
+		amrex::Long nf_outer = h_iteration_failure_counter[2];    // number of outer iterations failures
 
 		amrex::ParallelDescriptor::ReduceLongSum(nf_coupling);
 		amrex::ParallelDescriptor::ReduceLongSum(nf_dust);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -12,6 +12,7 @@
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include <array>
+#include <cstdint>
 #include <iostream>
 #include <set>
 #if __has_include(<filesystem>)
@@ -1951,10 +1952,10 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		if (print_rad_counter_) {
 			auto h_iteration_counter = iteration_counter.copyToHost();
-			long global_solver_count = h_iteration_counter[0];	      // number of Newton-Raphson solvings
-			long global_iteration_sum = h_iteration_counter[1];	      // sum of Newton-Raphson iterations
+			int64_t global_solver_count = h_iteration_counter[0];	      // number of Newton-Raphson solvings
+			int64_t global_iteration_sum = h_iteration_counter[1];	      // sum of Newton-Raphson iterations
 			int global_iteration_max = h_iteration_counter[2];	      // max number of Newton-Raphson iterations
-			long global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
+			int64_t global_decoupled_iteration_sum = h_iteration_counter[3]; // sum of decoupled gas-dust Newton-Raphson iterations
 
 			amrex::ParallelDescriptor::ReduceLongSum(global_solver_count);
 			amrex::ParallelDescriptor::ReduceLongSum(global_iteration_sum);
@@ -1983,9 +1984,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		}
 
 		auto h_iteration_failure_counter = iteration_failure_counter.copyToHost();
-		long nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
-		long nf_dust = h_iteration_failure_counter[1];	   // number of dust temperature failures
-		long nf_outer = h_iteration_failure_counter[2];	   // number of outer iterations failures
+		int64_t nf_coupling = h_iteration_failure_counter[0]; // number of matter-radiation coupling failures
+		int64_t nf_dust = h_iteration_failure_counter[1];	   // number of dust temperature failures
+		int64_t nf_outer = h_iteration_failure_counter[2];	   // number of outer iterations failures
 
 		amrex::ParallelDescriptor::ReduceLongSum(nf_coupling);
 		amrex::ParallelDescriptor::ReduceLongSum(nf_dust);


### PR DESCRIPTION
Replace 6 instances of plain `long` types with `int64_t` in radiation iteration/failure counters and add `#include <cstdint>` for definite integer types.

Follows Google C++ Style Guide recommendation for implementation-independent integer types.

Fixes #1211

Generated with [Claude Code](https://claude.ai/code)