### PR TITLE
Fix b-field indexing during reconstruction (Riemann solver input)

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1893,12 +1893,13 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// compute flux functions
 	AMREX_D_TERM(
-	    hydroFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0],
-					   fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1],
-					     fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2],
-					     fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
+	    hydroFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
+					   facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+	    , hydroFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1],
+					     facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+	    ,
+	    hydroFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2],
+					   facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -1950,8 +1951,8 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_FORCE_INLINE void
-QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
+AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf,
+									 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
 {
 	// per-direction neighbor offsets for those two components
 	std::array<int, 3> delta_x2{0, 0, 0};
@@ -1959,37 +1960,36 @@ QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc
 
 	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
 	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
-  if constexpr (DIR == FluxDir::X1) {
-    x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
-    x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
-    delta_x2[1] = 1;
-    delta_x3[2] = 1;
-  } else if constexpr (DIR == FluxDir::X2) {
-    x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
-    x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
-    delta_x2[2] = 1;
-    delta_x3[0] = 1;
-  } else if constexpr (DIR == FluxDir::X3) {
-    x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
-    x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
-    delta_x2[0] = 1;
-    delta_x3[1] = 1;
-  }
+	if constexpr (DIR == FluxDir::X1) {
+		x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+		x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+		delta_x2[1] = 1;
+		delta_x3[2] = 1;
+	} else if constexpr (DIR == FluxDir::X2) {
+		x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+		x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+		delta_x2[2] = 1;
+		delta_x3[0] = 1;
+	} else if constexpr (DIR == FluxDir::X3) {
+		x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+		x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+		delta_x2[0] = 1;
+		delta_x3[1] = 1;
+	}
 
-  auto perp_bfield_cc_comps_out = perp_bfield_cc_comps_mf.arrays();
-  constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
+	auto perp_bfield_cc_comps_out = perp_bfield_cc_comps_mf.arrays();
+	constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
 
-  amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-  amrex::ParallelFor(perp_bfield_cc_comps_mf, ng,
-    [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-      const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
-      const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
-      perp_bfield_cc_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+	amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+	amrex::ParallelFor(perp_bfield_cc_comps_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
+		const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
+		perp_bfield_cc_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
-      const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
-      const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
-      perp_bfield_cc_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
-    });
+		const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
+		const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
+		perp_bfield_cc_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+	});
 }
 
 template <typename problem_t>
@@ -2007,25 +2007,26 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 	if (reconstructionOrder_ == 5) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
-											   2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+											   ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+											ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 2) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
-													      ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(perp_bfield_cc_comps_mf, leftState_bfield,
+													      rightState_bfield, ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
-											     2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+											     ng_reconstruct, 2);
 		}
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
@@ -2085,12 +2086,12 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
-						      facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1],
-							facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2],
-							facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars);)
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0],
+						      flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1],
+							flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2],
+							flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -2114,7 +2115,8 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_m
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+										2);
 	}
 
 	// LLF solver

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -315,7 +315,9 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
-	void computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const;
+	void computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
+				 amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in,
+				 amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const;
 
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
@@ -1950,44 +1952,45 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_FORCE_INLINE void
-QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const
+AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf,
+									 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
+									 amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in,
+									 amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const
 {
-   // per-direction neighbor offsets for those two components
-  std::array<int,3> delta_x2{0,0,0};
-  std::array<int,3> delta_x3{0,0,0};
+	// per-direction neighbor offsets for those two components
+	std::array<int, 3> delta_x2{0, 0, 0};
+	std::array<int, 3> delta_x3{0, 0, 0};
 
-  if constexpr (DIR == FluxDir::X1) {
-    x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
-    x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
-    delta_x2[1] = 1;
-    delta_x3[2] = 1;
-  } else if constexpr (DIR == FluxDir::X2) {
-    x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
-    x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
-    delta_x2[2] = 1;
-    delta_x3[0] = 1;
-  } else if constexpr (DIR == FluxDir::X3) {
-    x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
-    x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
-    delta_x2[0] = 1;
-    delta_x3[1] = 1;
-  }
+	if constexpr (DIR == FluxDir::X1) {
+		x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+		x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+		delta_x2[1] = 1;
+		delta_x3[2] = 1;
+	} else if constexpr (DIR == FluxDir::X2) {
+		x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+		x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+		delta_x2[2] = 1;
+		delta_x3[0] = 1;
+	} else if constexpr (DIR == FluxDir::X3) {
+		x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+		x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+		delta_x2[0] = 1;
+		delta_x3[1] = 1;
+	}
 
-  auto bfield_cc_out = bfield_cc_mf.arrays();
-  constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
+	auto bfield_cc_out = bfield_cc_mf.arrays();
+	constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
 
-  amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-  amrex::ParallelFor(bfield_cc_mf, ng,
-    [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-      const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
-      const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
-      bfield_cc_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+	amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+	amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
+		const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
+		bfield_cc_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
-      const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
-      const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
-      bfield_cc_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
-    });
+		const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
+		const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
+		bfield_cc_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+	});
 }
 
 template <typename problem_t>

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -315,6 +315,9 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
+	void computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const;
+
+	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
@@ -1947,6 +1950,48 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
+AMREX_FORCE_INLINE void
+QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const
+{
+   // per-direction neighbor offsets for those two components
+  std::array<int,3> delta_x2{0,0,0};
+  std::array<int,3> delta_x3{0,0,0};
+
+  if constexpr (DIR == FluxDir::X1) {
+    x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+    x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+    delta_x2[1] = 1;
+    delta_x3[2] = 1;
+  } else if constexpr (DIR == FluxDir::X2) {
+    x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+    x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+    delta_x2[2] = 1;
+    delta_x3[0] = 1;
+  } else if constexpr (DIR == FluxDir::X3) {
+    x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+    x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+    delta_x2[0] = 1;
+    delta_x3[1] = 1;
+  }
+
+  auto bfield_cc_out = bfield_cc_mf.arrays();
+  constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
+
+  amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+  amrex::ParallelFor(bfield_cc_mf, ng,
+    [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+      const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
+      const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
+      bfield_cc_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+
+      const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
+      const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
+      bfield_cc_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+    });
+}
+
+template <typename problem_t>
+template <FluxDir DIR>
 void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState,
 						    amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
