### PR TITLE
Rewrite hydro retry algorithm

### DIFF
--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -6,8 +6,8 @@ The hydro integrator advances the conservative gas (and optionally MHD) variable
 - **Source splitting:** Each accepted substep begins and ends with `addStrangSplitSourcesWithBuiltin`, applying the problem-specific source terms for half a timestep.
 - **Runge–Kutta stages:** `advanceHydroAtLevel` implements an SSP-RK2 integrator (with an optional first-order Euler fallback) over two stages. Stage 1 advances from the old state to an intermediate state; Stage 2 starts from the intermediate state and computes the second stage fluxes. The final update is done from the initial state using the average from the Stage 1 and Stage 2 fluxes.
 - **Flux register coupling:** When refluxing is enabled the combined RK fluxes are accumulated via `incrementFluxRegisters`, guaranteeing flux conservation across AMR coarse/fine interfaces.
-- **Tracer and dual-energy support:** Face-averaged velocities produced during the update are reused to advance tracer particles at the end of the step. At each stage, face-centered velocities are used to update the auxiliary internal energy and perform a dual energy sync.
-- **CFL validation:** A final `isCflViolated` check compares the accepted timestep against the maximum signal speed of the provisional updated state. Any violation forces the retry logic to reduce the timestep, ensuring the user-specified `cflNumber_` is respected.
+- **Tracer and dual-energy support:** At each stage, face-centered velocities are used to update the auxiliary internal energy and perform a dual energy sync. Face-centered velocities produced during the update are averaged over the timestep and reused to advance tracer particles at the end of the step.
+- **CFL validation:** A final `isCflViolated` check compares the accepted timestep against the maximum signal speed of the provisional updated state. Any violation forces the retry logic to reduce the timestep and redo the hydro update, ensuring the user-specified `cflNumber_` is respected.
 
 ## Reconstruction and flux evaluation
 `advanceHydroAtLevel` delegates the spatial discretisation to `computeHydroFluxes`:
@@ -18,12 +18,12 @@ The hydro integrator advances the conservative gas (and optionally MHD) variable
 
 ## First-order fallback and stability guards
 Throughout each timestep the solver decorates the update with physics-aware stability checks:
-- `HydroSystem<problem_t>::AddInternalEnergyPdV` and `PredictStep` compute the stage RHS and provisional states. `redoFlag` flips only when the provisional density in a cell becomes non-positive, so flagged cells have their fluxes replaced with the pre-computed first-order counterparts via `replaceFluxes`/`replaceEMFs`. Because both RK stages share the corrected fluxes, the full timestep in those cells is carried out at first order.
+- `HydroSystem<problem_t>::AddInternalEnergyPdV` and `PredictStep` compute the stage RHS and provisional states. `redoFlag` flips only when the provisional density in a cell becomes non-positive, so flagged cells have their fluxes replaced with the pre-computed first-order counterparts via `replaceFluxes`/`replaceEMFs`. The full timestep in those cells is therefore carried out at first order in both space and time.
 - If any flagged cells remain after the first-order correction, the retry machinery escalates (unless `abortOnFofcFailure_` is set, in which case the attempt aborts immediately).
 - Post-update limiters (`EnforceLimits`) and optional dual-energy synchronization ensure the final conservative state obeys positivity constraints prior to CFL evaluation and refluxing.
 
 ## Source terms, radiation, and coupling hooks
-`advanceHydroAtLevel` only updates the conservative hydro variables. Radiation subcycling (`subcycleRadiationAtLevel`), additional operator-split source modules, and diagnostic output are invoked in the surrounding time-stepping loop. The hydro integrator exposes the face-averaged velocities and EMFs needed by those subsystems and writes detailed debug plotfiles when `lowLevelDebuggingOutput_` is enabled, easing diagnosis of instabilities.
+`advanceHydroAtLevel` only updates the conservative hydro variables. Radiation subcycling (`subcycleRadiationAtLevel`), additional operator-split source modules, and diagnostic output are invoked in the surrounding time-stepping loop.
 
 ## Hydro retries algorithm
 The retry loop surrounding the integrator helps prevent crashes in the presence of strong nonlinearities in the solution:
@@ -32,6 +32,4 @@ The retry loop surrounding the integrator helps prevent crashes in the presence 
 2. **Adaptive substepping:** Each retry increases the number of substeps as `nsubsteps = 2^{retry_count}` (capped by `max_retries = 6`). The remaining timestep `dt_remaining` is divided by this count so the integrator can succeed with a smaller CFL number without modifying the user-requested global step.
 3. **Substep execution:** For every substep the integrator reuses the checkpointed state as input, advances by `dt_step`, and, upon success, commits the new state to the accepted buffers. Partial progress updates `completed_time` so the next attempt only covers the unfinished interval.
 4. **Partial progress handling:** If an attempt fails after completing one or more substeps, the loop records that partial progress and restarts with at least one additional level of subdivision. This avoids losing successful substeps while still shrinking the timestep for the remaining portion.
-5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states leave actionable breadcrumbs.
-
-Together, the retry logic and the substep-level first-order fallback provide a layered defence against stiff source terms and strong shocks and rarefactions while preserving as much of the high-order solution as possible.
+5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states can be debugged.

