### PR TITLE
Use deterministic AMR flux register

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -956,6 +956,9 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 	if (do_reflux != 0) {
 		if (lev < finestLevel()) {
 			fr_as_crse = flux_reg_[lev + 1].get();
+			if (fr_as_crse != nullptr) {
+				fr_as_crse->setVal(0.0);
+			}
 		}
 		if (lev > 0) {
 			fr_as_fine = flux_reg_[lev].get();
@@ -2350,6 +2353,22 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 	fillBoundaryConditions(state_old_cc_[lev], state_old_cc_[lev], lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState,
 			       PostInterpState);
 
+	auto initRefluxFluxes = [&](std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes) {
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			amrex::BoxArray ba = state_new_cc_[lev].boxArray();
+			ba.surroundingNodes(dir);
+			fluxes[dir].define(ba, dmap[lev], state_new_cc_[lev].nComp(), 0);
+			fluxes[dir].setVal(0.0);
+		}
+	};
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> stage1Fluxes;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> stage2Fluxes;
+	if (do_reflux) {
+		initRefluxFluxes(stage1Fluxes);
+		initRefluxFluxes(stage2Fluxes);
+	}
+
 	// advance all grids on local processor (Stage 1 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -2364,16 +2383,23 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
 		if (do_reflux) {
-			// increment flux registers
-			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				stage1Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
+						  stage1Fluxes[dir].nComp());
+			}
 		}
+	}
+
+	if (do_reflux) {
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, stage1Fluxes, lev, 0.5 * dt_radiation);
 	}
 
 	// update ghost zones [intermediate stage stored in state_new_cc_]
 	fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_radiation), quokka::centering::cc, quokka::direction::na, PreInterpState,
 			       PostInterpState);
+
+	// stage2Fluxes already initialized when do_reflux
 
 	// advance all grids on local processor (Stage 2 of integrator)
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
@@ -2390,11 +2416,16 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
 		if (do_reflux) {
-			// increment flux registers
-			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				stage2Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
+						  stage2Fluxes[dir].nComp());
+			}
 		}
+	}
+
+	if (do_reflux) {
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, stage2Fluxes, lev, 0.5 * dt_radiation);
 	}
 }
 
@@ -2404,6 +2435,19 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 {
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> refluxFluxes;
+	if (do_reflux) {
+		auto initRefluxFluxes = [&](std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes) {
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				amrex::BoxArray ba = state_new_cc_[lev].boxArray();
+				ba.surroundingNodes(dir);
+				fluxes[dir].define(ba, dmap[lev], state_new_cc_[lev].nComp(), 0);
+				fluxes[dir].setVal(0.0);
+			}
+		};
+		initRefluxFluxes(refluxFluxes);
+	}
 
 	// update ghost zones [old timestep]
 	fillBoundaryConditions(state_old_cc_[lev], state_old_cc_[lev], lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState,
@@ -2423,11 +2467,16 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
 		if (do_reflux) {
-			// increment flux registers
-			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
+						  refluxFluxes[dir].nComp());
+			}
 		}
+	}
+
+	if (do_reflux) {
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, refluxFluxes, lev, 0.5 * dt_radiation);
 	}
 }
 
@@ -2436,6 +2485,19 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 							      int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> refluxFluxes;
+	if (do_reflux) {
+		auto initRefluxFluxes = [&](std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes) {
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				amrex::BoxArray ba = state_new_cc_[lev].boxArray();
+				ba.surroundingNodes(dir);
+				fluxes[dir].define(ba, dmap[lev], state_new_cc_[lev].nComp(), 0);
+				fluxes[dir].setVal(0.0);
+			}
+		};
+		initRefluxFluxes(refluxFluxes);
+	}
 
 	// update ghost zones [intermediate stage stored in state_new_cc_]
 	fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_radiation), quokka::centering::cc, quokka::direction::na, PreInterpState,
@@ -2459,11 +2521,16 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 		    dt_radiation, dx, indexRange, ncompHyperbolic_);
 
 		if (do_reflux) {
-			// increment flux registers
-			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
+						  refluxFluxes[dir].nComp());
+			}
 		}
+	}
+
+	if (do_reflux) {
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, refluxFluxes, lev, 0.5 * dt_radiation);
 	}
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2385,8 +2385,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 		if (do_reflux) {
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
 			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-				stage1Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
-						  stage1Fluxes[dir].nComp());
+				stage1Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(),
+										   0, stage1Fluxes[dir].nComp());
 			}
 		}
 	}
@@ -2418,8 +2418,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 		if (do_reflux) {
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
 			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-				stage2Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
-						  stage2Fluxes[dir].nComp());
+				stage2Fluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(),
+										   0, stage2Fluxes[dir].nComp());
 			}
 		}
 	}
@@ -2469,8 +2469,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 		if (do_reflux) {
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
 			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
-						  refluxFluxes[dir].nComp());
+				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(),
+										   0, refluxFluxes[dir].nComp());
 			}
 		}
 	}
@@ -2523,8 +2523,8 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 		if (do_reflux) {
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
 			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(), 0,
-						  refluxFluxes[dir].nComp());
+				refluxFluxes[dir][iter].copy<amrex::RunOn::Device>(expandedFluxes[dir], expandedFluxes[dir].box(), 0, expandedFluxes[dir].box(),
+										   0, refluxFluxes[dir].nComp());
 			}
 		}
 	}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -282,8 +282,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse,
-					    amrex::FluxRegister *fr_as_fine);
+	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
 
 	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
 				 amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
@@ -296,15 +295,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld_cc, amrex::MultiFab const &stateNew_cc);
 	auto computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int;
-	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps,
-					    amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
+	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
+					    amrex::FluxRegister *fr_as_fine);
 	void advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
 					  amrex::FluxRegister *fr_as_fine);
 	void advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
 					 amrex::FluxRegister *fr_as_fine);
 
-	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse,
-				      amrex::FluxRegister *fr_as_fine);
+	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -282,9 +282,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse,
-					    amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse = nullptr,
-					    amrex::EdgeFluxRegister *emf_as_fine = nullptr);
+	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
+					    amrex::EdgeFluxRegister *emf_as_crse = nullptr, amrex::EdgeFluxRegister *emf_as_fine = nullptr);
 
 	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
 				 amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse,
@@ -298,15 +297,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	// radiation subcycle
 	void swapRadiationState(amrex::MultiFab &stateOld_cc, amrex::MultiFab const &stateNew_cc);
 	auto computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int;
-	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps,
-					    amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
+	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
+					    amrex::FluxRegister *fr_as_fine);
 	void advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
 					  amrex::FluxRegister *fr_as_fine);
 	void advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
 					 amrex::FluxRegister *fr_as_fine);
 
-	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse,
-				      amrex::FluxRegister *fr_as_fine);
+	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
@@ -1351,9 +1349,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
-						      amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
-						      amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine, int lev, amrex::Real time,
-						      amrex::Real dt_lev) -> bool
+						      amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse,
+						      amrex::EdgeFluxRegister *emf_as_fine, int lev, amrex::Real time, amrex::Real dt_lev) -> bool
 {
 	const BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
@@ -1563,7 +1560,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			// sync internal energy (requires positive density)
 			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
 		}
-
 	}
 	amrex::Gpu::streamSynchronizeAll();
 
@@ -1575,8 +1571,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				fillBoundaryConditions(state_inter_fc_[idim], state_inter_fc_[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
-					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
-					       FillPatchType::fillpatch_function);
+						       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
+						       FillPatchType::fillpatch_function);
 			}
 		}
 
@@ -2396,7 +2392,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				auto &dest = reflux_flux_stage[idim][iter];
 				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
