### PR TITLE
Chong/gravity/particle kick

### DIFF
--- a/inputs/BinaryOrbit.in
+++ b/inputs/BinaryOrbit.in
@@ -32,3 +32,5 @@ tiny_profiler.enabled = 0
 cfl = 0.3
 max_timesteps = 2000
 stop_time = 5.0e7   # s
+
+problem.use_transmitting_bc_in_z = 1

--- a/inputs/BinaryOrbit.in
+++ b/inputs/BinaryOrbit.in
@@ -15,8 +15,8 @@ amr.v              = 1       # verbosity in Amr
 # *****************************************************************
 amr.n_cell          = 32 32 32
 amr.max_level       = 0     # number of levels = max_level + 1
-amr.blocking_factor = 32    # grid size must be divisible by this
-amr.max_grid_size   = 32    # at least 128 for GPUs
+amr.blocking_factor = 16    # grid size must be divisible by this
+amr.max_grid_size   = 16    # at least 128 for GPUs
 amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
 amr.grid_eff        = 1.0
 

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -30,8 +30,8 @@
 struct BinaryOrbit {
 };
 
-static bool do_split_particles = false; // NOLINT
-static int split_factor = 8;		// NOLINT
+static bool do_split_particles = false;	 // NOLINT
+static int split_factor = 8;		 // NOLINT
 static int use_transmitting_bc_in_z = 0; // NOLINT
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
@@ -153,9 +153,9 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 
 template <>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<BinaryOrbit>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<Real> const &consVar,
-												int /*dcomp*/, int /*numcomp*/, amrex::GeometryData const &geom,
-												const Real /*time*/, const amrex::BCRec * /*bcr*/, int /*bcomp*/,
-												int /*orig_comp*/)
+												 int /*dcomp*/, int /*numcomp*/,
+												 amrex::GeometryData const &geom, const Real /*time*/,
+												 const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
 {
 	// transmitting boundary condition in the z direction
 
@@ -205,9 +205,10 @@ auto problem_main() -> int
 
 	// A temporary hack: use geometry.is_periodic to set either int_dir or reflecting. Later, we should remove the redundant geometry::is_periodic runtime
 	// parameter.
-	auto BCs_cc = quokka::BC<BinaryOrbit>(is_periodic[0] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
-					      is_periodic[1] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
-					      is_periodic[2] == 1 ? quokka::BCType::int_dir : (use_transmitting_bc_in_z == 1 ? quokka::BCType::ext_dir : quokka::BCType::reflecting)); // NOLINT
+	auto BCs_cc = quokka::BC<BinaryOrbit>(
+	    is_periodic[0] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
+	    is_periodic[1] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
+	    is_periodic[2] == 1 ? quokka::BCType::int_dir : (use_transmitting_bc_in_z == 1 ? quokka::BCType::ext_dir : quokka::BCType::reflecting)); // NOLINT
 
 	// Problem initialization
 	QuokkaSimulation<BinaryOrbit> sim(BCs_cc);

--- a/src/problems/BinaryOrbitCIC/binary_orbit.cpp
+++ b/src/problems/BinaryOrbitCIC/binary_orbit.cpp
@@ -32,6 +32,7 @@ struct BinaryOrbit {
 
 static bool do_split_particles = false; // NOLINT
 static int split_factor = 8;		// NOLINT
+static int use_transmitting_bc_in_z = 0; // NOLINT
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	       // isothermal
@@ -150,6 +151,38 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 	++cycle;
 }
 
+template <>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<BinaryOrbit>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<Real> const &consVar,
+												int /*dcomp*/, int /*numcomp*/, amrex::GeometryData const &geom,
+												const Real /*time*/, const amrex::BCRec * /*bcr*/, int /*bcomp*/,
+												int /*orig_comp*/)
+{
+	// transmitting boundary condition in the z direction
+
+	if (use_transmitting_bc_in_z != 1) {
+		return;
+	}
+
+	auto [i, j, k] = iv.toArray();
+
+	amrex::Box const &box = geom.Domain();
+	const auto &domain_lo = box.loVect3d();
+	const auto &domain_hi = box.hiVect3d();
+	const int klo = domain_lo[2];
+	const int khi = domain_hi[2];
+
+	const int numcomp = HydroSystem<BinaryOrbit>::nvar_;
+	if (k < klo) {
+		for (int n = 0; n < numcomp; ++n) {
+			consVar(i, j, k, n) = consVar(i, j, klo, n);
+		}
+	} else if (k > khi) {
+		for (int n = 0; n < numcomp; ++n) {
+			consVar(i, j, k, n) = consVar(i, j, khi, n);
+		}
+	}
+}
+
 auto problem_main() -> int
 {
 	// read in runtiem parameter geometry.is_periodic
@@ -164,16 +197,17 @@ auto problem_main() -> int
 	//                                       quokka::BCType::int_dir,
 	//                                       quokka::BCType::reflecting); // mixed BCs
 
-	// A temporary hack: use geometry.is_periodic to set either int_dir or reflecting. Later, we should remove the redundant geometry::is_periodic runtime
-	// parameter.
-	auto BCs_cc = quokka::BC<BinaryOrbit>(is_periodic[0] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
-					      is_periodic[1] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
-					      is_periodic[2] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting);
-
 	// read in runtime parameters for this test problem
 	amrex::ParmParse const pp("problem");
 	pp.query("do_split_particles", do_split_particles);
 	pp.query("split_factor", split_factor);
+	pp.query("use_transmitting_bc_in_z", use_transmitting_bc_in_z);
+
+	// A temporary hack: use geometry.is_periodic to set either int_dir or reflecting. Later, we should remove the redundant geometry::is_periodic runtime
+	// parameter.
+	auto BCs_cc = quokka::BC<BinaryOrbit>(is_periodic[0] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
+					      is_periodic[1] == 1 ? quokka::BCType::int_dir : quokka::BCType::reflecting,
+					      is_periodic[2] == 1 ? quokka::BCType::int_dir : (use_transmitting_bc_in_z == 1 ? quokka::BCType::ext_dir : quokka::BCType::reflecting)); // NOLINT
 
 	// Problem initialization
 	QuokkaSimulation<BinaryOrbit> sim(BCs_cc);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1337,7 +1337,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 		amrex::Vector<amrex::MultiFab> rhs(finest_level + 1);
 		constexpr int nghost_phi = 3;
 		constexpr int nghost_deposit = nghost_phi; // CIC deposition requires 1 ghost cell
-		constexpr int nghost_drift = 1;	  // particle can drift up to 1 cell
+		constexpr int nghost_drift = 1;		   // particle can drift up to 1 cell
 		constexpr int nghost_rhs = nghost_deposit + nghost_drift;
 		constexpr int ncomp = 1;
 		amrex::Real rhs_min = std::numeric_limits<amrex::Real>::max();
@@ -1520,7 +1520,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}
 		});
