### PR TITLE
quokka::BCType and quokka::BC, a simple int enum approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Quokka is a two-moment radiation hydrodynamics code using the piecewise-paraboli
 - **Run specific test**: `ctest -R TestName`
 - **Exclude tests**: `ctest -E "Pattern*"`
 - **List test targets**: `cmake --build . --target help`
-- **Test inputs**: Located in `tests/` directory (`.in` files)
+- **Test inputs**: Located in `inputs/` directory (`.in` files)
 - **Code formatting**: `clang-format -i file.cpp` (run from `src/` directory)
 - **Static analysis**: Use `scripts/tidy.sh build changed` to run clang-tidy on modified files
 - **Lint options**: `scripts/tidy.sh build [changed|previous|origin|dev] [--fix]`
@@ -33,7 +33,7 @@ Quokka is a two-moment radiation hydrodynamics code using the piecewise-paraboli
   - `test_*.hpp`: Header with template specializations (removed in recent commits)
   - `CMakeLists.txt`: Defines executable target
 - Problems use template specialization pattern for `QuokkaSimulation<ProblemName>`
-- Input files (`.in`) in `tests/` configure geometry, AMR, physics parameters
+- Input files (`.in`) in `inputs/` configure geometry, AMR, physics parameters
 - Problems should ONLY contain `.cpp` files (no `.hpp` files per recent policy)
 
 ## Key Dependencies

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -39,14 +39,15 @@ template <typename problem_t> struct Physics_Indices {
 	static constexpr int nvarTotal_cc_adv = 1;
 	// number of cc quantities required for rad /+ hydro problem
 	static constexpr int nvarTotal_cc = []() constexpr {
-			if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
-				return nvarTotal_cc_adv;
-			} 
-			if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-				return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars + Physics_NumVars::numRadVarsPerGroup * Physics_Traits<problem_t>::nGroups;
-			} 
-			return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars;
-		}();
+		if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+			return nvarTotal_cc_adv;
+		}
+		if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
+			return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars +
+			       Physics_NumVars::numRadVarsPerGroup * Physics_Traits<problem_t>::nGroups;
+		}
+		return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars;
+	}();
 	// cell-centered
 	static constexpr int hydroFirstIndex = 0;
 	static constexpr int pscalarFirstIndex = Physics_NumVars::numHydroVars;

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -36,29 +36,25 @@ template <typename problem_t> struct Physics_Traits {
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {
 	// number of cc quantities required for advection problems
-	static const int nvarTotal_cc_adv = 1;
+	static constexpr int nvarTotal_cc_adv = 1;
 	// number of cc quantities required for rad /+ hydro problem
-	static constexpr int nvarTotal_cc_radhydro = []() constexpr {
-		if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-			return Physics_Traits<problem_t>::numPassiveScalars +
-			       Physics_NumVars::numHydroVars *
-				   static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) +
-			       Physics_NumVars::numRadVarsPerGroup * Physics_Traits<problem_t>::nGroups;
-		} else {
-			return Physics_Traits<problem_t>::numPassiveScalars +
-			       Physics_NumVars::numHydroVars *
-				   static_cast<int>(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled);
-		}
-	}();
+	static constexpr int nvarTotal_cc = []() constexpr {
+			if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+				return nvarTotal_cc_adv;
+			} 
+			if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
+				return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars + Physics_NumVars::numRadVarsPerGroup * Physics_Traits<problem_t>::nGroups;
+			} 
+			return Physics_Traits<problem_t>::numPassiveScalars + Physics_NumVars::numHydroVars;
+		}();
 	// cell-centered
-	static const int nvarTotal_cc = nvarTotal_cc_radhydro > 0 ? nvarTotal_cc_radhydro : nvarTotal_cc_adv;
-	static const int hydroFirstIndex = 0;
-	static const int pscalarFirstIndex = Physics_NumVars::numHydroVars;
-	static const int radFirstIndex = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
+	static constexpr int hydroFirstIndex = 0;
+	static constexpr int pscalarFirstIndex = Physics_NumVars::numHydroVars;
+	static constexpr int radFirstIndex = pscalarFirstIndex + Physics_Traits<problem_t>::numPassiveScalars;
 	// face-centered
-	static const int nvarPerDim_fc = Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
-	static const int nvarTotal_fc = AMREX_SPACEDIM * nvarPerDim_fc;
-	static const int mhdFirstIndex = 0;
+	static constexpr int nvarPerDim_fc = Physics_NumVars::numMHDVars_per_dim * static_cast<int>(Physics_Traits<problem_t>::is_mhd_enabled);
+	static constexpr int nvarTotal_fc = AMREX_SPACEDIM * nvarPerDim_fc;
+	static constexpr int mhdFirstIndex = 0;
 };
 
 #endif // PHYSICS_INFO_HPP_

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -12,7 +12,6 @@
 #endif
 #include "AMReX_Algorithm.H"
 #include "AMReX_Array.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BoxArray.H"
 #include "AMReX_Config.H"
 #include "AMReX_CoordSys.H"
@@ -26,6 +25,7 @@
 
 #include "linear_advection/AdvectionSimulation.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct SawtoothProblem {
 };
@@ -133,13 +133,7 @@ auto problem_main() -> int
 	const int max_timesteps = 1e4;
 	const int nvars = 1; // only density
 
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<SawtoothProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	AdvectionSimulation<SawtoothProblem> sim(BCs_cc);

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -24,8 +24,8 @@
 #include <fmt/format.h>
 
 #include "linear_advection/AdvectionSimulation.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct SawtoothProblem {
 };

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -131,7 +131,6 @@ auto problem_main() -> int
 	const double max_time = 1.0;
 	const double max_dt = 1.0e-4;
 	const int max_timesteps = 1e4;
-	const int nvars = 1; // only density
 
 	auto BCs_cc = quokka::BC<SawtoothProblem>(amrex::BCType::int_dir); // periodic
 

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -132,7 +132,7 @@ auto problem_main() -> int
 	const double max_dt = 1.0e-4;
 	const int max_timesteps = 1e4;
 
-	auto BCs_cc = quokka::BC<SawtoothProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<SawtoothProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	AdvectionSimulation<SawtoothProblem> sim(BCs_cc);

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -137,7 +137,6 @@ auto problem_main() -> int
 	const double CFL_number = 0.4;
 	const double max_time = 1.0;
 	const int max_timesteps = 1e4;
-	const int nvars = 1;
 
 	auto BCs_cc = quokka::BC<SquareProblem>(amrex::BCType::int_dir); // periodic
 

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -138,7 +138,7 @@ auto problem_main() -> int
 	const double max_time = 1.0;
 	const int max_timesteps = 1e4;
 
-	auto BCs_cc = quokka::BC<SquareProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<SquareProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	AdvectionSimulation<SquareProblem> sim(BCs_cc);

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -13,7 +13,6 @@
 
 #include "AMReX_Algorithm.H"
 #include "AMReX_Array.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_BoxArray.H"
 #include "AMReX_Config.H"
@@ -25,6 +24,7 @@
 #include "AMReX_REAL.H"
 
 #include "linear_advection/AdvectionSimulation.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -139,13 +139,7 @@ auto problem_main() -> int
 	const int max_timesteps = 1e4;
 	const int nvars = 1;
 
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<SquareProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	AdvectionSimulation<SquareProblem> sim(BCs_cc);

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -26,6 +26,7 @@
 #include "linear_advection/AdvectionSimulation.hpp"
 #include "linear_advection/linear_advection.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct SemiellipseProblem {
 };
@@ -132,14 +133,8 @@ auto problem_main() -> int
 	const double max_dt = 1e-4;
 	const int max_timesteps = 1e4;
 
-	const int nvars = 1; // only density
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	// Set boundary conditions - periodic
+	auto BCs_cc = quokka::BC<SemiellipseProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	AdvectionSimulation<SemiellipseProblem> sim(BCs_cc);

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -25,8 +25,8 @@
 #include "hyperbolic_system.hpp"
 #include "linear_advection/AdvectionSimulation.hpp"
 #include "linear_advection/linear_advection.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct SemiellipseProblem {
 };

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -134,7 +134,7 @@ auto problem_main() -> int
 	const int max_timesteps = 1e4;
 
 	// Set boundary conditions - periodic
-	auto BCs_cc = quokka::BC<SemiellipseProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<SemiellipseProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	AdvectionSimulation<SemiellipseProblem> sim(BCs_cc);

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -219,14 +219,14 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::Mu
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<AlfvenWaveCircular>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<AlfvenWaveCircular>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
 
@@ -218,14 +219,7 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::Mu
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<AlfvenWaveCircular>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -15,9 +15,9 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 struct AlfvenWaveCircular {
 };

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -229,14 +229,14 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::Mult
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<AlfvenWaveLinear>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<AlfvenWaveLinear>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "physics_info.hpp"
@@ -228,14 +229,7 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::Mult
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<AlfvenWaveLinear>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -15,10 +15,10 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -235,8 +235,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -22,6 +22,7 @@
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
+#include "util/BC.hpp"
 
 #include "AMReX_REAL.H"
 #include "QuokkaSimulation.hpp"
@@ -151,32 +152,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<BinaryOrbit>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<BinaryOrbit>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<BinaryOrbit>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<BinaryOrbit>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BoundaryCondition::reflecting);
 
 	// read in runtime parameters for this test problem
 	amrex::ParmParse const pp("problem");

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -152,6 +152,12 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
+	// Examples of the new unified BC interface (traditional enum, implicit int conversion):
+	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::int_dir);     // periodic
+	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::ext_dir);     // Dirichlet
+	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::ext_dir, 
+	//                                       quokka::BCType::int_dir, 
+	//                                       quokka::BCType::reflecting); // mixed BCs
 	auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::reflecting);
 
 	// read in runtime parameters for this test problem

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -152,7 +152,7 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::reflecting);
 
 	// read in runtime parameters for this test problem
 	amrex::ParmParse const pp("problem");

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -155,8 +155,8 @@ auto problem_main() -> int
 	// Examples of the new unified BC interface (traditional enum, implicit int conversion):
 	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::int_dir);     // periodic
 	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::ext_dir);     // Dirichlet
