### PR TITLE
Add option to save particles to csv files

### DIFF
--- a/inputs/ParticleRadiation.in
+++ b/inputs/ParticleRadiation.in
@@ -29,7 +29,8 @@ particles.disable_SN_feedback = true
 
 stop_time = 8.0e20
 max_timesteps = 4
-plotfile_interval = -1
+plotfile_interval = 4
+particle_interval = 4
 checkpoint_interval = -1
 
 tiny_profiler.enabled = 0

--- a/inputs/ParticleRadiation.in
+++ b/inputs/ParticleRadiation.in
@@ -30,7 +30,7 @@ particles.disable_SN_feedback = true
 stop_time = 8.0e20
 max_timesteps = 4
 plotfile_interval = 4
-particle_interval = 4
+particle_csv_interval = 4
 checkpoint_interval = -1
 
 tiny_profiler.enabled = 0

--- a/inputs/ParticleSink.in
+++ b/inputs/ParticleSink.in
@@ -30,6 +30,6 @@ particles.verbose = 1
 particles.sink_particle_use_uniform_kernel = true
 
 max_timesteps = 1
-plotfile_interval = -1
+plotfile_interval = 1
 
 tiny_profiler.enabled = 0

--- a/inputs/ParticleSink.in
+++ b/inputs/ParticleSink.in
@@ -31,5 +31,6 @@ particles.sink_particle_use_uniform_kernel = true
 
 max_timesteps = 1
 plotfile_interval = 1
+particle_interval = 1
 
 tiny_profiler.enabled = 0

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -186,7 +186,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
 	[[nodiscard]] auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
-		return particle_io::getParticleDataAtLevelZero(container_);
+		return particle_io::getAllParticleData(container_);
 	}
 
 	[[nodiscard]] auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -77,7 +77,8 @@ class PhysicsParticleDescriptorBase
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getAllParticleData() const -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
+	[[nodiscard]] virtual auto getAllParticleData() const
+	    -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Get particle data at level lev
 	[[nodiscard]] virtual auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
@@ -187,7 +188,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	//   - Integer data (e.g., id, type, etc.)
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
-	[[nodiscard]] auto getAllParticleData() const -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
+	[[nodiscard]] auto getAllParticleData() const
+	    -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
 		return particle_io::getAllParticleData(container_);
 	}
@@ -359,7 +361,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Compute maximum particle speed at a given level
 	[[nodiscard]] auto computeMaxParticleSpeed(int lev) const -> amrex::ValLocPair<amrex::Real, amrex::RealVect> override
 	{
-		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect { AMREX_D_DECL(NAN, NAN, NAN) }};
+		amrex::ValLocPair<amrex::Real, amrex::RealVect> max_speed{.value = 0, .index = amrex::RealVect{AMREX_D_DECL(NAN, NAN, NAN)}};
 
 		if (container_ != nullptr && this->getMassIndex() >= 0) {
 			// Only compute for particles that have velocity components

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -917,12 +917,21 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 	}
 
-	// Save particle data to file
-	void saveParticleDataToFile(const std::string &plotfilename)
+	// Save particle data to file only if particle count <= max_particles
+	void saveParticleDataToFileConditional(const std::string &plotfilename, int max_particles)
 	{
-		const BL_PROFILE("PhysicsParticleRegister::saveParticleDataToFile()");
+		const BL_PROFILE("PhysicsParticleRegister::saveParticleDataToFileConditional()");
 		for (const auto &[type, descriptor] : particleRegistry_) {
-			descriptor->saveParticleDataToFile(plotfilename, getParticleTypeName(type));
+			const int num_particles = descriptor->getNumParticles();
+			const std::string particle_type_name = getParticleTypeName(type);
+			
+			if (num_particles <= max_particles) {
+				amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
+				descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
+			} else {
+				amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles 
+				              << " particles exceeds limit of " << max_particles << "\n";
+			}
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -77,7 +77,7 @@ class PhysicsParticleDescriptorBase
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
+	[[nodiscard]] virtual auto getAllParticleData() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Get particle data at level lev
 	[[nodiscard]] virtual auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
@@ -184,7 +184,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	//   - Integer data (e.g., id, type, etc.)
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
-	[[nodiscard]] auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
+	[[nodiscard]] auto getAllParticleData() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
 		return particle_io::getAllParticleData(container_);
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -449,17 +449,23 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Implementation of particle data output to units file
 	void writeUnitsFile(const std::string &snapshot_name, const std::string &name) override
 	{
-		particle_io::writeUnitsFile<ContainerType, problem_t, particleType_>(container_, snapshot_name, name);
+		if (container_ != nullptr) {
+			particle_io::writeUnitsFile<ContainerType, problem_t, particleType_>(container_, snapshot_name, name);
+		}
 	}
 
 	void printParticleStatistics() const override
 	{
-		particle_io::printParticleStatistics<ContainerType, problem_t, particleType_>(container_, getMassIndex(), getEvolutionStageIndex());
+		if (container_ != nullptr) {
+			particle_io::printParticleStatistics<ContainerType, problem_t, particleType_>(container_, getMassIndex(), getEvolutionStageIndex());
+		}
 	}
 
 	void saveParticleDataToFile(const std::string &filename, const std::string &name) override
 	{
-		particle_io::saveParticleDataToFile<ContainerType>(container_, filename, name);
+		if (container_ != nullptr) {
+			particle_io::saveParticleDataToFile<ContainerType>(container_, filename, name);
+		}
 	}
 
 #if AMREX_SPACEDIM == 3

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -104,6 +104,9 @@ class PhysicsParticleDescriptorBase
 	// Print statistics of particles
 	virtual void printParticleStatistics() const = 0;
 
+	// Save particle data to file
+	virtual void saveParticleDataToFile(const std::string &plotfilename, const std::string &name) = 0;
+
 	// Get the number of particles
 	[[nodiscard]] virtual auto getNumParticles() const -> int = 0;
 
@@ -450,6 +453,11 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	void printParticleStatistics() const override
 	{
 		particle_io::printParticleStatistics<ContainerType, problem_t, particleType_>(container_, getMassIndex(), getEvolutionStageIndex());
+	}
+
+	void saveParticleDataToFile(const std::string &filename, const std::string &name) override
+	{
+		particle_io::saveParticleDataToFile<ContainerType>(container_, filename, name);
 	}
 
 #if AMREX_SPACEDIM == 3
@@ -898,6 +906,15 @@ template <typename problem_t> class PhysicsParticleRegister
 
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			descriptor->printParticleStatistics();
+		}
+	}
+
+	// Save particle data to file
+	void saveParticleDataToFile(const std::string &plotfilename)
+	{
+		const BL_PROFILE("PhysicsParticleRegister::saveParticleDataToFile()");
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			descriptor->saveParticleDataToFile(plotfilename, getParticleTypeName(type));
 		}
 	}
 

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -77,7 +77,7 @@ class PhysicsParticleDescriptorBase
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getAllParticleData() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
+	[[nodiscard]] virtual auto getAllParticleData() const -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Get particle data at level lev
 	[[nodiscard]] virtual auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
@@ -184,7 +184,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	//   - Integer data (e.g., id, type, etc.)
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
-	[[nodiscard]] auto getAllParticleData() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
+	[[nodiscard]] auto getAllParticleData() const -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
 		return particle_io::getAllParticleData(container_);
 	}

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -2,11 +2,11 @@
 #define PHYSICS_PARTICLES_HPP_
 
 #include <cstdint>
-#include <fstream>
-#include <iomanip>
 #include <map>
 #include <memory>
 #include <string>
+
+#include <fmt/format.h>
 
 #include "AMReX_Array4.H"
 #include "AMReX_BLProfiler.H"
@@ -16,6 +16,8 @@
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 #include "AMReX_Vector.H"
+
+#include "particle_IO.hpp"
 #include "particle_accretion.hpp"
 #include "particle_creation.hpp"
 #include "particle_deposition.hpp"
@@ -23,7 +25,6 @@
 #include "particle_radiation.hpp"
 #include "particle_types.hpp"
 #include "physics_info.hpp"