-		
+
 		amrex::Print() << "after solver, phi at k = 0: \n";
 		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			if (k == klo && i <= 17 && i >= 15 && j <= 17 && j >= 15) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1610,6 +1610,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		const auto dx_inv = geom[lev].InvCellSizeArray();
 		auto accel_arr = accel_cc.arrays();
 
+		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			if (k == -2) {
+				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
+			}
+		});
+
+
 		amrex::ParallelFor(accel_cc, amrex::IntVect{nghost_acc}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			// Compute cell-centered acceleration using central differences of potential
 			// accel = -grad(phi)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1335,8 +1335,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 
 		phi.resize(finest_level + 1);
 		amrex::Vector<amrex::MultiFab> rhs(finest_level + 1);
-		constexpr int nghost_phi = 1;
-		constexpr int nghost_deposit = 1; // CIC deposition requires 1 ghost cell
+		constexpr int nghost_phi = 3;
+		constexpr int nghost_deposit = nghost_phi; // CIC deposition requires 1 ghost cell
 		constexpr int nghost_drift = 1;	  // particle can drift up to 1 cell
 		constexpr int nghost_rhs = nghost_deposit + nghost_drift;
 		constexpr int ncomp = 1;
@@ -1498,6 +1498,36 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 			amrex::Print() << "\n";
 		}
 