-							 dest.nComp());
+								dest.nComp());
 			}
 		}
 	}
@@ -2436,7 +2432,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				auto &dest = reflux_flux_stage[idim][iter];
 				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
-							 dest.nComp());
+								dest.nComp());
 			}
 		}
 	}
@@ -2449,7 +2445,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-						       int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
+							       int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
@@ -2487,7 +2483,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				auto &dest = reflux_flux_stage[idim][iter];
 				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
-							 dest.nComp());
+								dest.nComp());
 			}
 		}
 	}
@@ -2500,7 +2496,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-						      int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
+							      int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
 
@@ -2541,7 +2537,7 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				auto &dest = reflux_flux_stage[idim][iter];
 				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
-							 dest.nComp());
+								dest.nComp());
 			}
 		}
 	}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -53,7 +53,6 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
-#include "AMReX_YAFluxRegister.H"
 
 #ifdef AMREX_USE_ASCENT
 #include "AMReX_Conduit_Blueprint.H"
@@ -101,7 +100,9 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	using AMRSimulation<problem_t>::dmap;
 	using AMRSimulation<problem_t>::istep;
 	using AMRSimulation<problem_t>::flux_reg_;
+	using AMRSimulation<problem_t>::emf_reg_;
 	using AMRSimulation<problem_t>::incrementFluxRegisters;
+	using AMRSimulation<problem_t>::incrementEMFRegisters;
 	using AMRSimulation<problem_t>::finest_level;
 	using AMRSimulation<problem_t>::finestLevel;
 	using AMRSimulation<problem_t>::tNew_;
@@ -281,11 +282,13 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void printCoordinates(int lev, const amrex::IntVect &cell_idx);
 
-	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
-					    amrex::YAFluxRegister *fr_as_fine);
+	void advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse,
+					    amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse = nullptr,
+					    amrex::EdgeFluxRegister *emf_as_fine = nullptr);
 
 	auto advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
-				 amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
+				 amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse,
+				 amrex::EdgeFluxRegister *emf_as_fine, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
 
 	void addStrangSplitSources(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev);
 	auto addStrangSplitSourcesWithBuiltin(amrex::MultiFab &state, int lev, amrex::Real time, amrex::Real dt_lev) -> bool;
@@ -296,14 +299,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void swapRadiationState(amrex::MultiFab &stateOld_cc, amrex::MultiFab const &stateNew_cc);
 	auto computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int;
 	void advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps,
-					    amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine);
-	void advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
-					  amrex::YAFluxRegister *fr_as_fine);
-	void advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::YAFluxRegister *fr_as_crse,
-					 amrex::YAFluxRegister *fr_as_fine);
+					    amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine);
+	void advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
+					  amrex::FluxRegister *fr_as_fine);
+	void advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int iter_count, int nsubsteps, amrex::FluxRegister *fr_as_crse,
+					 amrex::FluxRegister *fr_as_fine);
 
-	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
-				      amrex::YAFluxRegister *fr_as_fine);
+	void subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse,
+				      amrex::FluxRegister *fr_as_fine);
 
 	auto computeRadiationFluxes(amrex::Array4<const amrex::Real> const &consVar, const amrex::Box &indexRange, int nvars,
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
@@ -952,15 +955,24 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 	const BL_PROFILE("QuokkaSimulation::advanceSingleTimestepAtLevel()");
 
 	// get flux registers
-	amrex::YAFluxRegister *fr_as_crse = nullptr;
-	amrex::YAFluxRegister *fr_as_fine = nullptr;
-	if (do_reflux != 0) {
+	amrex::FluxRegister *fr_as_crse = nullptr;
+	amrex::FluxRegister *fr_as_fine = nullptr;
+	amrex::EdgeFluxRegister *emf_as_crse = nullptr;
+	amrex::EdgeFluxRegister *emf_as_fine = nullptr;
+	if (this->do_flux_register_reset != 0) {
 		if (lev < finestLevel()) {
 			fr_as_crse = flux_reg_[lev + 1].get();
-			fr_as_crse->reset();
+			fr_as_crse->setVal(0.0);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				emf_as_crse = emf_reg_[lev + 1].get();
+				emf_as_crse->reset();
+			}
 		}
 		if (lev > 0) {
 			fr_as_fine = flux_reg_[lev].get();
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				emf_as_fine = emf_reg_[lev].get();
+			}
 		}
 	}
 
@@ -975,7 +987,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 
 	// advance hydro
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
-		advanceHydroAtLevelWithRetries(lev, time, dt_lev, fr_as_crse, fr_as_fine);
+		advanceHydroAtLevelWithRetries(lev, time, dt_lev, fr_as_crse, fr_as_fine, emf_as_crse, emf_as_fine);
 	} else {
 		// copy hydro vars from state_old_cc_ to state_new_cc_
 		// (otherwise radiation update will be wrong!)
@@ -1182,21 +1194,14 @@ auto QuokkaSimulation<problem_t>::computeAxisAlignedProfile(const int axis, F co
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::YAFluxRegister *fr_as_crse,
-								 amrex::YAFluxRegister *fr_as_fine)
+void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex::Real time, amrex::Real dt_lev, amrex::FluxRegister *fr_as_crse,
+								 amrex::FluxRegister *fr_as_fine, amrex::EdgeFluxRegister *emf_as_crse,
+								 amrex::EdgeFluxRegister *emf_as_fine)
 {
 	const BL_PROFILE_REGION("HydroSolver");
 	// timestep retries
 	const int max_retries = 6;
 	bool success = false;
-
-	// save the pre-advance fine flux register state in originalFineData
-	amrex::MultiFab originalFineData;
-	if (fr_as_fine != nullptr) {
-		amrex::MultiFab const &fineData = fr_as_fine->getFineData();
-		originalFineData.define(fineData.boxArray(), fineData.DistributionMap(), fineData.nComp(), 0);
-		amrex::Copy(originalFineData, fineData, 0, 0, fineData.nComp(), 0);
-	}
 
 	amrex::AmrTracerParticleContainer::ContainerLike<amrex::DefaultAllocator> originalTracerPC;
 	if (do_tracers != 0) {
@@ -1218,10 +1223,15 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		if (retry_count > 0) {
 			// reset the flux registers to their pre-advance state
 			if (fr_as_crse != nullptr) {
-				fr_as_crse->reset();
+				fr_as_crse->setVal(0.0);
 			}
-			if (fr_as_fine != nullptr) {
-				amrex::Copy(fr_as_fine->getFineData(), originalFineData, 0, 0, originalFineData.nComp(), 0);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				if (emf_as_crse != nullptr) {
+					emf_as_crse->reset();
+				}
+				if (emf_as_fine != nullptr) {
+					emf_as_fine->reset();
+				}
 			}
 
 			if (do_tracers != 0) {
@@ -1258,7 +1268,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 				}
 			}
 
-			success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, time, dt_step);
+			success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, emf_as_crse, emf_as_fine, lev, time, dt_step);
 
 			if (!success) {
 				if (Verbose()) {
@@ -1341,17 +1351,11 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCoordinates
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old_cc_tmp, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_old_fc_tmp,
-						      amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine, int lev, amrex::Real time,
+						      amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
+						      amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine, int lev, amrex::Real time,
 						      amrex::Real dt_lev) -> bool
 {
 	const BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
-
-	amrex::Real fluxScaleFactor = NAN;
-	if (integratorOrder_ == 2) {
-		fluxScaleFactor = 0.5;
-	} else if (integratorOrder_ == 1) {
-		fluxScaleFactor = 1.0;
-	}
 
 	auto ba_cc = grids[lev];
 	auto dm = dmap[lev];
@@ -1405,7 +1409,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			fillBoundaryConditions(state_old_fc_tmp[idim], state_old_fc_tmp[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
-					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
+					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
+					       FillPatchType::fillpatch_function);
 		}
 	}
 
@@ -1559,10 +1564,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
 		}
 