-	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::ext_dir, 
-	//                                       quokka::BCType::int_dir, 
+	// auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::ext_dir,
+	//                                       quokka::BCType::int_dir,
 	//                                       quokka::BCType::reflecting); // mixed BCs
 	auto BCs_cc = quokka::BC<BinaryOrbit>(quokka::BCType::reflecting);
 

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -13,6 +13,7 @@
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuDevice.H"
 #include "AMReX_TableData.H"
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -13,7 +13,6 @@
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuDevice.H"
 #include "AMReX_TableData.H"
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
@@ -191,13 +190,13 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<CoolingTest>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(0, quokka::BCType::int_dir);
-		BCs_cc[n].setLo(1, quokka::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(1, quokka::BCType::ext_dir);  // Dirichlet
+		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(1, amrex::BCType::foextrap); // extrapolate
+		BCs_cc[n].setHi(1, amrex::BCType::ext_dir);  // Dirichlet
 #if AMREX_SPACEDIM == 3
-		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -190,13 +190,13 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<CoolingTest>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-		BCs_cc[n].setLo(1, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(1, amrex::BCType::ext_dir);  // Dirichlet
+		BCs_cc[n].setLo(0, quokka::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(0, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(1, quokka::BCType::foextrap); // extrapolate
+		BCs_cc[n].setHi(1, quokka::BCType::ext_dir);  // Dirichlet
 #if AMREX_SPACEDIM == 3
-		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -9,13 +9,13 @@
 #include <fmt/format.h>
 #include <random>
 
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuDevice.H"
 #include "AMReX_TableData.H"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -184,6 +184,9 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 
 	// Problem initialization
+	// Note: This problem has mixed BCs - periodic in x&z, different in y
+	// Using the new API doesn't support asymmetric lo/hi boundaries
+	// So we keep the manual setup for this special case
 	constexpr int ncomp_cc = Physics_Indices<CoolingTest>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -9,13 +9,13 @@
 #include <fmt/format.h>
 #include <random>
 
+#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuDevice.H"
 #include "AMReX_TableData.H"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/BC.hpp"
 
 using amrex::Real;
 

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -106,14 +106,14 @@ template <> void QuokkaSimulation<CurrentSheet>::setInitialConditionsOnGridFaceV
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<CurrentSheet>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<CurrentSheet>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<CurrentSheet>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -15,11 +15,11 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 struct CurrentSheet {
 };

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
@@ -105,14 +106,7 @@ template <> void QuokkaSimulation<CurrentSheet>::setInitialConditionsOnGridFaceV
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<CurrentSheet>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<CurrentSheet>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<CurrentSheet>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -112,8 +112,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/DiskGalaxy/galaxy.cpp
+++ b/src/problems/DiskGalaxy/galaxy.cpp
@@ -363,7 +363,7 @@ template <> void QuokkaSimulation<AgoraGalaxy>::ComputeDerivedVar(int lev, std::
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<AgoraGalaxy>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<AgoraGalaxy>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AgoraGalaxy> sim(BCs_cc);

--- a/src/problems/DiskGalaxy/galaxy.cpp
+++ b/src/problems/DiskGalaxy/galaxy.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 
 #include "AMReX_Array.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_FabArrayBase.H"
 #include "AMReX_GpuContainers.H"
@@ -28,6 +27,7 @@
 #include "math/quadrature.hpp"
 #include "particles/particle_types.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 struct AgoraGalaxy {
 };
@@ -363,20 +363,7 @@ template <> void QuokkaSimulation<AgoraGalaxy>::ComputeDerivedVar(int lev, std::
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<AgoraGalaxy>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<AgoraGalaxy>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<AgoraGalaxy>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	auto BCs_cc = quokka::BC<AgoraGalaxy>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<AgoraGalaxy>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AgoraGalaxy> sim(BCs_cc);

--- a/src/problems/DiskGalaxy/galaxy.cpp
+++ b/src/problems/DiskGalaxy/galaxy.cpp
@@ -376,19 +376,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = Physics_Indices<AgoraGalaxy>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<AgoraGalaxy>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AgoraGalaxy> sim(BCs_cc);

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -146,8 +146,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int n = 0; n < nvars_fc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_fc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_fc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_fc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_fc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -140,14 +140,14 @@ void checkMFs(amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const
 auto problem_main() -> int
 {
 	// Set boundary conditions - periodic
-	auto BCs_cc = quokka::BC<FCQuantities>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<FCQuantities>(quokka::BCType::int_dir);
 
 	const int nvars_fc = Physics_Indices<FCQuantities>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int n = 0; n < nvars_fc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_fc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_fc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_fc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_fc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -23,6 +23,7 @@
 #include "grid.hpp"
 #include "physics_info.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct FCQuantities {
 };
@@ -139,24 +140,9 @@ void checkMFs(amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const
 
 auto problem_main() -> int
 {
-	// Problem initialization
-	const int ncomp_cc = Physics_Indices<FCQuantities>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
-
-	const int nvars_fc = Physics_Indices<FCQuantities>::nvarTotal_fc;
-	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
-	for (int n = 0; n < nvars_fc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_fc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_fc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	// Set boundary conditions - periodic
+	auto BCs_cc = quokka::BC<FCQuantities>(amrex::BCType::int_dir);
+	auto BCs_fc = quokka::BC<FCQuantities>(amrex::BCType::int_dir);
 
 	QuokkaSimulation<FCQuantities> sim_write(BCs_cc, BCs_fc);
 	sim_write.setInitialConditions();

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -22,7 +22,6 @@
 #include "QuokkaSimulation.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
 
 struct FCQuantities {
@@ -142,7 +141,15 @@ auto problem_main() -> int
 {
 	// Set boundary conditions - periodic
 	auto BCs_cc = quokka::BC<FCQuantities>(amrex::BCType::int_dir);
-	auto BCs_fc = quokka::BC<FCQuantities>(amrex::BCType::int_dir);
+
+	const int nvars_fc = Physics_Indices<FCQuantities>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int n = 0; n < nvars_fc; ++n) {
+		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+			BCs_fc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_fc[n].setHi(i, amrex::BCType::int_dir);
+		}
+	}
 
 	QuokkaSimulation<FCQuantities> sim_write(BCs_cc, BCs_fc);
 	sim_write.setInitialConditions();

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -18,10 +18,10 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
 #include "test_fast_wave.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 
 struct FastWave {

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -18,6 +18,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
 #include "test_fast_wave.hpp"
@@ -230,14 +231,7 @@ void QuokkaSimulation<FastWave>::computeReferenceSolution_fc(amrex::MultiFab &re
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<FastWave>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<FastWave>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<FastWave>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -231,14 +231,14 @@ void QuokkaSimulation<FastWave>::computeReferenceSolution_fc(amrex::MultiFab &re
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<FastWave>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<FastWave>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<FastWave>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -237,8 +237,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -122,14 +122,14 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<FieldLoop>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<FieldLoop>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<FieldLoop>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -15,11 +15,11 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 struct FieldLoop {
 };

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -128,8 +128,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
@@ -121,14 +122,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<FieldLoop>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<FieldLoop>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<FieldLoop>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -128,28 +128,6 @@ auto problem_main() -> int
 	// const int nx = 1000;
 	// const double Lx = 1.0;
 
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == RadSystem<ParticleProblem>::x1GasMomentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleProblem>::x2GasMomentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleProblem>::x3GasMomentum_index) && (dim == 2)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleProblem>::x1RadFlux_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleProblem>::x2RadFlux_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleProblem>::x3RadFlux_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
 	// Boundary conditions
 	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BoundaryCondition::reflecting);
 

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -7,6 +7,7 @@
 #include <cstdlib>
 #include <fmt/format.h>
 
+#include "util/BC.hpp"
 #include "AMReX.H"
 #include "AMReX_BCRec.H"
 #include "AMReX_BC_TYPES.H"
@@ -150,19 +151,7 @@ auto problem_main() -> int
 	};
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<ParticleProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -129,7 +129,7 @@ auto problem_main() -> int
 	// const double Lx = 1.0;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
+++ b/src/problems/GravRadParticle3D/test_grav_rad_particle_3D.cpp
@@ -7,7 +7,6 @@
 #include <cstdlib>
 #include <fmt/format.h>
 
-#include "util/BC.hpp"
 #include "AMReX.H"
 #include "AMReX_BCRec.H"
 #include "AMReX_BC_TYPES.H"
@@ -17,6 +16,7 @@
 #include "hydro/EOS.hpp"
 #include "particles/PhysicsParticles.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 
 struct ParticleProblem {
 };

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -138,7 +138,7 @@ auto problem_main() -> int
 	constexpr bool reflecting_boundary = true;
 
 	auto BCs_cc = reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BoundaryCondition::reflecting)
-					  : quokka::BC<BlastProblem>(amrex::BCType::int_dir); // periodic
+					  : quokka::BC<BlastProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<BlastProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -12,7 +12,6 @@
 #endif
 #include "AMReX_Array.H"
 #include "AMReX_BCRec.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_Config.H"
 #include "AMReX_ParallelDescriptor.H"
@@ -27,6 +26,7 @@
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
+#include "util/BC.hpp"
 
 struct BlastProblem {
 };
@@ -137,38 +137,9 @@ auto problem_main() -> int
 	// Problem parameters
 	constexpr bool reflecting_boundary = true;
 
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<BlastProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<BlastProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<BlastProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = QuokkaSimulation<BlastProblem>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (reflecting_boundary) {
-				if (isNormalComp(n, i)) {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-					BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-				} else {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-					BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-				}
-			} else {
-				// periodic
-				BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-				BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			}
-		}
-	}
+	auto BCs_cc = reflecting_boundary ? 
+			quokka::BC<BlastProblem>(quokka::BoundaryCondition::reflecting) :
+			quokka::BC<BlastProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<BlastProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -137,9 +137,8 @@ auto problem_main() -> int
 	// Problem parameters
 	constexpr bool reflecting_boundary = true;
 
-	auto BCs_cc = reflecting_boundary ? 
-			quokka::BC<BlastProblem>(quokka::BoundaryCondition::reflecting) :
-			quokka::BC<BlastProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BoundaryCondition::reflecting)
+					  : quokka::BC<BlastProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<BlastProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -137,8 +137,8 @@ auto problem_main() -> int
 	// Problem parameters
 	constexpr bool reflecting_boundary = true;
 
-	auto BCs_cc = reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BCType::reflecting)
-					  : quokka::BC<BlastProblem>(quokka::BCType::int_dir); // periodic
+	auto BCs_cc =
+	    reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BCType::reflecting) : quokka::BC<BlastProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<BlastProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
+++ b/src/problems/HydroBlast2D/test_hydro2d_blast.cpp
@@ -137,7 +137,7 @@ auto problem_main() -> int
 	// Problem parameters
 	constexpr bool reflecting_boundary = true;
 
-	auto BCs_cc = reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BoundaryCondition::reflecting)
+	auto BCs_cc = reflecting_boundary ? quokka::BC<BlastProblem>(quokka::BCType::reflecting)
 					  : quokka::BC<BlastProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -6,9 +6,7 @@
 /// \file test_hydro3d_blast.cpp
 /// \brief Defines a test problem for a 3D explosion.
 ///
-
 #include "AMReX.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
@@ -18,8 +16,10 @@
 #include "math/interpolate.hpp"
 #include <fstream>
 
+
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 
 struct SedovProblem {
 };
@@ -218,37 +218,7 @@ template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vecto
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<SedovProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<SedovProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<SedovProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<SedovProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if constexpr (simulate_full_box) { // periodic boundaries
-				BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-				BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			} else { // octant symmetry
-				if (isNormalComp(n, i)) {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-					BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-				} else {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-					BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-				}
-			}
-		}
-	}
+	auto BCs_cc = simulate_full_box ? quokka::BC<SedovProblem>(amrex::BCType::int_dir) : quokka::BC<SedovProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<SedovProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -217,7 +217,7 @@ template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vecto
 
 auto problem_main() -> int
 {
-	auto BCs_cc = simulate_full_box ? quokka::BC<SedovProblem>(amrex::BCType::int_dir) : quokka::BC<SedovProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = simulate_full_box ? quokka::BC<SedovProblem>(quokka::BCType::int_dir) : quokka::BC<SedovProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<SedovProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -217,7 +217,7 @@ template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vecto
 
 auto problem_main() -> int
 {
-	auto BCs_cc = simulate_full_box ? quokka::BC<SedovProblem>(quokka::BCType::int_dir) : quokka::BC<SedovProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = simulate_full_box ? quokka::BC<SedovProblem>(quokka::BCType::int_dir) : quokka::BC<SedovProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<SedovProblem> sim(BCs_cc);

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -16,7 +16,6 @@
 #include "math/interpolate.hpp"
 #include <fstream>
 
-
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/BC.hpp"

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -10,7 +10,6 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
@@ -23,6 +22,7 @@
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct ContactProblem {
 };
@@ -190,16 +190,7 @@ void QuokkaSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab 
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int ncomp_cc = Physics_Indices<ContactProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
-		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ContactProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<ContactProblem> sim(BCs_cc);

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -21,8 +21,8 @@
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct ContactProblem {
 };

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -190,7 +190,7 @@ void QuokkaSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab 
 auto problem_main() -> int
 {
 	// Problem parameters
-	auto BCs_cc = quokka::BC<ContactProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<ContactProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<ContactProblem> sim(BCs_cc);

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -253,7 +253,7 @@ void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab
 auto problem_main() -> int
 {
 	// Problem parameters
-	auto BCs_cc = quokka::BC<HighMachProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<HighMachProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<HighMachProblem> sim(BCs_cc);

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -10,7 +10,6 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
@@ -28,6 +27,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fstream>
 #include <unistd.h>
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -253,16 +253,7 @@ void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int ncomp_cc = Physics_Indices<HighMachProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
-		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<HighMachProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<HighMachProblem> sim(BCs_cc);

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -25,9 +25,9 @@
 #include "util/matplotlibcpp.h"
 #endif
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fstream>
 #include <unistd.h>
-#include "util/BC.hpp"
 
 using amrex::Real;
 

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -129,7 +129,7 @@ template <> void QuokkaSimulation<KelvinHelmholzProblem>::refineGrid(int lev, am
 auto problem_main() -> int
 {
 	// Problem parameters
-	auto BCs_cc = quokka::BC<KelvinHelmholzProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<KelvinHelmholzProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<KelvinHelmholzProblem> sim(BCs_cc);

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -128,14 +128,7 @@ template <> void QuokkaSimulation<KelvinHelmholzProblem>::refineGrid(int lev, am
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int ncomp_cc = Physics_Indices<KelvinHelmholzProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir); // periodic
-		}
-	}
+	auto BCs_cc = quokka::BC<KelvinHelmholzProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<KelvinHelmholzProblem> sim(BCs_cc);

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -20,6 +20,7 @@
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -350,7 +350,7 @@ auto problem_main() -> int
 	const double initial_dt = 1e-5;
 	const int max_timesteps = 50000;
 
-	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -31,6 +31,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 
 struct ShocktubeProblem {
 };
@@ -349,17 +350,7 @@ auto problem_main() -> int
 	const double initial_dt = 1e-5;
 	const int max_timesteps = 50000;
 
-	// Problem initialization
-	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -34,6 +34,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 
@@ -252,19 +253,10 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 
 auto problem_main() -> int
 {
-	// Boundary conditions
-	const int ncomp_cc = Physics_Indices<QuirkProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		// outflow
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			// periodic
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	// Boundary conditions: ext_dir in x, periodic in y and z
+	auto BCs_cc = quokka::BC<QuirkProblem>(amrex::BCType::ext_dir,  // x: outflow
+	                                       amrex::BCType::int_dir,  // y: periodic
+	                                       amrex::BCType::int_dir); // z: periodic
 
 	// Problem initialization
 	QuokkaSimulation<QuirkProblem> sim(BCs_cc);

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -254,8 +254,8 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 auto problem_main() -> int
 {
 	// Boundary conditions: ext_dir in x, periodic in y and z
-	auto BCs_cc = quokka::BC<QuirkProblem>(quokka::BCType::ext_dir,	// x: outflow
-					       quokka::BCType::int_dir,	// y: periodic
+	auto BCs_cc = quokka::BC<QuirkProblem>(quokka::BCType::ext_dir,	 // x: outflow
+					       quokka::BCType::int_dir,	 // y: periodic
 					       quokka::BCType::int_dir); // z: periodic
 
 	// Problem initialization

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -254,9 +254,9 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 auto problem_main() -> int
 {
 	// Boundary conditions: ext_dir in x, periodic in y and z
-	auto BCs_cc = quokka::BC<QuirkProblem>(amrex::BCType::ext_dir,	// x: outflow
-					       amrex::BCType::int_dir,	// y: periodic
-					       amrex::BCType::int_dir); // z: periodic
+	auto BCs_cc = quokka::BC<QuirkProblem>(quokka::BCType::ext_dir,	// x: outflow
+					       quokka::BCType::int_dir,	// y: periodic
+					       quokka::BCType::int_dir); // z: periodic
 
 	// Problem initialization
 	QuokkaSimulation<QuirkProblem> sim(BCs_cc);

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -34,9 +34,9 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 
 using Real = amrex::Real;
 
@@ -254,9 +254,9 @@ AMRSimulation<QuirkProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 auto problem_main() -> int
 {
 	// Boundary conditions: ext_dir in x, periodic in y and z
-	auto BCs_cc = quokka::BC<QuirkProblem>(amrex::BCType::ext_dir,  // x: outflow
-	                                       amrex::BCType::int_dir,  // y: periodic
-	                                       amrex::BCType::int_dir); // z: periodic
+	auto BCs_cc = quokka::BC<QuirkProblem>(amrex::BCType::ext_dir,	// x: outflow
+					       amrex::BCType::int_dir,	// y: periodic
+					       amrex::BCType::int_dir); // z: periodic
 
 	// Problem initialization
 	QuokkaSimulation<QuirkProblem> sim(BCs_cc);

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -165,19 +165,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = Physics_Indices<RichtmeyerMeshkovProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RichtmeyerMeshkovProblem> sim(BCs_cc);

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -15,9 +15,9 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -10,7 +10,6 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
@@ -18,6 +17,7 @@
 #include "math/interpolate.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
@@ -165,7 +165,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RichtmeyerMeshkovProblem> sim(BCs_cc);

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -165,7 +165,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RichtmeyerMeshkovProblem> sim(BCs_cc);

--- a/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
+++ b/src/problems/HydroRichtmeyerMeshkov/test_hydro2d_rm.cpp
@@ -152,19 +152,6 @@ template <> void QuokkaSimulation<RichtmeyerMeshkovProblem>::setInitialCondition
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<RichtmeyerMeshkovProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<RichtmeyerMeshkovProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<RichtmeyerMeshkovProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
 	auto BCs_cc = quokka::BC<RichtmeyerMeshkovProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -23,6 +23,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 
 struct ShocktubeProblem {
 };
@@ -270,16 +271,7 @@ auto problem_main() -> int
 	const int max_timesteps = 20000;
 
 	// Problem initialization
-	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -271,7 +271,7 @@ auto problem_main() -> int
 	const int max_timesteps = 20000;
 
 	// Problem initialization
-	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -12,12 +12,12 @@
 #endif
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
 #include <string>
 #include <unordered_map>
-#include "util/BC.hpp"
 
 #include "AMReX_BC_TYPES.H"
 

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -356,7 +356,7 @@ auto problem_main() -> int
 	const double max_time = 0.4;
 	const int max_timesteps = 8000;
 
-	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <string>
 #include <unordered_map>
+#include "util/BC.hpp"
 
 #include "AMReX_BC_TYPES.H"
 
@@ -355,17 +356,7 @@ auto problem_main() -> int
 	const double max_time = 0.4;
 	const int max_timesteps = 8000;
 
-	// Problem initialization
-	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -25,8 +25,8 @@
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct ShocktubeProblem {
 };

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -249,7 +249,7 @@ auto problem_main() -> int
 	const double max_time = 1.0;
 	const int max_timesteps = 80000;
 
-	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
+++ b/src/problems/HydroShocktubeCMA/test_hydro_shocktube_cma.cpp
@@ -26,6 +26,7 @@
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct ShocktubeProblem {
 };
@@ -248,17 +249,7 @@ auto problem_main() -> int
 	const double max_time = 1.0;
 	const int max_timesteps = 80000;
 
-	// Problem initialization
-	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -16,7 +16,6 @@
 #include <fmt/format.h>
 #include <fstream>
 #include <vector>
-#include "util/BC.hpp"
 
 #include "AMReX_BC_TYPES.H"
 #include "QuokkaSimulation.hpp"
@@ -294,11 +293,11 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, quokka::BCType::foextrap); // Dirichlet
-		BCs_cc[0].setHi(0, quokka::BCType::ext_dir);
+		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
+		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -16,6 +16,7 @@
 #include <fmt/format.h>
 #include <fstream>
 #include <vector>
+#include "util/BC.hpp"
 
 #include "AMReX_BC_TYPES.H"
 #include "QuokkaSimulation.hpp"

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -293,11 +293,11 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[0].setLo(0, quokka::BCType::foextrap); // Dirichlet
+		BCs_cc[0].setHi(0, quokka::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -21,8 +21,8 @@
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -16,14 +16,13 @@
 #include <fmt/format.h>
 #include <fstream>
 
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 
 #include "QuokkaSimulation.hpp"
-#include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
@@ -315,17 +314,7 @@ auto problem_main() -> int
 	const double max_dt = 1e-3;
 	const int max_timesteps = 5000;
 
-	// Problem initialization
-	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -314,7 +314,7 @@ auto problem_main() -> int
 	const double max_dt = 1e-3;
 	const int max_timesteps = 5000;
 
-	auto BCs_cc = quokka::BC<ShocktubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -104,7 +104,7 @@ auto problem_main() -> int
 
 	// Problem initialization
 	const int ncomp_cc = Physics_Indices<WaveProblem>::nvarTotal_cc;
-	auto BCs_cc = quokka::BC<WaveProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<WaveProblem>(quokka::BCType::int_dir); // periodic
 
 	QuokkaSimulation<WaveProblem> sim(BCs_cc);
 

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -21,6 +21,7 @@
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct WaveProblem {
 };
@@ -103,13 +104,7 @@ auto problem_main() -> int
 
 	// Problem initialization
 	const int ncomp_cc = Physics_Indices<WaveProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<WaveProblem>(amrex::BCType::int_dir); // periodic
 
 	QuokkaSimulation<WaveProblem> sim(BCs_cc);
 

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -103,7 +103,6 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 
 	// Problem initialization
-	const int ncomp_cc = Physics_Indices<WaveProblem>::nvarTotal_cc;
 	auto BCs_cc = quokka::BC<WaveProblem>(quokka::BCType::int_dir); // periodic
 
 	QuokkaSimulation<WaveProblem> sim(BCs_cc);

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -20,8 +20,8 @@
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct WaveProblem {
 };

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -127,16 +127,16 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<Channel>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir); // NSCBC inflow
-		BCs_cc[n].setHi(0, quokka::BCType::ext_dir); // NSCBC outflow
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // NSCBC inflow
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir); // NSCBC outflow
 
 #if (AMREX_SPACEDIM >= 2)
-		BCs_cc[n].setLo(1, quokka::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(1, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(1, amrex::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 #endif
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, quokka::BCType::int_dir);
-		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(2, amrex::BCType::int_dir);
+		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -7,11 +7,11 @@
 /// \brief Implements a subsonic channel flow problem with Navier-Stokes
 ///        Characteristic Boundary Conditions (NSCBC).
 ///
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <random>
 #include <tuple>
 #include <vector>
-#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_Array.H"

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <tuple>
 #include <vector>
+#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_Array.H"

--- a/src/problems/NSCBC/channel.cpp
+++ b/src/problems/NSCBC/channel.cpp
@@ -126,16 +126,16 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<Channel>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // NSCBC inflow
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir); // NSCBC outflow
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir); // NSCBC inflow
+		BCs_cc[n].setHi(0, quokka::BCType::ext_dir); // NSCBC outflow
 
 #if (AMREX_SPACEDIM >= 2)
-		BCs_cc[n].setLo(1, amrex::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(1, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(1, quokka::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(1, quokka::BCType::int_dir);
 #endif
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, amrex::BCType::int_dir);
-		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(2, quokka::BCType::int_dir);
+		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -7,11 +7,11 @@
 /// \brief Implements a subsonic vortex flow problem with Navier-Stokes
 ///        Characteristic Boundary Conditions (NSCBC).
 ///
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <random>
 #include <tuple>
 #include <vector>
-#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_Array.H"

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -157,19 +157,19 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		if constexpr (outflow_boundary_along_x_axis) {
-			BCs_cc[n].setLo(0, quokka::BCType::ext_dir); // x- NSCBC outflow
-			BCs_cc[n].setHi(0, quokka::BCType::ext_dir);
-			BCs_cc[n].setLo(1, quokka::BCType::int_dir); // y- periodic
-			BCs_cc[n].setHi(1, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // x- NSCBC outflow
+			BCs_cc[n].setHi(0, amrex::BCType::ext_dir);
+			BCs_cc[n].setLo(1, amrex::BCType::int_dir); // y- periodic
+			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 		} else {
-			BCs_cc[n].setLo(0, quokka::BCType::int_dir); // x- periodic
-			BCs_cc[n].setHi(0, quokka::BCType::int_dir);
-			BCs_cc[n].setLo(1, quokka::BCType::ext_dir); // y- NSCBC outflow
-			BCs_cc[n].setHi(1, quokka::BCType::ext_dir);
+			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // x- periodic
+			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(1, amrex::BCType::ext_dir); // y- NSCBC outflow
+			BCs_cc[n].setHi(1, amrex::BCType::ext_dir);
 		}
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // z- periodic
-		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // z- periodic
+		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -11,6 +11,7 @@
 #include <random>
 #include <tuple>
 #include <vector>
+#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_Array.H"

--- a/src/problems/NSCBC/vortex.cpp
+++ b/src/problems/NSCBC/vortex.cpp
@@ -156,19 +156,19 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
 		if constexpr (outflow_boundary_along_x_axis) {
-			BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // x- NSCBC outflow
-			BCs_cc[n].setHi(0, amrex::BCType::ext_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::int_dir); // y- periodic
-			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(0, quokka::BCType::ext_dir); // x- NSCBC outflow
+			BCs_cc[n].setHi(0, quokka::BCType::ext_dir);
+			BCs_cc[n].setLo(1, quokka::BCType::int_dir); // y- periodic
+			BCs_cc[n].setHi(1, quokka::BCType::int_dir);
 		} else {
-			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // x- periodic
-			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::ext_dir); // y- NSCBC outflow
-			BCs_cc[n].setHi(1, amrex::BCType::ext_dir);
+			BCs_cc[n].setLo(0, quokka::BCType::int_dir); // x- periodic
+			BCs_cc[n].setHi(0, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(1, quokka::BCType::ext_dir); // y- NSCBC outflow
+			BCs_cc[n].setHi(1, quokka::BCType::ext_dir);
 		}
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // z- periodic
-		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // z- periodic
+		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/ODEIntegration/test_ode.cpp
+++ b/src/problems/ODEIntegration/test_ode.cpp
@@ -13,6 +13,7 @@
 #include "radiation/radiation_system.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
+#include "util/BC.hpp"
 
 struct ODETest {
 };

--- a/src/problems/ODEIntegration/test_ode.cpp
+++ b/src/problems/ODEIntegration/test_ode.cpp
@@ -11,9 +11,9 @@
 #include "extern_parameters.H"
 #include "math/ODEIntegrate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
-#include "util/BC.hpp"
 
 struct ODETest {
 };

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -18,11 +18,11 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 struct OrszagTang {
 };

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -126,8 +126,8 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -18,6 +18,7 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
@@ -119,14 +120,7 @@ template <> void QuokkaSimulation<OrszagTang>::setInitialConditionsOnGridFaceVar
 
 auto problem_main() -> int
 {
-	const int nvars_cc = Physics_Indices<OrszagTang>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars_cc);
-	for (int icomp = 0; icomp < nvars_cc; ++icomp) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_cc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_cc[icomp].setHi(idim, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<OrszagTang>(amrex::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<OrszagTang>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -120,14 +120,14 @@ template <> void QuokkaSimulation<OrszagTang>::setInitialConditionsOnGridFaceVar
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<OrszagTang>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<OrszagTang>(quokka::BCType::int_dir); // periodic
 
 	const int nvars_fc = Physics_Indices<OrszagTang>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
-			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setLo(idim, quokka::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -422,19 +422,6 @@ auto problem_main() -> int
 	const Real t_BH = r_BH / cs0;
 	const Real t_end = t_end_over_t_b * t_BH;
 
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<AccretionProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<AccretionProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<AccretionProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
 	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -14,9 +14,9 @@
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <gcem.hpp>
-#include "util/BC.hpp"
 
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -435,28 +435,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = Physics_Indices<AccretionProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// // periodic boundaries
-			// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			// octant symmetry
-			// // FOextrap
-			// for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// 	BCs_cc[n].setLo(i, amrex::BCType::foextrap);
-			// 	BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-			// }
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AccretionProblem> sim(BCs_cc);

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -3,7 +3,6 @@
 
 #include "AMReX.H"
 #include "AMReX_Array.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_GpuContainers.H"
 #include "AMReX_GpuQualifiers.H"
@@ -17,6 +16,7 @@
 #include "math/interpolate.hpp"
 #include "util/fextract.hpp"
 #include <gcem.hpp>
+#include "util/BC.hpp"
 
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
@@ -435,7 +435,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AccretionProblem> sim(BCs_cc);

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -435,7 +435,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<AccretionProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<AccretionProblem> sim(BCs_cc);

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -254,7 +254,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<TestParticle>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<TestParticle>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<TestParticle> sim(BCs_cc);

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -241,19 +241,6 @@ template <> void QuokkaSimulation<TestParticle>::computeAfterEvolve(amrex::Vecto
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<TestParticle>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<TestParticle>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<TestParticle>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
 	auto BCs_cc = quokka::BC<TestParticle>(quokka::BCType::reflecting);
 
 	// Problem initialization

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -6,6 +6,7 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
@@ -253,7 +254,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<TestParticle>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<TestParticle>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<TestParticle> sim(BCs_cc);

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -253,19 +253,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = Physics_Indices<TestParticle>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<TestParticle>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<TestParticle> sim(BCs_cc);

--- a/src/problems/ParticleRadiation/particle_radiation.cpp
+++ b/src/problems/ParticleRadiation/particle_radiation.cpp
@@ -11,6 +11,7 @@
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/valarray.hpp"
+#include "util/BC.hpp"
 
 struct ParticleRadiationProblem {
 };
@@ -200,7 +201,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleRadiationProblem> sim(BCs_cc);

--- a/src/problems/ParticleRadiation/particle_radiation.cpp
+++ b/src/problems/ParticleRadiation/particle_radiation.cpp
@@ -176,7 +176,7 @@ template <> void QuokkaSimulation<ParticleRadiationProblem>::setInitialCondition
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleRadiationProblem> sim(BCs_cc);

--- a/src/problems/ParticleRadiation/particle_radiation.cpp
+++ b/src/problems/ParticleRadiation/particle_radiation.cpp
@@ -10,8 +10,8 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/valarray.hpp"
 #include "util/BC.hpp"
+#include "util/valarray.hpp"
 
 struct ParticleRadiationProblem {
 };

--- a/src/problems/ParticleRadiation/particle_radiation.cpp
+++ b/src/problems/ParticleRadiation/particle_radiation.cpp
@@ -176,31 +176,6 @@ template <> void QuokkaSimulation<ParticleRadiationProblem>::setInitialCondition
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == RadSystem<ParticleRadiationProblem>::x1GasMomentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleRadiationProblem>::x2GasMomentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == RadSystem<ParticleRadiationProblem>::x3GasMomentum_index) && (dim == 2)) {
-			return true;
-		}
-		// Check radiation flux components
-		for (int g = 0; g < Physics_Traits<ParticleRadiationProblem>::nGroups; ++g) {
-			if ((n == RadSystem<ParticleRadiationProblem>::x1RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 0)) {
-				return true;
-			}
-			if ((n == RadSystem<ParticleRadiationProblem>::x2RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 1)) {
-				return true;
-			}
-			if ((n == RadSystem<ParticleRadiationProblem>::x3RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 2)) {
-				return true;
-			}
-		}
-		return false;
-	};
-
 	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization

--- a/src/problems/ParticleRadiation/particle_radiation.cpp
+++ b/src/problems/ParticleRadiation/particle_radiation.cpp
@@ -200,19 +200,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = RadSystem<ParticleRadiationProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<ParticleRadiationProblem>(quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleRadiationProblem> sim(BCs_cc);

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -86,15 +86,7 @@ template <> void QuokkaSimulation<ParticleSFProblem>::ErrorEst(int lev, amrex::T
 auto problem_main() -> int
 {
 
-	const int ncomp_cc = Physics_Indices<ParticleSFProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// periodic boundaries
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ParticleSFProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleSFProblem> sim(BCs_cc);

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -9,6 +9,7 @@
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
 #include "AMReX_SPACE.H"
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "fundamental_constants.H"

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -87,7 +87,7 @@ template <> void QuokkaSimulation<ParticleSFProblem>::ErrorEst(int lev, amrex::T
 auto problem_main() -> int
 {
 
-	auto BCs_cc = quokka::BC<ParticleSFProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ParticleSFProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleSFProblem> sim(BCs_cc);

--- a/src/problems/ParticleSink/test_particle_sink.cpp
+++ b/src/problems/ParticleSink/test_particle_sink.cpp
@@ -114,7 +114,7 @@ template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxA
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BCType::reflecting);
 
 	amrex::ParmParse const pp("problem");
 	pp.query("particles_file", particles_file);

--- a/src/problems/ParticleSink/test_particle_sink.cpp
+++ b/src/problems/ParticleSink/test_particle_sink.cpp
@@ -15,6 +15,7 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
+#include "util/BC.hpp"
 
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
@@ -113,36 +114,7 @@ template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxA
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<SinkProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<SinkProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<SinkProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<SinkProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// // periodic boundaries
-			// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			// octant symmetry
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BoundaryCondition::reflecting);
 
 	amrex::ParmParse const pp("problem");
 	pp.query("particles_file", particles_file);

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -14,6 +14,7 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
+#include "util/BC.hpp"
 
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
@@ -110,36 +111,7 @@ template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxA
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<SinkProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<SinkProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<SinkProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<SinkProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// periodic boundaries
-			// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			// octant symmetry
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<SinkProblem> sim(BCs_cc);

--- a/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
+++ b/src/problems/ParticleSinkFormation/test_particle_sink_formation.cpp
@@ -111,7 +111,7 @@ template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxA
 
 auto problem_main() -> int
 {
-	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<SinkProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<SinkProblem> sim(BCs_cc);

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -10,7 +10,6 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"
@@ -23,6 +22,7 @@
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -247,16 +247,7 @@ template <> void QuokkaSimulation<ScalarProblem>::refineGrid(int lev, amrex::Tag
 auto problem_main() -> int
 {
 	// Problem parameters
-	const int ncomp_cc = Physics_Indices<ScalarProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::int_dir); // periodic
-		BCs_cc[0].setHi(0, amrex::BCType::int_dir);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ScalarProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<ScalarProblem> sim(BCs_cc);

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -247,7 +247,7 @@ template <> void QuokkaSimulation<ScalarProblem>::refineGrid(int lev, amrex::Tag
 auto problem_main() -> int
 {
 	// Problem parameters
-	auto BCs_cc = quokka::BC<ScalarProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<ScalarProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<ScalarProblem> sim(BCs_cc);

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -21,8 +21,8 @@
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 using amrex::Real;
 

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -441,7 +441,7 @@ auto problem_main() -> int
 	pp.query("cloud_omega", omega_sphere);
 
 	// Set boundary conditions - extrapolate
-	auto BCs_cc = quokka::BC<PopIII>(amrex::BCType::foextrap);
+	auto BCs_cc = quokka::BC<PopIII>(quokka::BCType::foextrap);
 
 	// Problem initialization
 	QuokkaSimulation<PopIII> sim(BCs_cc);

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -8,8 +8,8 @@
 /// Author: Piyush Sharda (Leiden University, 2023)
 ///
 #include "hydro/hydro_system.hpp"
-#include "util/BC.hpp"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 #include <array>
 #include <fstream>
 

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -8,6 +8,7 @@
 /// Author: Piyush Sharda (Leiden University, 2023)
 ///
 #include "hydro/hydro_system.hpp"
+#include "util/BC.hpp"
 #include "math/interpolate.hpp"
 #include <array>
 #include <fstream>
@@ -439,15 +440,8 @@ auto problem_main() -> int
 	Real omega_sphere{};
 	pp.query("cloud_omega", omega_sphere);
 
-	// boundary conditions
-	const int ncomp_cc = Physics_Indices<PopIII>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap);
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-		}
-	}
+	// Set boundary conditions - extrapolate
+	auto BCs_cc = quokka::BC<PopIII>(amrex::BCType::foextrap);
 
 	// Problem initialization
 	QuokkaSimulation<PopIII> sim(BCs_cc);

--- a/src/problems/PrimordialChem/test_primordial_chem.cpp
+++ b/src/problems/PrimordialChem/test_primordial_chem.cpp
@@ -9,6 +9,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 #include <array>
 #include <fmt/format.h>
 #include <random>
@@ -250,21 +251,8 @@ auto problem_main() -> int
 	const double max_time = 5e16; // > 1 Gyr
 	const int max_timesteps = 5;
 
-	// Problem initialization
-	constexpr int ncomp_cc = Physics_Indices<PrimordialChemTest>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
-#if AMREX_SPACEDIM >= 2
-		BCs_cc[n].setLo(1, amrex::BCType::foextrap);
-		BCs_cc[n].setHi(1, amrex::BCType::foextrap);
-#endif
-#if AMREX_SPACEDIM == 3
-		BCs_cc[n].setLo(2, amrex::BCType::foextrap);
-		BCs_cc[n].setHi(2, amrex::BCType::foextrap);
-#endif
-	}
+	// Set boundary conditions - extrapolate
+	auto BCs_cc = quokka::BC<PrimordialChemTest>(amrex::BCType::foextrap);
 
 	QuokkaSimulation<PrimordialChemTest> sim(BCs_cc);
 

--- a/src/problems/PrimordialChem/test_primordial_chem.cpp
+++ b/src/problems/PrimordialChem/test_primordial_chem.cpp
@@ -252,7 +252,7 @@ auto problem_main() -> int
 	const int max_timesteps = 5;
 
 	// Set boundary conditions - extrapolate
-	auto BCs_cc = quokka::BC<PrimordialChemTest>(amrex::BCType::foextrap);
+	auto BCs_cc = quokka::BC<PrimordialChemTest>(quokka::BCType::foextrap);
 
 	QuokkaSimulation<PrimordialChemTest> sim(BCs_cc);
 

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -15,6 +15,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -278,13 +278,13 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<BeamProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- inflow
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
-		BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // left x2 -- inflow
-		BCs_cc[n].setHi(1, amrex::BCType::foextrap); // right x2 -- extrapolate
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- inflow
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(1, quokka::BCType::ext_dir);  // left x2 -- inflow
+		BCs_cc[n].setHi(1, quokka::BCType::foextrap); // right x2 -- extrapolate
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
+		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -13,9 +13,9 @@
 #include "AMReX_REAL.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadBeam/test_radiation_beam.cpp
+++ b/src/problems/RadBeam/test_radiation_beam.cpp
@@ -279,13 +279,13 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<BeamProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- inflow
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
-		BCs_cc[n].setLo(1, quokka::BCType::ext_dir);  // left x2 -- inflow
-		BCs_cc[n].setHi(1, quokka::BCType::foextrap); // right x2 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- inflow
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // left x2 -- inflow
+		BCs_cc[n].setHi(1, amrex::BCType::foextrap); // right x2 -- extrapolate
 #if (AMREX_SPACEDIM == 3)
-		BCs_cc[n].setLo(2, quokka::BCType::int_dir); // periodic
-		BCs_cc[n].setHi(2, quokka::BCType::int_dir);
+		BCs_cc[n].setLo(2, amrex::BCType::int_dir); // periodic
+		BCs_cc[n].setHi(2, amrex::BCType::int_dir);
 #endif
 	}
 

--- a/src/problems/RadDust/test_rad_dust.cpp
+++ b/src/problems/RadDust/test_rad_dust.cpp
@@ -5,9 +5,9 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_Print.H"
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "fundamental_constants.H"
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
@@ -151,14 +151,7 @@ auto problem_main() -> int
 	const double CFL_number_gas = 0.8;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<DustProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<DustProblem>(amrex::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<DustProblem> sim(BCs_cc);

--- a/src/problems/RadDust/test_rad_dust.cpp
+++ b/src/problems/RadDust/test_rad_dust.cpp
@@ -7,11 +7,11 @@
 #endif
 #include "AMReX_Print.H"
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "fundamental_constants.H"
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>

--- a/src/problems/RadDust/test_rad_dust.cpp
+++ b/src/problems/RadDust/test_rad_dust.cpp
@@ -151,7 +151,7 @@ auto problem_main() -> int
 	const double CFL_number_gas = 0.8;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<DustProblem>(amrex::BCType::int_dir); // periodic
+	auto BCs_cc = quokka::BC<DustProblem>(quokka::BCType::int_dir); // periodic
 
 	// Problem initialization
 	QuokkaSimulation<DustProblem> sim(BCs_cc);

--- a/src/problems/RadDustMG/test_rad_dust_MG.cpp
+++ b/src/problems/RadDustMG/test_rad_dust_MG.cpp
@@ -175,7 +175,7 @@ auto problem_main() -> int
 	const double CFL_number_gas = 0.8;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<DustProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<DustProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<DustProblem> sim(BCs_cc);

--- a/src/problems/RadDustMG/test_rad_dust_MG.cpp
+++ b/src/problems/RadDustMG/test_rad_dust_MG.cpp
@@ -12,6 +12,7 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_dust_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
@@ -174,14 +175,7 @@ auto problem_main() -> int
 	const double CFL_number_gas = 0.8;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<DustProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<DustProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<DustProblem> sim(BCs_cc);

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -11,10 +11,10 @@
 #include "util/matplotlibcpp.h"
 #endif
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <cstdint>
 #include <fmt/format.h>
 #include <string>
-#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_BC_TYPES.H"

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -183,13 +183,13 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		// for x-axis:
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap);
 		// for y-, z- axes:
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			// periodic
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir);
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -184,13 +184,13 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		// for x-axis:
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap);
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
 		// for y-, z- axes:
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			// periodic
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir);
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadForce/test_radiation_force.cpp
+++ b/src/problems/RadForce/test_radiation_force.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <fmt/format.h>
 #include <string>
+#include "util/BC.hpp"
 
 #include "AMReX.H"
 #include "AMReX_BC_TYPES.H"

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -201,7 +201,7 @@ auto problem_main() -> int
 	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<CoolingProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<CoolingProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<CoolingProblem> sim(BCs_cc);

--- a/src/problems/RadLineCooling/test_rad_line_cooling.cpp
+++ b/src/problems/RadLineCooling/test_rad_line_cooling.cpp
@@ -9,6 +9,7 @@
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_dust_system.hpp"
+#include "util/BC.hpp"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
@@ -200,14 +201,7 @@ auto problem_main() -> int
 	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<CoolingProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<CoolingProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<CoolingProblem> sim(BCs_cc);

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -9,6 +9,7 @@
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_dust_system.hpp"
+#include "util/BC.hpp"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
@@ -200,14 +201,7 @@ auto problem_main() -> int
 	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<CoolingProblemMG>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<CoolingProblemMG>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<CoolingProblemMG> sim(BCs_cc);

--- a/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
+++ b/src/problems/RadLineCoolingMG/test_rad_line_cooling_MG.cpp
@@ -201,7 +201,7 @@ auto problem_main() -> int
 	const double the_dt = 1.0e-2;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<CoolingProblemMG>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<CoolingProblemMG>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<CoolingProblemMG> sim(BCs_cc);

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -115,7 +115,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 							   amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/, const amrex::BCRec *bcr,
 							   int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 
@@ -214,11 +214,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_; // NOLINT(cppcoreguidelines-init-variables)
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -15,6 +15,7 @@
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -12,10 +12,10 @@
 #endif
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -116,7 +116,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 							   amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/, const amrex::BCRec *bcr,
 							   int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
+	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
 		return;
 	}
 

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -215,11 +215,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_; // NOLINT(cppcoreguidelines-init-variables)
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshak/test_radiation_marshak.cpp
+++ b/src/problems/RadMarshak/test_radiation_marshak.cpp
@@ -116,7 +116,7 @@ AMRSimulation<SuOlsonProblem>::setCustomBoundaryConditions(const amrex::IntVect 
 							   amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/, const amrex::BCRec *bcr,
 							   int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -215,11 +215,11 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				quokka::BCType::ext_dir);     // custom (Marshak) x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+				amrex::BCType::ext_dir);     // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -13,9 +13,9 @@
 #include "AMReX_BLassert.H"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "util/fextract.hpp"

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -15,6 +15,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "util/fextract.hpp"

--- a/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/test_radiation_marshak_asymptotic.cpp
@@ -214,11 +214,11 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir);     // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+				quokka::BCType::ext_dir);     // custom (Marshak) x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -18,6 +18,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "radiation/radiation_system.hpp"
 #include "simulation.hpp"

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -114,7 +114,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 							      int /*numcomp*/, amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/,
 							      const amrex::BCRec *bcr, int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
+	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
 		return;
 	}
 

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -113,7 +113,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 							      int /*numcomp*/, amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/,
 							      const amrex::BCRec *bcr, int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 
@@ -224,11 +224,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblemCgs>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -225,11 +225,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<SuOlsonProblemCgs>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // custom (Marshak) x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -16,9 +16,9 @@
 #include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "radiation/radiation_system.hpp"
 #include "simulation.hpp"

--- a/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
+++ b/src/problems/RadMarshakCGS/test_radiation_marshak_cgs.cpp
@@ -114,7 +114,7 @@ AMRSimulation<SuOlsonProblemCgs>::setCustomBoundaryConditions(const amrex::IntVe
 							      int /*numcomp*/, amrex::GeometryData const & /*geom*/, const amrex::Real /*time*/,
 							      const amrex::BCRec *bcr, int /*bcomp*/, int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -203,11 +203,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -13,10 +13,10 @@
 #include "AMReX.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_dust_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
-#include "util/BC.hpp"
 
 struct MarshakProblem {
 };

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -16,6 +16,7 @@
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
+#include "util/BC.hpp"
 
 struct MarshakProblem {
 };

--- a/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
+++ b/src/problems/RadMarshakDust/test_radiation_marshak_dust.cpp
@@ -202,11 +202,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -203,11 +203,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -204,11 +204,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -13,10 +13,10 @@
 #include "AMReX.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_dust_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
-#include "util/BC.hpp"
 
 struct MarshakProblem {
 };

--- a/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
+++ b/src/problems/RadMarshakDustPE/test_radiation_marshak_dust_and_PE.cpp
@@ -16,6 +16,7 @@
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
+#include "util/BC.hpp"
 
 struct MarshakProblem {
 };

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -269,11 +269,11 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				quokka::BCType::ext_dir);     // custom (Marshak) x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+				amrex::BCType::ext_dir);     // custom (Marshak) x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -10,6 +10,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -268,11 +268,11 @@ auto problem_main() -> int
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
 		BCs_cc[n].setLo(0,
-				amrex::BCType::ext_dir);     // custom (Marshak) x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+				quokka::BCType::ext_dir);     // custom (Marshak) x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
+++ b/src/problems/RadMarshakVaytet/test_radiation_marshak_Vaytet.cpp
@@ -8,9 +8,9 @@
 #include "AMReX_BLassert.H"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -17,8 +17,8 @@
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct CouplingProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -158,7 +158,7 @@ auto problem_main() -> int
 	const double constant_dt = 1.0e-8; // s
 
 	// Problem initialization
-	auto BCs_cc = quokka::BC<CouplingProblem>(amrex::BCType::foextrap); // extrapolate
+	auto BCs_cc = quokka::BC<CouplingProblem>(quokka::BCType::foextrap); // extrapolate
 
 	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 

--- a/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
+++ b/src/problems/RadMatterCoupling/test_radiation_matter_coupling.cpp
@@ -15,11 +15,10 @@
 #include <fmt/format.h>
 #include <vector>
 
-#include "AMReX_BC_TYPES.H"
-
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct CouplingProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -159,14 +158,7 @@ auto problem_main() -> int
 	const double constant_dt = 1.0e-8; // s
 
 	// Problem initialization
-	constexpr int ncomp_cc = Physics_Indices<CouplingProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap); // extrapolate
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-		}
-	}
+	auto BCs_cc = quokka::BC<CouplingProblem>(amrex::BCType::foextrap); // extrapolate
 
 	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -10,6 +10,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 #include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
@@ -159,15 +160,8 @@ auto problem_main() -> int
 	const int max_timesteps = 1e6;
 	const double constant_dt = 1.0e-8; // s
 
-	// Problem initialization
-	constexpr int ncomp_cc = Physics_Indices<CouplingProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap); // extrapolate
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-		}
-	}
+	// Set boundary conditions - extrapolate
+	auto BCs_cc = quokka::BC<CouplingProblem>(amrex::BCType::foextrap);
 
 	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -161,7 +161,7 @@ auto problem_main() -> int
 	const double constant_dt = 1.0e-8; // s
 
 	// Set boundary conditions - extrapolate
-	auto BCs_cc = quokka::BC<CouplingProblem>(amrex::BCType::foextrap);
+	auto BCs_cc = quokka::BC<CouplingProblem>(quokka::BCType::foextrap);
 
 	QuokkaSimulation<CouplingProblem> sim(BCs_cc);
 

--- a/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
+++ b/src/problems/RadMatterCouplingRSLA/test_radiation_matter_coupling_rsla.cpp
@@ -10,10 +10,10 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "util/BC.hpp"
 #include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #ifdef HAVE_PYTHON

--- a/src/problems/RadParticle/test_radparticle.cpp
+++ b/src/problems/RadParticle/test_radparticle.cpp
@@ -127,7 +127,7 @@ auto problem_main() -> int
 	const int max_timesteps = 5000;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<ParticleProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/RadParticle/test_radparticle.cpp
+++ b/src/problems/RadParticle/test_radparticle.cpp
@@ -15,6 +15,7 @@
 #include "particles/PhysicsParticles.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 
@@ -126,14 +127,7 @@ auto problem_main() -> int
 	const int max_timesteps = 5000;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<ParticleProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir); // periodic