--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -1,0 +1,37 @@
+# Hydro Integrator
+
+The hydro integrator advances the conservative gas (and optionally MHD) variables that live in `state_new_cc_` and the face-centered magnetic fields in `state_new_fc_`. The entry point is `QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries`, which is called once per AMR level from `AdvanceTimeStepOnLevel`. The routine is designed to deliver a second-order accurate, Strang-split update while remaining robust in the presence of stiff source terms, sharp shocks, and MHD-specific stability constraints.
+
+## High-level workflow
+- **Source splitting:** Each accepted substep begins and ends with `addStrangSplitSourcesWithBuiltin`, applying the problem-specific source terms for half a timestep. This keeps reactions, gravity, and other local physics time-centered relative to the hydrodynamic update.
+- **Runge–Kutta stages:** `advanceHydroAtLevel` implements an SSP-RK2 integrator (with an optional first-order Euler fallback) over two stages. Stage 1 advances from the old state to an intermediate state; Stage 2 combines the intermediate fluxes with Stage 1 using RK weights stored in `flux_rk2` and `avgFaceVel`.
+- **Flux register coupling:** When refluxing is enabled the combined RK fluxes are accumulated via `incrementFluxRegisters`, guaranteeing flux conservation across AMR coarse/fine interfaces.
+- **Tracer and dual-energy support:** Face-averaged velocities produced during the update are reused to advance tracer particles and to synchronize the dual-energy formulation after each stage.
+- **CFL validation:** A final `isCflViolated` check compares the accepted timestep against the local maximum signal speed. Any violation forces the retry logic to reduce the timestep, ensuring the user-specified `cflNumber_` is respected.
+
+## Reconstruction and flux evaluation
+`advanceHydroAtLevel` delegates the spatial discretisation to `computeHydroFluxes`:
+- Primitive variables are reconstructed from the conservative state in cell-centered (`state_old_cc_tmp`) and, when MHD is enabled, face-centered (`state_old_fc_tmp`) data structures.
+- Multi-dimensional flattening coefficients (`ComputeFlatteningCoefficients`) limit the slopes near shocks before higher-order reconstruction is applied.
+- Directional flux functions call the appropriate Riemann solver: `HLLC` for pure hydro, `HLLD` plus constrained transport (`SolveInductionEqn`) for MHD. The solver also returns face-centered velocities and the fastest MHD wave speeds used by the EMF update.
+- A first-order (donor-cell) set of fluxes is computed in parallel through `computeFOHydroFluxes`. These rely on the diffusive `LLF` solvers so that first-order flux correction has the most stable possible fallback without discarding the high-order solution everywhere.
+
+## First-order fallback and stability guards
+Throughout each timestep the solver decorates the update with physics-aware stability checks:
+- `HydroSystem<problem_t>::AddInternalEnergyPdV` and `PredictStep` compute the stage RHS and provisional states. `redoFlag` flips only when the provisional density in a cell becomes non-positive, so flagged cells have their fluxes replaced with the pre-computed first-order counterparts via `replaceFluxes`/`replaceEMFs`. Because both RK stages share the corrected fluxes, the full timestep in those cells is carried out at first order.
+- If any flagged cells remain after the first-order correction, the retry machinery escalates (unless `abortOnFofcFailure_` is set, in which case the attempt aborts immediately).
+- Post-update limiters (`EnforceLimits`) and optional dual-energy synchronization ensure the final conservative state obeys positivity constraints prior to CFL evaluation and refluxing.
+
+## Source terms, radiation, and coupling hooks
+`advanceHydroAtLevel` only updates the conservative hydro variables. Radiation subcycling (`subcycleRadiationAtLevel`), additional source modules, tracer advection, and diagnostic output are invoked in the surrounding time-stepping loop. The hydro integrator exposes the face-averaged velocities and EMFs needed by those subsystems and writes detailed debug plotfiles when `lowLevelDebuggingOutput_` is enabled, easing diagnosis of instabilities.
+
+## Hydro retries algorithm
+The retry loop surrounding the integrator guards against pathological timesteps and first-order fallback failures:
+
+1. **State checkpointing:** Before each attempt the routine snapshots the last accepted solution into `accepted_state_cc` (and `accepted_state_fc` for MHD). Failed attempts always restore these buffers so that no partial update contaminates subsequent retries.
+2. **Adaptive substepping:** Each retry increases the number of substeps as `nsubsteps = 2^{retry_count}` (capped by `max_retries = 6`). The remaining timestep `dt_remaining` is divided by this count so the integrator can succeed with a smaller CFL number without modifying the user-requested global step.
+3. **Substep execution:** For every substep the integrator reuses the checkpointed state as input, advances by `dt_step`, and, upon success, commits the new state to the accepted buffers. Partial progress updates `completed_time` so the next attempt only covers the unfinished interval.
+4. **Partial progress handling:** If an attempt fails after completing one or more substeps, the loop records that partial progress and restarts with at least one additional level of subdivision. This avoids losing successful substeps while still shrinking the timestep for the remaining portion.
+5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states leave actionable breadcrumbs.
+
+Together, the retry logic and the stage-level first-order fallback provide a layered defence against stiff source terms, extreme shocks, and unexpected CFL violations while preserving as much of the high-order solution as possible.

--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -1,20 +1,20 @@
 # Hydro Integrator
 
-The hydro integrator advances the conservative gas (and optionally MHD) variables that live in `state_new_cc_` and the face-centered magnetic fields in `state_new_fc_`. The entry point is `QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries`, which is called once per AMR level from `AdvanceTimeStepOnLevel`. The routine is designed to deliver a second-order accurate, Strang-split update while remaining robust in the presence of stiff source terms, sharp shocks, and MHD-specific stability constraints.
+The hydro integrator advances the conservative gas (and optionally MHD) variables that live in `state_new_cc_` and the face-centered magnetic fields in `state_new_fc_`. The entry point is `QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries`, which is called once per AMR level from `AdvanceTimeStepOnLevel`. The routine is designed to deliver a second-order accurate, Strang-split update while remaining robust in the presence of stiff source terms and strong shocks and rarefactions.
 
 ## High-level workflow
-- **Source splitting:** Each accepted substep begins and ends with `addStrangSplitSourcesWithBuiltin`, applying the problem-specific source terms for half a timestep. This keeps reactions, gravity, and other local physics time-centered relative to the hydrodynamic update.
-- **Runge–Kutta stages:** `advanceHydroAtLevel` implements an SSP-RK2 integrator (with an optional first-order Euler fallback) over two stages. Stage 1 advances from the old state to an intermediate state; Stage 2 combines the intermediate fluxes with Stage 1 using RK weights stored in `flux_rk2` and `avgFaceVel`.
+- **Source splitting:** Each accepted substep begins and ends with `addStrangSplitSourcesWithBuiltin`, applying the problem-specific source terms for half a timestep.
+- **Runge–Kutta stages:** `advanceHydroAtLevel` implements an SSP-RK2 integrator (with an optional first-order Euler fallback) over two stages. Stage 1 advances from the old state to an intermediate state; Stage 2 starts from the intermediate state and computes the second stage fluxes. The final update is done from the initial state using the average from the Stage 1 and Stage 2 fluxes.
 - **Flux register coupling:** When refluxing is enabled the combined RK fluxes are accumulated via `incrementFluxRegisters`, guaranteeing flux conservation across AMR coarse/fine interfaces.
-- **Tracer and dual-energy support:** Face-averaged velocities produced during the update are reused to advance tracer particles and to synchronize the dual-energy formulation after each stage.
-- **CFL validation:** A final `isCflViolated` check compares the accepted timestep against the local maximum signal speed. Any violation forces the retry logic to reduce the timestep, ensuring the user-specified `cflNumber_` is respected.
+- **Tracer and dual-energy support:** Face-averaged velocities produced during the update are reused to advance tracer particles at the end of the step. At each stage, face-centered velocities are used to update the auxiliary internal energy and perform a dual energy sync.
+- **CFL validation:** A final `isCflViolated` check compares the accepted timestep against the maximum signal speed of the provisional updated state. Any violation forces the retry logic to reduce the timestep, ensuring the user-specified `cflNumber_` is respected.
 
 ## Reconstruction and flux evaluation
 `advanceHydroAtLevel` delegates the spatial discretisation to `computeHydroFluxes`:
-- Primitive variables are reconstructed from the conservative state in cell-centered (`state_old_cc_tmp`) and, when MHD is enabled, face-centered (`state_old_fc_tmp`) data structures.
+- Primitive variables are reconstructed from the conservative state stored in the cell-centered (`state_old_cc_tmp`) and, when MHD is enabled, face-centered (`state_old_fc_tmp`) data structures.
 - Multi-dimensional flattening coefficients (`ComputeFlatteningCoefficients`) limit the slopes near shocks before higher-order reconstruction is applied.
 - Directional flux functions call the appropriate Riemann solver: `HLLC` for pure hydro, `HLLD` plus constrained transport (`SolveInductionEqn`) for MHD. The solver also returns face-centered velocities and the fastest MHD wave speeds used by the EMF update.
-- A first-order (donor-cell) set of fluxes is computed in parallel through `computeFOHydroFluxes`. These rely on the diffusive `LLF` solvers so that first-order flux correction has the most stable possible fallback without discarding the high-order solution everywhere.
+- Before the second-order update, a first-order (donor-cell) set of fluxes is computed through `computeFOHydroFluxes`. These rely on the diffusive `LLF` solvers so that first-order flux correction has the most stable possible fallback without discarding the high-order solution everywhere.
 
 ## First-order fallback and stability guards
 Throughout each timestep the solver decorates the update with physics-aware stability checks:
@@ -23,10 +23,10 @@ Throughout each timestep the solver decorates the update with physics-aware stab
 - Post-update limiters (`EnforceLimits`) and optional dual-energy synchronization ensure the final conservative state obeys positivity constraints prior to CFL evaluation and refluxing.
 
 ## Source terms, radiation, and coupling hooks
-`advanceHydroAtLevel` only updates the conservative hydro variables. Radiation subcycling (`subcycleRadiationAtLevel`), additional source modules, tracer advection, and diagnostic output are invoked in the surrounding time-stepping loop. The hydro integrator exposes the face-averaged velocities and EMFs needed by those subsystems and writes detailed debug plotfiles when `lowLevelDebuggingOutput_` is enabled, easing diagnosis of instabilities.
+`advanceHydroAtLevel` only updates the conservative hydro variables. Radiation subcycling (`subcycleRadiationAtLevel`), additional operator-split source modules, and diagnostic output are invoked in the surrounding time-stepping loop. The hydro integrator exposes the face-averaged velocities and EMFs needed by those subsystems and writes detailed debug plotfiles when `lowLevelDebuggingOutput_` is enabled, easing diagnosis of instabilities.
 
 ## Hydro retries algorithm
-The retry loop surrounding the integrator guards against pathological timesteps and first-order fallback failures:
+The retry loop surrounding the integrator helps prevent crashes in the presence of strong nonlinearities in the solution:
 
 1. **State checkpointing:** Before each attempt the routine snapshots the last accepted solution into `accepted_state_cc` (and `accepted_state_fc` for MHD). Failed attempts always restore these buffers so that no partial update contaminates subsequent retries.
 2. **Adaptive substepping:** Each retry increases the number of substeps as `nsubsteps = 2^{retry_count}` (capped by `max_retries = 6`). The remaining timestep `dt_remaining` is divided by this count so the integrator can succeed with a smaller CFL number without modifying the user-requested global step.
@@ -34,4 +34,4 @@ The retry loop surrounding the integrator guards against pathological timesteps 
 4. **Partial progress handling:** If an attempt fails after completing one or more substeps, the loop records that partial progress and restarts with at least one additional level of subdivision. This avoids losing successful substeps while still shrinking the timestep for the remaining portion.
 5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states leave actionable breadcrumbs.
 
-Together, the retry logic and the stage-level first-order fallback provide a layered defence against stiff source terms, extreme shocks, and unexpected CFL violations while preserving as much of the high-order solution as possible.
+Together, the retry logic and the substep-level first-order fallback provide a layered defence against stiff source terms and strong shocks and rarefactions while preserving as much of the high-order solution as possible.

--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -28,40 +28,39 @@ Throughout each timestep the solver decorates the update with physics-aware stab
 ## Hydro retries algorithm
 The retry loop surrounding the integrator helps prevent crashes in the presence of strong nonlinearities in the solution:
 
-1. **State checkpointing:** Before each attempt the routine snapshots the last accepted solution into `accepted_state_cc` (and `accepted_state_fc` for MHD). Failed attempts always restore these buffers so that no partial update contaminates subsequent retries.
-2. **Adaptive substepping:** Each retry chooses `nsubsteps = 2^{retry_count}` (with `retry_count ≤ max_retries = 6`). Progress is recorded as an integer number of base units, where one unit represents `dt_lev / (2^{max_retries})`. This guarantees that any retry can reinterpret previously accepted work exactly on its canonical grid.
-3. **Substep execution:** For the current retry level the code computes `units_per_substep = 2^{max_retries - retry_count}` and evaluates `completed_substeps = completed_units / units_per_substep`. Only the remaining substeps are executed. The floating-point time passed to `advanceHydroAtLevel` is reconstructed on demand from the integer unit count: `t_sub = t0 + completed_units * dt_lev / 2^{max_retries}`.
-4. **Partial progress handling:** Accepting a substep immediately increments the integer progress counter. If a failure occurs after some substeps succeed, the retry level is bumped (capped by `max_retries`) so the next attempt uses smaller substeps; a fully successful pass exits the outer loop immediately.
+1. **State checkpointing:** Before each attempt the routine snapshots the last accepted solution into `accepted_state_cc` (and `accepted_state_fc` for MHD). Failed attempts always call `restoreHydroState()` so that no partial update contaminates subsequent retries.
+2. **Adaptive substepping:** Each retry chooses `total_substeps = 2^{cur_retry_level}` (with `cur_retry_level ≤ max_retries = 6`). Progress is recorded as an integer number of base units, where one unit represents `dt_lev / (2^{max_retries})`. This guarantees that any retry can reinterpret previously accepted work exactly on its canonical grid.
+3. **Substep execution:** For the current retry level the code computes `units_per_substep = 2^{max_retries - cur_retry_level}` and evaluates `start_substep = completed_units / units_per_substep`. Only the remaining substeps are executed. The floating-point time passed to `advanceHydroAtLevel` is reconstructed on demand as `current_substep_time = time + substep_index * dt_substep`.
+4. **Partial progress handling:** Accepting a substep immediately increments `completed_units` and calls `updateAcceptedHydroState()`. If a failure occurs after some substeps succeed, the retry level is bumped (capped by `max_retries`) so the next attempt uses smaller substeps; a fully successful pass exits the outer loop immediately.
 5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states can be debugged.
 
 ### Pseudocode outline
 
 ```text
-t0 = currentLevelTime
-maxUnits = 1 << maxRetries
-acceptedState = snapshotCellCenteredState()
-acceptedFaceState = snapshotFaceCenteredState()
+time = currentLevelTime
+max_total_substeps = 1 << max_retries
+accepted_state_cc = snapshotCellCenteredState()
+accepted_state_fc = snapshotFaceCenteredState()
 
-completedUnits = 0
-curRetryLevel = 0
-while completedUnits < maxUnits and curRetryLevel <= maxRetries:
-    totalSubsteps = 1 << curRetryLevel
-    unitsPerSubstep = maxUnits // totalSubsteps
-    startSubstep = completedUnits // unitsPerSubstep
-    dtSubstep = dtTotal / totalSubsteps
+completed_units = 0
+cur_retry_level = 0
+while completed_units < max_total_substeps and cur_retry_level <= max_retries:
+    total_substeps = 1 << cur_retry_level
+    units_per_substep = max_total_substeps // total_substeps
+    start_substep = completed_units // units_per_substep
+    dt_substep = dt_lev / total_substeps
 
-    for substepIndex in range(startSubstep, totalSubsteps):
-        substepTime = t0 + substepIndex * dtSubstep
-        status = advanceHydroAtLevel(substepTime, dtSubstep)
-        if status.failed():
-            restoreStateFrom(acceptedState, acceptedFaceState)
-            curRetryLevel += 1
+    for substep_index in range(start_substep, total_substeps):
+        current_substep_time = time + substep_index * dt_substep
+        substep_success = advanceHydroAtLevel(current_substep_time, dt_substep)
+        if not substep_success:
+            restoreHydroState()
+            cur_retry_level += 1
             break
-        else:
-            completedUnits += unitsPerSubstep
-            commitAcceptedState()
+        completed_units += units_per_substep
+        updateAcceptedHydroState()
 
-if completedUnits < maxUnits:
+if completed_units < max_total_substeps:
     writeFatalDiagnostics()
     abortHydroStep()
 ```

