### PR TITLE
Fix FPE issue in matplotlibcpp::clf()

### DIFF
--- a/src/util/matplotlibcpp.h
+++ b/src/util/matplotlibcpp.h
@@ -1691,7 +1691,12 @@ inline void save(const std::string &filename)
 
 inline void clf()
 {
+	fenv_t orig_feenv;
+	feholdexcept(&orig_feenv); // disable FPE
+
 	PyObject *res = PyObject_CallObject(detail::_interpreter::get().s_python_function_clf, detail::_interpreter::get().s_python_empty_tuple);
+
+	fesetenv(&orig_feenv); // restore FPE
 
 	if (!res)
 		throw std::runtime_error("Call to clf() failed.");


### PR DESCRIPTION
Adds feholdexcept() and fesetenv() around the clf() function call to prevent floating point exceptions, similar to what's already done for save() and tight_layout() functions. This fixes the 'Erroneous arithmetic operation' error in ResampledCoolingTest when FPE is enabled.

## Summary
- Located the issue in matplotlibcpp::clf() function which lacked FPE protection
- Applied the same FPE disabling pattern used by other functions in the file
- Follows established conventions in the codebase

Fixes #1225 

Generated with [Claude Code](https://claude.ai/code)