### PR TITLE
always-success job for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,40 +3,8 @@ name: CodeQL
 on:
   push:
     branches: [ "development" ]
-    paths:
-      - 'src/**'
-      - 'extern/amrex/**'
-      - 'extern/Microphysics/**'
-      - 'extern/fmt/**'
-      - 'extern/grackle_data_files/**'
-      - 'extern/openPMD-api/**'
-      - 'extern/yaml-cpp/**'
-      - 'inputs/**'
-      - 'CMakeLists.txt'
-      - '**/*.cpp'
-      - '**/*.c'
-      - '**/*.hpp'
-      - '**/*.h'
-      - '.github/workflows/codeql.yml'
-      - '.github/workflows/codeql/codeql-config.yml'
   pull_request:
     branches: [ "development" ]
-    paths:
-      - 'src/**'
-      - 'extern/amrex/**'
-      - 'extern/Microphysics/**'
-      - 'extern/fmt/**'
-      - 'extern/grackle_data_files/**'
-      - 'extern/openPMD-api/**'
-      - 'extern/yaml-cpp/**'
-      - 'inputs/**'
-      - 'CMakeLists.txt'
-      - '**/*.cpp'
-      - '**/*.c'
-      - '**/*.hpp'
-      - '**/*.h'
-      - '.github/workflows/codeql.yml'
-      - '.github/workflows/codeql/codeql-config.yml'
   schedule:
     - cron: "27 3 * * 0"
 
@@ -48,20 +16,46 @@ permissions:
   contents: read
 
 jobs:
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code-changed: ${{ steps.changes.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            code:
+              - 'src/**'
+              - 'extern/amrex/**'
+              - 'extern/Microphysics/**'
+              - 'extern/fmt/**'
+              - 'extern/grackle_data_files/**'
+              - 'extern/openPMD-api/**'
+              - 'extern/yaml-cpp/**'
+              - 'inputs/**'
+              - 'CMakeLists.txt'
+              - '**/*.cpp'
+              - '**/*.c'
+              - '**/*.hpp'
+              - '**/*.h'
+              - '.github/workflows/codeql.yml'
+              - '.github/workflows/codeql/codeql-config.yml'
+
   analyze:
-    if: ${{ github.repository == 'quokka-astro/quokka' || github.event_name != 'schedule' }}
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.code-changed == 'true' && (github.repository == 'quokka-astro/quokka' || github.event_name != 'schedule') }}
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
         language: [ python, cpp ]
-
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -129,6 +123,27 @@ jobs:
         uses: github/codeql-action/analyze@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
         with:
           category: "/language:${{ matrix.language }}"
+
+  # Critical: Always-success job for branch protection
+  codeql-success:
+    needs: [check-changes, analyze]
+    if: always()  # Run regardless of analyze job outcome
+    runs-on: ubuntu-latest
+    steps:
+      - name: CodeQL Status
+        run: |
+          if [[ "${{ needs.check-changes.outputs.code-changed }}" == "true" ]]; then
+            if [[ "${{ needs.analyze.result }}" == "success" ]]; then
+              echo "CodeQL analysis completed successfully"
+              exit 0
+            else
+              echo "CodeQL analysis failed"
+              exit 1
+            fi
+          else
+            echo "CodeQL analysis skipped - no relevant code changes"
+            exit 0
+          fi
 
   save_pr_number:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Description
Following Claude's suggestions from #1217 , create a `codeql-success` task to replace `analyze` and send an always-success signal when codeql is skipped. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