@@ -1956,37 +2001,7 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
 	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		std::array<int, 3> delta_x2 = {0, 0, 0};
-		std::array<int, 3> delta_x3 = {0, 0, 0};
-		if constexpr (DIR == FluxDir::X1) {
-			delta_x2[1] = 1;
-			delta_x3[2] = 1;
-			x2State_fc_bfield_in = consVar_fc[1].const_arrays();
-			x3State_fc_bfield_in = consVar_fc[2].const_arrays();
-		} else if constexpr (DIR == FluxDir::X2) {
-			delta_x2[2] = 1;
-			delta_x3[0] = 1;
-			x2State_fc_bfield_in = consVar_fc[2].const_arrays();
-			x3State_fc_bfield_in = consVar_fc[0].const_arrays();
-		} else if constexpr (DIR == FluxDir::X3) {
-			delta_x2[0] = 1;
-			delta_x3[1] = 1;
-			x2State_fc_bfield_in = consVar_fc[0].const_arrays();
-			x3State_fc_bfield_in = consVar_fc[1].const_arrays();
-		}
-		auto bfield_cc_in = bfield_cc_mf.arrays();
-		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p =
-			    x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
-
-			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p =
-			    x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
-		});
+		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(bfield_cc_mf, consVar_fc, x2State_fc_bfield_in, x3State_fc_bfield_in);
 	}
 
 	if (reconstructionOrder_ == 5) {
@@ -2095,39 +2110,7 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_m
 	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
 	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		std::array<int, 3> delta_x2 = {0, 0, 0};
-		std::array<int, 3> delta_x3 = {0, 0, 0};
-
-		if constexpr (DIR == FluxDir::X1) {
-			delta_x2[1] = 1;
-			delta_x3[2] = 1;
-			x2State_fc_bfield_in = x1ConsVar_fc_mf[1].const_arrays();
-			x3State_fc_bfield_in = x1ConsVar_fc_mf[2].const_arrays();
-		} else if constexpr (DIR == FluxDir::X2) {
-			delta_x2[2] = 1;
-			delta_x3[0] = 1;
-			x2State_fc_bfield_in = x1ConsVar_fc_mf[2].const_arrays();
-			x3State_fc_bfield_in = x1ConsVar_fc_mf[0].const_arrays();
-		} else if constexpr (DIR == FluxDir::X3) {
-			delta_x2[0] = 1;
-			delta_x3[1] = 1;
-			x2State_fc_bfield_in = x1ConsVar_fc_mf[0].const_arrays();
-			x3State_fc_bfield_in = x1ConsVar_fc_mf[1].const_arrays();
-		}
-
-		auto bfield_cc_in = bfield_cc_mf.arrays();
-		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p =
-			    x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
-
-			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p =
-			    x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
-		});
+		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(bfield_cc_mf, x1ConsVar_fc_mf, x2State_fc_bfield_in, x3State_fc_bfield_in);
 	}
 
 	// donor-cell reconstruction

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -315,20 +315,20 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
-	void computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const;
+	void computeCCPerpBfieldComps(amrex::MultiFab &cc_bfield_perp_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const;
 
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 			       amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
 			       amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 			       amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total, int nvars);
 
 	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 				 amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
 				 amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, int ng_reconstruct_total,
 				 int nvars);
