### PR TITLE
Fix race conditions in ComputeEMF

### DIFF
--- a/docs/markdown/debugging.md
+++ b/docs/markdown/debugging.md
@@ -57,6 +57,35 @@ This will cause the CPU to wait until the GPU kernel execution is complete befor
 
 For more details, refer to the [AMReX GPU debugging guide](https://amrex-codes.github.io/amrex/docs_html/Debugging.html#basic-gpu-debugging).
 
+## Testing for GPU race conditions
+
+GPU race conditions can cause non-deterministic behavior where the same simulation produces different results on different runs, or crashes only intermittently. To systematically test for race conditions, use the provided test script:
+
+```bash
+./scripts/bash/test_gpu_race.sh -b <binary> -i <input_file> -n <max_timesteps>
+```
+
+**Parameters:**
+- `-b <binary>`: Path to the test binary (e.g., `./build/src/FieldLoop/test_field_loop`)
+- `-i <input_file>`: Path to the input file (e.g., `inputs/field_loop.in`)
+- `-n <max_timesteps>`: Maximum number of timesteps to run
+
+**Example:**
+```bash
+./scripts/bash/test_gpu_race.sh -b ./build/src/FieldLoop/test_field_loop -i inputs/field_loop.in -n 10
+```
+
+**How it works:**
+1. Runs the same simulation twice - once with `CUDA_LAUNCH_BLOCKING=1` (synchronous) and once with `CUDA_LAUNCH_BLOCKING=0` (asynchronous)
+2. Compares the final plotfiles using AMReX's `fcompare` tool with zero tolerance
+3. If the results differ, this indicates a race condition where kernel execution order affects the outcome
+
+**Interpreting results:**
+- **SUCCESS**: Plotfiles are identical - no race condition detected
+- **FAILURE**: Plotfiles differ or non-blocking run crashes - race condition detected
+
+The script preserves temporary files for analysis when a race condition is found. These can be examined to understand the nature of the differences between the two runs.
+
 ## When all else fails: Debugging with `printf`
 
 If you have tried *all* of the above steps, then you have to resort to adding `printf` statements within the GPU code. Note that `printf` inside GPU code is different from the CPU-side `printf` function, as explained in the [NVIDIA documentation](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#formatted-output).

--- a/scripts/bash/test_gpu_race.sh
+++ b/scripts/bash/test_gpu_race.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+# ABOUTME: Test script to detect GPU race conditions by comparing runs with different CUDA_LAUNCH_BLOCKING settings
+# ABOUTME: Runs the same test twice and uses fcompare to verify outputs match
+
+set -e
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 -b <binary> -i <input_file> -n <max_timesteps> [-s] [-h]"
+    echo ""
+    echo "Options:"
+    echo "  -b <binary>         Path to the test binary"
+    echo "  -i <input_file>     Path to the input file"
+    echo "  -n <max_timesteps>  Maximum number of timesteps to run"
+    echo "  -s                  Use single GPU stream (amrex.max_gpu_streams=1)"
+    echo "  -h                  Display this help message"
+    echo ""
+    echo "Example:"
+    echo "  $0 -b ./build/src/FieldLoop/test_field_loop -i inputs/field_loop.in -n 10"
+    echo "  $0 -b ./build/src/FieldLoop/test_field_loop -i inputs/field_loop.in -n 10 -s"
+    exit 1
+}
+
+# Initialize variables
+SINGLE_STREAM=false
+
+# Parse command line arguments
+while getopts "b:i:n:sh" opt; do
+    case ${opt} in
+        b)
+            BINARY="${OPTARG}"
+            ;;
+        i)
+            INPUT_FILE="${OPTARG}"
+            ;;
+        n)
+            MAX_TIMESTEPS="${OPTARG}"
+            ;;
+        s)
+            SINGLE_STREAM=true
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echo "Invalid option: -${OPTARG}" >&2
+            usage
+            ;;
+        :)
+            echo "Option -${OPTARG} requires an argument." >&2
+            usage
+            ;;
+    esac
+done
+
+# Check if all required arguments are provided
+if [ -z "${BINARY}" ] || [ -z "${INPUT_FILE}" ] || [ -z "${MAX_TIMESTEPS}" ]; then
+    echo "Error: Missing required arguments"
+    usage
+fi
+
+# Store the original working directory
+ORIG_DIR=$(pwd)
+
+# Convert relative paths to absolute paths based on current working directory
+if [[ "${BINARY}" != /* ]]; then
+    BINARY="${ORIG_DIR}/${BINARY}"
+fi
+
+if [[ "${INPUT_FILE}" != /* ]]; then
+    INPUT_FILE="${ORIG_DIR}/${INPUT_FILE}"
+fi
+
+# Check if binary exists
+if [ ! -f "${BINARY}" ]; then
+    echo "Error: Binary '${BINARY}' not found"
+    exit 1
+fi
+
+# Check if input file exists
+if [ ! -f "${INPUT_FILE}" ]; then
+    echo "Error: Input file '${INPUT_FILE}' not found"
+    exit 1
+fi
+
+# Check if fcompare exists, build if necessary
+# Look for fcompare relative to original working directory
+FCOMPARE_DIR="${ORIG_DIR}/extern/amrex/Tools/Plotfile"
+FCOMPARE=$(find "${FCOMPARE_DIR}" -name "fcompare.*.ex" 2>/dev/null | head -1)
+
+if [ -z "${FCOMPARE}" ] || [ ! -f "${FCOMPARE}" ]; then
+    echo "fcompare tool not found, building it..."
+    cd "${FCOMPARE_DIR}"
+    make -j$(nproc) programs=fcompare
+    cd "${ORIG_DIR}"
+    
+    # Find the built binary
+    FCOMPARE=$(find "${FCOMPARE_DIR}" -name "fcompare.*.ex" 2>/dev/null | head -1)
+    
+    if [ -z "${FCOMPARE}" ] || [ ! -f "${FCOMPARE}" ]; then
+        echo "Error: Failed to build fcompare tool"
+        exit 1
+    fi
+    echo "fcompare built successfully at: ${FCOMPARE}"
+fi
+
+# Create temporary directory for test outputs
+TEMP_DIR=$(mktemp -d -t gpu_race_test.XXXXXX)
+echo "Using temporary directory: ${TEMP_DIR}"
+
+# Function to clean up on exit (disabled - leaving files for analysis)
+cleanup() {
+    echo "Temporary directory preserved at: ${TEMP_DIR}"
+    echo "Use 'rm -rf ${TEMP_DIR}' to clean up when done analyzing."
+}
+trap cleanup EXIT
+
+# Copy input file to temp directory
+cp "${INPUT_FILE}" "${TEMP_DIR}/input.in"
+
+# Prepare additional arguments
+ADDITIONAL_ARGS=""
+if [ "${SINGLE_STREAM}" = true ]; then
+    ADDITIONAL_ARGS="amrex.max_gpu_streams=1"
+fi
+
+# Run with CUDA_LAUNCH_BLOCKING=1
+echo ""
+echo "=========================================="
+echo "Running with CUDA_LAUNCH_BLOCKING=1..."
+if [ "${SINGLE_STREAM}" = true ]; then
+    echo "(with amrex.max_gpu_streams=1)"
+fi
+echo "=========================================="
+cd "${TEMP_DIR}"
+mkdir run_blocking
+cd run_blocking
+echo "Running: CUDA_LAUNCH_BLOCKING=1 ${BINARY} ../input.in max_timesteps=${MAX_TIMESTEPS} plotfile_interval=${MAX_TIMESTEPS} ${ADDITIONAL_ARGS}..."
+CUDA_LAUNCH_BLOCKING=1 "${BINARY}" ../input.in \
+    max_timesteps=${MAX_TIMESTEPS} \
+    plotfile_interval=${MAX_TIMESTEPS} \
+    checkpoint_interval=-1 \
+    ascent_interval=-1 \
+    projection_interval=-1 \
+    statistics_interval=-1 \
+    slice_interval=-1 \
+    plotfile_prefix=plt_blocking \
+    ${ADDITIONAL_ARGS}
+echo "Blocking run completed, checking for plotfiles..."
+
+# Check if run completed successfully - find the FINAL (highest numbered) plotfile
+PLOTFILE_BLOCKING=$(find . -maxdepth 1 -name "plt_blocking*" -type d | sort | tail -1)
+if [ -z "${PLOTFILE_BLOCKING}" ]; then
+    echo "Error: No plotfile generated for blocking run"
+    echo "Contents of run directory:"
+    ls -la
+    exit 1
+fi
+
+# Get just the directory name (remove ./ prefix)
+PLOTFILE_BLOCKING=$(basename "${PLOTFILE_BLOCKING}")
+echo "Found blocking plotfile: ${PLOTFILE_BLOCKING}"
+
+# Run with CUDA_LAUNCH_BLOCKING=0
+echo ""
+echo "=========================================="
+echo "Running with CUDA_LAUNCH_BLOCKING=0..."
+if [ "${SINGLE_STREAM}" = true ]; then
+    echo "(with amrex.max_gpu_streams=1)"
+fi
+echo "=========================================="
+cd "${TEMP_DIR}"
+mkdir run_nonblocking
+cd run_nonblocking
+echo "Running: CUDA_LAUNCH_BLOCKING=0 ${BINARY} ../input.in max_timesteps=${MAX_TIMESTEPS} plotfile_interval=${MAX_TIMESTEPS} ${ADDITIONAL_ARGS}..."
+CUDA_LAUNCH_BLOCKING=0 "${BINARY}" ../input.in \
+    max_timesteps=${MAX_TIMESTEPS} \
+    plotfile_interval=${MAX_TIMESTEPS} \
+    checkpoint_interval=-1 \
+    ascent_interval=-1 \
+    projection_interval=-1 \
+    statistics_interval=-1 \
+    slice_interval=-1 \
+    plotfile_prefix=plt_nonblocking \
+    ${ADDITIONAL_ARGS}
+NONBLOCKING_EXIT_CODE=$?
+
+if [ ${NONBLOCKING_EXIT_CODE} -ne 0 ]; then
+    echo ""
+    echo "✗ RACE CONDITION DETECTED!"
+    echo ""
+    echo "The non-blocking run crashed (exit code: ${NONBLOCKING_EXIT_CODE})"
+    echo "while the blocking run completed successfully."
+    echo ""
+    echo "This indicates a GPU race condition causing non-deterministic behavior."
+    echo "The race condition causes instabilities that crash the simulation"
+    echo "when kernels execute in different orders."
+    echo ""
+    echo "Contents of non-blocking run directory:"
+    ls -la
+    echo ""
+    echo "Temporary directory preserved for analysis: ${TEMP_DIR}"
+    echo "- Blocking run results:     ${TEMP_DIR}/run_blocking/"
+    echo "- Non-blocking run results: ${TEMP_DIR}/run_nonblocking/"
+    exit 1
+fi
+
+echo "Non-blocking run completed, checking for plotfiles..."
+
+# Check if run completed successfully - find the FINAL (highest numbered) plotfile  
+PLOTFILE_NONBLOCKING=$(find . -maxdepth 1 -name "plt_nonblocking*" -type d | sort | tail -1)
+if [ -z "${PLOTFILE_NONBLOCKING}" ]; then
+    echo "Error: No plotfile generated for non-blocking run"
+    echo "Contents of run directory:"
+    ls -la
+    exit 1
+fi
+
+# Get just the directory name (remove ./ prefix)
+PLOTFILE_NONBLOCKING=$(basename "${PLOTFILE_NONBLOCKING}")
+echo "Found non-blocking plotfile: ${PLOTFILE_NONBLOCKING}"
+
+# Compare the plotfiles
+echo ""
+echo "=========================================="
+echo "Comparing plotfiles with fcompare..."
+echo "=========================================="
+cd "${TEMP_DIR}"
+
+# Get absolute paths
+PLOT_BLOCKING="${TEMP_DIR}/run_blocking/${PLOTFILE_BLOCKING}"
+PLOT_NONBLOCKING="${TEMP_DIR}/run_nonblocking/${PLOTFILE_NONBLOCKING}"
+
+# Run fcompare and capture output
+FCOMPARE_OUTPUT=$(mktemp)
+echo "Running fcompare command:"
+echo "${FCOMPARE}" --abs_tol 0.0 --rel_tol 0.0 "${PLOT_BLOCKING}" "${PLOT_NONBLOCKING}"
+echo ""
+
+# Check if fcompare binary exists
+if [ ! -f "${FCOMPARE}" ]; then
+    echo "Error: fcompare binary not found at ${FCOMPARE}"
+    exit 1
+fi
+
+# Check if plotfile directories exist
+if [ ! -d "${PLOT_BLOCKING}" ]; then
+    echo "Error: Blocking plotfile directory not found: ${PLOT_BLOCKING}"
+    exit 1
+fi
+
+if [ ! -d "${PLOT_NONBLOCKING}" ]; then
+    echo "Error: Non-blocking plotfile directory not found: ${PLOT_NONBLOCKING}"
+    exit 1
+fi
+
+echo "Running fcompare..."
+set +e  # Don't exit on error so we can capture crashed output
+"${FCOMPARE}" --abs_tol 0.0 --rel_tol 0.0 "${PLOT_BLOCKING}" "${PLOT_NONBLOCKING}" 2>&1 | tee "${FCOMPARE_OUTPUT}"
+FCOMPARE_EXIT_CODE=${PIPESTATUS[0]}
+set -e
+
+echo ""
+echo "fcompare completed with exit code: ${FCOMPARE_EXIT_CODE}"
+
+# Show captured output if there was any
+if [ -s "${FCOMPARE_OUTPUT}" ]; then
+    echo ""
+    echo "fcompare output:"
+    echo "----------------"
+    cat "${FCOMPARE_OUTPUT}"
+    echo "----------------"
+    echo ""
+else
+    echo ""
+    echo "No output captured from fcompare (process may have been killed by signal)"
+    echo ""
+fi
+
+# Check fcompare exit code
+if [ ${FCOMPARE_EXIT_CODE} -eq 0 ]; then
+    echo "✓ SUCCESS: Plotfiles are identical - No race condition detected"
+    exit 0
+else
+    echo "✗ FAILURE: Plotfiles differ - RACE CONDITION DETECTED!"
+    echo ""
+    echo "This indicates a GPU race condition in the code."
+    echo "The results depend on kernel execution order."
+    echo ""
+    echo "Temporary directory preserved for analysis: ${TEMP_DIR}"
+    echo "- Blocking run results:     ${TEMP_DIR}/run_blocking/"
+    echo "- Non-blocking run results: ${TEMP_DIR}/run_nonblocking/"
+    echo ""
+    exit 1
+fi

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -61,7 +61,8 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 	// significantly reduces the total memory used, which is a much bigger bottleneck.
 
 	// loop over each box-array on this level
-	for (amrex::MFIter mfi(cc_mf_cVars); mfi.isValid(); ++mfi) {
+	constexpr int nstreams = 1; // only run on 1 GPU stream to avoid race conditions
+	for (amrex::MFIter mfi(cc_mf_cVars, amrex::MFItInfo().SetNumStreams(nstreams)); mfi.isValid(); ++mfi) {
 		const amrex::Box &box_cc = mfi.validbox();
 
 		// extract cell-centered velocity fields

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -67,12 +67,13 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 
 		// extract cell-centered velocity fields
 		// indexing: field[3: x-component]
-		std::array<amrex::FArrayBox, 3> cc_fabs_Ux;
+		const amrex::Box &box_cc_U = amrex::grow(box_cc, nghost_cc);
+		std::array<amrex::FArrayBox, 3> cc_fabs_Ux = {
+			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
+			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
+			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena())
+		};
 		{
-			const amrex::Box &box_cc_U = amrex::grow(box_cc, nghost_cc);
-			cc_fabs_Ux[0].resize(box_cc_U, 1);
-			cc_fabs_Ux[1].resize(box_cc_U, 1);
-			cc_fabs_Ux[2].resize(box_cc_U, 1);
 			const auto &cc_a4_Ux0 = cc_fabs_Ux[0].array();
 			const auto &cc_a4_Ux1 = cc_fabs_Ux[1].array();
 			const auto &cc_a4_Ux2 = cc_fabs_Ux[2].array();
@@ -113,12 +114,10 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 
 			// initialise FArrayBox for storing the temporary edge-centered velocity fields created in each permutation of reconstructing from the
 			// cell-face indexing: field[2: i-side of edge]
-			std::array<amrex::FArrayBox, 2> ec_fabs_U_ieside;
-
-			// define the four possible velocity field quantities that could be reconstructed at the cell-edge
-			// also define the temporary velocity field quantities that will be used for computing the extrapolation
-			ec_fabs_U_ieside[0].resize(box_ec_r, 1);
-			ec_fabs_U_ieside[1].resize(box_ec_r, 1);
+			std::array<amrex::FArrayBox, 2> ec_fabs_U_ieside = {
+				amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena()),
+				amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena())
+			};
 
 			// indexing: field[2: i-compnent][2: i-side of edge]
 			// note: magnetic field components cannot be discontinuous along themselves (i.e., either side of the face where they are
@@ -131,10 +130,10 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 
 			// define quantities
 			for (int icomp = 0; icomp < 2; ++icomp) {
-				ec_fabs_Bi_ieside[icomp][0].resize(box_ec_r, 1);
-				ec_fabs_Bi_ieside[icomp][1].resize(box_ec_r, 1);
+				ec_fabs_Bi_ieside[icomp][0] = amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena());
+				ec_fabs_Bi_ieside[icomp][1] = amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena());
 				for (int iquad = 0; iquad < 4; ++iquad) {
-					ec_fabs_Ui_q[icomp][iquad].resize(box_ec_r, 1);
+					ec_fabs_Ui_q[icomp][iquad] = amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena());
 					ec_fabs_Ui_q[icomp][iquad].setVal<amrex::RunOn::Device>(0.0);
 				}
 			}
@@ -163,10 +162,11 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 				for (int icomp = 0; icomp < 2; ++icomp) {
 					// create temporary FArrayBox for storing the face-centered velocity field reconstructed from the cell-center
 					// indexing: field[2: i-side of face]
-					std::array<amrex::FArrayBox, 2> fc_fabs_U_ifside;
 					const int wcomp = extrap_dirs[icomp];
-					fc_fabs_U_ifside[0].resize(box_fc_U, 1);
-					fc_fabs_U_ifside[1].resize(box_fc_U, 1);
+					std::array<amrex::FArrayBox, 2> fc_fabs_U_ifside = {
+						amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena()),
+						amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena())
+					};
 
 					// extrapolate cell-centered velocity components to the cell-face
 					MHDSystem<problem_t>::ReconstructTo(dir2face, cc_fabs_Ux[wcomp].array(), fc_fabs_U_ifside[0].array(),
@@ -238,7 +238,7 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 
 				// compute electric field in the quadrant about the cell-edge: cross product between velocity and magnetic field in that
 				// define EMF FArrayBox
-				ec_fabs_E_q[iquad].resize(box_ec, 1);
+				ec_fabs_E_q[iquad] = amrex::FArrayBox(box_ec, 1, amrex::The_Async_Arena());
 				const auto &E2_qi = ec_fabs_E_q[iquad].array();
 
 				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) {

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -68,11 +68,9 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 		// extract cell-centered velocity fields
 		// indexing: field[3: x-component]
 		const amrex::Box &box_cc_U = amrex::grow(box_cc, nghost_cc);
-		std::array<amrex::FArrayBox, 3> cc_fabs_Ux = {
-			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
-			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
-			amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena())
-		};
+		std::array<amrex::FArrayBox, 3> cc_fabs_Ux = {amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
+							      amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena()),
+							      amrex::FArrayBox(box_cc_U, 1, amrex::The_Async_Arena())};
 		{
 			const auto &cc_a4_Ux0 = cc_fabs_Ux[0].array();
 			const auto &cc_a4_Ux1 = cc_fabs_Ux[1].array();
@@ -114,10 +112,8 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 
 			// initialise FArrayBox for storing the temporary edge-centered velocity fields created in each permutation of reconstructing from the
 			// cell-face indexing: field[2: i-side of edge]
-			std::array<amrex::FArrayBox, 2> ec_fabs_U_ieside = {
-				amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena()),
-				amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena())
-			};
+			std::array<amrex::FArrayBox, 2> ec_fabs_U_ieside = {amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena()),
+									    amrex::FArrayBox(box_ec_r, 1, amrex::The_Async_Arena())};
 
 			// indexing: field[2: i-compnent][2: i-side of edge]
 			// note: magnetic field components cannot be discontinuous along themselves (i.e., either side of the face where they are
@@ -163,10 +159,8 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 					// create temporary FArrayBox for storing the face-centered velocity field reconstructed from the cell-center
 					// indexing: field[2: i-side of face]
 					const int wcomp = extrap_dirs[icomp];
-					std::array<amrex::FArrayBox, 2> fc_fabs_U_ifside = {
-						amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena()),
-						amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena())
-					};
+					std::array<amrex::FArrayBox, 2> fc_fabs_U_ifside = {amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena()),
+											    amrex::FArrayBox(box_fc_U, 1, amrex::The_Async_Arena())};
 
 					// extrapolate cell-centered velocity components to the cell-face
 					MHDSystem<problem_t>::ReconstructTo(dir2face, cc_fabs_Ux[wcomp].array(), fc_fabs_U_ifside[0].array(),


### PR DESCRIPTION
### Description
Eliminates the race condition present in the ComputeEMF function on GPU by only launching into the default AMReX stream. This only fixes non-AMR MHD runs.

The cause of the race condition is as follows: when there are multiple boxes on a given GPU, each box in an MFIter loop is normally launched into a separate stream. These extra streams (beyond the first stream) may start executing their kernels before the previous kernels in the hydro update have finished (which all use the first stream, since they execute over the whole MultiFab, rather than individual boxes).

This has a potential negative performance impact. A performance-optimal fix is deferred to a later PR.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1258.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