-#include <fmt/format.h>
 
 namespace quokka
 {
@@ -185,205 +186,12 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
 	[[nodiscard]] auto getParticleDataAtLevelZero() const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
-		std::vector<std::vector<double>> real_data;
-		std::vector<std::vector<int>> int_data;
-
-		// // If max level > 0, return empty vectors. This function does not support multi-level particles.
-		// if (container_->finestLevel() > 0) {
-		// 	return {real_data, int_data};
-		// }
-
-		// All ranks must participate in copyParticles
-		if (container_ != nullptr) {
-			// Create single-box particle container for analysis on all ranks
-			ContainerType analysisPC{};
-			// Define a single box [0,1]^3 that will hold all particles on rank 0
-			amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
-			amrex::Geometry const geom(box);
-			amrex::BoxArray const boxArray(box);
-			// Force all particles to rank 0 by using a single-rank distribution
-			amrex::Vector<int> const ranks({0});
-			amrex::DistributionMapping const dmap(ranks);
-
-			// Initialize the analysis container and gather all particles to rank 0
-			analysisPC.Define(geom, dmap, boxArray);
-			analysisPC.copyParticles(*container_); // MPI communication happens here
-
-			// Only rank 0 processes the particles since they're all gathered there
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				// Get iterator for the single box on rank 0
-				typename ContainerType::ParIterType const pIter(analysisPC, 0);
-				if (pIter.isValid()) {
-					const amrex::Long np = pIter.numParticles();
-					auto &particles = pIter.GetArrayOfStructs();
-
-					// Transfer particle data from GPU to CPU for analysis
-					typename ContainerType::ParticleType *pData = particles().data();
-					amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
-					amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
-
-					// Check if particles have integer components
-					constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
-
-					// Pre-size vectors to avoid reallocations
-					real_data.reserve(np);
-					if constexpr (has_int_components) {
-						int_data.reserve(np);
-					}
-
-					// Extract positions, real components, and integer components from host data
-					for (int i = 0; i < np; ++i) {
-						const auto &p = pData_h[i];
-
-						// Process real data (positions and rdata)
-						std::vector<double> r_data;
-						// Pre-allocate to avoid reallocations
-						r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
-
-						// First add position components
-						for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-							r_data.push_back(p.pos(d));
-						}
-
-						// Then add all real components (mass, velocities, etc)
-						for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-							r_data.push_back(p.rdata(d));
-						}
-
-						real_data.push_back(std::move(r_data));
-
-						// Process integer data (idata) only if particles have integer components
-						if constexpr (has_int_components) {
-							std::vector<int> i_data;
-							// Pre-allocate to avoid reallocations
-							i_data.reserve(ContainerType::ParticleType::NInt);
-
-							// Add all integer components
-							for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
-								i_data.push_back(p.idata(d));
-							}
-
-							int_data.push_back(std::move(i_data));
-						}
-					}
-				}
-			}
-		}
-
-		return {real_data, int_data}; // Empty vectors on non-root ranks
+		return particle_io::getParticleDataAtLevelZero(container_);
 	}
 
 	[[nodiscard]] auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
-		std::vector<std::vector<double>> real_data;
-		std::vector<std::vector<int>> int_data;
-
-		if (container_ != nullptr) {
-			// Create single-box particle container for analysis on all ranks
-			ContainerType analysisPC{};
-			// Define a single box [0,1]^3 that will hold all particles on rank 0
-			amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
-			amrex::Geometry const geom(box);
-			amrex::BoxArray const boxArray(box);
-			// Force all particles to rank 0 by using a single-rank distribution
-			amrex::Vector<int> const ranks({0});
-			amrex::DistributionMapping const dmap(ranks);
-
-			// Initialize the analysis container
-			analysisPC.Define(geom, dmap, boxArray);
-
-			// Create a single destination tile on rank 0
-			auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
-
-			// Get particles only from the specified level
-			const auto &particles = container_->GetParticles(lev);
-
-			// First count total particles at this level
-			int total_np = 0;
-			for (const auto &kv : particles) {
-				total_np += kv.second.numParticles();
-			}
-
-			// Pre-size the destination tile
-			dst_tile.resize(total_np);
-
-			// Copy particles from each tile
-			int particle_offset = 0;
-			for (const auto &kv : particles) {
-				const auto &src_tile = kv.second;
-				const int np = src_tile.numParticles();
-				if (np > 0) {
-					const auto &src_aos = src_tile.GetArrayOfStructs();
-					auto &dst_aos = dst_tile.GetArrayOfStructs();
-					amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + particle_offset);
-					particle_offset += np;
-				}
-			}
-
-			// Now use MPI to gather all particles to rank 0
-			analysisPC.Redistribute(); // This handles the MPI communication
-
-			// Only rank 0 processes the particles since they're all gathered there
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				// Get iterator for the single box on rank 0
-				typename ContainerType::ParIterType const pIter(analysisPC, 0);
-				if (pIter.isValid()) {
-					const amrex::Long np = pIter.numParticles();
-					auto &particles = pIter.GetArrayOfStructs();
-
-					// Transfer particle data from GPU to CPU for analysis
-					typename ContainerType::ParticleType *pData = particles().data();
-					amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
-					amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
-
-					// Check if particles have integer components
-					constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
-
-					// Pre-size vectors to avoid reallocations
-					real_data.reserve(np);
-					if constexpr (has_int_components) {
-						int_data.reserve(np);
-					}
-
-					// Process each particle
-					for (int i = 0; i < np; ++i) {
-						const auto &p = pData_h[i];
-
-						// Process real data (positions and rdata)
-						std::vector<double> r_data;
-						// Pre-allocate to avoid reallocations
-						r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
-
-						// Add position components
-						for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-							r_data.push_back(p.pos(d));
-						}
-
-						// Add all real components
-						for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-							r_data.push_back(p.rdata(d));
-						}
-
-						real_data.push_back(std::move(r_data));
-
-						// Process integer data if particles have integer components
-						if constexpr (has_int_components) {
-							std::vector<int> i_data;
-							// Pre-allocate to avoid reallocations
-							i_data.reserve(ContainerType::ParticleType::NInt);
-
-							for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
-								i_data.push_back(p.idata(d));
-							}
-
-							int_data.push_back(std::move(i_data));
-						}
-					}
-				}
-			}
-		}
-
-		return {real_data, int_data}; // Empty vectors on non-root ranks
+		return particle_io::getParticleDataAtLevel(container_, lev);
 	}
 
 	// Get the number of particles in the container
@@ -636,88 +444,12 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Implementation of particle data output to units file
 	void writeUnitsFile(const std::string &snapshot_name, const std::string &name) override
 	{
-		if (container_ != nullptr) {
-			// Only write on rank 0
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				// Create the full path for the Fields.yaml file
-				std::string filename;
-#ifdef QUOKKA_USE_OPENPMD
-				// For OpenPMD, write the YAML file alongside the OpenPMD file
-				filename = snapshot_name + "_" + name + ".yaml";
-#else
-				// For standard output, write the YAML file in the particle directory
-				filename = snapshot_name + "/" + name + "/Fields.yaml";
-#endif
-
-				// Open the file for writing
-				std::ofstream outFile(filename);
-				if (!outFile) {
-					amrex::Abort("Error opening file for writing: " + filename);
-				}
-
-				// Get the units data for this particle type
-				const auto &unitsData = get_units_data();
-				if (unitsData.find(particleType_) == unitsData.end()) {
-					amrex::Abort(
-					    "Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
-				}
-
-				const auto &typeData = unitsData.at(particleType_);
-				if (!typeData.empty()) {
-					outFile << "# field: [M, L, T, Θ]\n";
-					// Write each field's units to the YAML file
-					for (const auto &[fieldName, units] : typeData[0]) {
-						outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
-					}
-				}
-
-				outFile.close();
-			}
-		}
+		particle_io::writeUnitsFile<ContainerType, problem_t, particleType_>(container_, snapshot_name, name);
 	}
 
 	void printParticleStatistics() const override
 	{
-		if (container_ != nullptr) {
-			// TODO(cch): add a getParticleTypeName() method to PhysicsParticleDescriptor and call it here
-			const std::string particle_type_name = PhysicsParticleRegister<problem_t>::getParticleTypeName(particleType_);
-			amrex::Print() << fmt::format("number of {} = {}\n", particle_type_name, getNumParticles());
-
-			const int max_number_to_print = 100;
-
-			for (int lev = 0; lev <= container_->finestLevel(); ++lev) {
-
-				// const auto &real_data = getParticleDataAtLevel(lev).first;
-				const auto [real_data, int_data] = getParticleDataAtLevel(lev);
-
-				const int evolution_stage_idx = getEvolutionStageIndex();
-
-				if (!real_data.empty()) {
-					amrex::Print() << "Level " << lev << "\n";
-					// Print header for detailed particle data
-					if (evolution_stage_idx >= 0) {
-						amrex::Print() << fmt::format("\t{:>20} | {:>20}\n", "mass", "evolution stage");
-					} else {
-						amrex::Print() << fmt::format("\t{:>20}\n", "mass");
-					}
-
-					// Print each particle's data with aligned columns
-					const int n_print = std::min(static_cast<int>(real_data.size()), max_number_to_print);
-					int i = 0;
-					for (; i < n_print; ++i) {
-						if (evolution_stage_idx >= 0) {
-							amrex::Print() << fmt::format("\t{:20.13e} | {:>20}\n", real_data[i][AMREX_SPACEDIM + getMassIndex()],
-										      int_data[i][evolution_stage_idx]);
-						} else {
-							amrex::Print() << fmt::format("\t{:20.13e}\n", real_data[i][AMREX_SPACEDIM + getMassIndex()]);
-						}
-					}
-					if (i == max_number_to_print) {
-						amrex::Print() << fmt::format("\t...\n");
-					}
-				}
-			}
-		}
+		particle_io::printParticleStatistics<ContainerType, problem_t, particleType_>(container_, getMassIndex(), getEvolutionStageIndex());
 	}
 
 #if AMREX_SPACEDIM == 3

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -924,13 +924,13 @@ template <typename problem_t> class PhysicsParticleRegister
 		for (const auto &[type, descriptor] : particleRegistry_) {
 			const int num_particles = descriptor->getNumParticles();
 			const std::string particle_type_name = getParticleTypeName(type);
-			
+
 			if (num_particles <= max_particles) {
 				amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
 				descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
 			} else {
-				amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles 
-				              << " particles exceeds limit of " << max_particles << "\n";
+				amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles << " particles exceeds limit of "
+					       << max_particles << "\n";
 			}
 		}
 	}

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -2,6 +2,7 @@
 #define PARTICLE_IO_HPP_
 
 #include <fstream>