-		if (do_reflux == 1) {
-			// increment flux registers
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
 
@@ -1574,7 +1575,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				fillBoundaryConditions(state_inter_fc_[idim], state_inter_fc_[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
-						       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
+					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
+					       FillPatchType::fillpatch_function);
 			}
 		}
 
@@ -1673,10 +1675,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			HydroSystem<problem_t>::SyncDualEnergy(stateFinal_cc, stateFinal_fc);
 		}
 
-		if (do_reflux == 1) {
-			// increment flux registers
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-		}
 	} else { // we are only doing forward Euler
 		amrex::Copy(state_new_cc_[lev], state_inter_cc_, 0, 0, ncompHydro_, 0);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1685,18 +1683,34 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 	}
-	amrex::Gpu::streamSynchronizeAll();
 
 	// advect tracer particles using avgFaceVel
 	if (do_tracers != 0) {
+		amrex::Gpu::streamSynchronizeAll();
 		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
 	}
 
 	// do Strang split source terms (second half-step)
 	auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
 
+	bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+	bool const success_final = (cfl_ok && burn_success_second);
+
+	if (success_final) {
+		if (this->do_flux_register_increment == 1) {
+			incrementFluxRegisters(fr_as_crse, fr_as_fine, flux_rk2, lev, dt_lev);
+		}
+		if (this->do_emf_register_increment == 1) {
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				// E = -v x B, our emf is v x B, so pass -dt_lev
+				incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components_rk_ave, lev, -1.0 * dt_lev);
+			}
+		}
+		amrex::Gpu::streamSynchronizeAll();
+	}
+
 	// check if we have violated the CFL timestep or reactions failed for source terms
-	return (!isCflViolated(lev, time, dt_lev) && burn_success_second);
+	return success_final;
 }
 
 template <typename problem_t>
@@ -2138,8 +2152,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationSta
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::YAFluxRegister *fr_as_crse,
-							   amrex::YAFluxRegister *fr_as_fine)
+void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real time, amrex::Real dt_lev_hydro, amrex::FluxRegister *fr_as_crse,
+							   amrex::FluxRegister *fr_as_fine)
 {
 	// compute radiation timestep
 	int nsubSteps = 0;
@@ -2337,7 +2351,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex::Real time, amrex::Real dt_radiation, int const iter_count,
-								 int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+								 int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	if (Verbose()) {
 		amrex::Print() << "\tsubstep " << iter_count << " t = " << time << '\n';
@@ -2345,6 +2359,15 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> reflux_flux_stage;
+	if (do_reflux) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_face = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+			reflux_flux_stage[idim].define(ba_face, dmap[lev], state_new_cc_[lev].nComp(), 0);
+			reflux_flux_stage[idim].setVal(0.0);
+		}
+	}
 
 	// We use the RK2-SSP method here. It needs two registers: one to store the old timestep,
 	// and another to store the intermediate stage (which is reused for the final stage).
@@ -2370,8 +2393,17 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 			// increment flux registers
 			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto &dest = reflux_flux_stage[idim][iter];
+				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
+							 dest.nComp());
+			}
 		}
+	}
+
+	if (do_reflux && this->do_flux_register_increment == 1) {
+		amrex::Gpu::streamSynchronizeAll();
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, reflux_flux_stage, lev, 0.5 * dt_radiation);
 	}
 
 	// update ghost zones [intermediate stage stored in state_new_cc_]
@@ -2379,6 +2411,11 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 			       PostInterpState);
 
 	// advance all grids on local processor (Stage 2 of integrator)
+	if (do_reflux) {
+		for (auto &mf : reflux_flux_stage) {
+			mf.setVal(0.0);
+		}
+	}
 	for (amrex::MFIter iter(state_new_cc_[lev]); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
 		auto const &stateOld_cc = state_old_cc_[lev].const_array(iter);
@@ -2396,17 +2433,35 @@ void QuokkaSimulation<problem_t>::advanceRadiationSubstepAtLevel(int lev, amrex:
 			// increment flux registers
 			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto &dest = reflux_flux_stage[idim][iter];
+				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
+							 dest.nComp());
+			}
 		}
+	}
+
+	if (do_reflux && this->do_flux_register_increment == 1) {
+		amrex::Gpu::streamSynchronizeAll();
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, reflux_flux_stage, lev, 0.5 * dt_radiation);
 	}
 }
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-							       int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+						       int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	// get cell sizes
 	auto const &dx = geom[lev].CellSizeArray();
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> reflux_flux_stage;
+	if (do_reflux) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_face = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+			reflux_flux_stage[idim].define(ba_face, dmap[lev], state_new_cc_[lev].nComp(), 0);
+			reflux_flux_stage[idim].setVal(0.0);
+		}
+	}
 
 	// update ghost zones [old timestep]
 	fillBoundaryConditions(state_old_cc_[lev], state_old_cc_[lev], lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState,
@@ -2429,16 +2484,34 @@ void QuokkaSimulation<problem_t>::advanceRadiationForwardEuler(int lev, amrex::R
 			// increment flux registers
 			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto &dest = reflux_flux_stage[idim][iter];
+				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
+							 dest.nComp());
+			}
 		}
+	}
+
+	if (do_reflux && this->do_flux_register_increment == 1) {
+		amrex::Gpu::streamSynchronizeAll();
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, reflux_flux_stage, lev, 0.5 * dt_radiation);
 	}
 }
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Real time, amrex::Real dt_radiation, int const /*iter_count*/,
-							      int const /*nsubsteps*/, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine)
+						      int const /*nsubsteps*/, amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine)
 {
 	auto const &dx = geom[lev].CellSizeArray();
+
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> reflux_flux_stage;
+	if (do_reflux) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_face = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+			reflux_flux_stage[idim].define(ba_face, dmap[lev], state_new_cc_[lev].nComp(), 0);
+			reflux_flux_stage[idim].setVal(0.0);
+		}
+	}
 
 	// update ghost zones [intermediate stage stored in state_new_cc_]
 	fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_radiation), quokka::centering::cc, quokka::direction::na, PreInterpState,
@@ -2465,8 +2538,17 @@ void QuokkaSimulation<problem_t>::advanceRadiationMidpointRK2(int lev, amrex::Re
 			// increment flux registers
 			// WARNING: as written, diffusive flux correction is not compatible with reflux!!
 			auto expandedFluxes = expandFluxArrays(fluxArrays, nstartHyperbolic_, state_new_cc_[lev].nComp());
-			incrementFluxRegisters(iter, fr_as_crse, fr_as_fine, expandedFluxes, lev, 0.5 * dt_radiation);
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto &dest = reflux_flux_stage[idim][iter];
+				dest.copy<amrex::RunOn::Device>(expandedFluxes[idim], expandedFluxes[idim].box(), 0, expandedFluxes[idim].box(), 0,
+							 dest.nComp());
+			}
 		}
+	}
+
+	if (do_reflux && this->do_flux_register_increment == 1) {
+		amrex::Gpu::streamSynchronizeAll();
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, reflux_flux_stage, lev, 0.5 * dt_radiation);
 	}
 }
 

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -21,7 +21,6 @@
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
 #include "AMReX_TagBox.H"
-#include "AMReX_YAFluxRegister.H"
 #include <AMReX_FluxRegister.H>
 
 #include "linear_advection/linear_advection.hpp"
