### PR TITLE
Refuse to run if ncells < nghost_cc_

### DIFF
--- a/inputs/MatterEnergyExchangeRSLA.in
+++ b/inputs/MatterEnergyExchangeRSLA.in
@@ -14,7 +14,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 6 6 6
+amr.n_cell          = 8 8 8
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/MatterEnergyExchangeRSLA.in
+++ b/inputs/MatterEnergyExchangeRSLA.in
@@ -14,7 +14,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 4 4 4
+amr.n_cell          = 6 6 6
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/ResampledCooling.in
+++ b/inputs/ResampledCooling.in
@@ -13,7 +13,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 6 6 6
+amr.n_cell          = 8 8 8
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/ResampledCooling.in
+++ b/inputs/ResampledCooling.in
@@ -13,7 +13,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 4 4 4
+amr.n_cell          = 6 6 6
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/TabulatedCooling.in
+++ b/inputs/TabulatedCooling.in
@@ -13,7 +13,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 6 6 6
+amr.n_cell          = 8 8 8
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/TabulatedCooling.in
+++ b/inputs/TabulatedCooling.in
@@ -13,7 +13,7 @@ amr.v              = 0       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 4 4 4
+amr.n_cell          = 6 6 6
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/energyexchange.in
+++ b/inputs/energyexchange.in
@@ -14,7 +14,7 @@ amr.v              = 1       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 4 4 4
+amr.n_cell          = 6 6 6
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/energyexchange.in
+++ b/inputs/energyexchange.in
@@ -14,7 +14,7 @@ amr.v              = 1       # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 6 6 6
+amr.n_cell          = 8 8 8
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 4     # grid size must be divisible by this
 

--- a/inputs/primordial_chem.in
+++ b/inputs/primordial_chem.in
@@ -14,10 +14,10 @@ amr.v               = 0     # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 6 6 6
+amr.n_cell          = 8 8 8
 amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 6   # grid size must be divisible by this
-amr.max_grid_size   = 6
+amr.blocking_factor = 2   # grid size must be divisible by this
+amr.max_grid_size   = 8
 
 do_reflux = 0
 do_subcycle = 0

--- a/inputs/primordial_chem.in
+++ b/inputs/primordial_chem.in
@@ -14,10 +14,10 @@ amr.v               = 0     # verbosity in Amr
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
-amr.n_cell          = 1 1 1
+amr.n_cell          = 6 6 6
 amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 1   # grid size must be divisible by this
-amr.max_grid_size   = 1
+amr.blocking_factor = 6   # grid size must be divisible by this
+amr.max_grid_size   = 6
 
 do_reflux = 0
 do_subcycle = 0

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -597,13 +597,12 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	const amrex::Box domain = Geom()[0].Domain();
 	const amrex::IntVect ncells{
 	    AMREX_D_DECL(domain.bigEnd(0) - domain.smallEnd(0) + 1, domain.bigEnd(1) - domain.smallEnd(1) + 1, domain.bigEnd(2) - domain.smallEnd(2) + 1)};
-	
+
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		if (ncells[idim] < nghost_cc_) {
-			amrex::Print() << "Number of cells in dimension " << idim << " (" << ncells[idim] 
-				       << ") is less than nghost_cc_ (" << nghost_cc_ << ")! "
-				       << "This will cause out-of-bounds access when filling ghost cells."
-				       << std::endl; // NOLINT(performance-avoid-endl)
+			amrex::Print() << "Number of cells in dimension " << idim << " (" << ncells[idim] << ") is less than nghost_cc_ (" << nghost_cc_
+				       << ")! "
+				       << "This will cause out-of-bounds access when filling ghost cells." << std::endl; // NOLINT(performance-avoid-endl)
 			amrex::Abort("Insufficient grid resolution for ghost cell operations!");
 		}
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -592,6 +592,22 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 		}
 	}
 
+	// check that ncells >= nghost_cc_ in each dimension
+	// (this is necessary to prevent out-of-bounds access when filling ghost cells)
+	const amrex::Box domain = Geom()[0].Domain();
+	const amrex::IntVect ncells{
+	    AMREX_D_DECL(domain.bigEnd(0) - domain.smallEnd(0) + 1, domain.bigEnd(1) - domain.smallEnd(1) + 1, domain.bigEnd(2) - domain.smallEnd(2) + 1)};
+	
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		if (ncells[idim] < nghost_cc_) {
+			amrex::Print() << "Number of cells in dimension " << idim << " (" << ncells[idim] 
+				       << ") is less than nghost_cc_ (" << nghost_cc_ << ")! "
+				       << "This will cause out-of-bounds access when filling ghost cells."
+				       << std::endl; // NOLINT(performance-avoid-endl)
+			amrex::Abort("Insufficient grid resolution for ghost cell operations!");
+		}
+	}
+
 	// add Quokka version to metadata
 	simulationMetadata_["quokka_version"] = QUOKKA_VERSION;
 


### PR DESCRIPTION
This PR adds validation to prevent out-of-bounds access when filling ghost cells by checking that each dimension has at least nghost_cc_ cells before proceeding with simulation initialization.

Changes:
- Added validation check in `AMRSimulation::initialize()` method
- Calculates ncells in each dimension from domain geometry
- Prints descriptive error message and aborts if validation fails
- Follows existing code patterns for error handling

Fixes #1226

Generated with [Claude Code](https://claude.ai/code)