+#include <iomanip>
 #include <string>
 #include <vector>
 
@@ -25,17 +26,19 @@ namespace particle_io
 // particles after redistribution) and copies all particles from all levels into it.
 //
 // The returned data for each particle contains:
-// - first:
+// - first: vector of particle IDs
+// - second:
 //   - First AMREX_SPACEDIM elements are positions [x,y,z]
 //   - Remaining elements are particle data (e.g., mass, velocities, etc.)
-// - second:
-//   - Integer data (e.g., id, type, etc.)
+// - third:
+//   - Integer data (e.g., type, etc.)
 //
 // Only rank 0 will return the actual particle data, other ranks return empty vectors.
-// @return: pair of vectors containing particle data on rank 0, empty vectors on other ranks
+// @return: tuple of vectors containing particle data on rank 0, empty vectors on other ranks
 template <typename ContainerType>
-[[nodiscard]] auto getAllParticleData(ContainerType *container) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
+[[nodiscard]] auto getAllParticleData(ContainerType *container) -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>>
 {
+    std::vector<int64_t> particle_ids;
     std::vector<std::vector<double>> real_data;
     std::vector<std::vector<int>> int_data;
 
@@ -72,6 +75,7 @@ template <typename ContainerType>
                 constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
 
                 // Pre-size vectors to avoid reallocations
+                particle_ids.reserve(np);
                 real_data.reserve(np);
                 if constexpr (has_int_components) {
                     int_data.reserve(np);
@@ -80,6 +84,9 @@ template <typename ContainerType>
                 // Extract positions, real components, and integer components from host data
                 for (int i = 0; i < np; ++i) {
                     const auto &p = pData_h[i];
+                    
+                    // Get particle ID
+                    particle_ids.push_back(p.id());
 
                     // Process real data (positions and rdata)
                     std::vector<double> r_data;
@@ -116,7 +123,7 @@ template <typename ContainerType>
         }
     }
 
-    return {real_data, int_data}; // Empty vectors on non-root ranks
+    return {particle_ids, real_data, int_data}; // Empty vectors on non-root ranks
 }
 
 // Get particle data at a specific level
@@ -320,6 +327,75 @@ void printParticleStatistics(ContainerType *container, int massIndex, int evolut
             }
         }
     }