@@ -305,31 +304,16 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 	// get geometry (used only for cell sizes)
 	auto const &geomLevel = geom[lev];
 
-#ifdef USE_YAFLUXREGISTER
 	// get flux registers
-	amrex::YAFluxRegister *fr_as_crse = nullptr;
-	amrex::YAFluxRegister *fr_as_fine = nullptr;
-
-	if (do_reflux) {
-		if (lev < finestLevel()) {
-			fr_as_crse = flux_reg_[lev + 1].get();
-			fr_as_crse->reset();
-		}
-		if (lev > 0) {
-			fr_as_fine = flux_reg_[lev].get();
-		}
-	}
-#else
-	amrex::FluxRegister *fine = nullptr;
-	amrex::FluxRegister *current = nullptr;
-
+	amrex::FluxRegister *fr_as_crse = nullptr;
+	amrex::FluxRegister *fr_as_fine = nullptr;
 	if (do_reflux && lev < finest_level) {
-		fine = flux_reg_[lev + 1].get();
-		fine->setVal(0.0);
+		fr_as_crse = flux_reg_[lev + 1].get();
+		fr_as_crse->setVal(0.0);
 	}
 
 	if (do_reflux && lev > 0) {
-		current = flux_reg_[lev].get();
+		fr_as_fine = flux_reg_[lev].get();
 	}
 
 	// create temporary MultiFab to store the fluxes from each grid on this level
@@ -340,10 +324,9 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 			amrex::BoxArray ba = state_new_cc_[lev].boxArray();
 			ba.surroundingNodes(j);
 			fluxes[j].define(ba, dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, 0);
-			fluxes[j].setVal(0.);
+			fluxes[j].setVal(0.0);
 		}
 	}
-#endif // USE_YAFLUXREGISTER
 
 	// We use the RK2-SSP integrator in a method-of-lines framework. It needs 2
 	// registers: one to store the old timestep, and one to store the intermediate stage
@@ -361,11 +344,11 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		fluxScaleFactor = 1.0;
 	}
 
-	// advance all grids on local processor (Stage 1 of integrator)
-	{
-		auto const &stateOld = state_old_cc_[lev];
-		auto &stateNew = state_new_cc_[lev];
-		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+		// advance all grids on local processor (Stage 1 of integrator)
+		{
+			auto const &stateOld = state_old_cc_[lev];
+			auto &stateNew = state_new_cc_[lev];
+			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
 		// this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
@@ -377,73 +360,41 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
 							      Physics_Indices<problem_t>::nvarTotal_cc);
 
-		if (do_reflux) {
-#ifdef USE_YAFLUXREGISTER
-			// increment flux registers
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-#else
-			for (int i = 0; i < AMREX_SPACEDIM; i++) {
-				fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);
+			if (do_reflux) {
+				for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+					fluxes[i].plus(fluxArrays[i], 0, fluxArrays[i].nComp(), 0);
+				}
 			}
-#endif // USE_YAFLUXREGISTER
 		}
-	}
 
-	if constexpr (integratorOrder_ == 2) {
+		if constexpr (integratorOrder_ == 2) {
 		// update ghost zones [w/ intermediate stage stored in state_new_cc_]
 		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_lev), quokka::centering::cc, quokka::direction::na,
 				       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
 
-		// advance all grids on local processor (Stage 2 of integrator)
-		{
-			auto const &stateInOld = state_old_cc_[lev];
-			auto const &stateInStar = state_new_cc_[lev];
-			auto &stateOut = state_new_cc_[lev];
-			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] =
-			    computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+			// advance all grids on local processor (Stage 2 of integrator)
+			{
+				auto const &stateInOld = state_old_cc_[lev];
+				auto const &stateInStar = state_new_cc_[lev];
+				auto &stateOut = state_new_cc_[lev];
+				auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] =
+				    computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 			// Stage 2 of RK2-SSP
 			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
 								       Physics_Indices<problem_t>::nvarTotal_cc);
 
-			if (do_reflux) {
-#ifdef USE_YAFLUXREGISTER
-				// increment flux registers
-				incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-#else
-				for (int i = 0; i < AMREX_SPACEDIM; i++) {
-					fluxes[i][iter].plus<amrex::RunOn::Gpu>(fluxArrays[i]);
+				if (do_reflux) {
+					for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+						fluxes[i].plus(fluxArrays[i], 0, fluxArrays[i].nComp(), 0);
+					}
 				}
-#endif // USE_YAFLUXREGISTER
 			}
 		}
-	}
 
-#ifndef USE_YAFLUXREGISTER
 	if (do_reflux) {
-		// rescale by face area
-		auto dx = geomLevel.CellSizeArray();
-		amrex::Real const cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-
-		for (int i = 0; i < AMREX_SPACEDIM; i++) {
-			amrex::Real const face_area = cell_vol / dx[i];
-			amrex::Real const rescaleFactor = fluxScaleFactor * dt_lev * face_area;
-			fluxes[i].mult(rescaleFactor);
-		}
-
-		if (current != nullptr) {
-			for (int i = 0; i < AMREX_SPACEDIM; i++) {
-				current->FineAdd(fluxes[i], i, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, 1.);
-			}
-		}
-
-		if (fine != nullptr) {
-			for (int i = 0; i < AMREX_SPACEDIM; i++) {
-				fine->CrseInit(fluxes[i], i, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, -1.);
-			}
-		}
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxes, lev, fluxScaleFactor * dt_lev);
 	}
-#endif
 }
 
 template <typename problem_t>

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -344,11 +344,11 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		fluxScaleFactor = 1.0;
 	}
 
-		// advance all grids on local processor (Stage 1 of integrator)
-		{
-			auto const &stateOld = state_old_cc_[lev];
-			auto &stateNew = state_new_cc_[lev];
-			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+	// advance all grids on local processor (Stage 1 of integrator)
+	{
+		auto const &stateOld = state_old_cc_[lev];
+		auto &stateNew = state_new_cc_[lev];
+		auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] = computeFluxes(stateOld, Physics_Indices<problem_t>::nvarTotal_cc, lev);
 
 		// Write face velocities to disk
 		// this->writeFaceVelocitiesToDisk(faceVelArrays, lev, cycleCount_);
@@ -360,37 +360,37 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::advanceSingle
 		LinearAdvectionSystem<problem_t>::PredictStep(stateOld, stateNew, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
 							      Physics_Indices<problem_t>::nvarTotal_cc);
 
+		if (do_reflux) {
+			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+				fluxes[i].plus(fluxArrays[i], 0, fluxArrays[i].nComp(), 0);
+			}
+		}
+	}
+
+	if constexpr (integratorOrder_ == 2) {
+		// update ghost zones [w/ intermediate stage stored in state_new_cc_]
+		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_lev), quokka::centering::cc, quokka::direction::na,
+				       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
+
+		// advance all grids on local processor (Stage 2 of integrator)
+		{
+			auto const &stateInOld = state_old_cc_[lev];
+			auto const &stateInStar = state_new_cc_[lev];
+			auto &stateOut = state_new_cc_[lev];
+			auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] =
+			    computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
+
+			// Stage 2 of RK2-SSP
+			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
+								       Physics_Indices<problem_t>::nvarTotal_cc);
+
 			if (do_reflux) {
 				for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 					fluxes[i].plus(fluxArrays[i], 0, fluxArrays[i].nComp(), 0);
 				}
 			}
 		}
