### PR TITLE
Update regression tests

### DIFF
--- a/inputs/SphericalCollapseAMR_regression.in
+++ b/inputs/SphericalCollapseAMR_regression.in
@@ -22,7 +22,7 @@ amr.grid_eff        = 1.0
 
 hydro.reconstruction_order = 3  # PPM
 cfl = 0.25
-max_timesteps = 1
+max_timesteps = 1000
 stop_time = 0.05
 
 derived_vars = gpot

--- a/inputs/SphericalCollapseAMR_regression.in
+++ b/inputs/SphericalCollapseAMR_regression.in
@@ -1,0 +1,40 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -0.6  -0.6 -0.6 
+geometry.prob_hi     =  0.6  0.6  0.6
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 128 128 128
+amr.max_level       = 1     # number of levels = max_level + 1
+amr.blocking_factor = 32    # grid size must be divisible by this
+amr.max_grid_size   = 64    # at least 128 for GPUs
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 1.0
+
+hydro.reconstruction_order = 3  # PPM
+cfl = 0.25
+max_timesteps = 1
+stop_time = 0.05
+
+derived_vars = gpot
+
+do_reflux = 1
+do_subcycle = 0
+do_tracers = 0          # turn on tracer particles
+
+ascent_interval = -1
+plotfile_interval = 200
+particle_csv_interval = -1
+checkpoint_interval = -1
+
+problem.num_particles = 1000000
+problem.seed = 42123

--- a/inputs/SphericalCollapse_regression.in
+++ b/inputs/SphericalCollapse_regression.in
@@ -1,0 +1,40 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -0.6  -0.6 -0.6 
+geometry.prob_hi     =  0.6  0.6  0.6
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 128 128 128
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 32    # grid size must be divisible by this
+amr.max_grid_size   = 64    # at least 128 for GPUs
+amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 1.0
+
+hydro.reconstruction_order = 3  # PPM
+cfl = 0.25
+max_timesteps = 1
+stop_time = 0.05
+
+derived_vars = gpot
+
+do_reflux = 1
+do_subcycle = 0
+do_tracers = 0          # turn on tracer particles
+
+ascent_interval = -1
+plotfile_interval = 200
+particle_csv_interval = -1
+checkpoint_interval = -1
+
+problem.num_particles = 1000000
+problem.seed = 42123

--- a/inputs/SphericalCollapse_regression.in
+++ b/inputs/SphericalCollapse_regression.in
@@ -22,7 +22,7 @@ amr.grid_eff        = 1.0
 
 hydro.reconstruction_order = 3  # PPM
 cfl = 0.25
-max_timesteps = 1
+max_timesteps = 1000
 stop_time = 0.05
 
 derived_vars = gpot

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -114,11 +114,10 @@ particleTypes = tracer_particles
 testSrcTree = .
 ignore_return_code = 1
 
-[RandomBlast-GPU]
+[SphericalCollapse-GPU]
 buildDir = .
-target = random_blast
-inputFile = inputs/RandomBlast_regression.in
-link1File = extern/grackle_data_files/input/CloudyData_UVB=HM2012.h5
+target = spherical_collapse
+inputFile = inputs/SphericalCollapse_regression.in
 dim = 3
 cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
 restartTest = 0
@@ -126,15 +125,14 @@ useMPI = 1
 numprocs = 1
 compileTest = 0
 doVis = 1
-visVar = temperature
+visVar = gpot
 testSrcTree = .
 ignore_return_code = 0
 
-[RandomBlastAMR-GPU]
+[SphericalCollapseAMR-GPU]
 buildDir = .
-target = random_blast
-inputFile = inputs/RandomBlastAMR_regression.in
-link1File = extern/grackle_data_files/input/CloudyData_UVB=HM2012.h5
+target = spherical_collapse
+inputFile = inputs/SphericalCollapseAMR_regression.in
 dim = 3
 cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
 restartTest = 0
@@ -142,7 +140,7 @@ useMPI = 1
 numprocs = 1
 compileTest = 0
 doVis = 1
-visVar = temperature
+visVar = gpot
 testSrcTree = .
 ignore_return_code = 0
 

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -7,24 +7,21 @@
 /// \brief Defines a test problem for pressureless spherical collapse.
 ///
 #include "hydro/hydro_system.hpp"
-#include "math/interpolate.hpp"
-#include <fstream>
-#include <limits>
 
