### PR TITLE
Make all particle operations deterministic

### DIFF
--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 
-#include "AMReX_Algorithm.H"
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
 #include "AMReX_BLProfiler.H"
@@ -13,6 +12,7 @@
 #include "AMReX_REAL.H"
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
+#include "particles/particle_utils.hpp"
 
 namespace quokka
 {
@@ -567,6 +567,9 @@ auto SNDeposition(ContainerType *container, amrex::MultiFab &state, amrex::Multi
 
 	// Step 2: Sum boundary values
 	state_buffer.SumBoundary(container->Geom(lev).periodicity());
+
+	// Apply roundoff to state_buffer
+	ParticleUtils::roundoffMultiFab(state_buffer);
 
 	// Step 3: Add the buffer to the state
 	SNFeedbackUtils::addBufferToState<problem_t>(state, state_buffer, SN_scheme_d, p_max_velocity);

--- a/src/particles/particle_utils.hpp
+++ b/src/particles/particle_utils.hpp
@@ -1,8 +1,8 @@
 #ifndef PARTICLE_UTILS_HPP_
 #define PARTICLE_UTILS_HPP_
 
-#include "AMReX_Gpu.H"
 #include "fundamental_constants.H"
+#include "AMReX_MultiFab.H"
 
 namespace quokka::ParticleUtils
 {
@@ -76,6 +76,46 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto computeJeansDensity(double 
 {
 	return jeansNo * jeansNo * M_PI * cs_cell * cs_cell / (C::Gconst * (dx * dx));
 }
+
+inline void roundoffMultiFab(amrex::MultiFab &mf)
+{
+	// Apply roundoff algorithm to reduce floating-point precision errors by removing
+	// the least significant bits from IEEE 754 double precision numbers.
+	//
+	// IEEE 754 double precision format:
+	// - 1 sign bit + 11 exponent bits + 52 mantissa bits = 64 total bits
+	// - The mantissa has an implicit leading 1, giving 53 bits of precision
+	//
+	// By removing 15 bits from the significand (mantissa), we effectively:
+	// - Reduce precision from 53 bits to 38 bits
+	// - In base 10: log10(2^53) ≈ 15.95 decimal digits → log10(2^38) ≈ 11.44 decimal digits
+	// - This removes approximately 4.5 decimal digits of precision
+	// - Equivalent to rounding to ~11-12 significant decimal digits instead of ~16
+	//
+	// The algorithm works by:
+	// 1. Multiplying by factor = 2^15 + 1 = 32769 to shift significant bits
+	// 2. The multiplication and subsequent operations naturally truncate lower-order bits
+	// 3. The final subtraction c - (c - sum) recovers the rounded value
+	constexpr unsigned int digit_to_remove = 15;					 // Remove 15 bits from mantissa
+	constexpr auto factor = static_cast<amrex::Real>((1ULL << digit_to_remove) + 1); // 2^15 + 1 = 32769
+
+	// Get array accessor for all patches at once
+	auto arr = mf.arrays();
+	const int ncomp = mf.nComp();
+
+	// Apply roundoff algorithm to every grid point and component in parallel
+	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+		// Process all components at this grid point
+		for (int n = 0; n < ncomp; ++n) {
+			const auto sum = arr[bx](i, j, k, n);
+			const auto c = factor * sum;
+			// The key roundoff step: c - (c - sum) removes the least significant bits
+			// This is mathematically equivalent to sum, but with reduced floating-point precision
+			arr[bx](i, j, k, n) = c - (c - sum);
+		}
+	});
+}
+
 
 } // namespace quokka::ParticleUtils
 

--- a/src/particles/particle_utils.hpp
+++ b/src/particles/particle_utils.hpp
@@ -1,8 +1,8 @@
 #ifndef PARTICLE_UTILS_HPP_
 #define PARTICLE_UTILS_HPP_
 
-#include "fundamental_constants.H"
 #include "AMReX_MultiFab.H"
+#include "fundamental_constants.H"
 
 namespace quokka::ParticleUtils
 {
@@ -115,7 +115,6 @@ inline void roundoffMultiFab(amrex::MultiFab &mf)
 		}
 	});
 }
-
 
 } // namespace quokka::ParticleUtils
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -298,7 +298,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void AverageDown();
 	void AverageDownTo(int crse_lev);
 	void timeStepWithSubcycling(int lev, amrex::Real time, int iteration);