-
-		if constexpr (integratorOrder_ == 2) {
-		// update ghost zones [w/ intermediate stage stored in state_new_cc_]
-		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, (time + dt_lev), quokka::centering::cc, quokka::direction::na,
-				       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone);
-
-			// advance all grids on local processor (Stage 2 of integrator)
-			{
-				auto const &stateInOld = state_old_cc_[lev];
-				auto const &stateInStar = state_new_cc_[lev];
-				auto &stateOut = state_new_cc_[lev];
-				auto [fluxArrays, faceVelArrays, leftStateArrays, rightStateArrays] =
-				    computeFluxes(stateInStar, Physics_Indices<problem_t>::nvarTotal_cc, lev);
-
-			// Stage 2 of RK2-SSP
-			LinearAdvectionSystem<problem_t>::AddFluxesRK2(stateOut, stateInOld, stateInStar, fluxArrays, dt_lev, geomLevel.CellSizeArray(),
-								       Physics_Indices<problem_t>::nvarTotal_cc);
-
-				if (do_reflux) {
-					for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-						fluxes[i].plus(fluxArrays[i], 0, fluxArrays[i].nComp(), 0);
-					}
-				}
-			}
-		}
+	}
 
 	if (do_reflux) {
 		incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxes, lev, fluxScaleFactor * dt_lev);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -67,7 +67,6 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Utility.H"
 #include "AMReX_Vector.H"
 #include "AMReX_VisMF.H"
-#include <AMReX_EdgeFluxRegister.H>
 #include <AMReX_FluxRegister.H>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
@@ -306,9 +305,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void incrementFluxRegisters(amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays,
 				    int lev, amrex::Real dt_lev);
 
-	void incrementEMFRegisters(amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine,
-				   std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int lev, amrex::Real dt_lev);
-
 	void particleMeshInteraction(amrex::Real time, amrex::Real dt);
 
 	// boundary condition
@@ -412,7 +408,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	// therefore flux_reg[0] and flux_reg[nlevs_max] are never actually used in
 	// the reflux operation
 	amrex::Vector<std::unique_ptr<amrex::FluxRegister>> flux_reg_;
-	amrex::Vector<std::unique_ptr<amrex::EdgeFluxRegister>> emf_reg_;
 
 	// This is for fillpatch during timestepping, but not for regridding.
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
@@ -443,16 +438,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::string> m_diagVars;
 
 	/// AMR-specific parameters
-	int regrid_int = 2;		    // regrid interval (number of coarse steps)
-	int do_reflux = 1;		    // 1 == reflux, 0 == no reflux
-	int do_subcycle = 1;		    // 1 == subcycle, 0 == no subcyle
-	int suppress_output = 0;	    // 1 == show timestepping, 0 == do not output each timestep
-	int do_flux_register_init = 1;	    // 1 == initialize flux registers, 0 == skip initialization
-	int do_flux_register_reset = 1;	    // 1 == reset flux registers each timestep, 0 == skip reset
-	int do_flux_register_increment = 1; // 1 == increment flux registers during updates, 0 == skip increment
-	int do_emf_register_increment = 1;  // 1 == increment EMF registers for MHD, 0 == skip EMF increment
-	int do_reflux_apply_cc = 1;	    // 1 == apply reflux correction for cell-centered vars, 0 == skip
-	int do_reflux_apply_fc = 1;	    // 1 == apply reflux correction for face-centered vars (MHD), 0 == skip
+	int regrid_int = 2;		 // regrid interval (number of coarse steps)
+	int do_reflux = 1;		 // 1 == reflux, 0 == no reflux
+	int do_subcycle = 1;		 // 1 == subcycle, 0 == no subcyle
+	int suppress_output = 0; // 1 == show timestepping, 0 == do not output each timestep
 
 	// performance metrics
 	amrex::Long cellUpdates_ = 0;
@@ -593,7 +582,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	state_old_fc_.resize(nlevs_max);
 	max_signal_speed_.resize(nlevs_max);
 	flux_reg_.resize(nlevs_max + 1);
-	emf_reg_.resize(nlevs_max + 1);
 	fillpatcher_.resize(nlevs_max + 1);
 	cellUpdatesEachLevel_.resize(nlevs_max, 0);
 
@@ -762,21 +750,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// Default do_reflux = 1
 	pp.query("do_reflux", do_reflux);
-	if (do_reflux == 0) {
-		do_flux_register_init = 0;
-		do_flux_register_reset = 0;
-		do_flux_register_increment = 0;
-		do_emf_register_increment = 0;
-		do_reflux_apply_cc = 0;
-		do_reflux_apply_fc = 0;
-	} else {
-		pp.query("do_flux_register_init", do_flux_register_init);
-		pp.query("do_flux_register_reset", do_flux_register_reset);
-		pp.query("do_flux_register_increment", do_flux_register_increment);
-		pp.query("do_emf_register_increment", do_emf_register_increment);
-		pp.query("do_reflux_apply_cc", do_reflux_apply_cc);
-		pp.query("do_reflux_apply_fc", do_reflux_apply_fc);
-	}
 
 	// Default do_subcycle = 1
 	pp.query("do_subcycle", do_subcycle);
@@ -1785,15 +1758,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 		// do post-timestep operations
 
 		if (do_reflux != 0) {
-			if (do_reflux_apply_cc != 0) {
-				amrex::Gpu::streamSynchronizeAll();
+			amrex::Gpu::streamSynchronizeAll();
+			if (flux_reg_[lev + 1] != nullptr) {
 				flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
-			}
-			if (do_reflux_apply_fc != 0) {
-				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					// NOLINTNEXTLINE(readability-container-data-pointer)
-					emf_reg_[lev + 1]->Reflux({AMREX_D_DECL(&state_new_fc_[lev][0], &state_new_fc_[lev][1], &state_new_fc_[lev][2])});
-				}
 			}
 		}
 
@@ -1880,35 +1847,6 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 	amrex::Gpu::streamSynchronizeAll();
 }
 
-template <typename problem_t>
-void AMRSimulation<problem_t>::incrementEMFRegisters(amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine,
-						     std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int const lev, amrex::Real const dt_lev)
-{
-	BL_PROFILE("AMRSimulation::incrementEMFRegisters()"); // NOLINT(misc-const-correctness)
-
-#if (AMREX_SPACEDIM == 3)
-	amrex::Gpu::streamSynchronizeAll();
-	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
-		if (emf_as_crse != nullptr) {
-			AMREX_ASSERT(lev < finestLevel());
-			AMREX_ASSERT(emf_as_crse == emf_reg_[lev + 1].get());
-			emf_as_crse->CrseAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
-					     dt_lev);
-		}
-
-		if (emf_as_fine != nullptr) {
-			AMREX_ASSERT(lev > 0);
-			AMREX_ASSERT(emf_as_fine == emf_reg_[lev].get());
-			emf_as_fine->FineAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
-					     dt_lev);
-		}
-	}
-	amrex::Gpu::streamSynchronizeAll();
-#else
-	amrex::ignore_unused(emf_as_crse, emf_as_fine, ec_emf_components, lev, dt_lev);
-#endif
-}
-
 template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterCellCentered() -> amrex::MFInterpolater *
 {
 	amrex::MFInterpolater *mapper = nullptr;
@@ -1957,15 +1895,8 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_flux_register_init != 0)) {
+	if (level > 0 && (do_reflux != 0)) {
 		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
-
-		// Initialize EdgeFluxRegister for MHD
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			const int nemf_vars = 1; // EMF has 1 component per dimension
-			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-										    Geom(level - 1), nemf_vars);
-		}
 	}
 
 	// face-centred
@@ -2008,15 +1939,8 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_flux_register_init != 0)) {
+	if (level > 0 && (do_reflux != 0)) {
 		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
-
-		// Initialize EdgeFluxRegister for MHD
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			const int nemf_vars = 1; // EMF has 1 component per dimension
-			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-										    Geom(level - 1), nemf_vars);
-		}
 	}
 
 	// face-centred