+		const int lev = 0;
+		amrex::Box const &box = geom[lev].Domain();
+
+		const auto &phi_arr = phi[lev].const_arrays();
+		const auto &domain_lo = box.loVect3d();
+		const auto &domain_hi = box.hiVect3d();
+		const int klo = domain_lo[2];
+		const int khi = domain_hi[2];
+
+		amrex::Print() << "after solver, phi at k = -2: \n";
+		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			if (k == klo - 2 && i <= 17 && i >= 15 && j <= 17 && j >= 15) {
+				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
+			}
+		});
+
+		amrex::Print() << "after solver, phi at k = -1: \n";
+		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			if (k == klo - 1 && i <= 17 && i >= 15 && j <= 17 && j >= 15) {
+				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
+			}
+		});
+		
+		amrex::Print() << "after solver, phi at k = 0: \n";
+		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			if (k == klo && i <= 17 && i >= 15 && j <= 17 && j >= 15) {
+				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
+			}
+		});
+
 		// check for NaN
 		for (int lev = 0; lev <= finest_level; ++lev) {
 			// NOTE: this fails when multiple levels are fully refined when open boundary condition is used.
@@ -1566,49 +1596,49 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		const int nghost_acc = 2;
 		const int nghost_phi = nghost_acc + 1; // Need extra ghost cell for centered difference
 
-		// Create potential MultiFab with sufficient ghost cells for gradient computation
-		amrex::MultiFab phi_extended(boxArray(lev), DistributionMap(lev), 1, nghost_phi);
-		// initialize to nan
-		phi_extended.setVal(std::numeric_limits<amrex::Real>::quiet_NaN());
+		// // Create potential MultiFab with sufficient ghost cells for gradient computation
+		// amrex::MultiFab phi_extended(boxArray(lev), DistributionMap(lev), 1, nghost_phi);
+		// // initialize to nan
+		// phi_extended.setVal(std::numeric_limits<amrex::Real>::quiet_NaN());
 
-		// Fill extended potential from existing phi using FillPatch
-		// This handles coarse-fine boundaries without InterpFromCoarseLevel
-		if (lev == 0) {
-			// Base level: just copy and fill boundaries
-			amrex::MultiFab::Copy(phi_extended, phi[lev], 0, 0, 1, 0);
-			phi_extended.FillBoundary(geom[lev].periodicity());
+		// // Fill extended potential from existing phi using FillPatch
+		// // This handles coarse-fine boundaries without InterpFromCoarseLevel
+		// if (lev == 0) {
+		// 	// Base level: just copy and fill boundaries
+		// 	amrex::MultiFab::Copy(phi_extended, phi[lev], 0, 0, 1, nghost_phi);
+		// 	// phi_extended.FillBoundary(geom[lev].periodicity());
 
-			// Apply physical boundary conditions to phi
-			amrex::Vector<amrex::BCRec> phiBC(1);
-			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-				phiBC[0].setLo(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].lo(i));
-				phiBC[0].setHi(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].hi(i));
-			}
+		// 	// Apply physical boundary conditions to phi
+		// 	amrex::Vector<amrex::BCRec> phiBC(1);
+		// 	for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+		// 		phiBC[0].setLo(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].lo(i));
+		// 		phiBC[0].setHi(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].hi(i));
+		// 	}
 
-			amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
-			amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiBdryFunct(geom[lev], phiBC, boundaryFunctor);
-			phiBdryFunct(phi_extended, 0, 1, phi_extended.nGrowVect(), 0., 0);
-		} else {
-			// Fine level: use FillPatchTwoLevels to properly handle coarse-fine boundaries
-			amrex::Vector<amrex::BCRec> phiBC(1);
-			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-				phiBC[0].setLo(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].lo(i));
-				phiBC[0].setHi(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].hi(i));
-			}
+		// 	amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
+		// 	amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiBdryFunct(geom[lev], phiBC, boundaryFunctor);
+		// 	phiBdryFunct(phi_extended, 0, 1, phi_extended.nGrowVect(), 0., 0);
+		// } else {
+		// 	// Fine level: use FillPatchTwoLevels to properly handle coarse-fine boundaries
+		// 	amrex::Vector<amrex::BCRec> phiBC(1);
+		// 	for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+		// 		phiBC[0].setLo(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].lo(i));
+		// 		phiBC[0].setHi(i, BCs_cc_[Physics_Indices<problem_t>::hydroFirstIndex].hi(i));
+		// 	}
 
-			amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
-			amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiBdryFunct(geom[lev], phiBC, boundaryFunctor);
-			amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiCoarseBdryFunct(geom[lev - 1], phiBC, boundaryFunctor);
+		// 	amrex::GpuBndryFuncFab<setFunctorParticleAccel> boundaryFunctor(setFunctorParticleAccel{});
+		// 	amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiBdryFunct(geom[lev], phiBC, boundaryFunctor);
+		// 	amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setFunctorParticleAccel>> phiCoarseBdryFunct(geom[lev - 1], phiBC, boundaryFunctor);
 
