### PR TITLE
fix: use AsyncVector instead of DeviceVector for temporary vectors

### DIFF
--- a/src/io/DiagPDF.cpp
+++ b/src/io/DiagPDF.cpp
@@ -139,7 +139,7 @@ void DiagPDF::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::V
 	}
 
 	// Data holders
-	amrex::Gpu::DeviceVector<amrex::Real> pdf_d(getTotalBinCount(), 0.0);
+	amrex::Gpu::AsyncVector<amrex::Real> pdf_d(getTotalBinCount(), 0.0);
 	amrex::Vector<amrex::Real> pdf(getTotalBinCount(), 0.0);
 
 	// Populate the data from each level on each proc
@@ -189,11 +189,11 @@ void DiagPDF::processDiag(int a_nstep, const amrex::Real &a_time, const amrex::V
 			multiply_by_gasDensity = true;
 		}
 
-		amrex::Gpu::DeviceVector<int> idx_d(nvars);
-		amrex::Gpu::DeviceVector<int> nbins_d(nvars);
-		amrex::Gpu::DeviceVector<int> doLog_d(nvars);
-		amrex::Gpu::DeviceVector<amrex::Real> lowBnd_d(nvars);
-		amrex::Gpu::DeviceVector<amrex::Real> binWidth_d(nvars);
+		amrex::Gpu::AsyncVector<int> idx_d(nvars);
+		amrex::Gpu::AsyncVector<int> nbins_d(nvars);
+		amrex::Gpu::AsyncVector<int> doLog_d(nvars);
+		amrex::Gpu::AsyncVector<amrex::Real> lowBnd_d(nvars);
+		amrex::Gpu::AsyncVector<amrex::Real> binWidth_d(nvars);
 
 		// copy arrays to device
 		amrex::Gpu::copy(amrex::Gpu::hostToDevice, fieldIdx.begin(), fieldIdx.end(), idx_d.begin());

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -41,8 +41,8 @@ static void createParticlesImpl(ContainerType *container, int mass_idx, amrex::M
 				const auto plo = geom.ProbLoArray();
 
 				// Count particles to be created in this box
-				amrex::Gpu::DeviceVector<unsigned int> counts(box.numPts()); // 1 if cell creates particle, 0 if not
-				amrex::Gpu::DeviceVector<unsigned int> offset(box.numPts()); // Will store starting index for each cell's particle
+				amrex::Gpu::AsyncVector<unsigned int> counts(box.numPts()); // 1 if cell creates particle, 0 if not
+				amrex::Gpu::AsyncVector<unsigned int> offset(box.numPts()); // Will store starting index for each cell's particle
 				auto *pcounts = counts.data();
 
 				// Count potential particles per cell

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -144,9 +144,9 @@ void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab
 	amrex::Gpu::HostVector<double> P_interp(x.size());
 	interpolate_arrays(x.data(), P_interp.data(), static_cast<int>(x.size()), x_exact.data(), P_exact.data(), static_cast<int>(x_exact.size()));
 
-	amrex::Gpu::DeviceVector<double> rho_g(d_interp.size());
-	amrex::Gpu::DeviceVector<double> vx_g(vx_interp.size());
-	amrex::Gpu::DeviceVector<double> P_g(P_interp.size());
+	amrex::Gpu::AsyncVector<double> rho_g(d_interp.size());
+	amrex::Gpu::AsyncVector<double> vx_g(vx_interp.size());
+	amrex::Gpu::AsyncVector<double> P_g(P_interp.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, d_interp.begin(), d_interp.end(), rho_g.begin());

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -208,9 +208,9 @@ void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFa
 	interpolate_arrays(xs.data(), eint_exact_interp.data(), static_cast<int>(xs.size()), xs_exact.data(), eint_exact.data(),
 			   static_cast<int>(xs_exact.size()));
 
-	amrex::Gpu::DeviceVector<double> rho_g(density_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> vx_g(velocity_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> P_g(pressure_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> rho_g(density_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> vx_g(velocity_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> P_g(pressure_exact_interp.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, density_exact_interp.begin(), density_exact_interp.end(), rho_g.begin());

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -174,9 +174,9 @@ void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFa
 		velocity_exact.push_back(vx);
 	}
 
-	amrex::Gpu::DeviceVector<double> rho_g(density_exact.size());
-	amrex::Gpu::DeviceVector<double> vx_g(velocity_exact.size());
-	amrex::Gpu::DeviceVector<double> P_g(pressure_exact.size());
+	amrex::Gpu::AsyncVector<double> rho_g(density_exact.size());
+	amrex::Gpu::AsyncVector<double> vx_g(velocity_exact.size());
+	amrex::Gpu::AsyncVector<double> P_g(pressure_exact.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, density_exact.begin(), density_exact.end(), rho_g.begin());

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -231,9 +231,9 @@ void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFa
 	interpolate_arrays(xs.data(), pressure_exact_interp.data(), static_cast<int>(xs.size()), xs_exact.data(), pressure_exact.data(),
 			   static_cast<int>(xs_exact.size()));
 
-	amrex::Gpu::DeviceVector<double> rho_g(density_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> vx_g(velocity_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> P_g(pressure_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> rho_g(density_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> vx_g(velocity_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> P_g(pressure_exact_interp.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, density_exact_interp.begin(), density_exact_interp.end(), rho_g.begin());

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -194,9 +194,9 @@ void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFa
 	interpolate_arrays(xs.data(), pressure_exact_interp.data(), static_cast<int>(xs.size()), xs_exact.data(), pressure_exact.data(),
 			   static_cast<int>(xs_exact.size()));
 
-	amrex::Gpu::DeviceVector<double> rho_g(density_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> vx_g(velocity_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> P_g(pressure_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> rho_g(density_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> vx_g(velocity_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> P_g(pressure_exact_interp.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, density_exact_interp.begin(), density_exact_interp.end(), rho_g.begin());

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -200,9 +200,9 @@ void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFa
 	interpolate_arrays(xs.data(), eint_exact_interp.data(), static_cast<int>(xs.size()), xs_exact.data(), eint_exact.data(),
 			   static_cast<int>(xs_exact.size()));
 
-	amrex::Gpu::DeviceVector<double> rho_g(density_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> vx_g(velocity_exact_interp.size());
-	amrex::Gpu::DeviceVector<double> P_g(pressure_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> rho_g(density_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> vx_g(velocity_exact_interp.size());
+	amrex::Gpu::AsyncVector<double> P_g(pressure_exact_interp.size());
 
 	// copy exact solution to device
 	amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, density_exact_interp.begin(), density_exact_interp.end(), rho_g.begin());


### PR DESCRIPTION
Replace DeviceVector with AsyncVector in all places where temporary vectors
are used inside MFIter loops. This prevents potential issues where
DeviceVector may go out of scope without explicit stream synchronization.

Changes made:
- particle_creation.hpp: Replace temporary counts and offset vectors
- DiagPDF.cpp: Replace temporary vectors for PDF calculations
- Test files: Replace temporary vectors for exact solution storage

This fix addresses potential non-reproducibility in simulations with
star formation by ensuring proper memory management for GPU operations.

Fixes #1272

Generated with [Claude Code](https://claude.ai/code)