@@ -1856,7 +1856,7 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab perp_bfield_cc_comps(ba, dm, 2, nghost_cc_);
+	amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, 3> flatCoefs;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
@@ -1893,12 +1893,12 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// compute flux functions
 	AMREX_D_TERM(
-	    hydroFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
+	    hydroFluxFunction<FluxDir::X1>(primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
 					   facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1],
+	    , hydroFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1],
 					     facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
 	    ,
-	    hydroFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2],
+	    hydroFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2],
 					   facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
@@ -1951,7 +1951,7 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
-AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf,
+AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computeCCPerpBfieldComps(amrex::MultiFab &cc_bfield_perp_comps_mf,
 									 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
 {
 	// per-direction neighbor offsets for those two components
@@ -1961,71 +1961,71 @@ AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::
 	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
 	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (DIR == FluxDir::X1) {
-		x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
-		x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+		x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // y-faces
+		x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // z-faces
 		delta_x2[1] = 1;
 		delta_x3[2] = 1;
 	} else if constexpr (DIR == FluxDir::X2) {
-		x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
-		x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+		x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // z-faces
+		x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // x-faces
 		delta_x2[2] = 1;
 		delta_x3[0] = 1;
 	} else if constexpr (DIR == FluxDir::X3) {
-		x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
-		x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+		x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // x-faces
+		x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // y-faces
 		delta_x2[0] = 1;
 		delta_x3[1] = 1;
 	}
 
-	auto perp_bfield_cc_comps_out = perp_bfield_cc_comps_mf.arrays();
-	constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
+	auto cc_bfield_perp_comps_out = cc_bfield_perp_comps_mf.arrays();
+	constexpr int b_comp = Physics_Indices<problem_t>::mhdFirstIndex;
 
 	amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-	amrex::ParallelFor(perp_bfield_cc_comps_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-		const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
-		const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
-		perp_bfield_cc_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+	amrex::ParallelFor(cc_bfield_perp_comps_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, b_comp);
+		const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], b_comp);
+		cc_bfield_perp_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
-		const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
-		const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
-		perp_bfield_cc_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+		const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, b_comp);
+		const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], b_comp);
+		cc_bfield_perp_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
 	});
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState,
 						    amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(perp_bfield_cc_comps_mf, consVar_fc);
+		QuokkaSimulation<problem_t>::template computeCCPerpBfieldComps<DIR>(cc_bfield_perp_comps_mf, consVar_fc);
 	}
 
 	if (reconstructionOrder_ == 5) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
 											   ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
 											ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 2) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(perp_bfield_cc_comps_mf, leftState_bfield,
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(cc_bfield_perp_comps_mf, leftState_bfield,
 													      rightState_bfield, ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
 											     ng_reconstruct, 2);
 		}
 	} else {
@@ -2060,7 +2060,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab perp_bfield_cc_comps(ba, dm, 2, nghost_cc_);
+	amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
@@ -2086,11 +2086,11 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0],
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0],
 						      flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1],
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1],
 							flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2],
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2],
 							flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
@@ -2102,20 +2102,20 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState,
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState,
 						      amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
 						      const int nvars)
 {
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(perp_bfield_cc_comps_mf, x1ConsVar_fc_mf);
+		QuokkaSimulation<problem_t>::template computeCCPerpBfieldComps<DIR>(cc_bfield_perp_comps_mf, x1ConsVar_fc_mf);
 	}
 
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
 										2);
 	}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1960,18 +1960,18 @@ QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc
 	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
 	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
   if constexpr (DIR == FluxDir::X1) {
-    x2State_fc_bfield_in = consVar_fc[1].const_arrays();
-    x3State_fc_bfield_in = consVar_fc[2].const_arrays();
+    x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
+    x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
     delta_x2[1] = 1;
     delta_x3[2] = 1;
   } else if constexpr (DIR == FluxDir::X2) {
-    x2State_fc_bfield_in = consVar_fc[2].const_arrays();
-    x3State_fc_bfield_in = consVar_fc[0].const_arrays();
+    x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
+    x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
     delta_x2[2] = 1;
     delta_x3[0] = 1;
   } else if constexpr (DIR == FluxDir::X3) {
-    x2State_fc_bfield_in = consVar_fc[0].const_arrays();
-    x3State_fc_bfield_in = consVar_fc[1].const_arrays();
+    x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // +x faces
+    x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
     delta_x2[0] = 1;
     delta_x3[1] = 1;
   }

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -319,15 +319,16 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux,
-			       amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
-			       amrex::MultiFab const &x1Flat, amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total,
-			       int nvars);
+	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+			       amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
+			       amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
+			       amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total, int nvars);
 
 	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux,