-		}
-	}
+	auto BCs_cc = quokka::BC<ParticleProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/RadParticle2D/test_radparticle_2D.cpp
+++ b/src/problems/RadParticle2D/test_radparticle_2D.cpp
@@ -107,7 +107,7 @@ auto problem_main() -> int
 	const double dt_max = 1e-2;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<ParticleProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ParticleProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/RadParticle2D/test_radparticle_2D.cpp
+++ b/src/problems/RadParticle2D/test_radparticle_2D.cpp
@@ -7,6 +7,7 @@
 #endif
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 
 struct ParticleProblem {
@@ -106,14 +107,7 @@ auto problem_main() -> int
 	const double dt_max = 1e-2;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<ParticleProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir); // periodic
-		}
-	}
+	auto BCs_cc = quokka::BC<ParticleProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ParticleProblem> sim(BCs_cc);

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -218,16 +218,16 @@ auto problem_main() -> int
 
 	amrex::Vector<amrex::BCRec> BCs_cc(Physics_Indices<ShadowProblem>::nvarTotal_cc);
 	for (int n = 0; n < Physics_Indices<ShadowProblem>::nvarTotal_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- streaming
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- streaming
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
+				BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
 			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
+				BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
 			}
 			// extrapolate upper
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
+			BCs_cc[n].setHi(i, quokka::BCType::foextrap);
 		}
 	}
 

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -16,9 +16,9 @@
 #include "AMReX_REAL.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -18,6 +18,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"

