### PR TITLE
chore: disable Docker container base image updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,16 +15,6 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: docker
-    directory: /.devcontainer/cuda-container
-    schedule:
-      interval: daily
-
-  - package-ecosystem: docker
-    directory: /.devcontainer/gcc-container
-    schedule:
-      interval: daily
-
   - package-ecosystem: pip
     directory: /.github/workflows/dependencies
     schedule:


### PR DESCRIPTION
Remove dependabot configurations for Docker container updates as they only make sense when rebuilding images.

This PR removes the two Docker package ecosystem entries from `.github/dependabot.yml` for:
- `/.devcontainer/cuda-container`
- `/.devcontainer/gcc-container`

All other dependabot configurations remain unchanged.

Fixes #1241

Generated with [Claude Code](https://claude.ai/code)