+}
+
+// Save particle data to a CSV file
+// This function gathers all particle data from all ranks and saves it to a CSV file on rank 0.
+// The CSV file will contain the following columns:
+// - ID: Particle ID
+// - x, y, z: Particle positions
+// - real_0, real_1, ...: Real components (e.g., mass, velocities, etc.)
+// - int_0, int_1, ...: Integer components (if any)
+//
+// Note: Only rank 0 will write the file, but all ranks must participate in the data gathering.
+// @param container: Particle container
+// @param filename: Name of the CSV file to write
+// @return: true if file was written successfully, false otherwise
+template <typename ContainerType>
+auto saveParticleDataToFile(ContainerType *container, const std::string &filename) -> bool
+{
+    // Get all particle data
+    const auto [particle_ids, real_data, int_data] = getAllParticleData(container);
+
+    // Only rank 0 writes the file
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        std::ofstream outFile(filename);
+        if (!outFile) {
+            return false;
+        }
+
+        // Write header
+        outFile << "ID";
+        // Position columns
+        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+            outFile << ",pos_" << d;
+        }
+        // Real component columns
+        for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+            outFile << ",real_" << d;
+        }
+        // Integer component columns
+        if constexpr (ContainerType::ParticleType::NInt > 0) {
+            for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+                outFile << ",int_" << d;
+            }
+        }
+        outFile << "\n";
+
+        // Write data
+        for (size_t i = 0; i < real_data.size(); ++i) {
+            // Write particle ID
+            outFile << particle_ids[i];
+
+            // Write position and real components
+            for (const auto &val : real_data[i]) {
+                outFile << "," << std::scientific << std::setprecision(15) << val;
+            }
+
+            // Write remaining integer components (skip ID which was written first)
+            if constexpr (ContainerType::ParticleType::NInt > 1) {
+                for (size_t j = 1; j < int_data[i].size(); ++j) {
+                    outFile << "," << int_data[i][j];
+                }
+            }
+            outFile << "\n";
+        }
+
+        outFile.close();
+        return true;
+    }
+
+    return true; // Non-root ranks always succeed
 }
 
 } // namespace particle_io

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -342,14 +342,14 @@ void printParticleStatistics(ContainerType *container, int massIndex, int evolut
 // @param filename: Name of the CSV file to write
 // @return: true if file was written successfully, false otherwise
 template <typename ContainerType>
-auto saveParticleDataToFile(ContainerType *container, const std::string &filename) -> bool
+auto saveParticleDataToFile(ContainerType *container, const std::string &filename, const std::string &name) -> bool
 {
     // Get all particle data
     const auto [particle_ids, real_data, int_data] = getAllParticleData(container);
 
     // Only rank 0 writes the file
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        std::ofstream outFile(filename);
+        std::ofstream outFile(filename + "/" + name + ".csv");
         if (!outFile) {
             return false;
         }

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -20,18 +20,21 @@ template <typename problem_t> class PhysicsParticleRegister;
 namespace particle_io
 {
 
-// Get positions and fields data from all particles at level 0 from all ranks and gather them on rank 0.
-// This method creates a temporary particle container on rank 0 and copies all particles to it.
+// Get positions and fields data from all particles across all levels and gather them on rank 0.
+// This method creates a temporary particle container on all ranks (though only rank 0 will contain
+// particles after redistribution) and copies all particles from all levels into it.
+//
 // The returned data for each particle contains:
 // - first:
 //   - First AMREX_SPACEDIM elements are positions [x,y,z]
 //   - Remaining elements are particle data (e.g., mass, velocities, etc.)
 // - second:
 //   - Integer data (e.g., id, type, etc.)
-// Only rank 0 will return the actual particle data, other ranks return an empty vector.
-// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
+//
+// Only rank 0 will return the actual particle data, other ranks return empty vectors.
+// @return: pair of vectors containing particle data on rank 0, empty vectors on other ranks
 template <typename ContainerType>
-[[nodiscard]] auto getParticleDataAtLevelZero(ContainerType *container) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
+[[nodiscard]] auto getAllParticleData(ContainerType *container) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
 {
     std::vector<std::vector<double>> real_data;
     std::vector<std::vector<int>> int_data;

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -1,0 +1,326 @@
+#ifndef PARTICLE_IO_HPP_
+#define PARTICLE_IO_HPP_
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "AMReX_ParallelDescriptor.H"
+#include "AMReX_SPACE.H"
+#include "AMReX_Vector.H"
+#include "particle_types.hpp"
+#include <fmt/format.h>
+
+namespace quokka
+{
+
+// Forward declarations
+template <typename problem_t> class PhysicsParticleRegister;
+
+namespace particle_io
+{
+
+// Get positions and fields data from all particles at level 0 from all ranks and gather them on rank 0.
+// This method creates a temporary particle container on rank 0 and copies all particles to it.
+// The returned data for each particle contains:
+// - first:
+//   - First AMREX_SPACEDIM elements are positions [x,y,z]
+//   - Remaining elements are particle data (e.g., mass, velocities, etc.)
+// - second:
+//   - Integer data (e.g., id, type, etc.)
+// Only rank 0 will return the actual particle data, other ranks return an empty vector.
+// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
+template <typename ContainerType>
+[[nodiscard]] auto getParticleDataAtLevelZero(ContainerType *container) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
+{
+    std::vector<std::vector<double>> real_data;
+    std::vector<std::vector<int>> int_data;
+
+    // All ranks must participate in copyParticles
+    if (container != nullptr) {
+        // Create single-box particle container for analysis on all ranks
+        ContainerType analysisPC{};
+        // Define a single box [0,1]^3 that will hold all particles on rank 0
+        amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
+        amrex::Geometry const geom(box);
+        amrex::BoxArray const boxArray(box);
+        // Force all particles to rank 0 by using a single-rank distribution
+        amrex::Vector<int> const ranks({0});
+        amrex::DistributionMapping const dmap(ranks);
+
+        // Initialize the analysis container and gather all particles to rank 0
+        analysisPC.Define(geom, dmap, boxArray);
+        analysisPC.copyParticles(*container); // MPI communication happens here
+
+        // Only rank 0 processes the particles since they're all gathered there
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            // Get iterator for the single box on rank 0
+            typename ContainerType::ParIterType const pIter(analysisPC, 0);
+            if (pIter.isValid()) {
+                const amrex::Long np = pIter.numParticles();
+                auto &particles = pIter.GetArrayOfStructs();
+
+                // Transfer particle data from GPU to CPU for analysis
+                typename ContainerType::ParticleType *pData = particles().data();
+                amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
+                amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+
+                // Check if particles have integer components
+                constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
+
+                // Pre-size vectors to avoid reallocations
+                real_data.reserve(np);
+                if constexpr (has_int_components) {
+                    int_data.reserve(np);
+                }
+
+                // Extract positions, real components, and integer components from host data
+                for (int i = 0; i < np; ++i) {
+                    const auto &p = pData_h[i];
+
+                    // Process real data (positions and rdata)
+                    std::vector<double> r_data;
+                    // Pre-allocate to avoid reallocations
+                    r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
+
+                    // First add position components
+                    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                        r_data.push_back(p.pos(d));
+                    }
+
+                    // Then add all real components (mass, velocities, etc)
+                    for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+                        r_data.push_back(p.rdata(d));
+                    }
+
+                    real_data.push_back(std::move(r_data));
+
+                    // Process integer data (idata) only if particles have integer components
+                    if constexpr (has_int_components) {
+                        std::vector<int> i_data;
+                        // Pre-allocate to avoid reallocations
+                        i_data.reserve(ContainerType::ParticleType::NInt);
+
+                        // Add all integer components
+                        for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+                            i_data.push_back(p.idata(d));
+                        }
+
+                        int_data.push_back(std::move(i_data));
+                    }
+                }
+            }
+        }
+    }
+
+    return {real_data, int_data}; // Empty vectors on non-root ranks
+}
+
+// Get particle data at a specific level
+template <typename ContainerType>
+[[nodiscard]] auto getParticleDataAtLevel(ContainerType *container, int lev) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
+{
+    std::vector<std::vector<double>> real_data;
+    std::vector<std::vector<int>> int_data;
+
+    if (container != nullptr) {
+        // Create single-box particle container for analysis on all ranks
+        ContainerType analysisPC{};
+        // Define a single box [0,1]^3 that will hold all particles on rank 0
+        amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
+        amrex::Geometry const geom(box);
+        amrex::BoxArray const boxArray(box);
+        // Force all particles to rank 0 by using a single-rank distribution
+        amrex::Vector<int> const ranks({0});
+        amrex::DistributionMapping const dmap(ranks);
+
+        // Initialize the analysis container
+        analysisPC.Define(geom, dmap, boxArray);
+
+        // Create a single destination tile on rank 0
+        auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
+
+        // Get particles only from the specified level
+        const auto &particles = container->GetParticles(lev);
+
+        // First count total particles at this level
+        int total_np = 0;
+        for (const auto &kv : particles) {
+            total_np += kv.second.numParticles();
+        }
+
+        // Pre-size the destination tile
+        dst_tile.resize(total_np);
+
+        // Copy particles from each tile
+        int particle_offset = 0;
+        for (const auto &kv : particles) {
+            const auto &src_tile = kv.second;
+            const int np = src_tile.numParticles();
+            if (np > 0) {
+                const auto &src_aos = src_tile.GetArrayOfStructs();
+                auto &dst_aos = dst_tile.GetArrayOfStructs();
+                amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + particle_offset);
+                particle_offset += np;
+            }
+        }
+
+        // Now use MPI to gather all particles to rank 0
+        analysisPC.Redistribute(); // This handles the MPI communication
+
+        // Only rank 0 processes the particles since they're all gathered there
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            // Get iterator for the single box on rank 0
+            typename ContainerType::ParIterType const pIter(analysisPC, 0);
+            if (pIter.isValid()) {
+                const amrex::Long np = pIter.numParticles();
+                auto &particles = pIter.GetArrayOfStructs();
+
+                // Transfer particle data from GPU to CPU for analysis
+                typename ContainerType::ParticleType *pData = particles().data();
+                amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
+                amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+
+                // Check if particles have integer components
+                constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
+
+                // Pre-size vectors to avoid reallocations
+                real_data.reserve(np);
+                if constexpr (has_int_components) {
+                    int_data.reserve(np);
+                }
+
+                // Process each particle
+                for (int i = 0; i < np; ++i) {
+                    const auto &p = pData_h[i];
+
+                    // Process real data (positions and rdata)
+                    std::vector<double> r_data;
+                    // Pre-allocate to avoid reallocations
+                    r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
+
+                    // Add position components
+                    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+                        r_data.push_back(p.pos(d));
+                    }
+
+                    // Add all real components
+                    for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+                        r_data.push_back(p.rdata(d));
+                    }
+
+                    real_data.push_back(std::move(r_data));
+
+                    // Process integer data if particles have integer components
+                    if constexpr (has_int_components) {
+                        std::vector<int> i_data;
+                        // Pre-allocate to avoid reallocations
+                        i_data.reserve(ContainerType::ParticleType::NInt);
+
+                        for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+                            i_data.push_back(p.idata(d));
+                        }
+
+                        int_data.push_back(std::move(i_data));
+                    }
+                }
+            }
+        }
+    }
+
+    return {real_data, int_data}; // Empty vectors on non-root ranks
+}
+
+// Write units info of particles to checkpoint/plotfile
+template <typename ContainerType, typename problem_t, ParticleType particleType>
+void writeUnitsFile(ContainerType *container, const std::string &snapshot_name, const std::string &name)
+{
+    if (container != nullptr) {
+        // Only write on rank 0
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            // Create the full path for the Fields.yaml file
+            std::string filename;
+#ifdef QUOKKA_USE_OPENPMD
+            // For OpenPMD, write the YAML file alongside the OpenPMD file
+            filename = snapshot_name + "_" + name + ".yaml";
+#else
+            // For standard output, write the YAML file in the particle directory
+            filename = snapshot_name + "/" + name + "/Fields.yaml";
+#endif
+
+            // Open the file for writing
+            std::ofstream outFile(filename);
+            if (!outFile) {
+                amrex::Abort("Error opening file for writing: " + filename);
+            }
+
+            // Get the units data for this particle type
+            const auto &unitsData = get_units_data();
+            if (unitsData.find(particleType) == unitsData.end()) {
+                amrex::Abort(
+                    "Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
+            }
+
+            const auto &typeData = unitsData.at(particleType);
+            if (!typeData.empty()) {
+                outFile << "# field: [M, L, T, Θ]\n";
+                // Write each field's units to the YAML file
+                for (const auto &[fieldName, units] : typeData[0]) {
+                    outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
+                }
+            }
+
+            outFile.close();
+        }
+    }
+}
+
+// Print statistics of particles
+template <typename ContainerType, typename problem_t, ParticleType particleType>
+void printParticleStatistics(ContainerType *container, int massIndex, int evolutionStageIndex)
+{
+    if (container != nullptr) {
+        // Get particle type name
+        const std::string particle_type_name = PhysicsParticleRegister<problem_t>::getParticleTypeName(particleType);
+        amrex::Print() << fmt::format("number of {} = {}\n", particle_type_name, 
+            static_cast<int>(container->TotalNumberOfParticles(true, false)));
+
+        const int max_number_to_print = 100;
+
+        for (int lev = 0; lev <= container->finestLevel(); ++lev) {
+            // Get particle data at this level
+            const auto [real_data, int_data] = getParticleDataAtLevel(container, lev);
+
+            if (!real_data.empty()) {
+                amrex::Print() << "Level " << lev << "\n";
+                // Print header for detailed particle data
+                if (evolutionStageIndex >= 0) {
+                    amrex::Print() << fmt::format("\t{:>20} | {:>20}\n", "mass", "evolution stage");
+                } else {
+                    amrex::Print() << fmt::format("\t{:>20}\n", "mass");
+                }
+
+                // Print each particle's data with aligned columns
+                const int n_print = std::min(static_cast<int>(real_data.size()), max_number_to_print);
+                int i = 0;
+                for (; i < n_print; ++i) {
+                    if (evolutionStageIndex >= 0) {
+                        amrex::Print() << fmt::format("\t{:20.13e} | {:>20}\n", real_data[i][AMREX_SPACEDIM + massIndex],
+                                                  int_data[i][evolutionStageIndex]);
+                    } else {
+                        amrex::Print() << fmt::format("\t{:20.13e}\n", real_data[i][AMREX_SPACEDIM + massIndex]);
+                    }
+                }
+                if (i == max_number_to_print) {
+                    amrex::Print() << fmt::format("\t...\n");
+                }
+            }
+        }
+    }
+}
+
+} // namespace particle_io
+
+} // namespace quokka
+
+#endif // PARTICLE_IO_HPP_

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -36,297 +36,297 @@ namespace particle_io
 // Only rank 0 will return the actual particle data, other ranks return empty vectors.
 // @return: tuple of vectors containing particle data on rank 0, empty vectors on other ranks
 template <typename ContainerType>