--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -29,7 +29,39 @@ Throughout each timestep the solver decorates the update with physics-aware stab
 The retry loop surrounding the integrator helps prevent crashes in the presence of strong nonlinearities in the solution:
 
 1. **State checkpointing:** Before each attempt the routine snapshots the last accepted solution into `accepted_state_cc` (and `accepted_state_fc` for MHD). Failed attempts always restore these buffers so that no partial update contaminates subsequent retries.
-2. **Adaptive substepping:** Each retry increases the number of substeps as `nsubsteps = 2^{retry_count}` (capped by `max_retries = 6`). The remaining timestep `dt_remaining` is divided by this count so the integrator can succeed with a smaller CFL number without modifying the user-requested global step.
-3. **Substep execution:** For every substep the integrator reuses the checkpointed state as input, advances by `dt_step`, and, upon success, commits the new state to the accepted buffers. Partial progress updates `completed_time` so the next attempt only covers the unfinished interval.
-4. **Partial progress handling:** If an attempt fails after completing one or more substeps, the loop records that partial progress and restarts with at least one additional level of subdivision. This avoids losing successful substeps while still shrinking the timestep for the remaining portion.
+2. **Adaptive substepping:** Each retry chooses `nsubsteps = 2^{retry_count}` (with `retry_count ≤ max_retries = 6`). Progress is recorded as an integer number of base units, where one unit represents `dt_lev / (2^{max_retries})`. This guarantees that any retry can reinterpret previously accepted work exactly on its canonical grid.
+3. **Substep execution:** For the current retry level the code computes `units_per_substep = 2^{max_retries - retry_count}` and evaluates `completed_substeps = completed_units / units_per_substep`. Only the remaining substeps are executed. The floating-point time passed to `advanceHydroAtLevel` is reconstructed on demand from the integer unit count: `t_sub = t0 + completed_units * dt_lev / 2^{max_retries}`.
+4. **Partial progress handling:** Accepting a substep immediately increments the integer progress counter. If a failure occurs after some substeps succeed, the retry level is bumped (capped by `max_retries`) so the next attempt uses smaller substeps; a fully successful pass exits the outer loop immediately.
 5. **Failure diagnostics:** Exceeding the retry budget triggers a fatal diagnostic: the code writes a `debug_hydro_state_fatal` plotfile (or Blueprint output when Ascent is enabled) and aborts, ensuring that difficult-to-integrate states can be debugged.
+
+### Pseudocode outline
+
+```text
+t0 = currentLevelTime
+maxUnits = 1 << maxRetries
+acceptedState = snapshotCellCenteredState()
+acceptedFaceState = snapshotFaceCenteredState()
+
+completedUnits = 0
+curRetryLevel = 0
+while completedUnits < maxUnits and curRetryLevel <= maxRetries:
+    totalSubsteps = 1 << curRetryLevel
+    unitsPerSubstep = maxUnits // totalSubsteps
+    startSubstep = completedUnits // unitsPerSubstep
+    dtSubstep = dtTotal / totalSubsteps
+
+    for substepIndex in range(startSubstep, totalSubsteps):
+        substepTime = t0 + substepIndex * dtSubstep
+        status = advanceHydroAtLevel(substepTime, dtSubstep)
+        if status.failed():
+            restoreStateFrom(acceptedState, acceptedFaceState)
+            curRetryLevel += 1
+            break
+        else:
+            completedUnits += unitsPerSubstep
+            commitAcceptedState()
+
+if completedUnits < maxUnits:
+    writeFatalDiagnostics()
+    abortHydroStep()
+```

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Developer Guide:
     - Contributing Guide: contributing.md
     - Flowchart: flowchart.md