@@ -2049,7 +1973,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int leve
 	max_signal_speed_[level].clear();
 
 	flux_reg_[level].reset(nullptr);
-	emf_reg_[level].reset(nullptr);
 	fillpatcher_[level].reset(nullptr);
 
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
@@ -2225,15 +2148,8 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real ti
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_flux_register_init != 0)) {
+	if (level > 0 && (do_reflux != 0)) {
 		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
-
-		// Initialize EdgeFluxRegister for MHD
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			const int nemf_vars = 1; // EMF has 1 component per dimension
-			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-										    Geom(level - 1), nemf_vars);
-		}
 	}
 
 	// face-centred
@@ -3575,13 +3491,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		state_new_cc_[lev].define(grids[lev], dmap[lev], ncomp_cc, nghost_cc);
 		max_signal_speed_[lev].define(ba, dm, 1, nghost_cc);
 
-		if (lev > 0 && (do_flux_register_init != 0)) {
+		if (lev > 0 && (do_reflux != 0)) {
 			flux_reg_[lev] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(lev - 1), lev, ncomp_cc);
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				const int nemf_vars = 1;
-				emf_reg_[lev] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(lev - 1), dm, DistributionMap(lev - 1), Geom(lev),
-											  Geom(lev - 1), nemf_vars);
-			}
 		}
 
 		const int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1757,10 +1757,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 
 		// do post-timestep operations
 
-                if (do_reflux != 0) {
-                        if (flux_reg_[lev + 1] != nullptr) {
-                                flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
-                        }
+		if (do_reflux != 0) {
+			if (flux_reg_[lev + 1] != nullptr) {
+				flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
+			}
 		}
 
 		AverageDownTo(lev); // average lev+1 down to lev
@@ -1831,17 +1831,17 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 		}
 	}
 
-        if (fr_as_fine != nullptr) {
-                AMREX_ASSERT(lev > 0);
-                AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
-                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-                        int const ncomp = fluxArrays[dir].nComp();
-                        if (ncomp == 0) {
-                                continue;
-                        }
-                        fr_as_fine->FineAdd(fluxArrays[dir], dir, 0, 0, ncomp, dt_lev * face_area[dir]);
-                }
-        }
+	if (fr_as_fine != nullptr) {
+		AMREX_ASSERT(lev > 0);
+		AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			int const ncomp = fluxArrays[dir].nComp();
+			if (ncomp == 0) {
+				continue;
+			}
+			fr_as_fine->FineAdd(fluxArrays[dir], dir, 0, 0, ncomp, dt_lev * face_area[dir]);
+		}
+	}
 }
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterCellCentered() -> amrex::MFInterpolater *

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -67,7 +67,8 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Utility.H"
 #include "AMReX_Vector.H"
 #include "AMReX_VisMF.H"
-#include "AMReX_YAFluxRegister.H"
+#include <AMReX_FluxRegister.H>
+#include <AMReX_EdgeFluxRegister.H>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <yaml-cpp/yaml.h>
@@ -98,8 +99,6 @@ namespace filesystem = experimental::filesystem;
 #ifdef QUOKKA_USE_OPENPMD
 #include "io/openPMD.hpp"
 #endif
-
-#define USE_YAFLUXREGISTER
 
 #ifdef AMREX_USE_ASCENT
 using namespace conduit;
@@ -304,11 +303,11 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void gravAccelAllLevels(amrex::Real dt);
 	void ellipticSolveAllLevels(amrex::Real dt);
 
-	void incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-				    std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int lev, amrex::Real dt_lev);
-
-	void incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
+	void incrementFluxRegisters(amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
 				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int lev, amrex::Real dt_lev);
+
+	void incrementEMFRegisters(amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine,
+				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int lev, amrex::Real dt_lev);
 
 	void particleMeshInteraction(amrex::Real time, amrex::Real dt);
 
@@ -412,7 +411,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	// the lev/lev-1 interface (and has grid spacing associated with lev-1)
 	// therefore flux_reg[0] and flux_reg[nlevs_max] are never actually used in
 	// the reflux operation
-	amrex::Vector<std::unique_ptr<amrex::YAFluxRegister>> flux_reg_;
+	amrex::Vector<std::unique_ptr<amrex::FluxRegister>> flux_reg_;
+	amrex::Vector<std::unique_ptr<amrex::EdgeFluxRegister>> emf_reg_;
 
 	// This is for fillpatch during timestepping, but not for regridding.
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
@@ -447,6 +447,12 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int do_reflux = 1;	 // 1 == reflux, 0 == no reflux
 	int do_subcycle = 1;	 // 1 == subcycle, 0 == no subcyle
 	int suppress_output = 0; // 1 == show timestepping, 0 == do not output each timestep
+	int do_flux_register_init = 1;	    // 1 == initialize flux registers, 0 == skip initialization
+	int do_flux_register_reset = 1;	    // 1 == reset flux registers each timestep, 0 == skip reset
+	int do_flux_register_increment = 1; // 1 == increment flux registers during updates, 0 == skip increment
+	int do_emf_register_increment = 1;  // 1 == increment EMF registers for MHD, 0 == skip EMF increment
+	int do_reflux_apply_cc = 1;	    // 1 == apply reflux correction for cell-centered vars, 0 == skip
+	int do_reflux_apply_fc = 1;	    // 1 == apply reflux correction for face-centered vars (MHD), 0 == skip
 
 	// performance metrics
 	amrex::Long cellUpdates_ = 0;
@@ -587,6 +593,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	state_old_fc_.resize(nlevs_max);
 	max_signal_speed_.resize(nlevs_max);
 	flux_reg_.resize(nlevs_max + 1);
+	emf_reg_.resize(nlevs_max + 1);
 	fillpatcher_.resize(nlevs_max + 1);
 	cellUpdatesEachLevel_.resize(nlevs_max, 0);
 
@@ -755,6 +762,21 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// Default do_reflux = 1
 	pp.query("do_reflux", do_reflux);
+	if (do_reflux == 0) {
+		do_flux_register_init = 0;
+		do_flux_register_reset = 0;
+		do_flux_register_increment = 0;
+		do_emf_register_increment = 0;
+		do_reflux_apply_cc = 0;
+		do_reflux_apply_fc = 0;
+	} else {
+		pp.query("do_flux_register_init", do_flux_register_init);
+		pp.query("do_flux_register_reset", do_flux_register_reset);
+		pp.query("do_flux_register_increment", do_flux_register_increment);
+		pp.query("do_emf_register_increment", do_emf_register_increment);
+		pp.query("do_reflux_apply_cc", do_reflux_apply_cc);
+		pp.query("do_reflux_apply_fc", do_reflux_apply_fc);
+	}
 
 	// Default do_subcycle = 1
 	pp.query("do_subcycle", do_subcycle);
@@ -1763,8 +1785,16 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 		// do post-timestep operations
 
 		if (do_reflux != 0) {
-			// update lev based on coarse-fine flux mismatch
-			flux_reg_[lev + 1]->Reflux(state_new_cc_[lev]);
+			if (do_reflux_apply_cc != 0) {
+				amrex::Gpu::streamSynchronizeAll();
+				flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
+			}
+			if (do_reflux_apply_fc != 0) {
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					// NOLINTNEXTLINE(readability-container-data-pointer)
+					emf_reg_[lev + 1]->Reflux({AMREX_D_DECL(&state_new_fc_[lev][0], &state_new_fc_[lev][1], &state_new_fc_[lev][2])});
+				}
+			}
 		}
 
 		AverageDownTo(lev); // average lev+1 down to lev
@@ -1800,47 +1830,83 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 }
 
 template <typename problem_t>