--- a/src/problems/RadShadow/test_radiation_shadow.cpp
+++ b/src/problems/RadShadow/test_radiation_shadow.cpp
@@ -219,16 +219,16 @@ auto problem_main() -> int
 
 	amrex::Vector<amrex::BCRec> BCs_cc(Physics_Indices<ShadowProblem>::nvarTotal_cc);
 	for (int n = 0; n < Physics_Indices<ShadowProblem>::nvarTotal_cc; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- streaming
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- streaming
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
-				BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
+				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
 			} else {
-				BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
+				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
 			}
 			// extrapolate upper
-			BCs_cc[n].setHi(i, quokka::BCType::foextrap);
+			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
 		}
 	}
 

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -13,10 +13,10 @@
 #include "AMReX.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
-#include "util/BC.hpp"
 
 struct StreamingProblem {
 };

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -176,11 +176,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<StreamingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -175,11 +175,11 @@ auto problem_main() -> int
 	constexpr int nvars = RadSystem<StreamingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
 	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(i, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 		}
 	}
 

--- a/src/problems/RadStreaming/test_radiation_streaming.cpp
+++ b/src/problems/RadStreaming/test_radiation_streaming.cpp
@@ -16,6 +16,7 @@
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
+#include "util/BC.hpp"
 
 struct StreamingProblem {
 };

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -180,15 +180,15 @@ auto problem_main() -> int
 	for (int n = 0; n < nvars; ++n) {
 		// assert at compile time
 		if constexpr (direction == 0) {
-			BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
-			BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
-			BCs_cc[n].setLo(1, amrex::BCType::int_dir);  // periodic
-			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
+			BCs_cc[n].setLo(1, quokka::BCType::int_dir);  // periodic
+			BCs_cc[n].setHi(1, quokka::BCType::int_dir);
 		} else {
-			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-			BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // Dirichlet x1
-			BCs_cc[n].setHi(1, amrex::BCType::foextrap); // extrapolate x1
+			BCs_cc[n].setLo(0, quokka::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(0, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(1, quokka::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setHi(1, quokka::BCType::foextrap); // extrapolate x1
 		}
 	}
 

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -17,6 +17,7 @@
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
+#include "util/BC.hpp"
 
 struct StreamingProblem {
 };

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -181,15 +181,15 @@ auto problem_main() -> int
 	for (int n = 0; n < nvars; ++n) {
 		// assert at compile time
 		if constexpr (direction == 0) {
-			BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // Dirichlet x1
-			BCs_cc[n].setHi(0, quokka::BCType::foextrap); // extrapolate x1
-			BCs_cc[n].setLo(1, quokka::BCType::int_dir);  // periodic
-			BCs_cc[n].setHi(1, quokka::BCType::int_dir);
+			BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setHi(0, amrex::BCType::foextrap); // extrapolate x1
+			BCs_cc[n].setLo(1, amrex::BCType::int_dir);  // periodic
+			BCs_cc[n].setHi(1, amrex::BCType::int_dir);
 		} else {
-			BCs_cc[n].setLo(0, quokka::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(0, quokka::BCType::int_dir);
-			BCs_cc[n].setLo(1, quokka::BCType::ext_dir);  // Dirichlet x1
-			BCs_cc[n].setHi(1, quokka::BCType::foextrap); // extrapolate x1
+			BCs_cc[n].setLo(0, amrex::BCType::int_dir); // periodic
+			BCs_cc[n].setHi(0, amrex::BCType::int_dir);
+			BCs_cc[n].setLo(1, amrex::BCType::ext_dir);  // Dirichlet x1
+			BCs_cc[n].setHi(1, amrex::BCType::foextrap); // extrapolate x1
 		}
 	}
 

--- a/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
+++ b/src/problems/RadStreamingY/test_radiation_streaming_y.cpp
@@ -14,10 +14,10 @@
 #include "AMReX_BLassert.H"
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
 #include <fmt/format.h>
-#include "util/BC.hpp"
 
 struct StreamingProblem {
 };

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -190,7 +190,7 @@ auto problem_main() -> int
 	const double max_time = 10.0;	// dimensionless time
 	// const double max_time = 3.16228;	  // dimensionless time
 
-	auto BCs_cc = quokka::BC<MarshakProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<MarshakProblem>(quokka::BCType::reflecting);
 
 	QuokkaSimulation<MarshakProblem> sim(BCs_cc);
 

--- a/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
+++ b/src/problems/RadSuOlson/test_radiation_SuOlson.cpp
@@ -29,6 +29,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 
 struct MarshakProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -189,41 +190,7 @@ auto problem_main() -> int
 	const double max_time = 10.0;	// dimensionless time
 	// const double max_time = 3.16228;	  // dimensionless time
 
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == RadSystem<MarshakProblem>::x1RadFlux_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == RadSystem<MarshakProblem>::x2RadFlux_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == RadSystem<MarshakProblem>::x3RadFlux_index) && (dim == 2)) {
-			return true;
-		}
-		if ((n == RadSystem<MarshakProblem>::x1GasMomentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == RadSystem<MarshakProblem>::x2GasMomentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == RadSystem<MarshakProblem>::x3GasMomentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	constexpr int nvars = RadSystem<MarshakProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	auto BCs_cc = quokka::BC<MarshakProblem>(quokka::BoundaryCondition::reflecting);
 
 	QuokkaSimulation<MarshakProblem> sim(BCs_cc);
 

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -266,16 +266,16 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<TophatProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- Marshak
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- Marshak
+		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
+				BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
 			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
+				BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
 			}
 			// extrapolate upper
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
+			BCs_cc[n].setHi(i, quokka::BCType::foextrap);
 		}
 	}
 

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -18,9 +18,9 @@
 #include "QuokkaSimulation.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -20,6 +20,7 @@
 #include "radiation/radiation_system.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "radiation/radiation_system.hpp"

--- a/src/problems/RadTophat/test_radiation_tophat.cpp
+++ b/src/problems/RadTophat/test_radiation_tophat.cpp
@@ -267,16 +267,16 @@ auto problem_main() -> int
 	constexpr int ncomp_cc = Physics_Indices<TophatProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[n].setLo(0, quokka::BCType::ext_dir);  // left x1 -- Marshak
-		BCs_cc[n].setHi(0, quokka::BCType::foextrap); // right x1 -- extrapolate
+		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);  // left x1 -- Marshak
+		BCs_cc[n].setHi(0, amrex::BCType::foextrap); // right x1 -- extrapolate
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			if (isNormalComp(n, i)) { // reflect lower
-				BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
+				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
 			} else {
-				BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
+				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
 			}
 			// extrapolate upper