-[[nodiscard]] auto getAllParticleData(ContainerType *container) -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>>
+[[nodiscard]] auto getAllParticleData(ContainerType *container)
+    -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>>
 {
-    std::vector<int64_t> particle_ids;
-    std::vector<std::vector<double>> real_data;
-    std::vector<std::vector<int>> int_data;
+	std::vector<int64_t> particle_ids;
+	std::vector<std::vector<double>> real_data;
+	std::vector<std::vector<int>> int_data;
 
-    // All ranks must participate in copyParticles
-    if (container != nullptr) {
-        // Create single-box particle container for analysis on all ranks
-        ContainerType analysisPC{};
-        // Define a single box [0,1]^3 that will hold all particles on rank 0
-        amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
-        amrex::Geometry const geom(box);
-        amrex::BoxArray const boxArray(box);
-        // Force all particles to rank 0 by using a single-rank distribution
-        amrex::Vector<int> const ranks({0});
-        amrex::DistributionMapping const dmap(ranks);
+	// All ranks must participate in copyParticles
+	if (container != nullptr) {
+		// Create single-box particle container for analysis on all ranks
+		ContainerType analysisPC{};
+		// Define a single box [0,1]^3 that will hold all particles on rank 0
+		amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
+		amrex::Geometry const geom(box);
+		amrex::BoxArray const boxArray(box);
+		// Force all particles to rank 0 by using a single-rank distribution
+		amrex::Vector<int> const ranks({0});
+		amrex::DistributionMapping const dmap(ranks);
 
-        // Initialize the analysis container and gather all particles to rank 0
-        analysisPC.Define(geom, dmap, boxArray);
-        analysisPC.copyParticles(*container); // MPI communication happens here
+		// Initialize the analysis container and gather all particles to rank 0
+		analysisPC.Define(geom, dmap, boxArray);
+		analysisPC.copyParticles(*container); // MPI communication happens here
 
-        // Only rank 0 processes the particles since they're all gathered there
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            // Get iterator for the single box on rank 0
-            typename ContainerType::ParIterType const pIter(analysisPC, 0);
-            if (pIter.isValid()) {
-                const amrex::Long np = pIter.numParticles();
-                auto &particles = pIter.GetArrayOfStructs();
+		// Only rank 0 processes the particles since they're all gathered there
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			// Get iterator for the single box on rank 0
+			typename ContainerType::ParIterType const pIter(analysisPC, 0);
+			if (pIter.isValid()) {
+				const amrex::Long np = pIter.numParticles();
+				auto &particles = pIter.GetArrayOfStructs();
 
-                // Transfer particle data from GPU to CPU for analysis
-                typename ContainerType::ParticleType *pData = particles().data();
-                amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
-                amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+				// Transfer particle data from GPU to CPU for analysis
+				typename ContainerType::ParticleType *pData = particles().data();
+				amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
+				amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
 
-                // Check if particles have integer components
-                constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
+				// Check if particles have integer components
+				constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
 
-                // Pre-size vectors to avoid reallocations
-                particle_ids.reserve(np);
-                real_data.reserve(np);
-                if constexpr (has_int_components) {
-                    int_data.reserve(np);
-                }
+				// Pre-size vectors to avoid reallocations
+				particle_ids.reserve(np);
+				real_data.reserve(np);
+				if constexpr (has_int_components) {
+					int_data.reserve(np);
+				}
 
-                // Extract positions, real components, and integer components from host data
-                for (int i = 0; i < np; ++i) {
-                    const auto &p = pData_h[i];
-                    
-                    // Get particle ID
-                    particle_ids.push_back(p.id());
+				// Extract positions, real components, and integer components from host data
+				for (int i = 0; i < np; ++i) {
+					const auto &p = pData_h[i];
 
-                    // Process real data (positions and rdata)
-                    std::vector<double> r_data;
-                    // Pre-allocate to avoid reallocations
-                    r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
+					// Get particle ID
+					particle_ids.push_back(p.id());
 
-                    // First add position components
-                    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-                        r_data.push_back(p.pos(d));
-                    }
+					// Process real data (positions and rdata)
+					std::vector<double> r_data;
+					// Pre-allocate to avoid reallocations
+					r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 
-                    // Then add all real components (mass, velocities, etc)
-                    for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-                        r_data.push_back(p.rdata(d));
-                    }
+					// First add position components
+					for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+						r_data.push_back(p.pos(d));
+					}
 
-                    real_data.push_back(std::move(r_data));
+					// Then add all real components (mass, velocities, etc)
+					for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+						r_data.push_back(p.rdata(d));
+					}
 
-                    // Process integer data (idata) only if particles have integer components
-                    if constexpr (has_int_components) {
-                        std::vector<int> i_data;
-                        // Pre-allocate to avoid reallocations
-                        i_data.reserve(ContainerType::ParticleType::NInt);
+					real_data.push_back(std::move(r_data));
 
-                        // Add all integer components
-                        for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
-                            i_data.push_back(p.idata(d));
-                        }
+					// Process integer data (idata) only if particles have integer components
+					if constexpr (has_int_components) {
+						std::vector<int> i_data;
+						// Pre-allocate to avoid reallocations
+						i_data.reserve(ContainerType::ParticleType::NInt);
 
-                        int_data.push_back(std::move(i_data));
-                    }
-                }
-            }
-        }
-    }
+						// Add all integer components
+						for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+							i_data.push_back(p.idata(d));
+						}
 
-    return {particle_ids, real_data, int_data}; // Empty vectors on non-root ranks
+						int_data.push_back(std::move(i_data));
+					}
+				}
+			}
+		}
+	}
+
+	return {particle_ids, real_data, int_data}; // Empty vectors on non-root ranks
 }
 
 // Get particle data at a specific level
 template <typename ContainerType>
 [[nodiscard]] auto getParticleDataAtLevel(ContainerType *container, int lev) -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>>
 {
-    std::vector<std::vector<double>> real_data;
-    std::vector<std::vector<int>> int_data;
+	std::vector<std::vector<double>> real_data;
+	std::vector<std::vector<int>> int_data;
 
-    if (container != nullptr) {
-        // Create single-box particle container for analysis on all ranks
-        ContainerType analysisPC{};
-        // Define a single box [0,1]^3 that will hold all particles on rank 0
-        amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
-        amrex::Geometry const geom(box);
-        amrex::BoxArray const boxArray(box);
-        // Force all particles to rank 0 by using a single-rank distribution
-        amrex::Vector<int> const ranks({0});
-        amrex::DistributionMapping const dmap(ranks);
+	if (container != nullptr) {
+		// Create single-box particle container for analysis on all ranks
+		ContainerType analysisPC{};
+		// Define a single box [0,1]^3 that will hold all particles on rank 0
+		amrex::Box const box(amrex::IntVect{AMREX_D_DECL(0, 0, 0)}, amrex::IntVect{AMREX_D_DECL(1, 1, 1)});
+		amrex::Geometry const geom(box);
+		amrex::BoxArray const boxArray(box);
+		// Force all particles to rank 0 by using a single-rank distribution
+		amrex::Vector<int> const ranks({0});
+		amrex::DistributionMapping const dmap(ranks);
 
-        // Initialize the analysis container
-        analysisPC.Define(geom, dmap, boxArray);
+		// Initialize the analysis container
+		analysisPC.Define(geom, dmap, boxArray);
 
-        // Create a single destination tile on rank 0
-        auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
+		// Create a single destination tile on rank 0
+		auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
 
-        // Get particles only from the specified level
-        const auto &particles = container->GetParticles(lev);
+		// Get particles only from the specified level
+		const auto &particles = container->GetParticles(lev);
 
-        // First count total particles at this level
-        int total_np = 0;
-        for (const auto &kv : particles) {
-            total_np += kv.second.numParticles();
-        }
+		// First count total particles at this level
+		int total_np = 0;
+		for (const auto &kv : particles) {
+			total_np += kv.second.numParticles();
+		}
 
-        // Pre-size the destination tile
-        dst_tile.resize(total_np);
+		// Pre-size the destination tile
+		dst_tile.resize(total_np);
 
-        // Copy particles from each tile
-        int particle_offset = 0;
-        for (const auto &kv : particles) {
-            const auto &src_tile = kv.second;
-            const int np = src_tile.numParticles();
-            if (np > 0) {
-                const auto &src_aos = src_tile.GetArrayOfStructs();
-                auto &dst_aos = dst_tile.GetArrayOfStructs();
-                amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + particle_offset);
-                particle_offset += np;
-            }
-        }
+		// Copy particles from each tile
+		int particle_offset = 0;
+		for (const auto &kv : particles) {
+			const auto &src_tile = kv.second;
+			const int np = src_tile.numParticles();
+			if (np > 0) {
+				const auto &src_aos = src_tile.GetArrayOfStructs();
+				auto &dst_aos = dst_tile.GetArrayOfStructs();
+				amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + particle_offset);
+				particle_offset += np;
+			}
+		}
 
-        // Now use MPI to gather all particles to rank 0
-        analysisPC.Redistribute(); // This handles the MPI communication
+		// Now use MPI to gather all particles to rank 0
+		analysisPC.Redistribute(); // This handles the MPI communication
 
-        // Only rank 0 processes the particles since they're all gathered there
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            // Get iterator for the single box on rank 0
-            typename ContainerType::ParIterType const pIter(analysisPC, 0);
-            if (pIter.isValid()) {
-                const amrex::Long np = pIter.numParticles();
-                auto &particles = pIter.GetArrayOfStructs();
+		// Only rank 0 processes the particles since they're all gathered there
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			// Get iterator for the single box on rank 0
+			typename ContainerType::ParIterType const pIter(analysisPC, 0);
+			if (pIter.isValid()) {
+				const amrex::Long np = pIter.numParticles();
+				auto &particles = pIter.GetArrayOfStructs();
 
-                // Transfer particle data from GPU to CPU for analysis
-                typename ContainerType::ParticleType *pData = particles().data();
-                amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
-                amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
+				// Transfer particle data from GPU to CPU for analysis
+				typename ContainerType::ParticleType *pData = particles().data();
+				amrex::Vector<typename ContainerType::ParticleType> pData_h(np);
+				amrex::Gpu::copy(amrex::Gpu::deviceToHost, pData, pData + np, pData_h.begin()); // NOLINT
 
-                // Check if particles have integer components
-                constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
+				// Check if particles have integer components
+				constexpr bool has_int_components = (ContainerType::ParticleType::NInt > 0);
 
-                // Pre-size vectors to avoid reallocations
-                real_data.reserve(np);
-                if constexpr (has_int_components) {
-                    int_data.reserve(np);
-                }
+				// Pre-size vectors to avoid reallocations
+				real_data.reserve(np);
+				if constexpr (has_int_components) {
+					int_data.reserve(np);
+				}
 
-                // Process each particle
-                for (int i = 0; i < np; ++i) {
-                    const auto &p = pData_h[i];
+				// Process each particle
+				for (int i = 0; i < np; ++i) {
+					const auto &p = pData_h[i];
 
-                    // Process real data (positions and rdata)
-                    std::vector<double> r_data;
-                    // Pre-allocate to avoid reallocations
-                    r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
+					// Process real data (positions and rdata)
+					std::vector<double> r_data;
+					// Pre-allocate to avoid reallocations
+					r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 
-                    // Add position components
-                    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-                        r_data.push_back(p.pos(d));
-                    }
+					// Add position components
+					for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+						r_data.push_back(p.pos(d));
+					}
 
-                    // Add all real components
-                    for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-                        r_data.push_back(p.rdata(d));
-                    }
+					// Add all real components
+					for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+						r_data.push_back(p.rdata(d));
+					}
 
-                    real_data.push_back(std::move(r_data));
+					real_data.push_back(std::move(r_data));
 
-                    // Process integer data if particles have integer components
-                    if constexpr (has_int_components) {
-                        std::vector<int> i_data;
-                        // Pre-allocate to avoid reallocations
-                        i_data.reserve(ContainerType::ParticleType::NInt);
+					// Process integer data if particles have integer components
+					if constexpr (has_int_components) {
+						std::vector<int> i_data;
+						// Pre-allocate to avoid reallocations
+						i_data.reserve(ContainerType::ParticleType::NInt);
 
-                        for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
-                            i_data.push_back(p.idata(d));
-                        }
+						for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+							i_data.push_back(p.idata(d));
+						}
 
-                        int_data.push_back(std::move(i_data));
-                    }
-                }
-            }
-        }
-    }
+						int_data.push_back(std::move(i_data));
+					}
+				}
+			}
+		}
+	}
 
