### PR TITLE
Fix bug in getParticleDataAtAllLevels()

### DIFF
--- a/inputs/SphericalCollapse.in
+++ b/inputs/SphericalCollapse.in
@@ -33,4 +33,5 @@ do_tracers = 0          # turn on tracer particles
 
 ascent_interval = 100
 plotfile_interval = 200
+particle_csv_interval = 200
 checkpoint_interval = 1000

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -922,18 +922,18 @@ template <typename problem_t> class PhysicsParticleRegister
 	void saveParticleDataToFileConditional(const std::string &plotfilename, int max_particles)
 	{
 		const BL_PROFILE("PhysicsParticleRegister::saveParticleDataToFileConditional()");
-			for (const auto &[type, descriptor] : particleRegistry_) {
-				const int num_particles = descriptor->getNumParticles();
-				const std::string particle_type_name = getParticleTypeName(type);
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			const int num_particles = descriptor->getNumParticles();
+			const std::string particle_type_name = getParticleTypeName(type);
 
-				if (num_particles <= max_particles) {
-					amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
-					descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
-				} else {
-					amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles << " particles exceeds limit of "
-									<< max_particles << "\n";
-				}
+			if (num_particles <= max_particles) {
+				amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
+				descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
+			} else {
+				amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles << " particles exceeds limit of "
+					       << max_particles << "\n";
 			}
+		}
 	}
 
 	// Prevent copying or moving of the registry to ensure single ownership

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -918,18 +918,6 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 	}
 
-	// test: save csv
-	void testcsv() const 
-	{
-		amrex::Print() << ">>> saving csv\n";
-
-		for (const auto &[type, descriptor] : particleRegistry_) {
-			const auto [ids1, positions_cicrad, int1] = descriptor->getParticleDataAtAllLevels();
-			// descriptor->getParticleDataAtLevel(0);
-			// descriptor->getParticleDataAtAllLevels();
-		}
-	}
-
 	// Save particle data to file only if particle count <= max_particles
 	void saveParticleDataToFileConditional(const std::string &plotfilename, int max_particles)
 	{

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -12,6 +12,7 @@
 #include "AMReX_BLProfiler.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_MultiFab.H"
+#include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParticleInterpolators.H"
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
@@ -77,7 +78,7 @@ class PhysicsParticleDescriptorBase
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
 
 	// New method to get particle positions and data
-	[[nodiscard]] virtual auto getAllParticleData() const
+	[[nodiscard]] virtual auto getParticleDataAtAllLevels() const
 	    -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> = 0;
 
 	// Get particle data at level lev
@@ -188,10 +189,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	//   - Integer data (e.g., id, type, etc.)
 	// Only rank 0 will return the actual particle data, other ranks return an empty vector.
 	// @return: tuple of vectors of particle data on rank 0, empty vectors on other ranks
-	[[nodiscard]] auto getAllParticleData() const
+	[[nodiscard]] auto getParticleDataAtAllLevels() const
 	    -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
 	{
-		return particle_io::getAllParticleData(container_);
+		return particle_io::getParticleDataAtAllLevels(container_);
 	}
 
 	[[nodiscard]] auto getParticleDataAtLevel(int lev) const -> std::pair<std::vector<std::vector<double>>, std::vector<std::vector<int>>> override
@@ -917,22 +918,34 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 	}
 