+    - Hydro Integrator: hydro_integrator.md
     - Debugging: debugging.md
     - Assertions and error checking: error_checking.md
     - Performance tips: performance.md

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1186,99 +1186,144 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 								 amrex::YAFluxRegister *fr_as_fine)
 {
 	const BL_PROFILE_REGION("HydroSolver");
-	// timestep retries
 	const int max_retries = 6;
-	bool success = false;
+	bool overall_success = true;
 
-	// save the pre-advance fine flux register state in originalFineData
-	amrex::MultiFab originalFineData;
-	if (fr_as_fine != nullptr) {
-		amrex::MultiFab const &fineData = fr_as_fine->getFineData();
-		originalFineData.define(fineData.boxArray(), fineData.DistributionMap(), fineData.nComp(), 0);
-		amrex::Copy(originalFineData, fineData, 0, 0, fineData.nComp(), 0);
+	amrex::MultiFab accepted_state_cc(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+	amrex::Copy(accepted_state_cc, state_old_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> accepted_state_fc;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+			accepted_state_fc[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			amrex::Copy(accepted_state_fc[idim], state_old_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+		}
 	}
 
-	amrex::AmrTracerParticleContainer::ContainerLike<amrex::DefaultAllocator> originalTracerPC;
-	if (do_tracers != 0) {
-		// save the pre-advance tracer particles
-		originalTracerPC = TracerPC->make_alike();	 // create empty particle container
-		originalTracerPC.copyParticles(*TracerPC, true); // do local copy of particles
-	}
-
-	for (int retry_count = 0; retry_count <= max_retries; ++retry_count) {
-		// reduce timestep by a factor of 2^retry_count
-		const int nsubsteps = static_cast<int>(std::pow(2, retry_count));
-		const amrex::Real dt_step = dt_lev / nsubsteps;
-
-		if (retry_count > 0 && Verbose()) {
-			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (nsubsteps = " << nsubsteps
-				       << ", dt_new = " << dt_step << ")\n";
-		}
-
-		if (retry_count > 0) {
-			// reset the flux registers to their pre-advance state
-			if (fr_as_crse != nullptr) {
-				fr_as_crse->reset();
-			}
-			if (fr_as_fine != nullptr) {
-				amrex::Copy(fr_as_fine->getFineData(), originalFineData, 0, 0, originalFineData.nComp(), 0);
-			}
-
-			if (do_tracers != 0) {
-				// reset the tracer particles to their pre-advance state
-				TracerPC->copyParticles(originalTracerPC, true);
-			}
-		}
-
-		// create temporary multifab for old cell-cenetered state
-		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-		amrex::Copy(state_old_cc_tmp, state_old_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-
-		// create temporary array (different faces) of multifabs for old face-centered state
-		std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+	auto restoreHydroState = [&]() {
+		amrex::Copy(state_new_cc_[lev], accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				state_old_fc_tmp[idim].define(amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim)), dmap[lev],
-							      Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-				amrex::Copy(state_old_fc_tmp[idim], state_old_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+				amrex::Copy(state_new_fc_[lev][idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
 			}
 		}
+	};
 
-		// subcycle advanceHydroAtLevel, checking return value
-		for (int substep = 0; substep < nsubsteps; ++substep) {
-			if (substep > 0) {
-				// since we are starting a new substep, we need to copy hydro state from
-				//  the new state vector to old state vector
-				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
-				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-						amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
-							    nghost_fc_);
+	auto updateAcceptedHydroState = [&]() {
+		amrex::Copy(accepted_state_cc, state_new_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				amrex::Copy(accepted_state_fc[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			}
+		}
+	};
+
+	restoreHydroState();
+
+	amrex::Real completed_time = 0.;
+	amrex::Real current_time = time;
+	int start_retry_count = 0;
+
+	while (completed_time < dt_lev && overall_success) {
+		amrex::Real dt_remaining = dt_lev - completed_time;
+		if (dt_remaining <= 0.) {
+			break;
+		}
+
+		bool completed_this_remaining = false;
+		bool partial_progress = false;
+		int retry_count = start_retry_count;
+
+		while (retry_count <= max_retries) {
+			const int nsubsteps = 1 << retry_count;
+			const amrex::Real dt_step = dt_remaining / static_cast<amrex::Real>(nsubsteps);
+
+			if (retry_count > 0 && Verbose()) {
+				amrex::Print() << "	>> Re-trying hydro advance at level " << lev << " with reduced timestep (remaining dt = " << dt_remaining
+					       << ", nsubsteps = " << nsubsteps << ", dt_new = " << dt_step << ")\n";
+			}
+
+			restoreHydroState();
+
+			amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+			amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+
+			std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+					auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+					state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+					amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+				}
+			}
+
+			bool attempt_success = true;
+			int substeps_accepted_in_attempt = 0;
+			amrex::Real substep_time = current_time;
+
+			for (int substep = 0; substep < nsubsteps; ++substep) {
+				if (substep > 0) {
+					amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
+					if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+						for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+							amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+						}
 					}
 				}
+
+				const bool substep_success =
+				    advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, substep_time, dt_step);
+				if (!substep_success) {
+					attempt_success = false;
+					break;
+				}
+
+				substep_time += dt_step;
+				++substeps_accepted_in_attempt;
+				completed_time += dt_step;
+				if (completed_time > dt_lev) {
+					completed_time = std::min(completed_time, dt_lev);
+				}
+				current_time = substep_time;
+
+				updateAcceptedHydroState();
 			}
 
-			success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, time, dt_step);
-
-			if (!success) {
-				if (Verbose()) {
-					amrex::Print() << "\t>> WARNING: Hydro advance failed on level " << lev << "\n";
-				}
+			if (attempt_success) {
+				completed_this_remaining = true;
+				start_retry_count = 0;
 				break;
 			}
+
+			restoreHydroState();
+
+			dt_remaining = dt_lev - completed_time;
+			if (substeps_accepted_in_attempt > 0) {
+				partial_progress = true;
+				start_retry_count = std::max(start_retry_count, 1);
+				break;
+			}
+
+			++retry_count;
+			start_retry_count = retry_count;
 		}
 
-		if (success) {
-			// we are done, do not attempt more retries
-			break;
+		if (!completed_this_remaining) {
+			if (!partial_progress && retry_count > max_retries) {
+				overall_success = false;
+			}
+			if (!overall_success) {
+				break;
+			}
+			continue;
 		}
 	}
 
-	if (!success) {
+	if (!overall_success) {
 		// crash, we have exceeded max_retries
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"
-			       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"
-			       << std::endl; // NOLINT(performance-avoid-endl)
+		       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"
+		       << std::endl; // NOLINT(performance-avoid-endl)
 
 		// write plotfile or Ascent Blueprint file
 		amrex::ParallelDescriptor::Barrier();
@@ -1346,12 +1391,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 {
 	const BL_PROFILE("QuokkaSimulation::advanceHydroAtLevel()");
 
-	amrex::Real fluxScaleFactor = NAN;
-	if (integratorOrder_ == 2) {
-		fluxScaleFactor = 0.5;
-	} else if (integratorOrder_ == 1) {
-		fluxScaleFactor = 1.0;
-	}
+	const amrex::Real stage1Weight = (integratorOrder_ == 2) ? 0.5 : 1.0;
 
 	auto ba_cc = grids[lev];
 	auto dm = dmap[lev];
@@ -1461,10 +1501,10 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::MultiFab::Saxpy(flux_rk2[idim], 0.5, fluxArrays[idim], 0, 0, ncompHydro_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, 0);
+			amrex::MultiFab::Saxpy(flux_rk2[idim], stage1Weight, fluxArrays[idim], 0, 0, ncompHydro_, 0);
+			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, 0);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], 0.5, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
+				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], stage1Weight, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
 			}
 		}
 
@@ -1559,10 +1599,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
 		}
 
-		if (do_reflux == 1) {
-			// increment flux registers
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-		}
 	}
 	amrex::Gpu::streamSynchronizeAll();
 
@@ -1673,10 +1709,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			HydroSystem<problem_t>::SyncDualEnergy(stateFinal_cc, stateFinal_fc);
 		}
 
-		if (do_reflux == 1) {
-			// increment flux registers
-			incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, fluxScaleFactor * dt_lev);
-		}
 	} else { // we are only doing forward Euler
 		amrex::Copy(state_new_cc_[lev], state_inter_cc_, 0, 0, ncompHydro_, 0);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1687,16 +1719,21 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	}
 	amrex::Gpu::streamSynchronizeAll();
 