-    return {real_data, int_data}; // Empty vectors on non-root ranks
+	return {real_data, int_data}; // Empty vectors on non-root ranks
 }
 
 // Write units info of particles to checkpoint/plotfile
 template <typename ContainerType, typename problem_t, ParticleType particleType>
 void writeUnitsFile(ContainerType *container, const std::string &snapshot_name, const std::string &name)
 {
-    if (container != nullptr) {
-        // Only write on rank 0
-        if (amrex::ParallelDescriptor::IOProcessor()) {
-            // Create the full path for the Fields.yaml file
-            std::string filename;
+	if (container != nullptr) {
+		// Only write on rank 0
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			// Create the full path for the Fields.yaml file
+			std::string filename;
 #ifdef QUOKKA_USE_OPENPMD
-            // For OpenPMD, write the YAML file alongside the OpenPMD file
-            filename = snapshot_name + "_" + name + ".yaml";
+			// For OpenPMD, write the YAML file alongside the OpenPMD file
+			filename = snapshot_name + "_" + name + ".yaml";
 #else
-            // For standard output, write the YAML file in the particle directory
-            filename = snapshot_name + "/" + name + "/Fields.yaml";
+			// For standard output, write the YAML file in the particle directory
+			filename = snapshot_name + "/" + name + "/Fields.yaml";
 #endif
 
-            // Open the file for writing
-            std::ofstream outFile(filename);
-            if (!outFile) {
-                amrex::Abort("Error opening file for writing: " + filename);
-            }
+			// Open the file for writing
+			std::ofstream outFile(filename);
+			if (!outFile) {
+				amrex::Abort("Error opening file for writing: " + filename);
+			}
 
-            // Get the units data for this particle type
-            const auto &unitsData = get_units_data();
-            if (unitsData.find(particleType) == unitsData.end()) {
-                amrex::Abort(
-                    "Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
-            }
+			// Get the units data for this particle type
+			const auto &unitsData = get_units_data();
+			if (unitsData.find(particleType) == unitsData.end()) {
+				amrex::Abort(
+				    "Error: Particle type not defined in units data map. Please add units for this particle type in get_units_data().");
+			}
 
-            const auto &typeData = unitsData.at(particleType);
-            if (!typeData.empty()) {
-                outFile << "# field: [M, L, T, Θ]\n";
-                // Write each field's units to the YAML file
-                for (const auto &[fieldName, units] : typeData[0]) {
-                    outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
-                }
-            }
+			const auto &typeData = unitsData.at(particleType);
+			if (!typeData.empty()) {
+				outFile << "# field: [M, L, T, Θ]\n";
+				// Write each field's units to the YAML file
+				for (const auto &[fieldName, units] : typeData[0]) {
+					outFile << fieldName << ": [" << units[0] << ", " << units[1] << ", " << units[2] << ", " << units[3] << "]\n";
+				}
+			}
 
-            outFile.close();
-        }
-    }
+			outFile.close();
+		}
+	}
 }
 
 // Print statistics of particles
 template <typename ContainerType, typename problem_t, ParticleType particleType>
 void printParticleStatistics(ContainerType *container, int massIndex, int evolutionStageIndex)
 {
-    if (container != nullptr) {
-        // Get particle type name
-        const std::string particle_type_name = PhysicsParticleRegister<problem_t>::getParticleTypeName(particleType);
-        amrex::Print() << fmt::format("number of {} = {}\n", particle_type_name, 
-            static_cast<int>(container->TotalNumberOfParticles(true, false)));
+	if (container != nullptr) {
+		// Get particle type name
+		const std::string particle_type_name = PhysicsParticleRegister<problem_t>::getParticleTypeName(particleType);
+		amrex::Print() << fmt::format("number of {} = {}\n", particle_type_name, static_cast<int>(container->TotalNumberOfParticles(true, false)));
 
-        const int max_number_to_print = 100;
+		const int max_number_to_print = 100;
 
-        for (int lev = 0; lev <= container->finestLevel(); ++lev) {
-            // Get particle data at this level
-            const auto [real_data, int_data] = getParticleDataAtLevel(container, lev);
+		for (int lev = 0; lev <= container->finestLevel(); ++lev) {
+			// Get particle data at this level
+			const auto [real_data, int_data] = getParticleDataAtLevel(container, lev);
 
-            if (!real_data.empty()) {
-                amrex::Print() << "Level " << lev << "\n";
-                // Print header for detailed particle data
-                if (evolutionStageIndex >= 0) {
-                    amrex::Print() << fmt::format("\t{:>20} | {:>20}\n", "mass", "evolution stage");
-                } else {
-                    amrex::Print() << fmt::format("\t{:>20}\n", "mass");
-                }
+			if (!real_data.empty()) {
+				amrex::Print() << "Level " << lev << "\n";
+				// Print header for detailed particle data
+				if (evolutionStageIndex >= 0) {
+					amrex::Print() << fmt::format("\t{:>20} | {:>20}\n", "mass", "evolution stage");
+				} else {
+					amrex::Print() << fmt::format("\t{:>20}\n", "mass");
+				}
 
-                // Print each particle's data with aligned columns
-                const int n_print = std::min(static_cast<int>(real_data.size()), max_number_to_print);
-                int i = 0;
-                for (; i < n_print; ++i) {
-                    if (evolutionStageIndex >= 0) {
-                        amrex::Print() << fmt::format("\t{:20.13e} | {:>20}\n", real_data[i][AMREX_SPACEDIM + massIndex],
-                                                  int_data[i][evolutionStageIndex]);
-                    } else {
-                        amrex::Print() << fmt::format("\t{:20.13e}\n", real_data[i][AMREX_SPACEDIM + massIndex]);
-                    }
-                }
-                if (i == max_number_to_print) {
-                    amrex::Print() << fmt::format("\t...\n");
-                }
-            }
-        }
-    }
+				// Print each particle's data with aligned columns
+				const int n_print = std::min(static_cast<int>(real_data.size()), max_number_to_print);
+				int i = 0;
+				for (; i < n_print; ++i) {
+					if (evolutionStageIndex >= 0) {
+						amrex::Print() << fmt::format("\t{:20.13e} | {:>20}\n", real_data[i][AMREX_SPACEDIM + massIndex],
+									      int_data[i][evolutionStageIndex]);
+					} else {
+						amrex::Print() << fmt::format("\t{:20.13e}\n", real_data[i][AMREX_SPACEDIM + massIndex]);
+					}
+				}
+				if (i == max_number_to_print) {
+					amrex::Print() << fmt::format("\t...\n");
+				}
+			}
+		}
+	}
 }
 
 // Save particle data to a CSV file
