### PR TITLE
Update Setonix profile

### DIFF
--- a/docs/markdown/running_on_hpc_clusters.md
+++ b/docs/markdown/running_on_hpc_clusters.md
@@ -14,17 +14,15 @@ A host file is provided [here](https://gist.github.com/BenWibking/5fa4d6d419dd0a
 
 ## Setonix (Pawsey)
 
-The recommended build procedure on Setonix is: :
+The recommended build procedure on Setonix is:
 
-    source scripts/setonix.profile
-    mkdir build; cd build
-    cmake .. -C ../cmake/setonix.cmake
-    make -j16
+    source scripts/hpc_profiles/setonix-gpu.profile
+    cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=HIP -DHDF5_ROOT="$PAWSEY_HDF5_HOME"
+    cmake --build build -j
 
-Then a single-node test job can be run with: :
+Then a single-node test job can be run with:
 
-    cd ..
-    sbatch scripts/setonix-1node.submit
+    sbatch scripts/slurm/setonix-1node.submit
 
 ### Workaround for interconnect issues
 

--- a/scripts/hpc_profiles/setonix-gpu.profile
+++ b/scripts/hpc_profiles/setonix-gpu.profile
@@ -14,7 +14,7 @@ module load cray-mpich
 module load cce/19.0.0
 
 # hdf5
-module load cray-hdf5
+module load hdf5/1.14.5-parallel-api-v112
 
 # adios2 (optional)
 #module load adios2/2.10.2-hdf5

--- a/scripts/hpc_profiles/setonix-gpu.profile
+++ b/scripts/hpc_profiles/setonix-gpu.profile
@@ -1,23 +1,23 @@
 #!/bin/bash
 
-source /opt/cray/pe/cpe/24.11/restore_lmod_system_defaults.sh
+source /opt/cray/pe/cpe/25.03/restore_lmod_system_defaults.sh
 
-module load cpe/24.11
-module load pawseyenv/2025.03
+module load cpe/25.03
+module load pawseyenv/2025.08
 
 module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
 
-module load rocm/6.3.2 # MUST use this version to avoid compiler bugs
+module load rocm/6.4.1 # MUST use 6.3+ to avoid compiler bugs
 module load cray-mpich
-module load cce/18.0.1
+module load cce/19.0.0
 
 # hdf5
 module load cray-hdf5
 
 # adios2 (optional)
-module load adios2/2.10.2-hdf5
+#module load adios2/2.10.2-hdf5
 
 # python
 module load cray-python/3.11.7

--- a/scripts/slurm/setonix-1node.submit
+++ b/scripts/slurm/setonix-1node.submit
@@ -22,7 +22,7 @@ export MPICH_OFI_NIC_POLICY=NUMA
 
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
-INPUTS="tests/benchmark_unigrid_512.in"
+INPUTS="inputs/benchmark_unigrid_512.in"
 
 srun bash -c "
     case \$((SLURM_LOCALID)) in

--- a/scripts/slurm/setonix-1node.submit
+++ b/scripts/slurm/setonix-1node.submit
@@ -12,7 +12,7 @@
 #SBATCH -N 1
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
-. scripts/setonix-gpu.profile
+. scripts/hpc_profiles/setonix-gpu.profile
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/slurm/setonix-64nodes.submit
+++ b/scripts/slurm/setonix-64nodes.submit
@@ -12,7 +12,7 @@
 #SBATCH -N 64
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
-. scripts/setonix-gpu.profile
+. scripts/hpc_profiles/setonix-gpu.profile
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1

--- a/scripts/slurm/setonix-64nodes.submit
+++ b/scripts/slurm/setonix-64nodes.submit
@@ -22,7 +22,7 @@ export MPICH_OFI_NIC_POLICY=NUMA
 
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
-INPUTS="tests/benchmark_unigrid_2048.in"
+INPUTS="inputs/benchmark_unigrid_2048.in"
 
 srun bash -c "
     case \$((SLURM_LOCALID)) in

--- a/scripts/slurm/setonix-8nodes.submit
+++ b/scripts/slurm/setonix-8nodes.submit
@@ -22,7 +22,7 @@ export MPICH_OFI_NIC_POLICY=NUMA
 
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
-INPUTS="tests/benchmark_unigrid_1024.in"
+INPUTS="inputs/benchmark_unigrid_1024.in"
 
 srun bash -c "
     case \$((SLURM_LOCALID)) in

--- a/scripts/slurm/setonix-8nodes.submit
+++ b/scripts/slurm/setonix-8nodes.submit
@@ -12,7 +12,7 @@
 #SBATCH -N 8
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
-. scripts/setonix-gpu.profile
+. scripts/hpc_profiles/setonix-gpu.profile
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
### Description
Updates the Setonix profile script to use the latest modules.

Configure with:
```
source scripts/hpc_profiles/setonix-gpu.profile
cmake -B build -S . -DAMReX_SPACEDIM=3 -DCMAKE_BUILD_TYPE=Release -DAMReX_GPU_BACKEND=HIP -DHDF5_ROOT="$PAWSEY_HDF5_HOME"
cmake --build build -j
```

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