-				 amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf,
-				 int ng_reconstruct_total, int nvars);
+	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+				 amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
+				 amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, int ng_reconstruct_total,
+				 int nvars);
 
 	void replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
 			   amrex::iMultiFab &redoFlag);
@@ -1888,9 +1889,13 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
+	AMREX_D_TERM(
+	    hydroFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0],
+					   fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+	    , hydroFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1],
+					     fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+	    , hydroFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2],
+					     fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -1942,8 +1947,9 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &flux,
-						    amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState,
+						    amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
+						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
@@ -1972,11 +1978,13 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
 		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p =
+			    x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
 			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
 			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p =
+			    x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
 			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
 		});
 	}
@@ -1984,7 +1992,8 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 	if (reconstructionOrder_ == 5) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+											   2);
 		}
 	} else if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
@@ -1994,12 +2003,14 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 	} else if (reconstructionOrder_ == 2) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(bfield_cc_mf, leftState_bfield, rightState_bfield,
+													      ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+											     2);
 		}
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
@@ -2010,10 +2021,13 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(
-		    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+											 rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds,
+											 &consVar_fc[static_cast<int>(DIR)], nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr, nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+											 rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr,
+											 nghost_vel_);
 	}
 }
 
@@ -2056,12 +2070,12 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
-						      reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
-							reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
-							reconstructRange, nvars);)
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
+						      facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1],
+							facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars);
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2],
+							facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -2072,7 +2086,8 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState,
+						      amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
 						      const int nvars)
@@ -2104,11 +2119,13 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_m
 		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
 		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p =
+			    x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
 			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
 			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p =
+			    x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
 			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
 		});
 	}
@@ -2121,11 +2138,13 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_m
 
 	// LLF solver
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(
-		    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds, &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+											    rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds,
+											    &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_,
-											nullptr, nullptr, nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+											rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr,
+											nghost_vel_);
 	}
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -319,13 +319,13 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
+	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux,
 			       amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
 			       amrex::MultiFab const &x1Flat, amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total,
 			       int nvars);
 
 	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &x1Flux,
+	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux,
 				 amrex::MultiFab &x1FaceVel, amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf,
 				 int ng_reconstruct_total, int nvars);
 
@@ -1427,13 +1427,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
 
-	int nvars = ncompHydro_;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		// also create space to append the two magnetic field components orthogonal to the solving direction
-		nvars += 3; // add-hoc +3 because +1 (primScalar0_index) precedes +2 (x2Magnetic_index and x3Magnetic_index) at the end of the enum of
-			    // primitive quantities
-	}
-	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] = computeFOHydroFluxes(state_old_cc_tmp, state_old_fc_tmp, nvars, lev);
+	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] = computeFOHydroFluxes(state_old_cc_tmp, state_old_fc_tmp, ncompHydro_, lev);
 
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1454,13 +1448,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		auto const &stateOld_fc = state_old_fc_tmp;
 		auto &stateNew_fc = state_inter_fc_;
 
-		int nvars = ncompHydro_;
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			// also create space to append the two magnetic field components orthogonal to the solving direction
-			nvars += 3; // add-hoc +3 because +1 (primScalar0_index) precedes +2 (x2Magnetic_index and x3Magnetic_index) at the end of the enum of
-				    // primitive quantities
-		}
-		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateOld_cc, stateOld_fc, nvars, lev);
+		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateOld_cc, stateOld_fc, ncompHydro_, lev);
 
 		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage1;
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1602,13 +1590,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		auto const &stateInter_fc = state_inter_fc_;
 		auto &stateFinal_fc = state_new_fc_[lev];
 