@@ -341,61 +341,60 @@ void printParticleStatistics(ContainerType *container, int massIndex, int evolut
 // @param container: Particle container
 // @param filename: Name of the CSV file to write
 // @return: true if file was written successfully, false otherwise
-template <typename ContainerType>
-auto saveParticleDataToFile(ContainerType *container, const std::string &filename, const std::string &name) -> bool
+template <typename ContainerType> auto saveParticleDataToFile(ContainerType *container, const std::string &filename, const std::string &name) -> bool
 {
-    // Get all particle data
-    const auto [particle_ids, real_data, int_data] = getAllParticleData(container);
+	// Get all particle data
+	const auto [particle_ids, real_data, int_data] = getAllParticleData(container);
 
-    // Only rank 0 writes the file
-    if (amrex::ParallelDescriptor::IOProcessor()) {
-        std::ofstream outFile(filename + "/" + name + ".csv");
-        if (!outFile) {
-            return false;
-        }
+	// Only rank 0 writes the file
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		std::ofstream outFile(filename + "/" + name + ".csv");
+		if (!outFile) {
+			return false;
+		}
 
-        // Write header
-        outFile << "ID";
-        // Position columns
-        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            outFile << ",pos_" << d;
-        }
-        // Real component columns
-        for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
-            outFile << ",real_" << d;
-        }
-        // Integer component columns
-        if constexpr (ContainerType::ParticleType::NInt > 0) {
-            for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
-                outFile << ",int_" << d;
-            }
-        }
-        outFile << "\n";
+		// Write header
+		outFile << "ID";
+		// Position columns
+		for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+			outFile << ",pos_" << d;
+		}
+		// Real component columns
+		for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
+			outFile << ",real_" << d;
+		}
+		// Integer component columns
+		if constexpr (ContainerType::ParticleType::NInt > 0) {
+			for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
+				outFile << ",int_" << d;
+			}
+		}
+		outFile << "\n";
 
-        // Write data
-        for (size_t i = 0; i < real_data.size(); ++i) {
-            // Write particle ID
-            outFile << particle_ids[i];
+		// Write data
+		for (size_t i = 0; i < real_data.size(); ++i) {
+			// Write particle ID
+			outFile << particle_ids[i];
 
-            // Write position and real components
-            for (const auto &val : real_data[i]) {
-                outFile << "," << std::scientific << std::setprecision(15) << val;
-            }
+			// Write position and real components
+			for (const auto &val : real_data[i]) {
+				outFile << "," << std::scientific << std::setprecision(15) << val;
+			}
 
-            // Write remaining integer components (skip ID which was written first)
-            if constexpr (ContainerType::ParticleType::NInt > 1) {
-                for (size_t j = 1; j < int_data[i].size(); ++j) {
-                    outFile << "," << int_data[i][j];
-                }
-            }
-            outFile << "\n";
-        }
+			// Write remaining integer components (skip ID which was written first)
+			if constexpr (ContainerType::ParticleType::NInt > 1) {
+				for (size_t j = 1; j < int_data[i].size(); ++j) {
+					outFile << "," << int_data[i][j];
+				}
+			}
+			outFile << "\n";
+		}
 
-        outFile.close();
-        return true;
-    }
+		outFile.close();
+		return true;
+	}
 
-    return true; // Non-root ranks always succeed
+	return true; // Non-root ranks always succeed
 }
 
 } // namespace particle_io

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -216,17 +216,20 @@ auto problem_main() -> int
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// Test CICRad particles
-		[[maybe_unused]] const auto [ids1, positions_cicrad, int1] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
+		[[maybe_unused]] const auto [ids1, positions_cicrad, int1] =
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
 		double position_error_cicrad = 0.0;
 		double position_norm_cicrad = 0.0;
 
 		// Test CIC particles
-		[[maybe_unused]] const auto [ids2, positions_cic, int2] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
+		[[maybe_unused]] const auto [ids2, positions_cic, int2] =
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
 		double position_error_cic = 0.0;
 		const double position_norm_cic = 1.0; // set to 1.0 since the particles are exactly at the origin
 
 		// Test Rad particles
-		[[maybe_unused]] const auto [ids3, positions_rad, int3] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
+		[[maybe_unused]] const auto [ids3, positions_rad, int3] =
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
 		double position_error_rad = 0.0;
 		double position_norm_rad = 0.0;
 

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -216,22 +216,22 @@ auto problem_main() -> int
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// Test CICRad particles
-		auto positions_cicrad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
+		[[maybe_unused]] const auto [ids1, positions_cicrad, int1] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
 		double position_error_cicrad = 0.0;
 		double position_norm_cicrad = 0.0;
 
 		// Test CIC particles
-		auto positions_cic = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
+		[[maybe_unused]] const auto [ids2, positions_cic, int2] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
 		double position_error_cic = 0.0;
 		const double position_norm_cic = 1.0; // set to 1.0 since the particles are exactly at the origin
 
 		// Test Rad particles
-		auto positions_rad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
+		[[maybe_unused]] const auto [ids3, positions_rad, int3] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
 		double position_error_rad = 0.0;
 		double position_norm_rad = 0.0;
 
 		// Test both particle types against exact solution