-			amrex::FillPatchTwoLevels(phi_extended, 0., {&phi[lev - 1]}, {0.}, {&phi[lev]}, {0.}, 0, 0, 1, geom[lev - 1], geom[lev],
-						  phiCoarseBdryFunct, 0, phiBdryFunct, 0, refRatio(lev - 1), &amrex::quadratic_interp, phiBC, 0);
-		}
+		// 	amrex::FillPatchTwoLevels(phi_extended, 0., {&phi[lev - 1]}, {0.}, {&phi[lev]}, {0.}, 0, 0, 1, geom[lev - 1], geom[lev],
+		// 				  phiCoarseBdryFunct, 0, phiBdryFunct, 0, refRatio(lev - 1), &amrex::quadratic_interp, phiBC, 0);
+		// }
 
 		// Create cell-centered acceleration MultiFab
 		amrex::MultiFab accel_cc(boxArray(lev), DistributionMap(lev), AMREX_SPACEDIM, nghost_acc);
 
 		// Compute acceleration directly from potential gradient at cell centers
-		const auto &phi_arr = phi_extended.const_arrays();
+		const auto &phi_arr = phi[lev].const_arrays();
 		const auto dx_inv = geom[lev].InvCellSizeArray();
 		auto accel_arr = accel_cc.arrays();
 
@@ -1620,7 +1650,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 
 		amrex::Print() << "phi_arr at k = -2: \n";
 
-		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			if (k == klo - 2 && i <= 2 && j <= 2) {
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}
@@ -1628,7 +1658,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 
 		amrex::Print() << "phi_arr at k = 2: \n";
 
-		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+		amrex::ParallelFor(phi[lev], amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			if (k == khi + 2 && i <= 2 && j <= 2) {
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1568,6 +1568,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 
 		// Create potential MultiFab with sufficient ghost cells for gradient computation
 		amrex::MultiFab phi_extended(boxArray(lev), DistributionMap(lev), 1, nghost_phi);
+		// initialize to nan
+		phi_extended.setVal(std::numeric_limits<amrex::Real>::quiet_NaN());
 
 		// Fill extended potential from existing phi using FillPatch
 		// This handles coarse-fine boundaries without InterpFromCoarseLevel
@@ -1619,7 +1621,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		amrex::Print() << "phi_arr at k = -2: \n";
 
 		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			if (k == klo - 2) {
+			if (k == klo - 2 && i <= 2 && j <= 2) {
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}
 		});
@@ -1627,7 +1629,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		amrex::Print() << "phi_arr at k = 2: \n";
 
 		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			if (k == khi + 2) {
+			if (k == khi + 2 && i <= 2 && j <= 2) {
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}
 		});

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1610,12 +1610,27 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 		const auto dx_inv = geom[lev].InvCellSizeArray();
 		auto accel_arr = accel_cc.arrays();
 
+		amrex::Box const &box = geom[lev].Domain();
+		const auto &domain_lo = box.loVect3d();
+		const auto &domain_hi = box.hiVect3d();
+		const int klo = domain_lo[2];
+		const int khi = domain_hi[2];
+
+		amrex::Print() << "phi_arr at k = -2: \n";
+
 		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-			if (k == -2) {
+			if (k == klo - 2) {
 				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
 			}
 		});
 
+		amrex::Print() << "phi_arr at k = 2: \n";
+
+		amrex::ParallelFor(phi_extended, amrex::IntVect{nghost_phi}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			if (k == khi + 2) {
+				printf("%.3e\n", phi_arr[bx](i, j, k, 0));
+			}
+		});
 
 		amrex::ParallelFor(accel_cc, amrex::IntVect{nghost_acc}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			// Compute cell-centered acceleration using central differences of potential

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1616,7 +1616,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::kickParticlesAllLev
 			}
 		});
 
-
 		amrex::ParallelFor(accel_cc, amrex::IntVect{nghost_acc}, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
 			// Compute cell-centered acceleration using central differences of potential
 			// accel = -grad(phi)


### PR DESCRIPTION
### Description

Define a test problem, BinaryOrbit, where the boundary condition in the x an y directions are periodic, and z direction is `ext_dir` (transmitting). The test failed because the z-direction ghost cells of `phi` are not filled. The code does not currently offer a way for the user to manually fill in those cells. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