-		int nvars = ncompHydro_;
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			// also create space to append the two magnetic field components orthogonal to the solving direction
-			nvars += 3; // add-hoc step: +3 because primScalar0_index precedes x2Magnetic_index and x3Magnetic_index at the end of the enum of
-				    // primitive quantities
-		}
-		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateInter_cc, stateInter_fc, nvars, lev);
+		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateInter_cc, stateInter_fc, ncompHydro_, lev);
 
 		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage2;
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1870,11 +1852,14 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
+	amrex::MultiFab bfield_cc(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, 3> flatCoefs;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -1885,6 +1870,8 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
+		leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
+		rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost - 1);
 		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructGhost - 1);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1901,12 +1888,9 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0],
-						    flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
-						      flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-		     , hydroFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
-						      flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
+	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+		     , hydroFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
+		     , hydroFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
 	amrex::Gpu::streamSynchronizeAll();
@@ -1958,53 +1942,65 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &flux,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &flux,
 						    amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
-	amrex::MultiArray4<const amrex::Real> x2State_fc_in;
-	amrex::MultiArray4<const amrex::Real> x3State_fc_in;
+	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
+	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		std::array<int, 3> delta_x2 = {0, 0, 0};
 		std::array<int, 3> delta_x3 = {0, 0, 0};
 		if constexpr (DIR == FluxDir::X1) {
 			delta_x2[1] = 1;
 			delta_x3[2] = 1;
-			x2State_fc_in = consVar_fc[1].const_arrays();
-			x3State_fc_in = consVar_fc[2].const_arrays();
+			x2State_fc_bfield_in = consVar_fc[1].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[2].const_arrays();
 		} else if constexpr (DIR == FluxDir::X2) {
 			delta_x2[2] = 1;
 			delta_x3[0] = 1;
-			x2State_fc_in = consVar_fc[2].const_arrays();
-			x3State_fc_in = consVar_fc[0].const_arrays();
+			x2State_fc_bfield_in = consVar_fc[2].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[0].const_arrays();
 		} else if constexpr (DIR == FluxDir::X3) {
 			delta_x2[0] = 1;
 			delta_x3[1] = 1;
-			x2State_fc_in = consVar_fc[0].const_arrays();
-			x3State_fc_in = consVar_fc[1].const_arrays();
+			x2State_fc_bfield_in = consVar_fc[0].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[1].const_arrays();
 		}
-		auto primVar_in = primVar_mf.arrays();
+		auto bfield_cc_in = bfield_cc_mf.arrays();
 		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-		amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			const double bx2_m = x2State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p = x2State_fc_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x2Magnetic_index) = 0.5 * (bx2_m + bx2_p);
+		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
-			const double bx3_m = x3State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p = x3State_fc_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x3Magnetic_index) = 0.5 * (bx3_m + bx3_p);
+			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
 		});
 	}
 
 	if (reconstructionOrder_ == 5) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		}
 	} else if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		}
 	} else if (reconstructionOrder_ == 2) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		}
 	} else {
 		amrex::Abort("Invalid reconstruction order specified!");
 	}
@@ -2015,10 +2011,9 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 	// interface-centered kernel
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(
-		    flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_, &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_vel_);
+		    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, primVar_mf,
-											 artificialViscosityK_, nullptr, nullptr, nghost_vel_);
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr, nghost_vel_);
 	}
 }
 
