### PR TITLE
Add metallicity variation to net cooling rate

### DIFF
--- a/extern/cooling/grackle_tables.py
+++ b/extern/cooling/grackle_tables.py
@@ -85,7 +85,7 @@ def interpolate_mu(nH, T, tables=None):
     return interp_mmw(log_nH, log_T)[0][0]
 
 
-def cooling_rate(nH, T, Z, redshift=0., tables=None):
+def cooling_rate(nH, T, zmet, redshift=0., tables=None):
     """compute the cooling rate at a given density, redshift, and temperature.
     Note that the rate tables are C-ordered (as specified by the HDF5 standard.)"""
     log_nH = np.log10(nH)
@@ -112,8 +112,8 @@ def cooling_rate(nH, T, Z, redshift=0., tables=None):
                                              kx=1,
                                              ky=1)
 
-    metalCool = Z * (10**interp_metalCooling(log_nH, log_T)[0, 0])
-    metalHeat = Z * (10**interp_metalHeating(log_nH, log_T)[0, 0])
+    metalCool = zmet * (10**interp_metalCooling(log_nH, log_T)[0, 0])
+    metalHeat = zmet * (10**interp_metalHeating(log_nH, log_T)[0, 0])
     primCool = 10**interp_primCooling(log_nH, log_T)[0, 0]
     primHeat = 10**interp_primHeating(log_nH, log_T)[0, 0]
 
@@ -140,7 +140,7 @@ def cooling_rate(nH, T, Z, redshift=0., tables=None):
       3.7e-2 * (T / 1.0e4)**(0.7) / \
           (1. + 2.0e-4 * (G_0 * Tsqrt / (n_e * phi)))
     Gamma_pe = 1.3e-24 * nH * epsilon * G_0
-    Edot += Z * Gamma_pe
+    Edot += zmet * Gamma_pe
 
     # Compton term (CMB photons)
     # [e.g., Hirata 2018: doi:10.1093/mnras/stx2854]

--- a/extern/cooling/grackle_tables.py
+++ b/extern/cooling/grackle_tables.py
@@ -85,7 +85,7 @@ def interpolate_mu(nH, T, tables=None):
     return interp_mmw(log_nH, log_T)[0][0]
 
 
-def cooling_rate(nH, T, redshift=0., tables=None):
+def cooling_rate(nH, T, Z, redshift=0., tables=None):
     """compute the cooling rate at a given density, redshift, and temperature.
     Note that the rate tables are C-ordered (as specified by the HDF5 standard.)"""
     log_nH = np.log10(nH)
@@ -112,8 +112,8 @@ def cooling_rate(nH, T, redshift=0., tables=None):
                                              kx=1,
                                              ky=1)
 
-    metalCool = 10**interp_metalCooling(log_nH, log_T)[0, 0]
-    metalHeat = 10**interp_metalHeating(log_nH, log_T)[0, 0]
+    metalCool = Z * (10**interp_metalCooling(log_nH, log_T)[0, 0])
+    metalHeat = Z * (10**interp_metalHeating(log_nH, log_T)[0, 0])
     primCool = 10**interp_primCooling(log_nH, log_T)[0, 0]
     primHeat = 10**interp_primHeating(log_nH, log_T)[0, 0]
 
@@ -140,7 +140,7 @@ def cooling_rate(nH, T, redshift=0., tables=None):
       3.7e-2 * (T / 1.0e4)**(0.7) / \
           (1. + 2.0e-4 * (G_0 * Tsqrt / (n_e * phi)))
     Gamma_pe = 1.3e-24 * nH * epsilon * G_0
-    Edot += Gamma_pe
+    Edot += Z * Gamma_pe
 
     # Compton term (CMB photons)
     # [e.g., Hirata 2018: doi:10.1093/mnras/stx2854]

