### PR TITLE
docs: correctly document AMREX_ASSERT and AMREX_ALWAYS_ASSERT behavior

### DIFF
--- a/docs/markdown/error_checking.md
+++ b/docs/markdown/error_checking.md
@@ -4,8 +4,10 @@
 
 AMReX provides several assertion macros:
 
--   `AMREX_ASSERT`: Works when ``CMAKE_BUILD_TYPE=Debug``.
--   `AMREX_ALWAYS_ASSERT`: Always works on CPU. **Works on GPU only if "-DNDEBUG" is NOT added to the compiler flags. Note that CMake adds "-DNDEBUG" by default when "CMAKE_BUILD_TYPE=Release".** (See this [GitHub discussion](https://github.com/AMReX-Codes/amrex/discussions/2648) for details.)
+-   `AMREX_ASSERT`: Enabled when either `-DAMREX_DEBUG` or `-DAMREX_USE_ASSERTION` is defined. When enabled, it calls `amrex::Assert()` which will abort unless both `-DNDEBUG` is defined AND `-DAMREX_USE_ASSERTION` is NOT defined. This means:
+    - The macro itself is a no-op when neither `AMREX_DEBUG` nor `AMREX_USE_ASSERTION` is defined
+    - When the macro is enabled and assertion fails, it will abort unless `NDEBUG` is defined without `AMREX_USE_ASSERTION`
+-   `AMREX_ALWAYS_ASSERT`: Always calls `amrex::Assert()` regardless of build configuration. The actual abort behavior follows the same rules as `AMREX_ASSERT` - it will abort unless both `-DNDEBUG` is defined AND `-DAMREX_USE_ASSERTION` is NOT defined. **Note that CMake adds "-DNDEBUG" by default when "CMAKE_BUILD_TYPE=Release".** (See this [GitHub discussion](https://github.com/AMReX-Codes/amrex/discussions/2648) for details.)
 
 ## Abort
 


### PR DESCRIPTION
Update error_checking.md to accurately reflect the behavior of AMREX_ASSERT and AMREX_ALWAYS_ASSERT macros based on the actual AMReX implementation.

Key changes:
- AMREX_ASSERT is enabled when either AMREX_DEBUG or AMREX_USE_ASSERTION is defined
- AMREX_ALWAYS_ASSERT always calls amrex::Assert() regardless of build configuration
- Both macros' abort behavior depends on NDEBUG and AMREX_USE_ASSERTION flags

Fixes #1255

Generated with [Claude Code](https://claude.ai/code)