-	void roundoffMultiFab(amrex::MultiFab &mf);
 	void calculateGpotAllLevels();
 	void gravAccelAllLevels(amrex::Real dt);
 	void ellipticSolveAllLevels(amrex::Real dt);
@@ -1322,45 +1321,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 #endif
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::roundoffMultiFab(amrex::MultiFab &mf)
-{
-	// Apply roundoff algorithm to reduce floating-point precision errors by removing
-	// the least significant bits from IEEE 754 double precision numbers.
-	//
-	// IEEE 754 double precision format:
-	// - 1 sign bit + 11 exponent bits + 52 mantissa bits = 64 total bits
-	// - The mantissa has an implicit leading 1, giving 53 bits of precision
-	//
-	// By removing 15 bits from the significand (mantissa), we effectively:
-	// - Reduce precision from 53 bits to 38 bits
-	// - In base 10: log10(2^53) ≈ 15.95 decimal digits → log10(2^38) ≈ 11.44 decimal digits
-	// - This removes approximately 4.5 decimal digits of precision
-	// - Equivalent to rounding to ~11-12 significant decimal digits instead of ~16
-	//
-	// The algorithm works by:
-	// 1. Multiplying by factor = 2^15 + 1 = 32769 to shift significant bits
-	// 2. The multiplication and subsequent operations naturally truncate lower-order bits
-	// 3. The final subtraction c - (c - sum) recovers the rounded value
-	constexpr unsigned int digit_to_remove = 15;					 // Remove 15 bits from mantissa
-	constexpr auto factor = static_cast<amrex::Real>((1ULL << digit_to_remove) + 1); // 2^15 + 1 = 32769
-
-	// Get array accessor for all patches at once
-	auto arr = mf.arrays();
-	const int ncomp = mf.nComp();
-
-	// Apply roundoff algorithm to every grid point and component in parallel
-	amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-		// Process all components at this grid point
-		for (int n = 0; n < ncomp; ++n) {
-			const auto sum = arr[bx](i, j, k, n);
-			const auto c = factor * sum;
-			// The key roundoff step: c - (c - sum) removes the least significant bits
-			// This is mathematically equivalent to sum, but with reduced floating-point precision
-			arr[bx](i, j, k, n) = c - (c - sum);
-		}
-	});
-}
-
 template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLevels()
 {
 #if AMREX_SPACEDIM == 3
@@ -1408,7 +1368,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 
 				// apply roundoff to buffer before adding to rhs
 				for (int lev = 0; lev <= finest_level; ++lev) {
-					roundoffMultiFab(rhs_buffer[lev]);
+					quokka::ParticleUtils::roundoffMultiFab(rhs_buffer[lev]);
 				}
 
 				// add buffer to rhs
@@ -1691,7 +1651,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	particleRegister_.computeSinkAccretion(state_new_cc_[lev], accretion_rate_at_level, lev, time, dt);
 
 	// Apply roundoff to accretion_rate_at_level
-	roundoffMultiFab(accretion_rate_at_level);
+	quokka::ParticleUtils::roundoffMultiFab(accretion_rate_at_level);
 
 	// Sink accretion, stage 2: update the particle states -- compute scale_down, apply to particle, apply to cells
 	particleRegister_.applySinkAccretion(state_new_cc_[lev], accretion_rate_at_level, geom[lev], lev, time, dt);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1690,7 +1690,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	// Sink accretion, stage 1: compute the accretion rate
 	particleRegister_.computeSinkAccretion(state_new_cc_[lev], accretion_rate_at_level, lev, time, dt);
 
-	// Sink accretion, stage 2: update the particle states
+	// Apply roundoff to accretion_rate_at_level
+	roundoffMultiFab(accretion_rate_at_level);
+
+	// Sink accretion, stage 2: update the particle states -- compute scale_down, apply to particle, apply to cells
 	particleRegister_.applySinkAccretion(state_new_cc_[lev], accretion_rate_at_level, geom[lev], lev, time, dt);
 
 	// We allow particle formation at the finest level only to avoid duplicate particle creation from multiple levels at the same location.


### PR DESCRIPTION
### Description

This should make all particle operations deterministic. Need to do Roundoff on the buffer MultiFab in the following processes: mass deposition, SN feedback, and sink accretion. Stochastic SF is cell by cell and requires no communication, so nothing has to be done for it. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