@@ -2035,16 +2030,21 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
+	amrex::MultiFab bfield_cc(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
 		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
 		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+		leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
+		rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
 		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
 		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -2056,11 +2056,11 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, leftState[0], rightState[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
 						      reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, leftState[1], rightState[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
 							reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, leftState[2], rightState[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
 							reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
@@ -2072,14 +2072,13 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
 						      const int nvars)
 {
-	amrex::MultiArray4<const amrex::Real> x2State_fc_in;
-	amrex::MultiArray4<const amrex::Real> x3State_fc_in;
-
+	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
+	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		std::array<int, 3> delta_x2 = {0, 0, 0};
 		std::array<int, 3> delta_x3 = {0, 0, 0};
@@ -2087,44 +2086,45 @@ void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_m
 		if constexpr (DIR == FluxDir::X1) {
 			delta_x2[1] = 1;
 			delta_x3[2] = 1;
-			x2State_fc_in = x1ConsVar_fc_mf[1].const_arrays();
-			x3State_fc_in = x1ConsVar_fc_mf[2].const_arrays();
+			x2State_fc_bfield_in = x1ConsVar_fc_mf[1].const_arrays();
+			x3State_fc_bfield_in = x1ConsVar_fc_mf[2].const_arrays();
 		} else if constexpr (DIR == FluxDir::X2) {
 			delta_x2[2] = 1;
 			delta_x3[0] = 1;
-			x2State_fc_in = x1ConsVar_fc_mf[2].const_arrays();
-			x3State_fc_in = x1ConsVar_fc_mf[0].const_arrays();
+			x2State_fc_bfield_in = x1ConsVar_fc_mf[2].const_arrays();
+			x3State_fc_bfield_in = x1ConsVar_fc_mf[0].const_arrays();
 		} else if constexpr (DIR == FluxDir::X3) {
 			delta_x2[0] = 1;
 			delta_x3[1] = 1;
-			x2State_fc_in = x1ConsVar_fc_mf[0].const_arrays();
-			x3State_fc_in = x1ConsVar_fc_mf[1].const_arrays();
+			x2State_fc_bfield_in = x1ConsVar_fc_mf[0].const_arrays();
+			x3State_fc_bfield_in = x1ConsVar_fc_mf[1].const_arrays();
 		}
 
-		auto primVar_in = primVar_mf.arrays();
-		primVar_mf.arrays();
+		auto bfield_cc_in = bfield_cc_mf.arrays();
 		amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
+		amrex::ParallelFor(bfield_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			const double bx2_m = x2State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			bfield_cc_in[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
-		amrex::ParallelFor(primVar_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			const double bx2_m = x2State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx2_p = x2State_fc_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x2Magnetic_index) = 0.5 * (bx2_m + bx2_p);
-
-			const double bx3_m = x3State_fc_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			const double bx3_p = x3State_fc_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
-			primVar_in[bx](i, j, k, HydroSystem<problem_t>::x3Magnetic_index) = 0.5 * (bx3_m + bx3_p);
+			const double bx3_m = x3State_fc_bfield_in[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
+			const double bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], Physics_Indices<problem_t>::mhdFirstIndex);
+			bfield_cc_in[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
 		});
 	}
 
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+	}
 
 	// LLF solver
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(
-		    flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_, &x1FSpds, &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_vel_);
+		    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds, &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_vel_);
 	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, primVar_mf, artificialViscosityK_,
+		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, artificialViscosityK_,
 											nullptr, nullptr, nghost_vel_);
 	}
 }

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1895,10 +1895,10 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	AMREX_D_TERM(
 	    hydroFluxFunction<FluxDir::X1>(primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
 					   facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1],
+	    , hydroFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1],
 					     facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
 	    ,
-	    hydroFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2],
+	    hydroFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2],
 					   facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1952,7 +1952,7 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computeCCPerpBfieldComps(amrex::MultiFab &cc_bfield_perp_comps_mf,
-									 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
+									      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
 {
 	// per-direction neighbor offsets for those two components
 	std::array<int, 3> delta_x2{0, 0, 0};

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -315,20 +315,20 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
 
 	template <FluxDir DIR>
-	void computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const;
+	void computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const;
 
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 			       amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
 			       amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 			       amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total, int nvars);
 
 	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
+	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
 				 amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
 				 amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, int ng_reconstruct_total,
 				 int nvars);
@@ -1856,7 +1856,7 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab bfield_cc(ba, dm, 2, nghost_cc_);
+	amrex::MultiFab perp_bfield_cc_comps(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, 3> flatCoefs;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
@@ -1893,11 +1893,11 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 	// compute flux functions
 	AMREX_D_TERM(
-	    hydroFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0],
+	    hydroFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0], facevel[0],
 					   fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1],
+	    , hydroFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[0], rightState_bfield[0], flux[1], facevel[1],
 					     fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);
-	    , hydroFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2],
+	    , hydroFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[0], rightState_bfield[0], flux[2], facevel[2],
 					     fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2], reconstructGhost, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
@@ -1951,12 +1951,14 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_FORCE_INLINE void
-QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiArray4<const amrex::Real> &x2State_fc_bfield_in, amrex::MultiArray4<const amrex::Real> &x3State_fc_bfield_in) const
+QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &perp_bfield_cc_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
 {
    // per-direction neighbor offsets for those two components
   std::array<int,3> delta_x2{0,0,0};
   std::array<int,3> delta_x3{0,0,0};
 
+	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
+	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
   if constexpr (DIR == FluxDir::X1) {
     x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // +y faces
     x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // +z faces
@@ -1974,57 +1976,55 @@ QuokkaSimulation<problem_t>::computePerpBfieldCC(amrex::MultiFab &bfield_cc_mf, 
     delta_x3[1] = 1;
   }
 
-  auto bfield_cc_out = bfield_cc_mf.arrays();
+  auto perp_bfield_cc_comps_out = perp_bfield_cc_comps_mf.arrays();
   constexpr int bcomp0 = Physics_Indices<problem_t>::mhdFirstIndex;
 
   amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-  amrex::ParallelFor(bfield_cc_mf, ng,
+  amrex::ParallelFor(perp_bfield_cc_comps_mf, ng,
     [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
       const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, bcomp0);
       const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], bcomp0);
-      bfield_cc_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+      perp_bfield_cc_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
 
       const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, bcomp0);
       const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], bcomp0);