-void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::MFIter &mfi, amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      std::array<amrex::FArrayBox, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
+void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
+						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
 {
 	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
+
+	if ((fr_as_crse == nullptr) && (fr_as_fine == nullptr)) {
+		return;
+	}
+
+	const auto dx = geom[lev].CellSizeArray();
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> face_area{};
+
+	if constexpr (AMREX_SPACEDIM == 1) {
+		face_area[0] = 1.0;
+	} else if constexpr (AMREX_SPACEDIM == 2) {
+		face_area[0] = dx[1];
+		face_area[1] = dx[0];
+	} else {
+		face_area[0] = dx[1] * dx[2];
+		face_area[1] = dx[0] * dx[2];
+		face_area[2] = dx[0] * dx[1];
+	}
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
 		AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
-		fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(&fluxArrays[0], &fluxArrays[1], &fluxArrays[2])}, // NOLINT(readability-container-data-pointer)
-				    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			int const ncomp = fluxArrays[dir].nComp();
+			if (ncomp == 0) {
+				continue;
+			}
+		fr_as_crse->CrseInit(fluxArrays[dir], dir, 0, 0, ncomp, -dt_lev * face_area[dir], amrex::FluxRegister::ADD);
+		}
 	}
 
 	if (fr_as_fine != nullptr) {
 		AMREX_ASSERT(lev > 0);
 		AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
-		fr_as_fine->FineAdd(mfi, {AMREX_D_DECL(&fluxArrays[0], &fluxArrays[1], &fluxArrays[2])}, // NOLINT(readability-container-data-pointer)
-				    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			int const ncomp = fluxArrays[dir].nComp();
+			if (ncomp == 0) {
+				continue;
+			}
+			fr_as_fine->FineAdd(fluxArrays[dir], dir, 0, 0, ncomp, dt_lev * face_area[dir]);
+		}
 	}
+
+	amrex::Gpu::streamSynchronizeAll();
 }
 
 template <typename problem_t>
-void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::YAFluxRegister *fr_as_crse, amrex::YAFluxRegister *fr_as_fine,
-						      std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int const lev, amrex::Real const dt_lev)
+void AMRSimulation<problem_t>::incrementEMFRegisters(amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine,
+						     std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int const lev, amrex::Real const dt_lev)
 {
-	BL_PROFILE("AMRSimulation::incrementFluxRegisters()"); // NOLINT(misc-const-correctness)
+	BL_PROFILE("AMRSimulation::incrementEMFRegisters()"); // NOLINT(misc-const-correctness)
 
+#if (AMREX_SPACEDIM == 3)
+	amrex::Gpu::streamSynchronizeAll();
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
-		if (fr_as_crse != nullptr) {
+		if (emf_as_crse != nullptr) {
 			AMREX_ASSERT(lev < finestLevel());
-			AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
-			fr_as_crse->CrseAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
-					    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+			AMREX_ASSERT(emf_as_crse == emf_reg_[lev + 1].get());
+			emf_as_crse->CrseAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
+					     dt_lev);
 		}
 
-		if (fr_as_fine != nullptr) {
+		if (emf_as_fine != nullptr) {
 			AMREX_ASSERT(lev > 0);
-			AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
-			fr_as_fine->FineAdd(mfi, {AMREX_D_DECL(fluxArrays[0].fabPtr(mfi), fluxArrays[1].fabPtr(mfi), fluxArrays[2].fabPtr(mfi))},
-					    geom[lev].CellSize(), dt_lev, amrex::RunOn::Gpu);
+			AMREX_ASSERT(emf_as_fine == emf_reg_[lev].get());
+			emf_as_fine->FineAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
+					     dt_lev);
 		}
 	}
+	amrex::Gpu::streamSynchronizeAll();
+#else
+	amrex::ignore_unused(emf_as_crse, emf_as_fine, ec_emf_components, lev, dt_lev);
+#endif
 }
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterCellCentered() -> amrex::MFInterpolater *
@@ -1891,9 +1957,15 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_reflux != 0)) {
-		flux_reg_[level] = std::make_unique<amrex::YAFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									   Geom(level - 1), refRatio(level - 1), level, ncomp_cc);
+	if (level > 0 && (do_flux_register_init != 0)) {
+		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
+
+		// Initialize EdgeFluxRegister for MHD
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			const int nemf_vars = 1; // EMF has 1 component per dimension
+			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
+									    Geom(level - 1), nemf_vars);
+		}
 	}
 
 	// face-centred
@@ -1936,9 +2008,15 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_reflux != 0)) {
-		flux_reg_[level] = std::make_unique<amrex::YAFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									   Geom(level - 1), refRatio(level - 1), level, ncomp_cc);
+	if (level > 0 && (do_flux_register_init != 0)) {
+		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
+
+		// Initialize EdgeFluxRegister for MHD
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			const int nemf_vars = 1; // EMF has 1 component per dimension
+			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
+									    Geom(level - 1), nemf_vars);
+		}
 	}
 
 	// face-centred
@@ -1968,10 +2046,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int leve
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
-	max_signal_speed_[level].clear();
+		max_signal_speed_[level].clear();
 
-	flux_reg_[level].reset(nullptr);
-	fillpatcher_[level].reset(nullptr);
+		flux_reg_[level].reset(nullptr);
+		emf_reg_[level].reset(nullptr);
+		fillpatcher_[level].reset(nullptr);
 
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -2146,9 +2225,15 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real ti
 	tNew_[level] = time;
 	tOld_[level] = time - 1.e200;
 
-	if (level > 0 && (do_reflux != 0)) {
-		flux_reg_[level] = std::make_unique<amrex::YAFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									   Geom(level - 1), refRatio(level - 1), level, ncomp_cc);
+	if (level > 0 && (do_flux_register_init != 0)) {
+		flux_reg_[level] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(level - 1), level, ncomp_cc);
+
+		// Initialize EdgeFluxRegister for MHD
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			const int nemf_vars = 1; // EMF has 1 component per dimension
+			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
+									    Geom(level - 1), nemf_vars);
+		}
 	}
 
 	// face-centred
@@ -3490,10 +3575,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		state_new_cc_[lev].define(grids[lev], dmap[lev], ncomp_cc, nghost_cc);
 		max_signal_speed_[lev].define(ba, dm, 1, nghost_cc);
 
-		if (lev > 0 && (do_reflux != 0)) {
-			flux_reg_[lev] = std::make_unique<amrex::YAFluxRegister>(ba, boxArray(lev - 1), dm, DistributionMap(lev - 1), Geom(lev), Geom(lev - 1),
-										 refRatio(lev - 1), lev, ncomp_cc);
-		}
+			if (lev > 0 && (do_flux_register_init != 0)) {
+				flux_reg_[lev] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(lev - 1), lev, ncomp_cc);
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					const int nemf_vars = 1;
+					emf_reg_[lev] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(lev - 1), dm, DistributionMap(lev - 1), Geom(lev),
+									    Geom(lev - 1), nemf_vars);
+				}
+			}
 
 		const int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;
 		const int nghost_fc = nghost_fc_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -67,8 +67,8 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Utility.H"
 #include "AMReX_Vector.H"
 #include "AMReX_VisMF.H"
-#include <AMReX_FluxRegister.H>
 #include <AMReX_EdgeFluxRegister.H>
+#include <AMReX_FluxRegister.H>
 #include <fmt/format.h>
 #include <fmt/ranges.h>
 #include <yaml-cpp/yaml.h>
@@ -303,11 +303,11 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void gravAccelAllLevels(amrex::Real dt);
 	void ellipticSolveAllLevels(amrex::Real dt);
 