+	// test: save csv
+	void testcsv() const 
+	{
+		amrex::Print() << ">>> saving csv\n";
+
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			const auto [ids1, positions_cicrad, int1] = descriptor->getParticleDataAtAllLevels();
+			// descriptor->getParticleDataAtLevel(0);
+			// descriptor->getParticleDataAtAllLevels();
+		}
+	}
+
 	// Save particle data to file only if particle count <= max_particles
 	void saveParticleDataToFileConditional(const std::string &plotfilename, int max_particles)
 	{
 		const BL_PROFILE("PhysicsParticleRegister::saveParticleDataToFileConditional()");
-		for (const auto &[type, descriptor] : particleRegistry_) {
-			const int num_particles = descriptor->getNumParticles();
-			const std::string particle_type_name = getParticleTypeName(type);
+			for (const auto &[type, descriptor] : particleRegistry_) {
+				const int num_particles = descriptor->getNumParticles();
+				const std::string particle_type_name = getParticleTypeName(type);
 
-			if (num_particles <= max_particles) {
-				amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
-				descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
-			} else {
-				amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles << " particles exceeds limit of "
-					       << max_particles << "\n";
+				if (num_particles <= max_particles) {
+					amrex::Print() << "Saving " << num_particles << " " << particle_type_name << " to CSV file\n";
+					descriptor->saveParticleDataToFile(plotfilename, particle_type_name);
+				} else {
+					amrex::Print() << "Skipping " << particle_type_name << " CSV output: " << num_particles << " particles exceeds limit of "
+									<< max_particles << "\n";
+				}
 			}
-		}
 	}
 
 	// Prevent copying or moving of the registry to ensure single ownership

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -36,7 +36,7 @@ namespace particle_io
 // Only rank 0 will return the actual particle data, other ranks return empty vectors.
 // @return: tuple of vectors containing particle data on rank 0, empty vectors on other ranks
 template <typename ContainerType>
-[[nodiscard]] auto getAllParticleData(ContainerType *container)
+[[nodiscard]] auto getParticleDataAtAllLevels(ContainerType *container)
     -> std::tuple<std::vector<int64_t>, std::vector<std::vector<double>>, std::vector<std::vector<int>>>
 {
 	std::vector<int64_t> particle_ids;
@@ -344,7 +344,7 @@ void printParticleStatistics(ContainerType *container, int massIndex, int evolut
 template <typename ContainerType> auto saveParticleDataToFile(ContainerType *container, const std::string &filename, const std::string &name) -> bool
 {
 	// Get all particle data
-	const auto [particle_ids, real_data, int_data] = getAllParticleData(container);
+	const auto [particle_ids, real_data, int_data] = getParticleDataAtLevel(container, 0);
 
 	// Only rank 0 writes the file
 	if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -43,7 +43,6 @@ template <typename ContainerType>
 	std::vector<std::vector<double>> real_data;
 	std::vector<std::vector<int>> int_data;
 
-	// All ranks must participate in copyParticles
 	if (container != nullptr) {
 		// Create single-box particle container for analysis on all ranks
 		ContainerType analysisPC{};
@@ -55,9 +54,43 @@ template <typename ContainerType>
 		amrex::Vector<int> const ranks({0});
 		amrex::DistributionMapping const dmap(ranks);
 
-		// Initialize the analysis container and gather all particles to rank 0
+		// Initialize the analysis container
 		analysisPC.Define(geom, dmap, boxArray);
-		analysisPC.copyParticles(*container); // MPI communication happens here
+
+		// Create a single destination tile on rank 0
+		auto &dst_tile = analysisPC.DefineAndReturnParticleTile(0, 0, 0);
+
+		// Count total particles across all levels
+		int total_np = 0;
+		for (int lev = 0; lev <= container->finestLevel(); ++lev) {
+			const auto &particles = container->GetParticles(lev);
+			for (const auto &kv : particles) {
+				total_np += kv.second.numParticles();
+			}
+		}
+
+		// Pre-size the destination tile
+		dst_tile.resize(total_np);
+
+		// Copy particles from all levels to the destination tile
+		int particle_offset = 0;
+		for (int lev = 0; lev <= container->finestLevel(); ++lev) {
+			const auto &particles = container->GetParticles(lev);
+			
+			for (const auto &kv : particles) {
+				const auto &src_tile = kv.second;
+				const int np = src_tile.numParticles();
+				if (np > 0) {
+					const auto &src_aos = src_tile.GetArrayOfStructs();
+					auto &dst_aos = dst_tile.GetArrayOfStructs();
+					amrex::Gpu::copy(amrex::Gpu::deviceToDevice, src_aos.data(), src_aos.data() + np, dst_aos.data() + particle_offset);
+					particle_offset += np;
+				}
+			}
+		}
+
+		// Now use MPI to gather all particles to rank 0
+		analysisPC.Redistribute(); // This handles the MPI communication
 
 		// Only rank 0 processes the particles since they're all gathered there
 		if (amrex::ParallelDescriptor::IOProcessor()) {
@@ -82,7 +115,7 @@ template <typename ContainerType>
 					int_data.reserve(np);
 				}
 
-				// Extract positions, real components, and integer components from host data
+				// Process each particle
 				for (int i = 0; i < np; ++i) {
 					const auto &p = pData_h[i];
 
@@ -94,25 +127,24 @@ template <typename ContainerType>
 					// Pre-allocate to avoid reallocations
 					r_data.reserve(AMREX_SPACEDIM + ContainerType::ParticleType::NReal);
 
-					// First add position components
+					// Add position components
 					for (int d = 0; d < AMREX_SPACEDIM; ++d) {
 						r_data.push_back(p.pos(d));
 					}
 
-					// Then add all real components (mass, velocities, etc)
+					// Add all real components
 					for (int d = 0; d < ContainerType::ParticleType::NReal; ++d) {
 						r_data.push_back(p.rdata(d));
 					}
 
 					real_data.push_back(std::move(r_data));
 
-					// Process integer data (idata) only if particles have integer components
+					// Process integer data if particles have integer components
 					if constexpr (has_int_components) {
 						std::vector<int> i_data;
 						// Pre-allocate to avoid reallocations
 						i_data.reserve(ContainerType::ParticleType::NInt);
 
-						// Add all integer components
 						for (int d = 0; d < ContainerType::ParticleType::NInt; ++d) {
 							i_data.push_back(p.idata(d));
 						}
@@ -344,7 +376,7 @@ void printParticleStatistics(ContainerType *container, int massIndex, int evolut
 template <typename ContainerType> auto saveParticleDataToFile(ContainerType *container, const std::string &filename, const std::string &name) -> bool
 {
 	// Get all particle data
-	const auto [particle_ids, real_data, int_data] = getParticleDataAtLevel(container, 0);
+	const auto [particle_ids, real_data, int_data] = getParticleDataAtAllLevels(container);
 
 	// Only rank 0 writes the file
 	if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/src/particles/particle_IO.hpp
+++ b/src/particles/particle_IO.hpp
@@ -76,7 +76,7 @@ template <typename ContainerType>
 		int particle_offset = 0;
 		for (int lev = 0; lev <= container->finestLevel(); ++lev) {
 			const auto &particles = container->GetParticles(lev);
-			
+
 			for (const auto &kv : particles) {
 				const auto &src_tile = kv.second;
 				const int np = src_tile.numParticles();

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -217,19 +217,19 @@ auto problem_main() -> int
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// Test CICRad particles
 		[[maybe_unused]] const auto [ids1, positions_cicrad, int1] =
-		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getAllParticleData();
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CICRad)->getParticleDataAtAllLevels();
 		double position_error_cicrad = 0.0;
 		double position_norm_cicrad = 0.0;
 
 		// Test CIC particles
 		[[maybe_unused]] const auto [ids2, positions_cic, int2] =
-		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getAllParticleData();
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleDataAtAllLevels();
 		double position_error_cic = 0.0;
 		const double position_norm_cic = 1.0; // set to 1.0 since the particles are exactly at the origin
 
 		// Test Rad particles
 		[[maybe_unused]] const auto [ids3, positions_rad, int3] =
-		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getAllParticleData();
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Rad)->getParticleDataAtAllLevels();
 		double position_error_rad = 0.0;
 		double position_norm_rad = 0.0;
 

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -163,7 +163,7 @@ auto problem_main() -> int
 	// get total particle mass of the initial state
 	const int mass_index = 3;
 	[[maybe_unused]] const auto [ids_init, real_data_init, int_data_init] =
-	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtAllLevels();
 	amrex::Real const m_stars_init = std::accumulate(real_data_init.begin(), real_data_init.end(), 0.0,
 							 [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_init = m_gas_init + m_stars_init;
@@ -179,7 +179,7 @@ auto problem_main() -> int
 
 	// get total particle mass after step 1
 	[[maybe_unused]] const auto [ids_step1, real_data_step1, int_data_step1] =
-	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtAllLevels();
 	const int n_stars_step1 = static_cast<int>(real_data_step1.size());
 
 	if (n_stars_step1 != 1) {
@@ -217,7 +217,7 @@ auto problem_main() -> int
 
 	// get total particle mass after the end
 	[[maybe_unused]] const auto [ids_final, real_data_final, int_data_final] =
-	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getAllParticleData();
+	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtAllLevels();
 	amrex::Real const m_stars_final = std::accumulate(real_data_final.begin(), real_data_final.end(), 0.0,
 							  [mass_index](double sum, const auto &particle) { return sum + particle[mass_index]; });
 	const double m_tot_final = m_gas_final + m_stars_final;


### PR DESCRIPTION
### Description
The current code uses `analysisPC.copyParticles(*container);` to copy all particles from the particle container to a buffer container `analysisPC`. However, `copyParticles` expects the destination container to have the same number of levels as the source. When amr.max_level > 0, the source container has multiple levels but the analysis container only has level 0, causing a segfault.

In this update, I use the paradigm of `getParticleDataAtLevel` in `getParticleDataAtAllLevels` and loop over all levels to collect all particles from all levels and all multifabls into a single vector. This is robust for arbitrary `max_level` on multiple ranks. 

Set `particle_csv_interval = 200` in SphericalCollpase.in to test this update. Before this update, this test will fail with a segfault. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