-			BCs_cc[n].setHi(i, quokka::BCType::foextrap);
+			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
 		}
 	}
 

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -28,6 +28,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 
 struct TubeProblem {
 };
@@ -266,17 +267,7 @@ auto problem_main() -> int
 	constexpr double tmax = Lx / a0;
 	constexpr int max_timesteps = 2000;
 
-	// Boundary conditions
-	constexpr int nvars = RadSystem<TubeProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir); // Dirichlet x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir); // Dirichlet x1
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<TubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<TubeProblem> sim(BCs_cc);

--- a/src/problems/RadTube/test_radiation_tube.cpp
+++ b/src/problems/RadTube/test_radiation_tube.cpp
@@ -267,7 +267,7 @@ auto problem_main() -> int
 	constexpr double tmax = Lx / a0;
 	constexpr int max_timesteps = 2000;
 
-	auto BCs_cc = quokka::BC<TubeProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<TubeProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<TubeProblem> sim(BCs_cc);

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -9,6 +9,7 @@
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include <cmath>
 #include <fmt/format.h>
 #include <fstream>
@@ -205,14 +206,7 @@ auto problem_main() -> int
 	const double max_dt = 1.0;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<PulseProblem> sim(BCs_cc);

--- a/src/problems/RadhydroBB/test_radhydro_bb.cpp
+++ b/src/problems/RadhydroBB/test_radhydro_bb.cpp
@@ -206,7 +206,7 @@ auto problem_main() -> int
 	const double max_dt = 1.0;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<PulseProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<PulseProblem> sim(BCs_cc);

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -203,7 +203,7 @@ auto problem_main() -> int
 
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
-	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<PulseProblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -11,10 +11,10 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 struct PulseProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
+++ b/src/problems/RadhydroPulse/test_radhydro_pulse.cpp
@@ -14,6 +14,7 @@
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 struct PulseProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -202,18 +203,7 @@ auto problem_main() -> int
 
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
-	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		// periodic boundary condition in the x-direction will not work
-		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -203,7 +203,7 @@ auto problem_main() -> int
 
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
-	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<PulseProblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -11,10 +11,10 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 struct PulseProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
+++ b/src/problems/RadhydroPulseDyn/test_radhydro_pulse_dyn.cpp
@@ -14,6 +14,7 @@
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 struct PulseProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -202,18 +203,7 @@ auto problem_main() -> int
 
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
-	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		// periodic boundary condition in the x-direction will not work
-		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -11,6 +11,7 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
@@ -200,14 +201,7 @@ auto problem_main() -> int
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
+++ b/src/problems/RadhydroPulseGrey/test_radhydro_pulse_grey.cpp
@@ -201,7 +201,7 @@ auto problem_main() -> int
 	const double max_dt = 1e-3; // t_cr = 2 cm / cs = 7e-8 s
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<PulseProblem>(quokka::BCType::int_dir);
 
 	// Problem 1: non-advecting pulse
 

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -15,6 +15,7 @@
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include "util/BC.hpp"
 
 // Single-group problem
 struct SGProblem {
@@ -247,18 +248,7 @@ auto problem_main() -> int
 
 	// Problem 1: pulse with grey radiation
 
-	// Boundary conditions
-	constexpr int nvars = RadSystem<SGProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		// periodic boundary condition in the x-direction will not work
-		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc[n].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<SGProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<SGProblem> sim(BCs_cc);
@@ -308,18 +298,7 @@ auto problem_main() -> int
 
 	// Problem 2: advecting pulse
 
-	// Boundary conditions
-	constexpr int nvars2 = RadSystem<MGproblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc2(nvars2);
-	for (int n = 0; n < nvars2; ++n) {
-		// periodic boundary condition in the x-direction will not work
-		BCs_cc2[n].setLo(0, amrex::BCType::foextrap); // extrapolate
-		BCs_cc2[n].setHi(0, amrex::BCType::foextrap);
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc2[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc2[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc2 = quokka::BC<MGproblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<MGproblem> sim2(BCs_cc2);

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -248,7 +248,7 @@ auto problem_main() -> int
 
 	// Problem 1: pulse with grey radiation
 
-	auto BCs_cc = quokka::BC<SGProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<SGProblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<SGProblem> sim(BCs_cc);
@@ -298,7 +298,7 @@ auto problem_main() -> int
 
 	// Problem 2: advecting pulse
 
-	auto BCs_cc2 = quokka::BC<MGproblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc2 = quokka::BC<MGproblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<MGproblem> sim2(BCs_cc2);

--- a/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
+++ b/src/problems/RadhydroPulseMGconst/test_radhydro_pulse_MG_const_kappa.cpp
@@ -12,10 +12,10 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
-#include "util/BC.hpp"
 
 // Single-group problem
 struct SGProblem {

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -14,6 +14,7 @@
 #include "physics_info.hpp"
 #include "radiation/planck_integral.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
@@ -304,14 +305,7 @@ auto problem_main() -> int
 	amrex::ParmParse const pp("rad");
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<MGProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<MGProblem>(amrex::BCType::int_dir);
 
 	// Problem 1: advecting pulse with multigroup integration
 

--- a/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
+++ b/src/problems/RadhydroPulseMGint/test_radhydro_pulse_MG_int.cpp
@@ -305,7 +305,7 @@ auto problem_main() -> int
 	amrex::ParmParse const pp("rad");
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<MGProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MGProblem>(quokka::BCType::int_dir);
 
 	// Problem 1: advecting pulse with multigroup integration
 

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -322,19 +322,19 @@ auto problem_main() -> int
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if constexpr (simulate_full_box) {
 				// periodic boundaries (not recommended for this problem)
-				// BCs_cc[n].setLo(i, quokka::BCType::int_dir);
-				// BCs_cc[n].setHi(i, quokka::BCType::int_dir);
+				// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
+				// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
 				// outflow boundaries
-				BCs_cc[n].setLo(i, quokka::BCType::foextrap);
-				BCs_cc[n].setHi(i, quokka::BCType::foextrap);
+				BCs_cc[n].setLo(i, amrex::BCType::foextrap);
+				BCs_cc[n].setHi(i, amrex::BCType::foextrap);
 			} else {
 				// reflecting boundaries, outflow boundaries
 				if (isNormalComp(n, i)) {
-					BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
-					BCs_cc[n].setHi(i, quokka::BCType::foextrap); // outflow
+					BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
+					BCs_cc[n].setHi(i, amrex::BCType::foextrap); // outflow
 				} else {
-					BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
-					BCs_cc[n].setHi(i, quokka::BCType::foextrap); // outflow
+					BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
+					BCs_cc[n].setHi(i, amrex::BCType::foextrap); // outflow
 				}
 			}
 		}

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -17,8 +17,8 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
-#include <fstream>
 #include "util/BC.hpp"
+#include <fstream>
 
 #include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -18,6 +18,7 @@
 #include "hydro/hydro_system.hpp"
 #include "math/interpolate.hpp"
 #include <fstream>
+#include "util/BC.hpp"
 
 #include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -321,19 +321,19 @@ auto problem_main() -> int
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			if constexpr (simulate_full_box) {
 				// periodic boundaries (not recommended for this problem)
-				// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-				// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
+				// BCs_cc[n].setLo(i, quokka::BCType::int_dir);
+				// BCs_cc[n].setHi(i, quokka::BCType::int_dir);
 				// outflow boundaries
-				BCs_cc[n].setLo(i, amrex::BCType::foextrap);
-				BCs_cc[n].setHi(i, amrex::BCType::foextrap);
+				BCs_cc[n].setLo(i, quokka::BCType::foextrap);
+				BCs_cc[n].setHi(i, quokka::BCType::foextrap);
 			} else {
 				// reflecting boundaries, outflow boundaries
 				if (isNormalComp(n, i)) {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-					BCs_cc[n].setHi(i, amrex::BCType::foextrap); // outflow
+					BCs_cc[n].setLo(i, quokka::BCType::reflect_odd);
+					BCs_cc[n].setHi(i, quokka::BCType::foextrap); // outflow
 				} else {
-					BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-					BCs_cc[n].setHi(i, amrex::BCType::foextrap); // outflow
+					BCs_cc[n].setLo(i, quokka::BCType::reflect_even);
+					BCs_cc[n].setHi(i, quokka::BCType::foextrap); // outflow
 				}
 			}
 		}

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -22,6 +22,7 @@
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -239,16 +240,7 @@ auto problem_main() -> int
 	const double max_dt = max_dtau / c_s0;
 	const double max_time = max_tau / c_s0;
 
-	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -21,8 +21,8 @@
 #include "AMReX_ParallelDescriptor.H"
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -112,7 +112,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
+	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
 		return;
 	}
 

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -112,7 +112,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 
@@ -240,7 +240,7 @@ auto problem_main() -> int
 	const double max_dt = max_dtau / c_s0;
 	const double max_time = max_tau / c_s0;
 
-	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShockProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroShock/test_radhydro_shock.cpp
+++ b/src/problems/RadhydroShock/test_radhydro_shock.cpp
@@ -112,7 +112,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -113,7 +113,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -22,8 +22,8 @@
 #include "AMReX_BC_TYPES.H"
 
 #include "util/ArrayUtil.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -113,7 +113,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != amrex::BCType::ext_dir) && (bcr->hi(0) != amrex::BCType::ext_dir)) {
+	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
 		return;
 	}
 
@@ -241,7 +241,7 @@ auto problem_main() -> int
 	//  const double max_dt = max_dtau / c_s0;
 	const double max_time = 1.0e-9; // 9.08e-10; // s
 
-	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShockProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -23,6 +23,7 @@
 
 #include "util/ArrayUtil.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -240,16 +241,7 @@ auto problem_main() -> int
 	//  const double max_dt = max_dtau / c_s0;
 	const double max_time = 1.0e-9; // 9.08e-10; // s
 
-	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
+++ b/src/problems/RadhydroShockCGS/test_radhydro_shock_cgs.cpp
@@ -113,7 +113,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if ((bcr->lo(0) != quokka::BCType::ext_dir) && (bcr->hi(0) != quokka::BCType::ext_dir)) {
+	if ((bcr->lo(0) != static_cast<int>(quokka::BCType::ext_dir)) && (bcr->hi(0) != static_cast<int>(quokka::BCType::ext_dir))) {
 		return;
 	}
 

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -106,7 +106,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if (!((bcr->lo(0) == amrex::BCType::ext_dir) || (bcr->hi(0) == amrex::BCType::ext_dir))) { // NOLINT
+	if (!((bcr->lo(0) == quokka::BCType::ext_dir) || (bcr->hi(0) == quokka::BCType::ext_dir))) { // NOLINT
 		return;
 	}
 
@@ -236,7 +236,7 @@ auto problem_main() -> int
 	//  const double max_dt = max_dtau / c_s0;
 	const double max_time = 1.0e-9; // 9.08e-10; // s
 
-	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<ShockProblem>(quokka::BCType::ext_dir, quokka::BCType::int_dir, quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -18,8 +18,8 @@
 
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
-#include "util/fextract.hpp"
 #include "util/BC.hpp"
+#include "util/fextract.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -106,7 +106,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if (!((bcr->lo(0) == static_cast<int>(quokka::BCType::ext_dir)) || (bcr->hi(0) == static_cast<int>(quokka::BCType::ext_dir)))) { // NOLINT
+	if (!((bcr->lo(0) == quokka::BCType::ext_dir) || (bcr->hi(0) == quokka::BCType::ext_dir))) { // NOLINT
 		return;
 	}
 

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -106,7 +106,7 @@ AMRSimulation<ShockProblem>::setCustomBoundaryConditions(const amrex::IntVect &i
 							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec *bcr, int /*bcomp*/,
 							 int /*orig_comp*/)
 {
-	if (!((bcr->lo(0) == quokka::BCType::ext_dir) || (bcr->hi(0) == quokka::BCType::ext_dir))) { // NOLINT
+	if (!((bcr->lo(0) == static_cast<int>(quokka::BCType::ext_dir)) || (bcr->hi(0) == static_cast<int>(quokka::BCType::ext_dir)))) { // NOLINT
 		return;
 	}
 

--- a/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/test_radhydro_shock_multigroup.cpp
@@ -19,6 +19,7 @@
 #include "radiation/radiation_system.hpp"
 #include "util/ArrayUtil.hpp"
 #include "util/fextract.hpp"
+#include "util/BC.hpp"
 
 struct ShockProblem {
 }; // dummy type to allow compile-type polymorphism via template specialization
@@ -235,16 +236,7 @@ auto problem_main() -> int
 	//  const double max_dt = max_dtau / c_s0;
 	const double max_time = 1.0e-9; // 9.08e-10; // s
 
-	constexpr int nvars = RadSystem<ShockProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		BCs_cc[n].setLo(0, amrex::BCType::ext_dir);	    // custom x1
-		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);	    // custom x1
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {	    // x2- and x3- directions
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<ShockProblem>(amrex::BCType::ext_dir, amrex::BCType::int_dir, amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<ShockProblem> sim(BCs_cc);

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -154,7 +154,7 @@ auto problem_main() -> int
 	const double max_dt = 1.0;
 
 	// Boundary conditions
-	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
+	auto BCs_cc = quokka::BC<PulseProblem>(quokka::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<PulseProblem> sim(BCs_cc);

--- a/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/test_radhydro_uniform_advecting.cpp
@@ -11,6 +11,7 @@
 #include "math/interpolate.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <fmt/format.h>
 #include <fstream>
@@ -153,14 +154,7 @@ auto problem_main() -> int
 	const double max_dt = 1.0;
 
 	// Boundary conditions
-	constexpr int nvars = RadSystem<PulseProblem>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-	}
+	auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::int_dir);
 
 	// Problem initialization
 	QuokkaSimulation<PulseProblem> sim(BCs_cc);

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -23,12 +23,12 @@
 #include <fmt/format.h>
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "cooling/GrackleLikeCooling.hpp"
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "math/quadrature.hpp"
 #include "physics_info.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -309,9 +309,7 @@ auto problem_main() -> int
 	pp.query("use_periodic_bc", use_periodic_bc);
 
 	// Problem initialization
-	auto BCs_cc = (use_periodic_bc == 1) ? 
-			quokka::BC<RandomBlast>(amrex::BCType::int_dir) :
-			quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = (use_periodic_bc == 1) ? quokka::BC<RandomBlast>(amrex::BCType::int_dir) : quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
 
 	QuokkaSimulation<RandomBlast> sim(BCs_cc);
 	sim.densityFloor_ = 1.0e-5 * rho0; // density floor (to prevent vacuum)

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -309,7 +309,7 @@ auto problem_main() -> int
 	pp.query("use_periodic_bc", use_periodic_bc);
 
 	// Problem initialization
-	auto BCs_cc = (use_periodic_bc == 1) ? quokka::BC<RandomBlast>(quokka::BCType::int_dir) : quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = (use_periodic_bc == 1) ? quokka::BC<RandomBlast>(quokka::BCType::int_dir) : quokka::BC<RandomBlast>(quokka::BCType::reflecting);
 
 	QuokkaSimulation<RandomBlast> sim(BCs_cc);
 	sim.densityFloor_ = 1.0e-5 * rho0; // density floor (to prevent vacuum)

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -309,7 +309,7 @@ auto problem_main() -> int
 	pp.query("use_periodic_bc", use_periodic_bc);
 
 	// Problem initialization
-	auto BCs_cc = (use_periodic_bc == 1) ? quokka::BC<RandomBlast>(amrex::BCType::int_dir) : quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = (use_periodic_bc == 1) ? quokka::BC<RandomBlast>(quokka::BCType::int_dir) : quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
 
 	QuokkaSimulation<RandomBlast> sim(BCs_cc);
 	sim.densityFloor_ = 1.0e-5 * rho0; // density floor (to prevent vacuum)

--- a/src/problems/RandomBlast/blast.cpp
+++ b/src/problems/RandomBlast/blast.cpp
@@ -7,7 +7,6 @@
 /// \brief Implements the random blast problem with radiative cooling.
 ///
 #include "AMReX.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLProfiler.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_FabArray.H"
@@ -24,6 +23,7 @@
 #include <fmt/format.h>
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "cooling/GrackleLikeCooling.hpp"
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
@@ -309,37 +309,9 @@ auto problem_main() -> int
 	pp.query("use_periodic_bc", use_periodic_bc);
 
 	// Problem initialization
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<RandomBlast>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<RandomBlast>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<RandomBlast>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int nvars = HydroSystem<RandomBlast>::nvar_;
-	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (use_periodic_bc == 1) { // periodic boundaries
-				BCs_cc[n].setLo(idim, amrex::BCType::int_dir);
-				BCs_cc[n].setHi(idim, amrex::BCType::int_dir);
-			} else { // reflecting boundaries
-				if (isNormalComp(n, idim)) {
-					BCs_cc[n].setLo(idim, amrex::BCType::reflect_odd);
-					BCs_cc[n].setHi(idim, amrex::BCType::reflect_odd);
-				} else {
-					BCs_cc[n].setLo(idim, amrex::BCType::reflect_even);
-					BCs_cc[n].setHi(idim, amrex::BCType::reflect_even);
-				}
-			}
-		}
-	}
+	auto BCs_cc = (use_periodic_bc == 1) ? 
+			quokka::BC<RandomBlast>(amrex::BCType::int_dir) :
+			quokka::BC<RandomBlast>(quokka::BoundaryCondition::reflecting);
 
 	QuokkaSimulation<RandomBlast> sim(BCs_cc);
 	sim.densityFloor_ = 1.0e-5 * rho0; // density floor (to prevent vacuum)

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -168,7 +168,7 @@ template <> void QuokkaSimulation<RTProblem>::refineGrid(int lev, amrex::TagBoxA
 auto problem_main() -> int
 {
 	// Set boundary conditions: periodic in x, reflecting in y and z
-	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir,		    // x: periodic
+	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir,		    // x: periodic
 					    quokka::BoundaryCondition::reflecting,  // y: reflecting
 					    quokka::BoundaryCondition::reflecting); // z: reflecting
 

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -19,6 +19,7 @@
 #include "AMReX_ParmParse.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
 
 struct RTProblem {
@@ -166,38 +167,10 @@ template <> void QuokkaSimulation<RTProblem>::refineGrid(int lev, amrex::TagBoxA
 
 auto problem_main() -> int
 {
-	// Set boundary conditions
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<RTProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<RTProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<RTProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<RTProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		// periodic in x-direction
-		BCs_cc[n].setLo(0, amrex::BCType::int_dir);
-		BCs_cc[n].setHi(0, amrex::BCType::int_dir);
-
-		// reflecting in y- and z- directions
-		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	// Set boundary conditions: periodic in x, reflecting in y and z
+	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir,                        // x: periodic
+	                                     quokka::BoundaryCondition::reflecting,        // y: reflecting
+	                                     quokka::BoundaryCondition::reflecting);       // z: reflecting
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -168,8 +168,8 @@ template <> void QuokkaSimulation<RTProblem>::refineGrid(int lev, amrex::TagBoxA
 auto problem_main() -> int
 {
 	// Set boundary conditions: periodic in x, reflecting in y and z
-	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir,		    // x: periodic
-					    quokka::BCType::reflecting,  // y: reflecting
+	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir,	 // x: periodic
+					    quokka::BCType::reflecting,	 // y: reflecting
 					    quokka::BCType::reflecting); // z: reflecting
 
 	// Problem initialization

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -169,8 +169,8 @@ auto problem_main() -> int
 {
 	// Set boundary conditions: periodic in x, reflecting in y and z
 	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir,		    // x: periodic
-					    quokka::BoundaryCondition::reflecting,  // y: reflecting
-					    quokka::BoundaryCondition::reflecting); // z: reflecting
+					    quokka::BCType::reflecting,  // y: reflecting
+					    quokka::BCType::reflecting); // z: reflecting
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -19,8 +19,8 @@
 #include "AMReX_ParmParse.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
+#include "util/BC.hpp"
 
 struct RTProblem {
 };
@@ -168,9 +168,9 @@ template <> void QuokkaSimulation<RTProblem>::refineGrid(int lev, amrex::TagBoxA
 auto problem_main() -> int
 {
 	// Set boundary conditions: periodic in x, reflecting in y and z
-	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir,                        // x: periodic
-	                                     quokka::BoundaryCondition::reflecting,        // y: reflecting
-	                                     quokka::BoundaryCondition::reflecting);       // z: reflecting
+	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir,		    // x: periodic
+					    quokka::BoundaryCondition::reflecting,  // y: reflecting
+					    quokka::BoundaryCondition::reflecting); // z: reflecting
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -21,6 +21,7 @@
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
+#include "util/BC.hpp"
 
 struct RTProblem {
 };
@@ -210,25 +211,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	const int ncomp_cc = Physics_Indices<RTProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		// periodic in x- and y-directions
-		for (int i = 0; i < (AMREX_SPACEDIM - 1); ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-		}
-
-		// reflecting in z- direction
-		int const i = AMREX_SPACEDIM - 1;
-		if (isNormalComp(n, i)) {
-			BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-			BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-		} else {
-			BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-			BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-		}
-	}
+	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir, amrex::BCType::int_dir, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -198,19 +198,6 @@ template <> void QuokkaSimulation<RTProblem>::computeAfterTimestep()
 auto problem_main() -> int
 {
 	// Set boundary conditions
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<RTProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<RTProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<RTProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
 	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir, quokka::BCType::int_dir, quokka::BCType::reflecting);
 
 	// Problem initialization

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -211,7 +211,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<RTProblem>(amrex::BCType::int_dir, amrex::BCType::int_dir, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir, quokka::BCType::int_dir, quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -211,7 +211,7 @@ auto problem_main() -> int
 		return false;
 	};
 
-	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir, quokka::BCType::int_dir, quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<RTProblem>(quokka::BCType::int_dir, quokka::BCType::int_dir, quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<RTProblem> sim(BCs_cc);

--- a/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
+++ b/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
@@ -12,11 +12,11 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
-#include "util/BC.hpp"
 #include "cooling/GrackleLikeCooling.hpp"
 #include "cooling/ResampledCooling.hpp"
 #include "cooling/TabulatedCooling.hpp"
 #include "math/interpolate.hpp"
+#include "util/BC.hpp"
 #include <fmt/format.h>
 #include <fstream>
 #include <iomanip>

--- a/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
+++ b/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
@@ -12,6 +12,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "util/BC.hpp"
 #include "cooling/GrackleLikeCooling.hpp"
 #include "cooling/ResampledCooling.hpp"
 #include "cooling/TabulatedCooling.hpp"
@@ -172,15 +173,8 @@ auto problem_main() -> int
 	std::string output_csv_file;
 	pp.query("output_csv_file", output_csv_file);
 
-	// Problem initialization
-	constexpr int ncomp_cc = Physics_Indices<ResampledCoolingTest>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap); // extrapolate
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-		}
-	}
+	// Set boundary conditions - extrapolate
+	auto BCs_cc = quokka::BC<ResampledCoolingTest>(amrex::BCType::foextrap);
 
 	QuokkaSimulation<ResampledCoolingTest> sim(BCs_cc);
 

--- a/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
+++ b/src/problems/ResampledCoolingTest/test_resampled_cooling.cpp
@@ -174,7 +174,7 @@ auto problem_main() -> int
 	pp.query("output_csv_file", output_csv_file);
 
 	// Set boundary conditions - extrapolate
-	auto BCs_cc = quokka::BC<ResampledCoolingTest>(amrex::BCType::foextrap);
+	auto BCs_cc = quokka::BC<ResampledCoolingTest>(quokka::BCType::foextrap);
 
 	QuokkaSimulation<ResampledCoolingTest> sim(BCs_cc);
 

--- a/src/problems/SN/test_SN.cpp
+++ b/src/problems/SN/test_SN.cpp
@@ -155,7 +155,7 @@ template <> void QuokkaSimulation<SNProblem>::computeAfterTimestep()
 auto problem_main() -> int
 {
 	// Set boundary conditions - octant symmetry (reflecting)
-	auto BCs_cc = quokka::BC<SNProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<SNProblem>(quokka::BCType::reflecting);
 
 	// get n_amb from the input file
 	amrex::ParmParse const pp("problem");

--- a/src/problems/SN/test_SN.cpp
+++ b/src/problems/SN/test_SN.cpp
@@ -15,6 +15,7 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
+#include "util/BC.hpp"
 
 struct SNProblem {
 };
@@ -153,36 +154,8 @@ template <> void QuokkaSimulation<SNProblem>::computeAfterTimestep()
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<SNProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<SNProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<SNProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<SNProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			// // periodic boundaries
-			// BCs_cc[n].setLo(i, amrex::BCType::int_dir);
-			// BCs_cc[n].setHi(i, amrex::BCType::int_dir);
-			// octant symmetry
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	// Set boundary conditions - octant symmetry (reflecting)
+	auto BCs_cc = quokka::BC<SNProblem>(quokka::BoundaryCondition::reflecting);
 
 	// get n_amb from the input file
 	amrex::ParmParse const pp("problem");

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -899,9 +899,9 @@ auto problem_main() -> int
 {
 	// Problem initialization
 	// Set boundary conditions: ext_dir in x, periodic in y and z
-	auto boundaryConditions = quokka::BC<ShockCloud>(amrex::BCType::ext_dir,  // x: Dirichlet/NSCBC
-							 amrex::BCType::int_dir,  // y: periodic
-							 amrex::BCType::int_dir); // z: periodic
+	auto boundaryConditions = quokka::BC<ShockCloud>(quokka::BCType::ext_dir,  // x: Dirichlet/NSCBC
+							 quokka::BCType::int_dir,  // y: periodic
+							 quokka::BCType::int_dir); // z: periodic
 	QuokkaSimulation<ShockCloud> sim(boundaryConditions);
 
 	// Read problem parameters

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -24,6 +24,7 @@
 #include <fmt/format.h>
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "cooling/ResampledCooling.hpp"
 #include "cooling/TabulatedCooling.hpp"
 #include "fundamental_constants.H"
@@ -897,18 +898,10 @@ template <> void QuokkaSimulation<ShockCloud>::refineGrid(int lev, amrex::TagBox
 auto problem_main() -> int
 {
 	// Problem initialization
-	constexpr int nvars = QuokkaSimulation<ShockCloud>::nvarTotal_cc_;
-	amrex::Vector<amrex::BCRec> boundaryConditions(nvars);
-	for (int n = 0; n < nvars; ++n) {
-		boundaryConditions[n].setLo(0, amrex::BCType::ext_dir); // Dirichlet
-		boundaryConditions[n].setHi(0, amrex::BCType::ext_dir); // NSCBC outflow
-
-		boundaryConditions[n].setLo(1, amrex::BCType::int_dir); // periodic
-		boundaryConditions[n].setHi(1, amrex::BCType::int_dir);
-
-		boundaryConditions[n].setLo(2, amrex::BCType::int_dir);
-		boundaryConditions[n].setHi(2, amrex::BCType::int_dir);
-	}
+	// Set boundary conditions: ext_dir in x, periodic in y and z
+	auto boundaryConditions = quokka::BC<ShockCloud>(amrex::BCType::ext_dir,  // x: Dirichlet/NSCBC
+	                                                  amrex::BCType::int_dir,  // y: periodic
+	                                                  amrex::BCType::int_dir); // z: periodic
 	QuokkaSimulation<ShockCloud> sim(boundaryConditions);
 
 	// Read problem parameters

--- a/src/problems/ShockCloud/cloud.cpp
+++ b/src/problems/ShockCloud/cloud.cpp
@@ -24,7 +24,6 @@
 #include <fmt/format.h>
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "cooling/ResampledCooling.hpp"
 #include "cooling/TabulatedCooling.hpp"
 #include "fundamental_constants.H"
@@ -35,6 +34,7 @@
 #include "io/projection.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 
@@ -900,8 +900,8 @@ auto problem_main() -> int
 	// Problem initialization
 	// Set boundary conditions: ext_dir in x, periodic in y and z
 	auto boundaryConditions = quokka::BC<ShockCloud>(amrex::BCType::ext_dir,  // x: Dirichlet/NSCBC
-	                                                  amrex::BCType::int_dir,  // y: periodic
-	                                                  amrex::BCType::int_dir); // z: periodic
+							 amrex::BCType::int_dir,  // y: periodic
+							 amrex::BCType::int_dir); // z: periodic
 	QuokkaSimulation<ShockCloud> sim(boundaryConditions);
 
 	// Read problem parameters

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -22,8 +22,8 @@
 
 #include "AMReX_SPACE.H"
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
+#include "util/BC.hpp"
 
 struct CollapseProblem {
 };

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -141,7 +141,7 @@ template <> void QuokkaSimulation<CollapseProblem>::ComputeDerivedVar(int lev, s
 auto problem_main() -> int
 {
 	// boundary conditions
-	auto BCs_cc = quokka::BC<CollapseProblem>(quokka::BoundaryCondition::reflecting);
+	auto BCs_cc = quokka::BC<CollapseProblem>(quokka::BCType::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<CollapseProblem> sim(BCs_cc);

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -12,7 +12,6 @@
 #include <limits>
 
 #include "AMReX.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_Config.H"
 #include "AMReX_FabArrayUtility.H"
@@ -23,6 +22,7 @@
 
 #include "AMReX_SPACE.H"
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "hydro/hydro_system.hpp"
 
 struct CollapseProblem {
@@ -140,32 +140,8 @@ template <> void QuokkaSimulation<CollapseProblem>::ComputeDerivedVar(int lev, s
 
 auto problem_main() -> int
 {
-	auto isNormalComp = [=](int n, int dim) {
-		if ((n == HydroSystem<CollapseProblem>::x1Momentum_index) && (dim == 0)) {
-			return true;
-		}
-		if ((n == HydroSystem<CollapseProblem>::x2Momentum_index) && (dim == 1)) {
-			return true;
-		}
-		if ((n == HydroSystem<CollapseProblem>::x3Momentum_index) && (dim == 2)) {
-			return true;
-		}
-		return false;
-	};
-
-	const int ncomp_cc = Physics_Indices<CollapseProblem>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (isNormalComp(n, i)) {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-			} else {
-				BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-				BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-			}
-		}
-	}
+	// boundary conditions
+	auto BCs_cc = quokka::BC<CollapseProblem>(quokka::BoundaryCondition::reflecting);
 
 	// Problem initialization
 	QuokkaSimulation<CollapseProblem> sim(BCs_cc);

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -26,10 +26,10 @@
 #include "AMReX_TableData.H"
 
 #include "QuokkaSimulation.hpp"
-#include "util/BC.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "turbulence/TurbDataReader.hpp"
+#include "util/BC.hpp"
 
 using amrex::Real;
 

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -15,7 +15,6 @@
 
 #include "AMReX.H"
 #include "AMReX_Arena.H"
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_Config.H"
 #include "AMReX_FabArrayUtility.H"
@@ -27,6 +26,7 @@
 #include "AMReX_TableData.H"
 
 #include "QuokkaSimulation.hpp"
+#include "util/BC.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "turbulence/TurbDataReader.hpp"
@@ -224,14 +224,7 @@ auto problem_main() -> int
 	pp.query("virial_parameter", alpha_vir);
 
 	// boundary conditions
-	const int ncomp_cc = Physics_Indices<StarCluster>::nvarTotal_cc;
-	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-	for (int n = 0; n < ncomp_cc; ++n) {
-		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			BCs_cc[n].setLo(i, amrex::BCType::foextrap);
-			BCs_cc[n].setHi(i, amrex::BCType::foextrap);
-		}
-	}
+	auto BCs_cc = quokka::BC<StarCluster>(amrex::BCType::foextrap);
 
 	// Problem initialization
 	QuokkaSimulation<StarCluster> sim(BCs_cc);

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -224,7 +224,7 @@ auto problem_main() -> int
 	pp.query("virial_parameter", alpha_vir);
 
 	// boundary conditions
-	auto BCs_cc = quokka::BC<StarCluster>(amrex::BCType::foextrap);
+	auto BCs_cc = quokka::BC<StarCluster>(quokka::BCType::foextrap);
 
 	// Problem initialization
 	QuokkaSimulation<StarCluster> sim(BCs_cc);

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -1,105 +1,105 @@
 #ifndef BC_HPP_
 #define BC_HPP_
 
-#include "AMReX_BC_TYPES.H"
 #include "AMReX_BCRec.H"
+#include "AMReX_BC_TYPES.H"
 #include "AMReX_Vector.H"
 #include "hydro/hydro_system.hpp"
 #include "physics_numVars.hpp"
 #include "radiation/radiation_system.hpp"
 #include <array>
 
-namespace quokka {
+namespace quokka
+{
 
-namespace BoundaryCondition {
-    // Special boundary condition for reflecting walls
-    // Uses both reflect_odd and reflect_even depending on component
-    constexpr int reflecting = 8881;
+namespace BoundaryCondition
+{
+// Special boundary condition for reflecting walls
+// Uses both reflect_odd and reflect_even depending on component
+constexpr int reflecting = 8881;
 } // namespace BoundaryCondition
 
-namespace detail {
+namespace detail
+{
 
-    // Check if a component is a normal component (momentum or radiation flux) in a given dimension
-    template <typename problem_t>
-    constexpr bool isNormalComponent(int n, int dim) {
-        // Check radiation flux components if radiation is enabled
-        if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
-            // Check gas momentum components in RadSystem
-            if ((n == RadSystem<problem_t>::x1GasMomentum_index) && (dim == 0)) {
-                return true;
-            }
-            if ((n == RadSystem<problem_t>::x2GasMomentum_index) && (dim == 1)) {
-                return true;
-            }
-            if ((n == RadSystem<problem_t>::x3GasMomentum_index) && (dim == 2)) {
-                return true;
-            }
-            
-            // Check radiation flux components for all groups
-            for (int g = 0; g < Physics_Traits<problem_t>::nGroups; ++g) {
-                if ((n == RadSystem<problem_t>::x1RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 0)) {
-                    return true;
-                }
-                if ((n == RadSystem<problem_t>::x2RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 1)) {
-                    return true;
-                }
-                if ((n == RadSystem<problem_t>::x3RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 2)) {
-                    return true;
-                }
-            }
-        } else {
-        		// Check hydro momentum components
-            if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
-                return true;
-            }
-            if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
-                return true;
-            }
-            if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
-                return true;
-            }
-				}
-        
-        return false;
-    }
+// Check if a component is a normal component (momentum or radiation flux) in a given dimension
+template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
+{
+	// Check radiation flux components if radiation is enabled
+	if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
+		// Check gas momentum components in RadSystem
+		if ((n == RadSystem<problem_t>::x1GasMomentum_index) && (dim == 0)) {
+			return true;
+		}
+		if ((n == RadSystem<problem_t>::x2GasMomentum_index) && (dim == 1)) {
+			return true;
+		}
+		if ((n == RadSystem<problem_t>::x3GasMomentum_index) && (dim == 2)) {
+			return true;
+		}
+
+		// Check radiation flux components for all groups
+		for (int g = 0; g < Physics_Traits<problem_t>::nGroups; ++g) {
+			if ((n == RadSystem<problem_t>::x1RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 0)) {
+				return true;
+			}
+			if ((n == RadSystem<problem_t>::x2RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 1)) {
+				return true;
+			}
+			if ((n == RadSystem<problem_t>::x3RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 2)) {
+				return true;
+			}
+		}
+	} else {
+		// Check hydro momentum components
+		if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
+			return true;
+		}
+		if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
+			return true;
+		}
+		if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
+			return true;
+		}
+	}
+
+	return false;
+}
 } // namespace detail
 
 // Three parameter version - sets each dimension separately
-template <typename problem_t>
-amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z) {
-    const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
-    amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
-    
-    std::array<int, 3> bcs = {bc_x, bc_y, bc_z};
-    
-    for (int n = 0; n < ncomp_cc; ++n) {
-        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-            if (bcs[i] == BoundaryCondition::reflecting) {
-                // For reflecting boundaries, use reflect_odd for normal momentum components
-                // and reflect_even for all other components (including tangential momentum)
-                if (detail::isNormalComponent<problem_t>(n, i)) {
-                    BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
-                    BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
-                } else {
-                    BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
-                    BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
-                }
-            } else {
-                // For all other boundaries, use the AMReX BC type directly
-                BCs_cc[n].setLo(i, bcs[i]);
-                BCs_cc[n].setHi(i, bcs[i]);
-            }
-        }
-    }
-    
-    return BCs_cc;
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z)
+{
+	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+
+	std::array<int, 3> bcs = {bc_x, bc_y, bc_z};
+
+	for (int n = 0; n < ncomp_cc; ++n) {
+		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+			if (bcs[i] == BoundaryCondition::reflecting) {
+				// For reflecting boundaries, use reflect_odd for normal momentum components
+				// and reflect_even for all other components (including tangential momentum)
+				if (detail::isNormalComponent<problem_t>(n, i)) {
+					BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
+					BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
+				} else {
+					BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
+					BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
+				}
+			} else {
+				// For all other boundaries, use the AMReX BC type directly
+				BCs_cc[n].setLo(i, bcs[i]);
+				BCs_cc[n].setHi(i, bcs[i]);
+			}
+		}
+	}
+
+	return BCs_cc;
 }
 
 // Single parameter version - sets all dimensions to the same boundary condition
-template <typename problem_t>
-amrex::Vector<amrex::BCRec> BC(int bc) {
-    return BC<problem_t>(bc, bc, bc);
-}
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc) { return BC<problem_t>(bc, bc, bc); }
 
 } // namespace quokka
 

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -12,38 +12,34 @@
 namespace quokka
 {
 
-enum class BoundaryCondition : int
-{
+enum class BoundaryCondition : int {
 	// Standard AMReX boundary conditions (using actual amrex::BCType values, safe from AMReX changes)
-	bogus               = amrex::BCType::bogus,
-	reflect_odd         = amrex::BCType::reflect_odd,
-	int_dir             = amrex::BCType::int_dir,             // interior/periodic
-	reflect_even        = amrex::BCType::reflect_even,
-	foextrap            = amrex::BCType::foextrap,            // first order extrapolation
-	ext_dir             = amrex::BCType::ext_dir,             // external Dirichlet
-	hoextrap            = amrex::BCType::hoextrap,            // higher order extrapolation
-	hoextrapcc          = amrex::BCType::hoextrapcc,          // higher order extrapolation to cell center
-	ext_dir_cc          = amrex::BCType::ext_dir_cc,          // external Dirichlet at cell center
+	bogus = amrex::BCType::bogus,
+	reflect_odd = amrex::BCType::reflect_odd,
+	int_dir = amrex::BCType::int_dir, // interior/periodic
+	reflect_even = amrex::BCType::reflect_even,
+	foextrap = amrex::BCType::foextrap,	// first order extrapolation
+	ext_dir = amrex::BCType::ext_dir,	// external Dirichlet
+	hoextrap = amrex::BCType::hoextrap,	// higher order extrapolation
+	hoextrapcc = amrex::BCType::hoextrapcc, // higher order extrapolation to cell center
+	ext_dir_cc = amrex::BCType::ext_dir_cc, // external Dirichlet at cell center
 	direction_dependent = amrex::BCType::direction_dependent,
-	user_1              = amrex::BCType::user_1,
-	user_2              = amrex::BCType::user_2,
-	user_3              = amrex::BCType::user_3,
-	
+	user_1 = amrex::BCType::user_1,
+	user_2 = amrex::BCType::user_2,
+	user_3 = amrex::BCType::user_3,
+
 	// Quokka-specific boundary conditions (custom values, not conflicting with AMReX values)
-	reflecting          = 8881, // Special: uses reflect_odd/reflect_even based on component
-	// outflow_nscbc       = 8882, // Future: NSCBC outflow
-	// inflow_nscbc        = 8883, // Future: NSCBC inflow
-	// custom_wall         = 8884  // Future: custom wall treatment
+	reflecting = 8881, // Special: uses reflect_odd/reflect_even based on component
+			   // outflow_nscbc       = 8882, // Future: NSCBC outflow
+			   // inflow_nscbc        = 8883, // Future: NSCBC inflow
+			   // custom_wall         = 8884  // Future: custom wall treatment
 };
 
 namespace detail
 {
 
 // Implicit conversion function for clean syntax
-constexpr int toInt(BoundaryCondition bc) noexcept
-{
-	return static_cast<int>(bc);
-}
+constexpr int toInt(BoundaryCondition bc) noexcept { return static_cast<int>(bc); }
 
 // Check if a component is a normal component (momentum or radiation flux) in a given dimension
 template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
@@ -123,14 +119,14 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 }
 
 // Overloads for BoundaryCondition enum class - provides clean, type-safe syntax
-template <typename problem_t> 
-amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc) { 
-	return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc)); 
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc)
+{
+	return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc));
 }
 
