### PR TITLE
add .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,55 @@
+# This file is used by Git to map multiple names/emails to canonical authors
+# Format: Proper Name <proper@email.com> <commit@email.com>
+# Format: Proper Name <proper@email.com> Commit Name <commit@email.com>
+
+# Aditi Vijayan
+Aditi Vijayan <aditi.vijayan@anu.edu.au> <45175933+aditivijayan@users.noreply.github.com>
+Aditi Vijayan <aditi.vijayan@anu.edu.au> <aditi@setonix-01.pawsey.org.au>
+Aditi Vijayan <aditi.vijayan@anu.edu.au> <aditi@setonix-03.pawsey.org.au>
+Aditi Vijayan <aditi.vijayan@anu.edu.au> <vijayanaditi@gmail.com>
+Aditi Vijayan <aditi.vijayan@anu.edu.au> aditivijayan <vijayanaditi@gmail.com>
+
+# Ben Wibking
+Ben Wibking <benwibking@gmail.com> <ben@wibking.com>
+Ben Wibking <benwibking@gmail.com> <benjamin.wibking@anu.edu.au>
+Ben Wibking <benwibking@gmail.com> <wibking.1@astronomy.ohio-state.edu>
+Ben Wibking <benwibking@gmail.com> <wibkingb@msu.edu>
+Ben Wibking <benwibking@gmail.com> Benjamin Wibking <benjamin.wibking@anu.edu.au>
+Ben Wibking <benwibking@gmail.com> Benjamin Wibking <wibkingb@msu.edu>
+
+# ChongChong He
+ChongChong He <chongchonghe99@gmail.com> <che1234@umd.edu>
+ChongChong He <chongchonghe99@gmail.com> <chongchong.he@anu.edu.au>
+ChongChong He <chongchonghe99@gmail.com> chongchonghe <chongchong.he@anu.edu.au>
+ChongChong He <chongchonghe99@gmail.com> chongchonghe <chongchonghe99@gmail.com>
+
+# Conrad Chan
+Conrad Chan <8309215+conradtchan@users.noreply.github.com>
+
+# Liz Cole
+Liz Cole <lizmcole@gmail.com> lizmcole <lizmcole@gmail.com>
+Liz Cole <lizmcole@gmail.com> lizmcole <lizmcole@users.noreply.github.com>
+
+# Mark Krumholz
+Mark Krumholz <mark.krumholz@anu.edu.au>
+
+# Neco Kriel
+Neco Kriel <necokriel@gmail.com> <43261821+AstroKriel@users.noreply.github.com>
+Neco Kriel <necokriel@gmail.com> neco kriel <necokriel@gmail.com>
+
+# Pakshing Li
+Pakshing Li <pakshingli@shao.ac.cn> pakshingli <pakshingli@shao.ac.cn>
+Pakshing Li <pakshingli@shao.ac.cn> pakshingli <pakshingLi@shao.ac.cn>
+Pakshing Li <pakshingli@shao.ac.cn> pakshingli <psli2000@hotmail.com>
+
+# Piyush Sharda
+Piyush Sharda <34922596+psharda@users.noreply.github.com> <psharda@RSAA-043527.local>
+Piyush Sharda <34922596+psharda@users.noreply.github.com> <psharda@RSAA-43608.local>
+
+# Bots (excluded from statistics by default in many tools)
+Claude Bot <noreply@anthropic.com> Claude <noreply@anthropic.com>
+Claude Bot <209825114+claude[bot]@users.noreply.github.com> claude[bot] <209825114+claude[bot]@users.noreply.github.com>
+Dependabot <49699333+dependabot[bot]@users.noreply.github.com> dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+Devin AI <158243242+devin-ai-integration[bot]@users.noreply.github.com>
+Pre-commit CI <66853113+pre-commit-ci[bot]@users.noreply.github.com> pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
+StepSecurity Bot <bot@stepsecurity.io>

--- a/scripts/bash/compute_sloc_by_author.py
+++ b/scripts/bash/compute_sloc_by_author.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+ABOUTME: Computes the number of single lines of code (SLOC) written by each committer
+ABOUTME: Uses git blame to attribute each line to its original author
+"""
+
+import subprocess
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def get_tracked_files():
+    """Get all tracked files in the repository."""
+    result = subprocess.run(['git', 'ls-files'], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error getting tracked files: {result.stderr}")
+        sys.exit(1)
+    return result.stdout.strip().split('\n')
+
+
+def is_code_file(filepath):
+    """Determine if a file should be counted as code."""
+    code_extensions = {
+        '.cpp', '.hpp', '.h', '.c', '.cc', '.cxx',
+        '.py', '.sh', '.cmake', '.f90', '.f', '.F90'
+    }
+    return Path(filepath).suffix.lower() in code_extensions
+
+
+def count_lines_by_author(filepath):
+    """Count lines attributed to each author using git blame with mailmap support."""
+    author_lines = defaultdict(int)
+    
+    try:
+        # Git will automatically use .mailmap if it exists and is configured
+        result = subprocess.run(
+            ['git', 'blame', '--line-porcelain', filepath],
+            capture_output=True,
+            text=True
+        )
+        
+        if result.returncode != 0:
+            return author_lines
+        
+        lines = result.stdout.strip().split('\n')
+        for i, line in enumerate(lines):
+            if line.startswith('author '):
+                author = line[7:]  # Remove 'author ' prefix
+                # Skip empty lines by checking the actual content
+                # The content line comes after metadata lines
+                for j in range(i + 1, len(lines)):
+                    if lines[j].startswith('\t'):
+                        content = lines[j][1:]  # Remove tab
+                        if content.strip():  # Only count non-empty lines
+                            author_lines[author] += 1
+                        break
+    
+    except Exception as e:
+        print(f"Error processing {filepath}: {e}")
+    
+    return author_lines
+
+
+def main():
+    """Main function to compute SLOC by author."""
+    print("Computing SLOC by author...")
+    
+    # Check if .mailmap exists
+    if os.path.exists('.mailmap'):
+        print("Using .mailmap for author name canonicalization")
+    else:
+        print("Warning: No .mailmap file found. Author names may not be consistent.")
+    
+    # Get all tracked files
+    files = get_tracked_files()
+    code_files = [f for f in files if is_code_file(f) and os.path.exists(f)]
+    
+    print(f"Found {len(code_files)} code files to analyze")
+    
+    # Count lines by author
+    total_by_author = defaultdict(int)
+    
+    for i, filepath in enumerate(code_files):
+        if i % 50 == 0:
+            print(f"Processing file {i+1}/{len(code_files)}...")
+        
+        author_lines = count_lines_by_author(filepath)
+        for author, count in author_lines.items():
+            total_by_author[author] += count
+    
+    # Sort by SLOC count
+    sorted_authors = sorted(total_by_author.items(), key=lambda x: x[1], reverse=True)
+    
+    # Display results
+    print("\n" + "="*60)
+    print(f"{'Author':<40} {'SLOC':>10}")
+    print("="*60)
+    
+    total_sloc = sum(total_by_author.values())
+    
+    for author, sloc in sorted_authors:
+        percentage = (sloc / total_sloc * 100) if total_sloc > 0 else 0
+        print(f"{author:<40} {sloc:>10,} ({percentage:5.1f}%)")
+    
+    print("="*60)
+    print(f"{'Total':<40} {total_sloc:>10,}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Description
Adds a [`.mailmap` file](https://git-scm.com/docs/gitmailmap) to attribute commits to unique people. This is useful in order to find who wrote specific lines of code, for instance, using `git blame`.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