--- a/extern/cooling/grackle_tables.py
+++ b/extern/cooling/grackle_tables.py
@@ -140,7 +140,7 @@ def cooling_rate(nH, T, zmet, redshift=0., tables=None):
       3.7e-2 * (T / 1.0e4)**(0.7) / \
           (1. + 2.0e-4 * (G_0 * Tsqrt / (n_e * phi)))
     Gamma_pe = 1.3e-24 * nH * epsilon * G_0
-    Edot += zmet * Gamma_pe
+    Edot += (zmet * Gamma_pe)
 
     # Compton term (CMB photons)
     # [e.g., Hirata 2018: doi:10.1093/mnras/stx2854]

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -178,7 +178,7 @@ def find_eint_range(tables):
     return eint_min, eint_max
 
 
-def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, Z=1.0,
+def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, zmet=1.0,
                             output_file='resampled_cooling_tables.h5'):
     """Resample cooling tables on a not-quite-logarithmic grid of density and specific internal energy.    
     Uses the fast logarithm approximation from https://arxiv.org/pdf/2206.08957 for grid spacing.
@@ -261,7 +261,7 @@ def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, Z=1.0,
         for j, e_int in enumerate(eint_grid):
             try:
                 T = compute_temperature_from_nH_e(nH, e_int, tables=tables)
-                Edot = cooling_rate(nH, T, Z, redshift=0., tables=tables)
+                Edot = cooling_rate(nH, T, zmet, redshift=0., tables=tables)
                 mu = interpolate_mu(nH, T, tables=tables)
                 cs = compute_sound_speed(rho, T, mu)
                 P = compute_pressure(rho, T, mu)
@@ -410,7 +410,7 @@ def main():
     parser.add_argument('--output', type=str, default='resampled_cooling_tables.h5',
                         help='Output HDF5 file name (default: resampled_cooling_tables.h5)')
 
-    parser.add_argument('--Z', type=float, default=1.0,
+    parser.add_argument('--zmet', type=float, default=1.0,
                         help='Gas Metallicity scaled to Solar (default: 1.0)')
     
     args = parser.parse_args()
@@ -430,7 +430,7 @@ def main():
             args.grackle_file,
             n_rho=args.n_rho,
             n_eint=args.n_eint,
-            Z = args.Z,
+            zmet = args.zmet,
             output_file=args.output
         )
 

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -178,7 +178,7 @@ def find_eint_range(tables):
     return eint_min, eint_max
 
 
-def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, 
+def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, Z=1.0,
                             output_file='resampled_cooling_tables.h5'):
     """Resample cooling tables on a not-quite-logarithmic grid of density and specific internal energy.    
     Uses the fast logarithm approximation from https://arxiv.org/pdf/2206.08957 for grid spacing.
@@ -261,7 +261,7 @@ def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100,
         for j, e_int in enumerate(eint_grid):
             try:
                 T = compute_temperature_from_nH_e(nH, e_int, tables=tables)
-                Edot = cooling_rate(nH, T, redshift=0., tables=tables)
+                Edot = cooling_rate(nH, T, Z, redshift=0., tables=tables)
                 mu = interpolate_mu(nH, T, tables=tables)
                 cs = compute_sound_speed(rho, T, mu)
                 P = compute_pressure(rho, T, mu)
@@ -409,6 +409,9 @@ def main():
                         help='Number of specific energy points (default: 200)')
     parser.add_argument('--output', type=str, default='resampled_cooling_tables.h5',
                         help='Output HDF5 file name (default: resampled_cooling_tables.h5)')
+
+    parser.add_argument('--Z', type=float, default=1.0,
+                        help='Gas Metallicity scaled to Solar (default: 1.0)')
     
     args = parser.parse_args()
     
@@ -427,6 +430,7 @@ def main():
             args.grackle_file,
             n_rho=args.n_rho,
             n_eint=args.n_eint,
+            Z = args.Z,
             output_file=args.output
         )
 


### PR DESCRIPTION
Adding metallicity variation to heating/cooling. Metallicity dependence added to metal heating and cooling and photoelectric heating. Metallicity is parsed scaled to solar, the default being unity.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