-template <typename problem_t> 
-amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z) { 
-	return BC<problem_t>(detail::toInt(bc_x), detail::toInt(bc_y), detail::toInt(bc_z)); 
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z)
+{
+	return BC<problem_t>(detail::toInt(bc_x), detail::toInt(bc_y), detail::toInt(bc_z));
 }
 
 } // namespace quokka

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -6,7 +6,6 @@
 #include "AMReX_Vector.H"
 #include "hydro/hydro_system.hpp"
 #include <array>
-#include <radiation/radiation_system.hpp>
 
 namespace quokka {
 
@@ -37,7 +36,7 @@ namespace detail {
 // Three parameter version - sets each dimension separately
 template <typename problem_t>
 amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z) {
-    const int ncomp_cc = Physics_Indices<problem_t>::nvar_;
+    const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
     amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
     
     std::array<int, 3> bcs = {bc_x, bc_y, bc_z};

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -36,13 +36,13 @@ enum mathematicalBndryTypes : int {
 			   // inflow_nscbc = 8883, // Future: NSCBC inflow
 			   // custom_wall = 8884  // Future: custom wall treatment
 };
-}
+} // namespace BCType
 
 namespace detail
 {
 
 // Check if a component is a normal component (momentum or radiation flux) in a given dimension
-template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
+template <typename problem_t> constexpr auto isNormalComponent(int n, int dim) -> bool
 {
 	// Check radiation flux components if radiation is enabled
 	if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
@@ -87,7 +87,7 @@ template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
 } // namespace detail
 
 // Three parameter version - sets each dimension separately
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z)
+template <typename problem_t> auto BC(int bc_x, int bc_y, int bc_z) -> amrex::Vector<amrex::BCRec>
 {
 	const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
@@ -119,7 +119,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 }
 
 // Overloads for BCType enum - provides clean, type-safe syntax
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc) { return BC<problem_t>(bc, bc, bc); }
+template <typename problem_t> auto BC(int bc) -> amrex::Vector<amrex::BCRec> { return BC<problem_t>(bc, bc, bc); }
 
 // Note: BCType values implicitly convert to int, so we can use them directly with the int version
 // Usage: BC<Problem>(BCType::reflecting) or BC<Problem>(BCType::ext_dir, BCType::int_dir, BCType::reflecting)

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -12,15 +12,38 @@
 namespace quokka
 {
 
-namespace BoundaryCondition
+enum class BoundaryCondition : int
 {
-// Special boundary condition for reflecting walls
-// Uses both reflect_odd and reflect_even depending on component
-constexpr int reflecting = 8881;
-} // namespace BoundaryCondition
+	// Standard AMReX boundary conditions (using actual amrex::BCType values, safe from AMReX changes)
+	bogus               = amrex::BCType::bogus,
+	reflect_odd         = amrex::BCType::reflect_odd,
+	int_dir             = amrex::BCType::int_dir,             // interior/periodic
+	reflect_even        = amrex::BCType::reflect_even,
+	foextrap            = amrex::BCType::foextrap,            // first order extrapolation
+	ext_dir             = amrex::BCType::ext_dir,             // external Dirichlet
+	hoextrap            = amrex::BCType::hoextrap,            // higher order extrapolation
+	hoextrapcc          = amrex::BCType::hoextrapcc,          // higher order extrapolation to cell center
+	ext_dir_cc          = amrex::BCType::ext_dir_cc,          // external Dirichlet at cell center
+	direction_dependent = amrex::BCType::direction_dependent,
+	user_1              = amrex::BCType::user_1,
+	user_2              = amrex::BCType::user_2,
+	user_3              = amrex::BCType::user_3,
+	
+	// Quokka-specific boundary conditions (custom values, not conflicting with AMReX values)
+	reflecting          = 8881, // Special: uses reflect_odd/reflect_even based on component
+	// outflow_nscbc       = 8882, // Future: NSCBC outflow
+	// inflow_nscbc        = 8883, // Future: NSCBC inflow
+	// custom_wall         = 8884  // Future: custom wall treatment
+};
 
 namespace detail
 {
+
+// Implicit conversion function for clean syntax
+constexpr int toInt(BoundaryCondition bc) noexcept
+{
+	return static_cast<int>(bc);
+}
 
 // Check if a component is a normal component (momentum or radiation flux) in a given dimension
 template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
@@ -77,7 +100,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 
 	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (bcs[i] == BoundaryCondition::reflecting) {
+			if (bcs[i] == static_cast<int>(BoundaryCondition::reflecting)) {
 				// For reflecting boundaries, use reflect_odd for normal momentum components
 				// and reflect_even for all other components (including tangential momentum)
 				if (detail::isNormalComponent<problem_t>(n, i)) {
@@ -88,7 +111,8 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 					BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
 				}
 			} else {
-				// For all other boundaries, use the AMReX BC type directly
+				// For standard AMReX boundaries, use the BC type directly
+				// (quokka::BoundaryCondition values map directly to amrex::BCType values)
 				BCs_cc[n].setLo(i, bcs[i]);
 				BCs_cc[n].setHi(i, bcs[i]);
 			}
@@ -98,8 +122,16 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 	return BCs_cc;
 }
 
-// Single parameter version - sets all dimensions to the same boundary condition
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc) { return BC<problem_t>(bc, bc, bc); }
+// Overloads for BoundaryCondition enum class - provides clean, type-safe syntax
+template <typename problem_t> 
+amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc) { 
+	return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc)); 
+}
+
+template <typename problem_t> 
+amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z) { 
+	return BC<problem_t>(detail::toInt(bc_x), detail::toInt(bc_y), detail::toInt(bc_z)); 
+}
 
 } // namespace quokka
 

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -21,19 +21,6 @@ namespace detail {
     // Check if a component is a normal component (momentum or radiation flux) in a given dimension
     template <typename problem_t>
     constexpr bool isNormalComponent(int n, int dim) {
-        // Check hydro momentum components
-        if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
-            if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
-                return true;
-            }
-            if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
-                return true;
-            }
-            if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
-                return true;
-            }
-        }
-        
         // Check radiation flux components if radiation is enabled
         if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
             // Check gas momentum components in RadSystem