-#include "AMReX.H"
 #include "AMReX_BLassert.H"
-#include "AMReX_Config.H"
-#include "AMReX_FabArrayUtility.H"
 #include "AMReX_MultiFab.H"
-#include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
-#include "AMReX_Print.H"
-#include "AMReX_SPACE.H"
 #include "QuokkaSimulation.hpp"
 #include "util/BC.hpp"
 
-static int num_particles_ = 1000; // NOLINT
-static int seed_ = 42;		  // NOLINT
+struct GlobalConfig {
+	static int num_particles;
+	static int seed;
+};
+
+// Initialize static members with default values
+int GlobalConfig::num_particles = 1000;
+int GlobalConfig::seed = 42;
 
 struct CollapseProblem {
 };
@@ -99,8 +96,8 @@ template <> void QuokkaSimulation<CollapseProblem>::createInitialCICParticles()
 {
 	// add particles at random positions in the box
 	const bool generate_on_root_rank = true;
-	const int iseed = seed_;
-	const int num_particles = num_particles_;
+	const int iseed = GlobalConfig::seed;
+	const int num_particles = GlobalConfig::num_particles;
 	const double total_particle_mass = 0.5; // about 0.1 of the total fluid mass
 	const double particle_mass = total_particle_mass / static_cast<double>(num_particles);
 
@@ -145,8 +142,8 @@ auto problem_main() -> int
 	auto BCs_cc = quokka::BC<CollapseProblem>(quokka::BCType::reflecting);
 
 	amrex::ParmParse const pp("problem");
-	pp.query("num_particles", num_particles_);
-	pp.query("seed", seed_);
+	pp.query("num_particles", GlobalConfig::num_particles);
+	pp.query("seed", GlobalConfig::seed);
 
 	// Problem initialization
 	QuokkaSimulation<CollapseProblem> sim(BCs_cc);

--- a/src/problems/SphericalCollapse/spherical_collapse.cpp
+++ b/src/problems/SphericalCollapse/spherical_collapse.cpp
@@ -19,11 +19,12 @@
 #include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_Print.H"
-
 #include "AMReX_SPACE.H"
 #include "QuokkaSimulation.hpp"
-#include "hydro/hydro_system.hpp"
 #include "util/BC.hpp"
+
+static int num_particles_ = 1000; // NOLINT
+static int seed_ = 42;		  // NOLINT
 
 struct CollapseProblem {
 };
@@ -98,8 +99,8 @@ template <> void QuokkaSimulation<CollapseProblem>::createInitialCICParticles()
 {
 	// add particles at random positions in the box
 	const bool generate_on_root_rank = true;
-	const int iseed = 42;
-	const int num_particles = 1000;
+	const int iseed = seed_;
+	const int num_particles = num_particles_;
 	const double total_particle_mass = 0.5; // about 0.1 of the total fluid mass
 	const double particle_mass = total_particle_mass / static_cast<double>(num_particles);
 
@@ -142,6 +143,10 @@ auto problem_main() -> int
 {
 	// boundary conditions
 	auto BCs_cc = quokka::BC<CollapseProblem>(quokka::BCType::reflecting);
+
+	amrex::ParmParse const pp("problem");
+	pp.query("num_particles", num_particles_);
+	pp.query("seed", seed_);
 
 	// Problem initialization
 	QuokkaSimulation<CollapseProblem> sim(BCs_cc);


### PR DESCRIPTION
### Description
Update regression tests: replace RandomBlast with SphericalCollpase. Since we won't do energy ejection from cells anymore, we could remove the RandomBlast test. 

All the regression tests:


| test                                  | hydro | cooling | gravity | AMR  | particle | radiation |
| ------------------------------------- | ----- | ------- | ------- | ---- | -------- | --------- |
| [Sedov-GPU]                           | 1     |         |         |      |          |           |
| [SedovAMR-GPU]                        | 1     |         |         | 1    |          |           |
| [ShockCloud-GPU]                      | 1     | 1       |         |      |          |           |
| [SphericalCollapse-GPU]               | 1     |         | 1       |      | 1        |           |
| [SphericalCollapseAMR-GPU] (disabled) | 1     |         | 1       | 1    | 1        |           |
| [RadhydroShell-GPU]                   | 1     |         |         |      |          | 1         |
| [DiskGalaxy-GPU] (disabled)           | 1     | 1       | 1       | 1    | 1        | 1         |


### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