-		for (auto &position : positions_cicrad.first) {
+		for (const auto &position : positions_cicrad) {
 			if (position[0] * exact_x > 0.0) {
 				position_error_cicrad += std::abs(position[0] - exact_x);
 				position_error_cicrad += std::abs(position[1] - exact_y);
@@ -246,7 +246,7 @@ auto problem_main() -> int
 			position_norm_cicrad += std::abs(exact_z);
 		}
 
-		for (auto &position : positions_cic.first) {
+		for (const auto &position : positions_cic) {
 			if (position[0] * exact_x > 0.0) {
 				position_error_cic += std::abs(position[0] - exact_x_cic);
 				position_error_cic += std::abs(position[1] - exact_y_cic);
@@ -258,7 +258,7 @@ auto problem_main() -> int
 			}
 		}
 
-		for (auto &position : positions_rad.first) {
+		for (const auto &position : positions_rad) {
 			if (position[0] * exact_x_rad > 0.0) {
 				position_error_rad += std::abs(position[0] - exact_x_rad);
 				position_error_rad += std::abs(position[1] - exact_y_rad);
@@ -288,17 +288,17 @@ auto problem_main() -> int
 
 		amrex::Print() << "Exact positions of the CICRad particles should be: " << exact_x << ", " << exact_y << ", " << exact_z << "\n";
 		amrex::Print() << "Real positions are: \n";
-		for (auto &position : positions_cicrad.first) {
+		for (const auto &position : positions_cicrad) {
 			amrex::Print() << position[0] << ", " << position[1] << ", " << position[2] << "\n";
 		}
 		amrex::Print() << "Exact positions of the CIC particles should be: " << exact_x_cic << ", " << exact_y_cic << ", " << exact_z_cic << "\n";
 		amrex::Print() << "Real positions are: \n";
-		for (auto &position : positions_cic.first) {
+		for (const auto &position : positions_cic) {
 			amrex::Print() << position[0] << ", " << position[1] << ", " << position[2] << "\n";
 		}
 		amrex::Print() << "Exact positions of the Rad particles should be: " << exact_x_rad << ", " << exact_y_rad << ", " << exact_z_rad << "\n";
 		amrex::Print() << "Real positions are: \n";
-		for (auto &position : positions_rad.first) {
+		for (const auto &position : positions_rad) {
 			amrex::Print() << position[0] << ", " << position[1] << ", " << position[2] << "\n";
 		}
 		amrex::Print() << "Relative L1 norm on radiation energy = " << rel_err << "\n";

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -216,17 +216,17 @@ auto problem_main() -> int
 
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// Test CICRad particles
-		auto positions_cicrad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getParticleDataAtLevelZero();
+		auto positions_cicrad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
 		double position_error_cicrad = 0.0;
 		double position_norm_cicrad = 0.0;
 
 		// Test CIC particles
-		auto positions_cic = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleDataAtLevelZero();
+		auto positions_cic = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
 		double position_error_cic = 0.0;
 		const double position_norm_cic = 1.0; // set to 1.0 since the particles are exactly at the origin
 
 		// Test Rad particles
-		auto positions_rad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getParticleDataAtLevelZero();
+		auto positions_rad = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
 		double position_error_rad = 0.0;
 		double position_norm_rad = 0.0;
 

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -162,7 +162,8 @@ auto problem_main() -> int
 
 	// get total particle mass of the initial state
 	const int mass_index = 3;
-	[[maybe_unused]] const auto [ids_init, real_data_init, int_data_init] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	[[maybe_unused]] const auto [ids_init, real_data_init, int_data_init] =
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	amrex::Real const m_stars_init = std::accumulate(real_data_init.begin(), real_data_init.end(), 0.0,
 							 [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_init = m_gas_init + m_stars_init;
@@ -177,7 +178,8 @@ auto problem_main() -> int
 	amrex::Real const m_gas_step1 = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after step 1
-	[[maybe_unused]] const auto [ids_step1, real_data_step1, int_data_step1] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	[[maybe_unused]] const auto [ids_step1, real_data_step1, int_data_step1] =
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	const int n_stars_step1 = static_cast<int>(real_data_step1.size());
 
 	if (n_stars_step1 != 1) {
@@ -214,7 +216,8 @@ auto problem_main() -> int
 	amrex::Real const m_gas_final = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after the end
-	[[maybe_unused]] const auto [ids_final, real_data_final, int_data_final] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	[[maybe_unused]] const auto [ids_final, real_data_final, int_data_final] =
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	amrex::Real const m_stars_final = std::accumulate(real_data_final.begin(), real_data_final.end(), 0.0,
 							  [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_final = m_gas_final + m_stars_final;

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -162,7 +162,7 @@ auto problem_main() -> int
 
 	// get total particle mass of the initial state
 	const int mass_index = 3;
-	const auto &real_data_init = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevelZero().first;
+	const auto &real_data_init = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
 	amrex::Real const m_stars_init = std::accumulate(real_data_init.begin(), real_data_init.end(), 0.0,
 							 [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_init = m_gas_init + m_stars_init;
@@ -177,7 +177,7 @@ auto problem_main() -> int
 	amrex::Real const m_gas_step1 = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after step 1
-	const auto &real_data_step1 = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevelZero().first;
+	const auto &real_data_step1 = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
 	const int n_stars_step1 = static_cast<int>(real_data_step1.size());
 
 	if (n_stars_step1 != 1) {
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	amrex::Real const m_gas_final = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after the end
-	const auto &real_data_final = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevelZero().first;
+	const auto &real_data_final = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
 	amrex::Real const m_stars_final = std::accumulate(real_data_final.begin(), real_data_final.end(), 0.0,
 							  [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_final = m_gas_final + m_stars_final;

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -162,7 +162,7 @@ auto problem_main() -> int
 
 	// get total particle mass of the initial state
 	const int mass_index = 3;
-	const auto &real_data_init = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
+	[[maybe_unused]] const auto [ids_init, real_data_init, int_data_init] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	amrex::Real const m_stars_init = std::accumulate(real_data_init.begin(), real_data_init.end(), 0.0,
 							 [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_init = m_gas_init + m_stars_init;
@@ -177,7 +177,7 @@ auto problem_main() -> int
 	amrex::Real const m_gas_step1 = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after step 1
-	const auto &real_data_step1 = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
+	[[maybe_unused]] const auto [ids_step1, real_data_step1, int_data_step1] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	const int n_stars_step1 = static_cast<int>(real_data_step1.size());
 
 	if (n_stars_step1 != 1) {
@@ -214,7 +214,7 @@ auto problem_main() -> int
 	amrex::Real const m_gas_final = sim.state_new_cc_[0].sum(HydroSystem<SinkProblem>::density_index) * vol;
 
 	// get total particle mass after the end
-	const auto &real_data_final = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData().first;
+	[[maybe_unused]] const auto [ids_final, real_data_final, int_data_final] = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
 	amrex::Real const m_stars_final = std::accumulate(real_data_final.begin(), real_data_final.end(), 0.0,
 							  [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_final = m_gas_final + m_stars_final;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -725,7 +725,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	pp.query("projection_interval", projectionInterval_);
 
 	// Default output interval
-	pp.query("particle_interval", particleInterval_);
+	pp.query("particle_csv_interval", particleInterval_);
 
 	// Default statistics interval
 	pp.query("statistics_interval", statisticsInterval_);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2837,7 +2837,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteParticleFile()
 	amrex::UtilCreateCleanDirectory(partfilename, true);
 
 	// Save particle data to CSV files inside the created directory
-	particleRegister_.saveParticleDataToFile(partfilename);
+	// Only save if particle count <= 1000 for each type
+	particleRegister_.saveParticleDataToFileConditional(partfilename, 1000);
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(std::string const &MetadataFileName) const

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2801,6 +2801,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 
 	// write all particles in particleRegister_ to plotfile
 	particleRegister_.writePlotFile(plotfilename);
+
+	// write particles to CSV file
+	particleRegister_.saveParticleDataToFile(plotfilename);
 #endif
 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2830,7 +2830,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteParticleFile()
 
 	// Create particle file name using the same pattern as PlotFileName
 	const std::string partfilename = amrex::Concatenate("part", istep[0], 5);
-	
+
 	amrex::Print() << "Writing particle file " << partfilename << "\n";
 
 	// Create directory, renaming existing one if it exists (following AMReX pattern)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1043,6 +1043,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	int last_ascent_step = 0;
 #endif
 	int last_projection_step = 0;
+	int last_particle_step = 0;
 	int last_statistics_step = 0;
 	int last_plot_file_step = 0;
 	int last_chk_file_step = 0;
@@ -1198,6 +1199,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 			WriteProjectionPlotfile();
 		}
 
+		if (particleInterval_ > 0 && (step + 1) % particleInterval_ == 0) {
+			last_particle_step = step + 1;
+			WriteParticleFile();
+		}
+
 		// print particle statistics
 		if constexpr (Particle_Traits<problem_t>::particle_switch != ParticleSwitch::None) {
 			if (quokka::particle_verbose > 0) {
@@ -1285,6 +1291,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	// write final projection
 	if (projectionInterval_ > 0 && istep[0] > last_projection_step) {
 		WriteProjectionPlotfile();
+	}
+
+	// write final particle file
+	if (particleInterval_ > 0 && istep[0] > last_particle_step) {
+		WriteParticleFile();
 	}
 
 	// write final statistics

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2821,9 +2821,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 
 	// write all particles in particleRegister_ to plotfile
 	particleRegister_.writePlotFile(plotfilename);
-
-	// write particles to CSV file
-	particleRegister_.saveParticleDataToFile(plotfilename);
 #endif
 }
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -177,6 +177,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int plotfileInterval_ = -1;				     // -1 == no output
 	int projectionInterval_ = -1;				     // -1 == no output
 	int statisticsInterval_ = -1;				     // -1 == no output
+	int particleInterval_ = -1;				     // -1 == no output
 	amrex::Real plotTimeInterval_ = -1.0;			     // time interval for plt file
 	bool skipInitialPlotfile_ = false;			     // skip writing plotfile at t=0
 	amrex::Real checkpointTimeInterval_ = -1.0;		     // time interval for checkpoints
@@ -336,6 +337,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void ReadMetadataFile(std::string const &chkfilename);
 	void WriteStatisticsFile();
 	void WritePlotFile();
+	void WriteParticleFile();
 	void WriteProjectionPlotfile() const;
 	void WriteCheckpointFile() const;
 	void SetLastCheckpointSymlink(std::string const &checkpointname) const;
@@ -722,6 +724,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default projection interval
 	pp.query("projection_interval", projectionInterval_);
 
+	// Default output interval
+	pp.query("particle_interval", particleInterval_);
+
 	// Default statistics interval
 	pp.query("statistics_interval", statisticsInterval_);
 
@@ -855,6 +860,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::setInitialCondition
 
 	if (projectionInterval_ > 0) {
 		WriteProjectionPlotfile();
+	}
+
+	if (particleInterval_ > 0) {
+		WriteParticleFile();
 	}
 
 	if (statisticsInterval_ > 0) {
@@ -2805,6 +2814,22 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	// write particles to CSV file
 	particleRegister_.saveParticleDataToFile(plotfilename);
 #endif
+}
+
+template <typename problem_t> void AMRSimulation<problem_t>::WriteParticleFile()
+{
+	const BL_PROFILE("AMRSimulation::WriteParticleFile()");
+
+	// Create particle file name using the same pattern as PlotFileName
+	const std::string partfilename = amrex::Concatenate("part", istep[0], 5);
+	
+	amrex::Print() << "Writing particle file " << partfilename << "\n";
+
+	// Create directory, renaming existing one if it exists (following AMReX pattern)
+	amrex::UtilCreateCleanDirectory(partfilename, true);
+
+	// Save particle data to CSV files inside the created directory
+	particleRegister_.saveParticleDataToFile(partfilename);
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(std::string const &MetadataFileName) const


### PR DESCRIPTION
### Description
Add a function `saveParticleDataToFile` to save particle data to CSV files. This is helpful for quick debugging, or visualizing particles with any tools. An example particle folder looks like this:

```
part00000/StochasticStellarPop_particles.csv
```

The CSV file will contain the following columns:
- ID: Particle ID
- x, y, z: Particle positions
- real_0, real_1, ...: Real components (e.g., mass, velocities, etc.)
- int_0, int_1, ...: Integer components (if any)

This is controlled by the runtime parameter `particle_csv_interval`, which works the same way as `plotfile_interval`. CSV data writing is turned off by default, and if turned on, it will write all particle types with fewer than 1000 particles. 

Also changed:
- moved the IO functions (getParticleDataAtLevelZero getParticleDataAtLevel writeUnitsFile printParticleStatistics) into a new file particle_IO.hpp 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