@@ -57,7 +44,18 @@ namespace detail {
             if ((n == RadSystem<problem_t>::x3RadFlux_index) && (dim == 2)) {
                 return true;
             }
-        }
+        } else {
+        		// Check hydro momentum components
+            if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
+                return true;
+            }
+            if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
+                return true;
+            }
+            if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
+                return true;
+            }
+				}
         
         return false;
     }

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -12,7 +12,8 @@
 namespace quokka
 {
 
-namespace BCType {
+namespace BCType
+{
 enum mathematicalBndryTypes : int {
 	// Standard AMReX boundary conditions (using actual amrex::BCType values, safe from AMReX changes)
 	bogus = amrex::BCType::bogus,
@@ -31,9 +32,9 @@ enum mathematicalBndryTypes : int {
 
 	// Quokka-specific boundary conditions (custom values, not conflicting with AMReX values)
 	reflecting = 8881, // Special: uses reflect_odd/reflect_even based on component
-	// outflow_nscbc = 8882, // Future: NSCBC outflow
-	// inflow_nscbc = 8883, // Future: NSCBC inflow
-	// custom_wall = 8884  // Future: custom wall treatment
+			   // outflow_nscbc = 8882, // Future: NSCBC outflow
+			   // inflow_nscbc = 8883, // Future: NSCBC inflow
+			   // custom_wall = 8884  // Future: custom wall treatment
 };
 }
 

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -9,33 +9,13 @@
 
 namespace quokka {
 
-enum class BoundaryCondition {
-    reflecting,  // Uses both reflect_odd and reflect_even depending on component
-    ext_dir,     // External Dirichlet boundary
-    int_dir,     // Internal/periodic boundary
-    foextrap,    // First-order extrapolation
-    hoextrap     // Higher-order extrapolation
-};
+namespace BoundaryCondition {
+    // Special boundary condition for reflecting walls
+    // Uses both reflect_odd and reflect_even depending on component
+    constexpr int reflecting = 8881;
+} // namespace BoundaryCondition
 
 namespace detail {
-    // Helper function to convert BoundaryCondition enum to AMReX BCType
-    constexpr int toAMReXBCType(BoundaryCondition bc) {
-        switch (bc) {
-            case BoundaryCondition::ext_dir:
-                return amrex::BCType::ext_dir;
-            case BoundaryCondition::int_dir:
-                return amrex::BCType::int_dir;
-            case BoundaryCondition::foextrap:
-                return amrex::BCType::foextrap;
-            case BoundaryCondition::hoextrap:
-                return amrex::BCType::hoextrap;
-            case BoundaryCondition::reflecting:
-                // This will be handled specially in the main function
-                return -999; // Placeholder
-            default:
-                return amrex::BCType::bogus;
-        }
-    }
 
     // Check if a component is a normal momentum component in a given dimension
     template <typename problem_t>
@@ -53,19 +33,13 @@ namespace detail {
     }
 } // namespace detail
 
-// Single parameter version - sets all dimensions to the same boundary condition
-template <typename problem_t>
-amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc) {
-    return BC<problem_t>(bc, bc, bc);
-}
-
 // Three parameter version - sets each dimension separately
 template <typename problem_t>
-amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z) {
+amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z) {
     const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
     amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
     
-    std::array<BoundaryCondition, 3> bcs = {bc_x, bc_y, bc_z};
+    std::array<int, 3> bcs = {bc_x, bc_y, bc_z};
     
     for (int n = 0; n < ncomp_cc; ++n) {
         for (int i = 0; i < AMREX_SPACEDIM; ++i) {
@@ -80,15 +54,20 @@ amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, B
                     BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
                 }
             } else {
-                // For non-reflecting boundaries, use the same BC type for all components
-                int amrex_bc_type = detail::toAMReXBCType(bcs[i]);
-                BCs_cc[n].setLo(i, amrex_bc_type);
-                BCs_cc[n].setHi(i, amrex_bc_type);
+                // For all other boundaries, use the AMReX BC type directly
+                BCs_cc[n].setLo(i, bcs[i]);
+                BCs_cc[n].setHi(i, bcs[i]);
             }
         }
     }
     
     return BCs_cc;
+}
+
+// Single parameter version - sets all dimensions to the same boundary condition
+template <typename problem_t>
+amrex::Vector<amrex::BCRec> BC(int bc) {
+    return BC<problem_t>(bc, bc, bc);
 }
 
 } // namespace quokka

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -12,7 +12,8 @@
 namespace quokka
 {
 
-enum class BCType : int {
+namespace BCType {
+enum mathematicalBndryTypes : int {
 	// Standard AMReX boundary conditions (using actual amrex::BCType values, safe from AMReX changes)
 	bogus = amrex::BCType::bogus,
 	reflect_odd = amrex::BCType::reflect_odd,
@@ -30,16 +31,14 @@ enum class BCType : int {
 
 	// Quokka-specific boundary conditions (custom values, not conflicting with AMReX values)
 	reflecting = 8881, // Special: uses reflect_odd/reflect_even based on component
-			   // outflow_nscbc       = 8882, // Future: NSCBC outflow
-			   // inflow_nscbc        = 8883, // Future: NSCBC inflow
-			   // custom_wall         = 8884  // Future: custom wall treatment
+	// outflow_nscbc = 8882, // Future: NSCBC outflow
+	// inflow_nscbc = 8883, // Future: NSCBC inflow
+	// custom_wall = 8884  // Future: custom wall treatment
 };
+}
 
 namespace detail
 {
-
-// Implicit conversion function for clean syntax
-constexpr int toInt(BCType bc) noexcept { return static_cast<int>(bc); }
 
 // Check if a component is a normal component (momentum or radiation flux) in a given dimension
 template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
@@ -96,7 +95,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 
 	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (bcs[i] == static_cast<int>(BCType::reflecting)) {
+			if (bcs[i] == BCType::reflecting) {
 				// For reflecting boundaries, use reflect_odd for normal momentum components
 				// and reflect_even for all other components (including tangential momentum)
 				if (detail::isNormalComponent<problem_t>(n, i)) {
@@ -118,13 +117,11 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 	return BCs_cc;
 }
 
-// Overloads for BCType enum class - provides clean, type-safe syntax
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc) { return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc)); }
+// Overloads for BCType enum - provides clean, type-safe syntax
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc) { return BC<problem_t>(bc, bc, bc); }
 
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc_x, BCType bc_y, BCType bc_z)
-{
-	return BC<problem_t>(detail::toInt(bc_x), detail::toInt(bc_y), detail::toInt(bc_z));
-}
+// Note: BCType values implicitly convert to int, so we can use them directly with the int version
+// Usage: BC<Problem>(BCType::reflecting) or BC<Problem>(BCType::ext_dir, BCType::int_dir, BCType::reflecting)
 
 } // namespace quokka
 

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -1,0 +1,96 @@
+#ifndef BC_HPP_
+#define BC_HPP_
+
+#include "AMReX_BC_TYPES.H"
+#include "AMReX_BCRec.H"
+#include "AMReX_Vector.H"
+#include "hydro/hydro_system.hpp"
+#include <array>
+
+namespace quokka {
+
+enum class BoundaryCondition {
+    reflecting,  // Uses both reflect_odd and reflect_even depending on component
+    ext_dir,     // External Dirichlet boundary
+    int_dir,     // Internal/periodic boundary
+    foextrap,    // First-order extrapolation
+    hoextrap     // Higher-order extrapolation
+};
+
+namespace detail {
+    // Helper function to convert BoundaryCondition enum to AMReX BCType
+    constexpr int toAMReXBCType(BoundaryCondition bc) {
+        switch (bc) {
+            case BoundaryCondition::ext_dir:
+                return amrex::BCType::ext_dir;
+            case BoundaryCondition::int_dir:
+                return amrex::BCType::int_dir;
+            case BoundaryCondition::foextrap:
+                return amrex::BCType::foextrap;
+            case BoundaryCondition::hoextrap:
+                return amrex::BCType::hoextrap;
+            case BoundaryCondition::reflecting:
+                // This will be handled specially in the main function
+                return -999; // Placeholder
+            default:
+                return amrex::BCType::bogus;
+        }
+    }
+
+    // Check if a component is a normal momentum component in a given dimension
+    template <typename problem_t>
+    constexpr bool isNormalMomentumComponent(int n, int dim) {
+        if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
+            return true;
+        }
+        if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
+            return true;
+        }
+        if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
+            return true;
+        }
+        return false;
+    }
+} // namespace detail
+
+// Single parameter version - sets all dimensions to the same boundary condition
+template <typename problem_t>
+amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc) {
+    return BC<problem_t>(bc, bc, bc);
+}
+
+// Three parameter version - sets each dimension separately
+template <typename problem_t>
+amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z) {
+    const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
+    amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
+    
+    std::array<BoundaryCondition, 3> bcs = {bc_x, bc_y, bc_z};
+    
+    for (int n = 0; n < ncomp_cc; ++n) {
+        for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+            if (bcs[i] == BoundaryCondition::reflecting) {
+                // For reflecting boundaries, use reflect_odd for normal momentum components
+                // and reflect_even for all other components (including tangential momentum)
+                if (detail::isNormalMomentumComponent<problem_t>(n, i)) {
+                    BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
+                    BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
+                } else {
+                    BCs_cc[n].setLo(i, amrex::BCType::reflect_even);
+                    BCs_cc[n].setHi(i, amrex::BCType::reflect_even);
+                }
+            } else {
+                // For non-reflecting boundaries, use the same BC type for all components
+                int amrex_bc_type = detail::toAMReXBCType(bcs[i]);
+                BCs_cc[n].setLo(i, amrex_bc_type);
+                BCs_cc[n].setHi(i, amrex_bc_type);
+            }
+        }
+    }
+    
+    return BCs_cc;
+}
+
+} // namespace quokka
+
+#endif // BC_HPP_

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -5,6 +5,7 @@
 #include "AMReX_BCRec.H"
 #include "AMReX_Vector.H"
 #include "hydro/hydro_system.hpp"