-	// advect tracer particles using avgFaceVel
-	if (do_tracers != 0) {
-		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
-	}
-
 	// do Strang split source terms (second half-step)
 	auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
 
-	// check if we have violated the CFL timestep or reactions failed for source terms
-	return (!isCflViolated(lev, time, dt_lev) && burn_success_second);
+	bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+	bool const final_success = (cfl_ok && burn_success_second);
+
+	if (do_reflux == 1 && final_success) {
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, flux_rk2, lev, dt_lev);
+	}
+
+	if (do_tracers != 0 && final_success) {
+		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
+	}
+
+	return final_success;
 }
 
 template <typename problem_t>

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1224,66 +1224,66 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 	int cur_retry_level = 0;
 
 	while (completed_units < max_total_substeps && cur_retry_level <= max_retries) {
-	  const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
-	  const int units_per_substep = max_total_substeps / total_substeps;
-	  const int start_substep = completed_units / units_per_substep;
-	  const amrex::Real dt_substep = dt_lev / static_cast<amrex::Real>(total_substeps);
-	  const amrex::Real dt_attempt_remaining = dt_substep * static_cast<amrex::Real>(total_substeps - start_substep);
+		const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
+		const int units_per_substep = max_total_substeps / total_substeps;
+		const int start_substep = completed_units / units_per_substep;
+		const amrex::Real dt_substep = dt_lev / static_cast<amrex::Real>(total_substeps);
+		const amrex::Real dt_attempt_remaining = dt_substep * static_cast<amrex::Real>(total_substeps - start_substep);
 
-	  if (cur_retry_level > 0 && Verbose()) {
-	    amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (remaining dt = " << dt_attempt_remaining
-			   << ", total substeps = " << total_substeps << ", completed substeps = " << start_substep << ", dt_new = " << dt_substep
-			   << ")\n";
-	  }
-	  
-	  amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-	  amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-	  
-	  std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
-	  if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-	    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-	      auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
-	      state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-	      amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-	    }
-	  }
-	  
-	  bool attempt_failed = false;
-	  
-	  for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
-            if (substep_index > start_substep) {
-	      amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
-	      if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		  amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0,
-			      Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+		if (cur_retry_level > 0 && Verbose()) {
+			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (remaining dt = " << dt_attempt_remaining
+				       << ", total substeps = " << total_substeps << ", completed substeps = " << start_substep << ", dt_new = " << dt_substep
+				       << ")\n";
 		}
-	      }
-            }
 
-	    const amrex::Real current_substep_time = time + static_cast<amrex::Real>(substep_index) * dt_substep;
-	    const bool substep_success =
-	      advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, current_substep_time, dt_substep);
-	    if (!substep_success) {
-	      attempt_failed = true;
-	      break;
-	    }
-	    
-	    completed_units += units_per_substep;
-	    if (completed_units > max_total_substeps) {
-	      completed_units = max_total_substeps;
-	    }
-	    
-	    updateAcceptedHydroState();
-	  }
-	  
-	  if (attempt_failed) {
-	    restoreHydroState();
-	    ++cur_retry_level;
-	    continue;
-	  }
-	  
-	  break;
+		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+		amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+				state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+				amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			}
+		}
+
+		bool attempt_failed = false;
+
+		for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
+			if (substep_index > start_substep) {
+				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+						amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
+							    nghost_fc_);
+					}
+				}
+			}
+
+			const amrex::Real current_substep_time = time + static_cast<amrex::Real>(substep_index) * dt_substep;
+			const bool substep_success =
+			    advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, current_substep_time, dt_substep);
+			if (!substep_success) {
+				attempt_failed = true;
+				break;
+			}
+
+			completed_units += units_per_substep;
+			if (completed_units > max_total_substeps) {
+				completed_units = max_total_substeps;
+			}
+
+			updateAcceptedHydroState();
+		}
+
+		if (attempt_failed) {
+			restoreHydroState();
+			++cur_retry_level;
+			continue;
+		}
+
+		break;
 	}
 
 	if (completed_units < max_total_substeps) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1235,7 +1235,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		int retry_count = start_retry_count;
 
 		while (retry_count <= max_retries) {
-			const int nsubsteps = static_cast<int>(1u << static_cast<unsigned>(retry_count));
+			const int nsubsteps = static_cast<int>(1U << static_cast<unsigned>(retry_count));
 			const amrex::Real dt_step = dt_remaining / static_cast<amrex::Real>(nsubsteps);
 
 			if (retry_count > 0 && Verbose()) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1219,7 +1219,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		}
 	};
 
-	const int max_total_substeps = 1 << max_retries;
+	const int max_total_substeps = static_cast<int>(1U << static_cast<unsigned>(max_retries));
 	int completed_units = 0;
 	int cur_retry_level = 0;
 
@@ -1270,9 +1270,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 			}
 
 			completed_units += units_per_substep;
-			if (completed_units > max_total_substeps) {
-				completed_units = max_total_substeps;
-			}
+			completed_units = std::min(completed_units, max_total_substeps);
 
 			updateAcceptedHydroState();
 		}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1189,7 +1189,6 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 {
 	const BL_PROFILE_REGION("HydroSolver");
 	const int max_retries = 6;
-	bool overall_success = true;
 
 	amrex::MultiFab accepted_state_cc(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 	amrex::Copy(accepted_state_cc, state_old_cc_[lev], 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
@@ -1220,13 +1219,11 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		}
 	};
 
-	restoreHydroState();
+	const int max_total_substeps = 1 << max_retries;
+	int completed_units = 0;
+	int cur_retry_level = 0;
 
-    const int max_total_substeps = 1 << max_retries;
-    int completed_units = 0;
-    int cur_retry_level = 0;
-
-    while (overall_success && completed_units < max_total_substeps && cur_retry_level <= max_retries) {
+	while (completed_units < max_total_substeps && cur_retry_level <= max_retries) {
         const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
         const int units_per_substep = max_total_substeps / total_substeps;
         AMREX_ALWAYS_ASSERT(max_total_substeps % total_substeps == 0);
@@ -1257,9 +1254,9 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
             }
         }
 
-        bool attempt_failed = false;
+		bool attempt_failed = false;
 
-        for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
+		for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
             if (substep_index > start_substep) {
                 amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
                 if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -1292,13 +1289,10 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 			continue;
 		}
 
-        break;
-    }
+		break;
+	}
 
-    if (completed_units < max_total_substeps) {
-        overall_success = false;
-    }
-	if (!overall_success) {
+	if (completed_units < max_total_substeps) {
 		// crash, we have exceeded max_retries
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"
 			       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1465,14 +1465,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 							 emfReconstructionOrder_, emfAveragingType_, emf_scheme_);
 		}
 
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::MultiFab::Saxpy(flux_rk2[idim], stage1Weight, fluxArrays[idim], 0, 0, ncompHydro_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, 0);
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], stage1Weight, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
-			}
-		}
-
 		amrex::MultiFab rhs(grids[lev], dmap[lev], ncompHydro_, 0);
 		amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
 		redoFlag.setVal(quokka::redoFlag::none);