-	void incrementFluxRegisters(amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine,
-				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays, int lev, amrex::Real dt_lev);
+	void incrementFluxRegisters(amrex::FluxRegister *fr_as_crse, amrex::FluxRegister *fr_as_fine, std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxArrays,
+				    int lev, amrex::Real dt_lev);
 
 	void incrementEMFRegisters(amrex::EdgeFluxRegister *emf_as_crse, amrex::EdgeFluxRegister *emf_as_fine,
-				    std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int lev, amrex::Real dt_lev);
+				   std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_emf_components, int lev, amrex::Real dt_lev);
 
 	void particleMeshInteraction(amrex::Real time, amrex::Real dt);
 
@@ -443,10 +443,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::string> m_diagVars;
 
 	/// AMR-specific parameters
-	int regrid_int = 2;	 // regrid interval (number of coarse steps)
-	int do_reflux = 1;	 // 1 == reflux, 0 == no reflux
-	int do_subcycle = 1;	 // 1 == subcycle, 0 == no subcyle
-	int suppress_output = 0; // 1 == show timestepping, 0 == do not output each timestep
+	int regrid_int = 2;		    // regrid interval (number of coarse steps)
+	int do_reflux = 1;		    // 1 == reflux, 0 == no reflux
+	int do_subcycle = 1;		    // 1 == subcycle, 0 == no subcyle
+	int suppress_output = 0;	    // 1 == show timestepping, 0 == do not output each timestep
 	int do_flux_register_init = 1;	    // 1 == initialize flux registers, 0 == skip initialization
 	int do_flux_register_reset = 1;	    // 1 == reset flux registers each timestep, 0 == skip reset
 	int do_flux_register_increment = 1; // 1 == increment flux registers during updates, 0 == skip increment
@@ -1861,7 +1861,7 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 			if (ncomp == 0) {
 				continue;
 			}
-		fr_as_crse->CrseInit(fluxArrays[dir], dir, 0, 0, ncomp, -dt_lev * face_area[dir], amrex::FluxRegister::ADD);
+			fr_as_crse->CrseInit(fluxArrays[dir], dir, 0, 0, ncomp, -dt_lev * face_area[dir], amrex::FluxRegister::ADD);
 		}
 	}
 
@@ -1964,7 +1964,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			const int nemf_vars = 1; // EMF has 1 component per dimension
 			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									    Geom(level - 1), nemf_vars);
+										    Geom(level - 1), nemf_vars);
 		}
 	}
 
@@ -2015,7 +2015,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			const int nemf_vars = 1; // EMF has 1 component per dimension
 			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									    Geom(level - 1), nemf_vars);
+										    Geom(level - 1), nemf_vars);
 		}
 	}
 
@@ -2046,11 +2046,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::ClearLevel(int leve
 
 	state_new_cc_[level].clear();
 	state_old_cc_[level].clear();
-		max_signal_speed_[level].clear();
+	max_signal_speed_[level].clear();
 
-		flux_reg_[level].reset(nullptr);
-		emf_reg_[level].reset(nullptr);
-		fillpatcher_[level].reset(nullptr);
+	flux_reg_[level].reset(nullptr);
+	emf_reg_[level].reset(nullptr);
+	fillpatcher_[level].reset(nullptr);
 
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -2232,7 +2232,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromScratch(int level, amrex::Real ti
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			const int nemf_vars = 1; // EMF has 1 component per dimension
 			emf_reg_[level] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(level - 1), dm, DistributionMap(level - 1), Geom(level),
-									    Geom(level - 1), nemf_vars);
+										    Geom(level - 1), nemf_vars);
 		}
 	}
 
@@ -3575,14 +3575,14 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		state_new_cc_[lev].define(grids[lev], dmap[lev], ncomp_cc, nghost_cc);
 		max_signal_speed_[lev].define(ba, dm, 1, nghost_cc);
 
-			if (lev > 0 && (do_flux_register_init != 0)) {
-				flux_reg_[lev] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(lev - 1), lev, ncomp_cc);
-				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					const int nemf_vars = 1;
-					emf_reg_[lev] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(lev - 1), dm, DistributionMap(lev - 1), Geom(lev),
-									    Geom(lev - 1), nemf_vars);
-				}
+		if (lev > 0 && (do_flux_register_init != 0)) {
+			flux_reg_[lev] = std::make_unique<amrex::FluxRegister>(ba, dm, refRatio(lev - 1), lev, ncomp_cc);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				const int nemf_vars = 1;
+				emf_reg_[lev] = std::make_unique<amrex::EdgeFluxRegister>(ba, boxArray(lev - 1), dm, DistributionMap(lev - 1), Geom(lev),
+											  Geom(lev - 1), nemf_vars);
 			}
+		}
 
 		const int ncomp_per_dim_fc = Physics_Indices<problem_t>::nvarPerDim_fc;
 		const int nghost_fc = nghost_fc_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -438,9 +438,9 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::string> m_diagVars;
 
 	/// AMR-specific parameters
-	int regrid_int = 2;		 // regrid interval (number of coarse steps)
-	int do_reflux = 1;		 // 1 == reflux, 0 == no reflux
-	int do_subcycle = 1;		 // 1 == subcycle, 0 == no subcyle
+	int regrid_int = 2;	 // regrid interval (number of coarse steps)
+	int do_reflux = 1;	 // 1 == reflux, 0 == no reflux
+	int do_subcycle = 1;	 // 1 == subcycle, 0 == no subcyle
 	int suppress_output = 0; // 1 == show timestepping, 0 == do not output each timestep
 
 	// performance metrics

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1757,11 +1757,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 
 		// do post-timestep operations
 
-		if (do_reflux != 0) {
-			amrex::Gpu::streamSynchronizeAll();
-			if (flux_reg_[lev + 1] != nullptr) {
-				flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
-			}
+                if (do_reflux != 0) {
+                        if (flux_reg_[lev + 1] != nullptr) {
+                                flux_reg_[lev + 1]->Reflux(state_new_cc_[lev], 1.0, 0, 0, state_new_cc_[lev].nComp(), geom[lev]);
+                        }
 		}
 
 		AverageDownTo(lev); // average lev+1 down to lev
@@ -1832,19 +1831,17 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 		}
 	}
 
-	if (fr_as_fine != nullptr) {
-		AMREX_ASSERT(lev > 0);
-		AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
-		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-			int const ncomp = fluxArrays[dir].nComp();
-			if (ncomp == 0) {
-				continue;
-			}
-			fr_as_fine->FineAdd(fluxArrays[dir], dir, 0, 0, ncomp, dt_lev * face_area[dir]);
-		}
-	}
-
-	amrex::Gpu::streamSynchronizeAll();
+        if (fr_as_fine != nullptr) {
+                AMREX_ASSERT(lev > 0);
+                AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
+                for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+                        int const ncomp = fluxArrays[dir].nComp();
+                        if (ncomp == 0) {
+                                continue;
+                        }
+                        fr_as_fine->FineAdd(fluxArrays[dir], dir, 0, 0, ncomp, dt_lev * face_area[dir]);
+                }
+        }
 }
 
 template <typename problem_t> auto AMRSimulation<problem_t>::getAmrInterpolaterCellCentered() -> amrex::MFInterpolater *


### PR DESCRIPTION
### Description
`amrex::FluxRegister` is deterministic, while our previous `amrex::YAFluxRegister` was not (due to using atomics). We need this to be deterministic for AMR simulations to be reproducible.

Using the deterministic `amrex::FluxRegister` requires passing it a MultiFab of fluxes, so this increases the memory usage of the radiation update, which did not previously have such a MultiFab.

Depends on https://github.com/quokka-astro/quokka/pull/1343.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
