### PR TITLE
update exit behavior when max_walltime is set

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1224,7 +1224,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 			break;
 		}
 
-		if (maxWalltime_ > 0 && getWalltime() > std::max(0.9 * maxWalltime_, maxWalltime_ - 300)) {
+		if (maxWalltime_ > 0 && getWalltime() > std::max(0.9 * maxWalltime_, static_cast<double>(maxWalltime_ - 300))) {
 			// we have exceeded the walltime limit
 			break;
 		}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1222,8 +1222,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 			break;
 		}
 
-		if (maxWalltime_ > 0 && getWalltime() > 0.9 * maxWalltime_) {
-			// we have exceeded 90% of maxWalltime_
+		if (maxWalltime_ > 0 && getWalltime() > (maxWalltime_ - 300)) {
+			// we have exceeded the walltime limit (with a buffer of 300 seconds)
 			break;
 		}
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1224,8 +1224,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 			break;
 		}
 
-		if (maxWalltime_ > 0 && getWalltime() > (maxWalltime_ - 300)) {
-			// we have exceeded the walltime limit (with a buffer of 300 seconds)
+		if (maxWalltime_ > 0 && getWalltime() > std::max(0.9 * maxWalltime_, maxWalltime_ - 300)) {
+			// we have exceeded the walltime limit
 			break;
 		}
 	}


### PR DESCRIPTION
### Description
Exiting at 90% of `max_walltime` is not very efficient when the job walltime is large. Instead, we stop the simulation 5 minutes before `max_walltime` (unless the walltime is less than 50 minutes, in which case we fall back to stopping at 90% of the limit).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