@@ -1553,7 +1545,15 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], stage1Weight, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
+			}
 			MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components_rk_stage1, dt_lev, geom[lev].CellSizeArray());
+		}
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			amrex::MultiFab::Saxpy(flux_rk2[idim], stage1Weight, fluxArrays[idim], 0, 0, ncompHydro_, 0);
+			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, 0);
 		}
 
 		// prevent vacuum

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -11,7 +11,9 @@
 
 #include "grid.hpp"
 #include "hydro/EOS.hpp"
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <iostream>
 #include <set>
 #if __has_include(<filesystem>)
@@ -1220,108 +1222,82 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 
 	restoreHydroState();
 
-	amrex::Real completed_time = 0.;
-	amrex::Real current_time = time;
-	int start_retry_count = 0;
+    const int max_total_substeps = 1 << max_retries;
+    int completed_units = 0;
+    int cur_retry_level = 0;
 
-	while (completed_time < dt_lev && overall_success) {
-		amrex::Real dt_remaining = dt_lev - completed_time;
-		if (dt_remaining <= 0.) {
-			break;
+    while (overall_success && completed_units < max_total_substeps && cur_retry_level <= max_retries) {
+        const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
+        const int units_per_substep = max_total_substeps / total_substeps;
+        AMREX_ALWAYS_ASSERT(max_total_substeps % total_substeps == 0);
+
+        const int start_substep = completed_units / units_per_substep;
+        const amrex::Real dt_substep = dt_lev / static_cast<amrex::Real>(total_substeps);
+        const amrex::Real dt_attempt_remaining =
+            dt_substep * static_cast<amrex::Real>(total_substeps - start_substep);
+
+		if (cur_retry_level > 0 && Verbose()) {
+			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev
+			               << " with reduced timestep (remaining dt = " << dt_attempt_remaining
+			               << ", total substeps = " << total_substeps
+			               << ", completed substeps = " << start_substep
+			               << ", dt_new = " << dt_substep << ")\n";
 		}
 
-		bool completed_this_remaining = false;
-		bool partial_progress = false;
-		int retry_count = start_retry_count;
+		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+		amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 
-		while (retry_count <= max_retries) {
-			const int nsubsteps = static_cast<int>(1U << static_cast<unsigned>(retry_count));
-			const amrex::Real dt_step = dt_remaining / static_cast<amrex::Real>(nsubsteps);
+        std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+        if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+                state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+                amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0,
+                              Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+            }
+        }
 
-			if (retry_count > 0 && Verbose()) {
-				amrex::Print() << "	>> Re-trying hydro advance at level " << lev
-					       << " with reduced timestep (remaining dt = " << dt_remaining << ", nsubsteps = " << nsubsteps
-					       << ", dt_new = " << dt_step << ")\n";
-			}
+        bool attempt_failed = false;
 
-			restoreHydroState();
+        for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
+            if (substep_index > start_substep) {
+                amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
+                if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+                    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                        amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0,
+                                      Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+                    }
+                }
+            }
 
-			amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-			amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
+			const amrex::Real current_substep_time = time + static_cast<amrex::Real>(substep_index) * dt_substep;
+            const bool substep_success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev,
+                                                             current_substep_time, dt_substep);
+            if (!substep_success) {
+                attempt_failed = true;
+                break;
+            }
 
-			std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-					auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
-					state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-					amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
-						    nghost_fc_);
-				}
-			}
+            completed_units += units_per_substep;
+            if (completed_units > max_total_substeps) {
+                completed_units = max_total_substeps;
+            }
 
-			bool attempt_success = true;
-			int substeps_accepted_in_attempt = 0;
-			amrex::Real substep_time = current_time;
-
-			for (int substep = 0; substep < nsubsteps; ++substep) {
-				if (substep > 0) {
-					amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
-					if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-						for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-							amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0,
-								    Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-						}
-					}
-				}
-
-				const bool substep_success =
-				    advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, substep_time, dt_step);
-				if (!substep_success) {
-					attempt_success = false;
-					break;
-				}
-
-				substep_time += dt_step;
-				++substeps_accepted_in_attempt;
-				completed_time += dt_step;
-				if (completed_time > dt_lev) {
-					completed_time = std::min(completed_time, dt_lev);
-				}
-				current_time = substep_time;
-
-				updateAcceptedHydroState();
-			}
-
-			if (attempt_success) {
-				completed_this_remaining = true;
-				start_retry_count = 0;
-				break;
-			}
-
-			restoreHydroState();
-
-			dt_remaining = dt_lev - completed_time;
-			if (substeps_accepted_in_attempt > 0) {
-				partial_progress = true;
-				start_retry_count = std::max(start_retry_count, 1);
-				break;
-			}
-
-			++retry_count;
-			start_retry_count = retry_count;
+			updateAcceptedHydroState();
 		}
 
-		if (!completed_this_remaining) {
-			if (!partial_progress && retry_count > max_retries) {
-				overall_success = false;
-			}
-			if (!overall_success) {
-				break;
-			}
+		if (attempt_failed) {
+			restoreHydroState();
+			++cur_retry_level;
 			continue;
 		}
-	}
 
