### PR TITLE
fix error in debug.yml

### DIFF
--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release \
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
               -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
               -DAMReX_SPACEDIM=1
 

--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -48,9 +48,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
-              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-              -DAMReX_SPACEDIM=1
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DAMReX_SPACEDIM=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake-arm64-release.yml
+++ b/.github/workflows/cmake-arm64-release.yml
@@ -48,9 +48,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
-              -DAMReX_SPACEDIM=1
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DAMReX_SPACEDIM=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -161,16 +161,6 @@ void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_cc
 	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
 
 	amrex::ParallelFor(cons_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-		// First-capture the magnetic field arrays by accessing them early
-		// This forces NVCC to capture them before the constexpr if block
-		[[maybe_unused]] auto fc_x0_ref = cons_fc_x0[bx];
-#if AMREX_SPACEDIM >= 2
-		[[maybe_unused]] auto fc_x1_ref = cons_fc_x1[bx];
-#endif
-#if AMREX_SPACEDIM == 3
-		[[maybe_unused]] auto fc_x2_ref = cons_fc_x2[bx];
-#endif
-
 		const amrex::Real rho = cons_cc[bx](i, j, k, density_index);
 		const amrex::Real px = cons_cc[bx](i, j, k, x1Momentum_index);
 		const amrex::Real py = cons_cc[bx](i, j, k, x2Momentum_index);
@@ -191,6 +181,15 @@ void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_cc
 		amrex::Real magnetic_energy = 0.;
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// First-capture the magnetic field arrays by accessing them early
+			// This forces NVCC to capture them before the constexpr if block
+			[[maybe_unused]] auto fc_x0_ref = cons_fc_x0[bx];
+#if AMREX_SPACEDIM >= 2
+			[[maybe_unused]] auto fc_x1_ref = cons_fc_x1[bx];
+#endif
+#if AMREX_SPACEDIM == 3
+			[[maybe_unused]] auto fc_x2_ref = cons_fc_x2[bx];
+#endif
 			// note, bx is the box, and bxi is the magnetic-field component
 			const amrex::Real b_x0_m = fc_x0_ref(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
 			const amrex::Real b_x0_p = fc_x0_ref(i + 1, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
@@ -987,10 +986,6 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	// Include ghost cells when computing face velocities
 	amrex::IntVect ng{AMREX_D_DECL(nghost_vel, nghost_vel, nghost_vel)};
 	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
-		// first capture
-		[[maybe_unused]] const auto x1ConsVar_fc_ref = x1ConsVar_fc_in[bx];
-		[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
-
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState_bfield(x1LeftState_bfield_in[bx]);
@@ -1040,6 +1035,8 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		double magnetic_energy_L = 0.0;
 		double magnetic_energy_R = 0.0;
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// first capture
+			[[maybe_unused]] const auto x1ConsVar_fc_ref = x1ConsVar_fc_in[bx];
 			quokka::Array4View<const amrex::Real, DIR> x1ConsVar_fc(x1ConsVar_fc_ref);
 			bx1 = x1ConsVar_fc(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
 			by_L = x1LeftState_bfield(i, j, k, 0);
@@ -1183,12 +1180,14 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		} else if constexpr (RIEMANN == RiemannSolver::LLF) {
 			F_canonical = quokka::Riemann::LLF<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR);
 		} else if constexpr (RIEMANN == RiemannSolver::LLF_MHD) {
+			[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
 			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
 			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::LLF_MHD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
 			F_canonical = F_canonical_tmp;
 			x1FSpds(i, j, k, 0) = fspd_m;
 			x1FSpds(i, j, k, 1) = fspd_p;
 		} else if constexpr (RIEMANN == RiemannSolver::HLLD) {
+			[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
 			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
 			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
 			F_canonical = F_canonical_tmp;

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -161,6 +161,25 @@ void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_cc
 	amrex::IntVect ng{AMREX_D_DECL(nghost, nghost, nghost)};
 
 	amrex::ParallelFor(cons_cc_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		// First-capture the magnetic field arrays by accessing them early
+		// This forces NVCC to capture them before the constexpr if block
+		std::remove_cv_t<std::remove_reference_t<decltype(cons_fc_x0[bx])>> fc_x0_ref{};
+		if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			// If not wrapped in this if clause, this will fail in Debug mode due to nan values
+			fc_x0_ref = cons_fc_x0[bx];
+		}
+#if AMREX_SPACEDIM >= 2
+		std::remove_cv_t<std::remove_reference_t<decltype(cons_fc_x1[bx])>> fc_x1_ref{};
+		if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			fc_x1_ref = cons_fc_x1[bx];
+		}
+#endif
+#if AMREX_SPACEDIM == 3
+		std::remove_cv_t<std::remove_reference_t<decltype(cons_fc_x2[bx])>> fc_x2_ref{};
+		if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			fc_x2_ref = cons_fc_x2[bx];
+		}
+#endif
 		const amrex::Real rho = cons_cc[bx](i, j, k, density_index);
 		const amrex::Real px = cons_cc[bx](i, j, k, x1Momentum_index);
 		const amrex::Real py = cons_cc[bx](i, j, k, x2Momentum_index);
@@ -181,15 +200,6 @@ void HydroSystem<problem_t>::ConservedToPrimitive(amrex::MultiFab const &cons_cc
 		amrex::Real magnetic_energy = 0.;
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			// First-capture the magnetic field arrays by accessing them early
-			// This forces NVCC to capture them before the constexpr if block
-			[[maybe_unused]] auto fc_x0_ref = cons_fc_x0[bx];
-#if AMREX_SPACEDIM >= 2
-			[[maybe_unused]] auto fc_x1_ref = cons_fc_x1[bx];
-#endif
-#if AMREX_SPACEDIM == 3
-			[[maybe_unused]] auto fc_x2_ref = cons_fc_x2[bx];
-#endif
 			// note, bx is the box, and bxi is the magnetic-field component
 			const amrex::Real b_x0_m = fc_x0_ref(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
 			const amrex::Real b_x0_p = fc_x0_ref(i + 1, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
@@ -986,6 +996,16 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 	// Include ghost cells when computing face velocities
 	amrex::IntVect ng{AMREX_D_DECL(nghost_vel, nghost_vel, nghost_vel)};
 	amrex::ParallelFor(x1Flux_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i_in, int j_in, int k_in) {
+		// first capture
+		[[maybe_unused]] std::remove_cv_t<std::remove_reference_t<decltype(x1ConsVar_fc_in[bx])>> x1ConsVar_fc_ref{};
+		if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			x1ConsVar_fc_ref = x1ConsVar_fc_in[bx];
+		}
+		[[maybe_unused]] std::remove_cv_t<std::remove_reference_t<decltype(x1FSpds_in[bx])>> x1FSpds_ref{};
+		if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			x1FSpds_ref = x1FSpds_in[bx];
+		}
+
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState(x1LeftState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1RightState(x1RightState_in[bx]);
 		quokka::Array4View<const amrex::Real, DIR> x1LeftState_bfield(x1LeftState_bfield_in[bx]);
@@ -1035,8 +1055,6 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		double magnetic_energy_L = 0.0;
 		double magnetic_energy_R = 0.0;
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			// first capture
-			[[maybe_unused]] const auto x1ConsVar_fc_ref = x1ConsVar_fc_in[bx];
 			quokka::Array4View<const amrex::Real, DIR> x1ConsVar_fc(x1ConsVar_fc_ref);
 			bx1 = x1ConsVar_fc(i, j, k, Physics_Indices<problem_t>::mhdFirstIndex);
 			by_L = x1LeftState_bfield(i, j, k, 0);
@@ -1180,14 +1198,12 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		} else if constexpr (RIEMANN == RiemannSolver::LLF) {
 			F_canonical = quokka::Riemann::LLF<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR);
 		} else if constexpr (RIEMANN == RiemannSolver::LLF_MHD) {
-			[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
 			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
 			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::LLF_MHD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
 			F_canonical = F_canonical_tmp;
 			x1FSpds(i, j, k, 0) = fspd_m;
 			x1FSpds(i, j, k, 1) = fspd_p;
 		} else if constexpr (RIEMANN == RiemannSolver::HLLD) {
-			[[maybe_unused]] const auto x1FSpds_ref = x1FSpds_in[bx];
 			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
 			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
 			F_canonical = F_canonical_tmp;


### PR DESCRIPTION
### Description

@BenWibking This was a mistake. I don't know when was that mistake made. The cmake-amr64-debug.yml workflow is not actually building in Release mode. It seems like for a long time no debug tests have been running on github. After debug is actually turned on, the debug tests failed. I had to make some change about face-centered variables, and now all 1D tests in debug mode passed. 

### Related issues
None.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