+#include "physics_numVars.hpp"
 #include "radiation/radiation_system.hpp"
 #include <array>
 
@@ -34,15 +35,17 @@ namespace detail {
                 return true;
             }
             
-            // Check radiation flux components
-            if ((n == RadSystem<problem_t>::x1RadFlux_index) && (dim == 0)) {
-                return true;
-            }
-            if ((n == RadSystem<problem_t>::x2RadFlux_index) && (dim == 1)) {
-                return true;
-            }
-            if ((n == RadSystem<problem_t>::x3RadFlux_index) && (dim == 2)) {
-                return true;
+            // Check radiation flux components for all groups
+            for (int g = 0; g < Physics_Traits<problem_t>::nGroups; ++g) {
+                if ((n == RadSystem<problem_t>::x1RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 0)) {
+                    return true;
+                }
+                if ((n == RadSystem<problem_t>::x2RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 1)) {
+                    return true;
+                }
+                if ((n == RadSystem<problem_t>::x3RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) && (dim == 2)) {
+                    return true;
+                }
             }
         } else {
         		// Check hydro momentum components

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -119,10 +119,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 }
 
 // Overloads for BCType enum class - provides clean, type-safe syntax
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc)
-{
-	return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc));
-}
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc) { return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc)); }
 
 template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc_x, BCType bc_y, BCType bc_z)
 {

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -12,7 +12,7 @@
 namespace quokka
 {
 
-enum class BoundaryCondition : int {
+enum class BCType : int {
 	// Standard AMReX boundary conditions (using actual amrex::BCType values, safe from AMReX changes)
 	bogus = amrex::BCType::bogus,
 	reflect_odd = amrex::BCType::reflect_odd,
@@ -39,7 +39,7 @@ namespace detail
 {
 
 // Implicit conversion function for clean syntax
-constexpr int toInt(BoundaryCondition bc) noexcept { return static_cast<int>(bc); }
+constexpr int toInt(BCType bc) noexcept { return static_cast<int>(bc); }
 
 // Check if a component is a normal component (momentum or radiation flux) in a given dimension
 template <typename problem_t> constexpr bool isNormalComponent(int n, int dim)
@@ -96,7 +96,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 
 	for (int n = 0; n < ncomp_cc; ++n) {
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-			if (bcs[i] == static_cast<int>(BoundaryCondition::reflecting)) {
+			if (bcs[i] == static_cast<int>(BCType::reflecting)) {
 				// For reflecting boundaries, use reflect_odd for normal momentum components
 				// and reflect_even for all other components (including tangential momentum)
 				if (detail::isNormalComponent<problem_t>(n, i)) {
@@ -108,7 +108,7 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 				}
 			} else {
 				// For standard AMReX boundaries, use the BC type directly
-				// (quokka::BoundaryCondition values map directly to amrex::BCType values)
+				// (quokka::BCType values map directly to amrex::BCType values)
 				BCs_cc[n].setLo(i, bcs[i]);
 				BCs_cc[n].setHi(i, bcs[i]);
 			}
@@ -118,13 +118,13 @@ template <typename problem_t> amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y,
 	return BCs_cc;
 }
 
-// Overloads for BoundaryCondition enum class - provides clean, type-safe syntax
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc)
+// Overloads for BCType enum class - provides clean, type-safe syntax
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc)
 {
 	return BC<problem_t>(detail::toInt(bc), detail::toInt(bc), detail::toInt(bc));
 }
 
-template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BoundaryCondition bc_x, BoundaryCondition bc_y, BoundaryCondition bc_z)
+template <typename problem_t> amrex::Vector<amrex::BCRec> BC(BCType bc_x, BCType bc_y, BCType bc_z)
 {
 	return BC<problem_t>(detail::toInt(bc_x), detail::toInt(bc_y), detail::toInt(bc_z));
 }

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -6,6 +6,7 @@
 #include "AMReX_Vector.H"
 #include "hydro/hydro_system.hpp"
 #include <array>
+#include <radiation/radiation_system.hpp>
 
 namespace quokka {
 
@@ -36,7 +37,7 @@ namespace detail {
 // Three parameter version - sets each dimension separately
 template <typename problem_t>
 amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z) {
-    const int ncomp_cc = Physics_Indices<problem_t>::nvarTotal_cc;
+    const int ncomp_cc = Physics_Indices<problem_t>::nvar_;
     amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
     
     std::array<int, 3> bcs = {bc_x, bc_y, bc_z};

--- a/src/util/BC.hpp
+++ b/src/util/BC.hpp
@@ -5,6 +5,7 @@
 #include "AMReX_BCRec.H"
 #include "AMReX_Vector.H"
 #include "hydro/hydro_system.hpp"
+#include "radiation/radiation_system.hpp"
 #include <array>
 
 namespace quokka {
@@ -17,18 +18,47 @@ namespace BoundaryCondition {
 
 namespace detail {
 
-    // Check if a component is a normal momentum component in a given dimension
+    // Check if a component is a normal component (momentum or radiation flux) in a given dimension
     template <typename problem_t>
-    constexpr bool isNormalMomentumComponent(int n, int dim) {
-        if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
-            return true;
+    constexpr bool isNormalComponent(int n, int dim) {
+        // Check hydro momentum components
+        if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
+            if ((n == HydroSystem<problem_t>::x1Momentum_index) && (dim == 0)) {
+                return true;
+            }
+            if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
+                return true;
+            }
+            if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
+                return true;
+            }
         }
-        if ((n == HydroSystem<problem_t>::x2Momentum_index) && (dim == 1)) {
-            return true;
+        
+        // Check radiation flux components if radiation is enabled
+        if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
+            // Check gas momentum components in RadSystem
+            if ((n == RadSystem<problem_t>::x1GasMomentum_index) && (dim == 0)) {
+                return true;
+            }
+            if ((n == RadSystem<problem_t>::x2GasMomentum_index) && (dim == 1)) {
+                return true;
+            }
+            if ((n == RadSystem<problem_t>::x3GasMomentum_index) && (dim == 2)) {
+                return true;
+            }
+            
+            // Check radiation flux components
+            if ((n == RadSystem<problem_t>::x1RadFlux_index) && (dim == 0)) {
+                return true;
+            }
+            if ((n == RadSystem<problem_t>::x2RadFlux_index) && (dim == 1)) {
+                return true;
+            }
+            if ((n == RadSystem<problem_t>::x3RadFlux_index) && (dim == 2)) {
+                return true;
+            }
         }
-        if ((n == HydroSystem<problem_t>::x3Momentum_index) && (dim == 2)) {
-            return true;
-        }
+        
         return false;
     }
 } // namespace detail
@@ -46,7 +76,7 @@ amrex::Vector<amrex::BCRec> BC(int bc_x, int bc_y, int bc_z) {
             if (bcs[i] == BoundaryCondition::reflecting) {
                 // For reflecting boundaries, use reflect_odd for normal momentum components
                 // and reflect_even for all other components (including tangential momentum)
-                if (detail::isNormalMomentumComponent<problem_t>(n, i)) {
+                if (detail::isNormalComponent<problem_t>(n, i)) {
                     BCs_cc[n].setLo(i, amrex::BCType::reflect_odd);
                     BCs_cc[n].setHi(i, amrex::BCType::reflect_odd);
                 } else {


### PR DESCRIPTION
A simpler version of #1313 . Use traditional enum `quokka::BCType` the same way as `amrex::BCType`, so no conversion is required. In the enum class approach, we always have to do `static_cast<int>` for BC comparison anyway. The extra type protection brought by enum class is not useful, so it's better just keep it simple. 

### Description
One-liner `BCs_cc` definition:

Same BC in all three directions:
```
auto BCs_cc = quokka::BC<ParticleProblem>(amrex::BCType::int_dir);
```

Different BC in different directions:
```
auto BCs_cc = quokka::BC<PulseProblem>(amrex::BCType::foextrap, amrex::BCType::int_dir, amrex::BCType::int_dir);
```

Changes:
- Created `util/BC.hpp` for easier BC generation. 
- Updated all test problems to use this new API. Some test problems use mixed BC for upper and lower bound and this new API does not apply, so I kept them as unchanged. I don't plan to deal with them right now. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