+        break;
+    }
+
+    if (completed_units < max_total_substeps) {
+        overall_success = false;
+    }
 	if (!overall_success) {
 		// crash, we have exceeded max_retries
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1222,66 +1222,62 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 
 	restoreHydroState();
 
-    const int max_total_substeps = 1 << max_retries;
-    int completed_units = 0;
-    int cur_retry_level = 0;
+	const int max_total_substeps = 1 << max_retries;
+	int completed_units = 0;
+	int cur_retry_level = 0;
 
-    while (overall_success && completed_units < max_total_substeps && cur_retry_level <= max_retries) {
-        const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
-        const int units_per_substep = max_total_substeps / total_substeps;
-        AMREX_ALWAYS_ASSERT(max_total_substeps % total_substeps == 0);
+	while (overall_success && completed_units < max_total_substeps && cur_retry_level <= max_retries) {
+		const int total_substeps = static_cast<int>(1U << static_cast<unsigned>(cur_retry_level));
+		const int units_per_substep = max_total_substeps / total_substeps;
+		AMREX_ALWAYS_ASSERT(max_total_substeps % total_substeps == 0);
 
-        const int start_substep = completed_units / units_per_substep;
-        const amrex::Real dt_substep = dt_lev / static_cast<amrex::Real>(total_substeps);
-        const amrex::Real dt_attempt_remaining =
-            dt_substep * static_cast<amrex::Real>(total_substeps - start_substep);
+		const int start_substep = completed_units / units_per_substep;
+		const amrex::Real dt_substep = dt_lev / static_cast<amrex::Real>(total_substeps);
+		const amrex::Real dt_attempt_remaining = dt_substep * static_cast<amrex::Real>(total_substeps - start_substep);
 
 		if (cur_retry_level > 0 && Verbose()) {
-			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev
-			               << " with reduced timestep (remaining dt = " << dt_attempt_remaining
-			               << ", total substeps = " << total_substeps
-			               << ", completed substeps = " << start_substep
-			               << ", dt_new = " << dt_substep << ")\n";
+			amrex::Print() << "\t>> Re-trying hydro advance at level " << lev << " with reduced timestep (remaining dt = " << dt_attempt_remaining
+				       << ", total substeps = " << total_substeps << ", completed substeps = " << start_substep << ", dt_new = " << dt_substep
+				       << ")\n";
 		}
 
 		amrex::MultiFab state_old_cc_tmp(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 		amrex::Copy(state_old_cc_tmp, accepted_state_cc, 0, 0, Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
 
-        std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
-        if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
-                state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-                amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0,
-                              Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-            }
-        }
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> state_old_fc_tmp;
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
+				state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+				amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+			}
+		}
 
-        bool attempt_failed = false;
+		bool attempt_failed = false;
 
-        for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
-            if (substep_index > start_substep) {
-                amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
-                if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-                    for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                        amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0,
-                                      Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-                    }
-                }
-            }
+		for (int substep_index = start_substep; substep_index < total_substeps; ++substep_index) {
+			if (substep_index > start_substep) {
+				amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+						amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
+							    nghost_fc_);
+					}
+				}
+			}
 
 			const amrex::Real current_substep_time = time + static_cast<amrex::Real>(substep_index) * dt_substep;
-            const bool substep_success = advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev,
-                                                             current_substep_time, dt_substep);
-            if (!substep_success) {
-                attempt_failed = true;
-                break;
-            }
+			const bool substep_success =
+			    advanceHydroAtLevel(state_old_cc_tmp, state_old_fc_tmp, fr_as_crse, fr_as_fine, lev, current_substep_time, dt_substep);
+			if (!substep_success) {
+				attempt_failed = true;
+				break;
+			}
 
-            completed_units += units_per_substep;
-            if (completed_units > max_total_substeps) {
-                completed_units = max_total_substeps;
-            }
+			completed_units += units_per_substep;
+			if (completed_units > max_total_substeps) {
+				completed_units = max_total_substeps;
+			}
 
 			updateAcceptedHydroState();
 		}
@@ -1292,12 +1288,12 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 			continue;
 		}
 
-        break;
-    }
+		break;
+	}
 
-    if (completed_units < max_total_substeps) {
-        overall_success = false;
-    }
+	if (completed_units < max_total_substeps) {
+		overall_success = false;
+	}
 	if (!overall_success) {
 		// crash, we have exceeded max_retries
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1239,8 +1239,9 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 			const amrex::Real dt_step = dt_remaining / static_cast<amrex::Real>(nsubsteps);
 
 			if (retry_count > 0 && Verbose()) {
-				amrex::Print() << "	>> Re-trying hydro advance at level " << lev << " with reduced timestep (remaining dt = " << dt_remaining
-					       << ", nsubsteps = " << nsubsteps << ", dt_new = " << dt_step << ")\n";
+				amrex::Print() << "	>> Re-trying hydro advance at level " << lev
+					       << " with reduced timestep (remaining dt = " << dt_remaining << ", nsubsteps = " << nsubsteps
+					       << ", dt_new = " << dt_step << ")\n";
 			}
 
 			restoreHydroState();
@@ -1253,7 +1254,8 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 					auto ba_fc = amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim));
 					state_old_fc_tmp[idim].define(ba_fc, dmap[lev], Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-					amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+					amrex::Copy(state_old_fc_tmp[idim], accepted_state_fc[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc,
+						    nghost_fc_);
 				}
 			}
 
@@ -1266,7 +1268,8 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 					amrex::Copy(state_old_cc_tmp, state_new_cc_[lev], 0, 0, ncompHydro_, nghost_cc_);
 					if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 						for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-							amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
+							amrex::Copy(state_old_fc_tmp[idim], state_new_fc_[lev][idim], 0, 0,
+								    Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
 						}
 					}
 				}
@@ -1322,8 +1325,8 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 	if (!overall_success) {
 		// crash, we have exceeded max_retries
 		amrex::Print() << "\nQUOKKA FATAL ERROR\n"
-		       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"
-		       << std::endl; // NOLINT(performance-avoid-endl)
+			       << "Hydro update exceeded max_retries on level " << lev << ". Cannot continue, crashing...\n"
+			       << std::endl; // NOLINT(performance-avoid-endl)
 
 		// write plotfile or Ascent Blueprint file
 		amrex::ParallelDescriptor::Barrier();
@@ -1598,7 +1601,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			// sync internal energy (requires positive density)
 			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
 		}
-
 	}
 	amrex::Gpu::streamSynchronizeAll();
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1235,7 +1235,7 @@ void QuokkaSimulation<problem_t>::advanceHydroAtLevelWithRetries(int lev, amrex:
 		int retry_count = start_retry_count;
 
 		while (retry_count <= max_retries) {
-			const int nsubsteps = 1 << retry_count;
+			const int nsubsteps = static_cast<int>(1u << static_cast<unsigned>(retry_count));
 			const amrex::Real dt_step = dt_remaining / static_cast<amrex::Real>(nsubsteps);
 
 			if (retry_count > 0 && Verbose()) {


### PR DESCRIPTION
### Description
This rewrites the hydro retry algorithm so that it never rolls back the state after an accepted substep. Instead, if a non-initial substep fails during a retry, it will reduce the timestep only for the remaining interval between the current accepted time and the final level time `time + dt_lev`.

Also, we now only update the flux register and tracer particles after a substep has been accepted. This avoids the need to backup and restore the flux register and the tracer particles, which reduces the overall memory usage of the hydro update.

Pseudocode implementation:
```
time = currentLevelTime
max_total_substeps = 1 << max_retries
accepted_state_cc = snapshotCellCenteredState()
accepted_state_fc = snapshotFaceCenteredState()

completed_units = 0
cur_retry_level = 0
while completed_units < max_total_substeps and cur_retry_level <= max_retries:
    total_substeps = 1 << cur_retry_level
    units_per_substep = max_total_substeps // total_substeps
    start_substep = completed_units // units_per_substep
    dt_substep = dt_lev / total_substeps

    for substep_index in range(start_substep, total_substeps):
        current_substep_time = time + substep_index * dt_substep
        substep_success = advanceHydroAtLevel(current_substep_time, dt_substep)
        if not substep_success:
            restoreHydroState()
            cur_retry_level += 1
            break
        completed_units += units_per_substep
        updateAcceptedHydroState()

if completed_units < max_total_substeps:
    writeFatalDiagnostics()
    abortHydroStep()
```

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