-      bfield_cc_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+      perp_bfield_cc_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
     });
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState,
+void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState,
 						    amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
 						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars)
 {
-	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
-	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(bfield_cc_mf, consVar_fc, x2State_fc_bfield_in, x3State_fc_bfield_in);
+		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(perp_bfield_cc_comps_mf, consVar_fc);
 	}
 
 	if (reconstructionOrder_ == 5) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
 											   2);
 		}
 	} else if (reconstructionOrder_ == 3) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 2) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(bfield_cc_mf, leftState_bfield, rightState_bfield,
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield,
 													      ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
 											     2);
 		}
 	} else {
@@ -2059,7 +2059,7 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 	// allocate temporary MultiFabs
 	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab bfield_cc(ba, dm, 2, nghost_cc_);
+	amrex::MultiFab perp_bfield_cc_comps(ba, dm, 2, nghost_cc_);
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
@@ -2085,11 +2085,11 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
 
 	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, bfield_cc, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
+	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, perp_bfield_cc_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0], flux[0],
 						      facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, bfield_cc, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1],
+		     , hydroFOFluxFunction<FluxDir::X2>(primVar, perp_bfield_cc_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1], flux[1],
 							facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, bfield_cc, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2],
+		     , hydroFOFluxFunction<FluxDir::X3>(primVar, perp_bfield_cc_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2], flux[2],
 							facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars);)
 
 	// synchronization point to prevent MultiFabs from going out of scope
@@ -2101,22 +2101,20 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 
 template <typename problem_t>
 template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &bfield_cc_mf, amrex::MultiFab &leftState,
+void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &perp_bfield_cc_comps_mf, amrex::MultiFab &leftState,
 						      amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
 						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
 						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
 						      const int nvars)
 {
-	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
-	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(bfield_cc_mf, x1ConsVar_fc_mf, x2State_fc_bfield_in, x3State_fc_bfield_in);
+		QuokkaSimulation<problem_t>::template computePerpBfieldCC<DIR>(perp_bfield_cc_comps_mf, x1ConsVar_fc_mf);
 	}
 
 	// donor-cell reconstruction
 	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(bfield_cc_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(perp_bfield_cc_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct, 2);
 	}
 
 	// LLF solver

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -74,7 +74,7 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 		pressure_index,
 		primEint_index,	   // auxiliary internal energy (rho * e)
 		primScalar0_index, // first passive scalar (only present if nscalars > 0!)
-		// TODO(benwibking): = check what is enabled
+				   // TODO(benwibking): = check what is enabled
 	};
 
 	static void ConservedToPrimitive(amrex::MultiFab const &cons_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf,
@@ -123,8 +123,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	template <RiemannSolver RIEMANN, FluxDir DIR>
 	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &leftState_bfield_mf, amrex::MultiFab const &rightState_bfield_mf,
-					amrex::MultiFab const &primVar_mf, amrex::Real K_visc,
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &leftState_bfield_mf,
+				  amrex::MultiFab const &rightState_bfield_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc,
 				  amrex::MultiFab *x1FSpds_mf = nullptr, amrex::MultiFab const *x1ConsVar_fc_mf = nullptr, int nghost_vel = 2);
 
 	template <FluxDir DIR>
@@ -957,8 +957,8 @@ void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf, amrex::
 template <typename problem_t>
 template <RiemannSolver RIEMANN, FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &x1LeftState_bfield_mf, amrex::MultiFab const &x1RightState_bfield_mf,
-						 amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &x1LeftState_bfield_mf,
+					   amrex::MultiFab const &x1RightState_bfield_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
 					   amrex::MultiFab *x1FSpds_mf, amrex::MultiFab const *x1ConsVar_fc_mf, const int nghost_vel)
 {
 

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -75,9 +75,6 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 		primEint_index,	   // auxiliary internal energy (rho * e)
 		primScalar0_index, // first passive scalar (only present if nscalars > 0!)
 		// TODO(benwibking): = check what is enabled
-		x2Magnetic_index, // when magnetic fields exist, then we also store cc-ave of the two orthogonal b-fields, so they can be reconstructed to the
-				  // solving face
-		x3Magnetic_index,
 	};
 
 	static void ConservedToPrimitive(amrex::MultiFab const &cons_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf,
@@ -126,7 +123,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	template <RiemannSolver RIEMANN, FluxDir DIR>
 	static void ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, amrex::Real K_visc,
+				  amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &leftState_bfield_mf, amrex::MultiFab const &rightState_bfield_mf,
+					amrex::MultiFab const &primVar_mf, amrex::Real K_visc,
 				  amrex::MultiFab *x1FSpds_mf = nullptr, amrex::MultiFab const *x1ConsVar_fc_mf = nullptr, int nghost_vel = 2);
 
 	template <FluxDir DIR>
@@ -959,7 +957,8 @@ void HydroSystem<problem_t>::SyncDualEnergy(amrex::MultiFab &consVar_mf, amrex::
 template <typename problem_t>
 template <RiemannSolver RIEMANN, FluxDir DIR>
 void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::MultiFab &x1FaceVel_mf, amrex::MultiFab const &x1LeftState_mf,
-					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
+					   amrex::MultiFab const &x1RightState_mf, amrex::MultiFab const &x1LeftState_bfield_mf, amrex::MultiFab const &x1RightState_bfield_mf,
+						 amrex::MultiFab const &primVar_mf, const amrex::Real K_visc,
 					   amrex::MultiFab *x1FSpds_mf, amrex::MultiFab const *x1ConsVar_fc_mf, const int nghost_vel)
 {
 
@@ -971,6 +970,8 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 
 	auto const &x1LeftState_in = x1LeftState_mf.const_arrays();
 	auto const &x1RightState_in = x1RightState_mf.const_arrays();
+	auto const &x1LeftState_bfield_in = x1LeftState_bfield_mf.const_arrays();
+	auto const &x1RightState_bfield_in = x1RightState_bfield_mf.const_arrays();
 	auto const &primVar_in = primVar_mf.const_arrays();
 	auto x1Flux_in = x1Flux_mf.arrays();
 	auto x1FaceVel_in = x1FaceVel_mf.arrays();
@@ -993,6 +994,8 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
+		quokka::Array4View<const amrex::Real, DIR> x1LeftState_bfield(x1LeftState_bfield_in[bx]);
+		quokka::Array4View<const amrex::Real, DIR> x1RightState_bfield(x1RightState_bfield_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> q(primVar_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1Flux(x1Flux_in[bx]);
 		quokka::Array4View<amrex::Real, DIR> x1FaceVel(x1FaceVel_in[bx]);
@@ -1040,10 +1043,10 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			quokka::Array4View<const amrex::Real, DIR> x1ConsVar_fc(x1ConsVar_fc_ref);
 			bx1 = x1ConsVar_fc(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
-			by_L = x1LeftState(i, j, k, x2Magnetic_index);
-			bz_L = x1LeftState(i, j, k, x3Magnetic_index);
-			by_R = x1RightState(i, j, k, x2Magnetic_index);
-			bz_R = x1RightState(i, j, k, x3Magnetic_index);
+			by_L = x1LeftState_bfield(i, j, k, 0);
+			bz_L = x1LeftState_bfield(i, j, k, 1);
+			by_R = x1RightState_bfield(i, j, k, 0);
+			bz_R = x1RightState_bfield(i, j, k, 1);
 			magnetic_energy_L = 0.5 * (bx1 * bx1 + by_L * by_L + bz_L * bz_L);
 			magnetic_energy_R = 0.5 * (bx1 * bx1 + by_R * by_R + bz_R * bz_R);
 		}

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -74,7 +74,6 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 		pressure_index,
 		primEint_index,	   // auxiliary internal energy (rho * e)
 		primScalar0_index, // first passive scalar (only present if nscalars > 0!)
-				   // TODO(benwibking): = check what is enabled
 	};
 
 	static void ConservedToPrimitive(amrex::MultiFab const &cons_cc_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf,


### PR DESCRIPTION
### Description
In this PR I have fixed the indexing problem where the b-field was previously piggy-backing off of the existing infrastructure to interpolate conserved quantities to interfaces for the Riemann solver. That adhoc solution broke once passive scalars were enabled with more than a single species. I have now fixed this with a short term solution, where the orthogonal b-field components are now stored in their own MultiFabs and interpolated independently. A longer term solution has already been proposed in #748 and [typed MultiFab design document](https://github.com/quokka-astro/quokka/blob/6dd620edf75ff97490180b7eafe01bd6de237085/docs/markdown/typed_multifab.md) which we may want to implement in the future.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
