### PR TITLE
Pass time to reference soln

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -823,7 +823,8 @@ void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref,
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real time)
+							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir,
+							      amrex::Real time)
 {
 	// user should implement
 }

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -231,11 +231,11 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeBeforeTimestep() override;
 	void computeAfterTimestep() override;
 	void computeAfterLevelAdvance(int lev, amrex::Real time, amrex::Real dt_lev, int /*ncycle*/);
-	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
+	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real time) override;
 	void computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo);
+				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real time);
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir, amrex::Real time);
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 
@@ -816,14 +816,14 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::ErrorEst(int lev
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+							   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real time)
 {
 	// user should implement
 }
 
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real time)
 {
 	// user should implement
 }
@@ -836,7 +836,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 	    mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { printf("%f\n", mf_fc[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex)); });
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
+template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real time)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
@@ -880,7 +880,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::Print() << "Checking cc-quantities\n";
 		const int ncomp = state_new_cc_[0].nComp();
 		amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
-		computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
+		computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), time);
 
 		// compute error norm
 		amrex::MultiFab residual(boxArray(0), DistributionMap(0), ncomp, 0);
@@ -909,7 +909,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 				amrex::MultiFab state_ref_level0(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0),
 								 ncomp, nghost);
 
-				computeReferenceSolution_fc(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
+				computeReferenceSolution_fc(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim}, time);
 
 				// compute error norm
 				amrex::MultiFab residual(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0), ncomp,

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -85,7 +85,8 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void computeAfterTimestep() override;
 	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real time) override;
 	void computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
+				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
+				      amrex::Real time);
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -83,9 +83,9 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int /*ncycle*/) override;
 	void computeBeforeTimestep() override;
 	void computeAfterTimestep() override;
-	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) override;
+	void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real time) override;
 	void computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi);
+				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;
@@ -258,17 +258,17 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::FixupState(in
 template <typename problem_t>
 void AdvectionSimulation<problem_t>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
+							      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
 {
 	// user implemented
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/)
+template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/, amrex::Real time)
 {
 	// compute reference solution
 	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
-	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), geom[0].ProbHiArray());
+	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), geom[0].ProbHiArray(), time);
 
 	// compute error norm
 	amrex::MultiFab residual(boxArray(0), DistributionMap(0), ncomp, 0);

--- a/src/problems/Advection/test_advection.cpp
+++ b/src/problems/Advection/test_advection.cpp
@@ -70,7 +70,7 @@ template <> void AdvectionSimulation<SawtoothProblem>::setInitialConditionsOnGri
 template <>
 void AdvectionSimulation<SawtoothProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
+								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
 
 	// fill reference solution multifab

--- a/src/problems/Advection2D/test_advection2d.cpp
+++ b/src/problems/Advection2D/test_advection2d.cpp
@@ -75,7 +75,7 @@ template <> void AdvectionSimulation<SquareProblem>::setInitialConditionsOnGrid(
 template <>
 void AdvectionSimulation<SquareProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
 	// compute exact solution
 

--- a/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/test_advection_semiellipse.cpp
@@ -69,7 +69,7 @@ template <> void AdvectionSimulation<SemiellipseProblem>::setInitialConditionsOn
 template <>
 void AdvectionSimulation<SemiellipseProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/)
+								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
 
 	// fill reference solution multifab

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -183,7 +183,7 @@ template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGri
 
 template <>
 void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -201,7 +201,7 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::Multi
 
 template <>
 void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -201,7 +201,8 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::Multi
 
 template <>
 void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real /*time*/)
+								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir,
+								       amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -211,7 +211,8 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFa
 
 template <>
 void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real time)
+								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir,
+								     amrex::Real time)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -193,7 +193,7 @@ template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGridF
 
 template <>
 void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real time)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -204,14 +204,14 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFa
 			for (int n = 0; n < ncomp; ++n) {
 				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
 			}
-			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, 0);
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, time);
 		});
 	}
 }
 
 template <>
 void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real time)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -222,7 +222,7 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::Mult
 			for (int n = 0; n < ncomp; ++n) {
 				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
 			}
-			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, 0);
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, time);
 		});
 	}
 }

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -213,7 +213,8 @@ void QuokkaSimulation<FastWave>::computeReferenceSolution(amrex::MultiFab &ref, 
 
 template <>
 void QuokkaSimulation<FastWave>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real /*time*/)
+							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir,
+							     amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -195,7 +195,7 @@ template <> void QuokkaSimulation<FastWave>::setInitialConditionsOnGridFaceVars(
 
 template <>
 void QuokkaSimulation<FastWave>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+							  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -213,7 +213,7 @@ void QuokkaSimulation<FastWave>::computeReferenceSolution(amrex::MultiFab &ref, 
 
 template <>
 void QuokkaSimulation<FastWave>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+							     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
+++ b/src/problems/HydroBlast3D/test_hydro3d_blast.cpp
@@ -137,7 +137,7 @@ template <> void QuokkaSimulation<SedovProblem>::refineGrid(int lev, amrex::TagB
 	}
 }
 
-template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
+template <> void QuokkaSimulation<SedovProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real /*time*/)
 {
 	amrex::ParmParse const pp("blast_problem");
 	bool checkSolution = true;

--- a/src/problems/HydroContact/test_hydro_contact.cpp
+++ b/src/problems/HydroContact/test_hydro_contact.cpp
@@ -91,7 +91,7 @@ template <> void QuokkaSimulation<ContactProblem>::setInitialConditionsOnGrid(qu
 
 template <>
 void QuokkaSimulation<ContactProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -89,7 +89,7 @@ template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(q
 
 template <>
 void QuokkaSimulation<HighMachProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const & /*dx*/,
-								 amrex::GpuArray<Real, AMREX_SPACEDIM> const & /*prob_lo*/)
+								 amrex::GpuArray<Real, AMREX_SPACEDIM> const & /*prob_lo*/, amrex::Real /*time*/)
 {
 
 	// extract solution

--- a/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
+++ b/src/problems/HydroLeblanc/test_hydro_leblanc.cpp
@@ -149,7 +149,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 
 	// read in exact solution

--- a/src/problems/HydroQuirk/test_quirk.cpp
+++ b/src/problems/HydroQuirk/test_quirk.cpp
@@ -191,7 +191,7 @@ template <> void QuokkaSimulation<QuirkProblem>::computeAfterTimestep()
 	}
 }
 
-template <> void QuokkaSimulation<QuirkProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/)
+template <> void QuokkaSimulation<QuirkProblem>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/, amrex::Real /*time*/)
 {
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		auto const &deltas_vec = getDeltaEntropyVector();

--- a/src/problems/HydroSMS/test_hydro_sms.cpp
+++ b/src/problems/HydroSMS/test_hydro_sms.cpp
@@ -139,7 +139,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 
 	auto const box = geom[0].Domain();

--- a/src/problems/HydroShocktube/test_hydro_shocktube.cpp
+++ b/src/problems/HydroShocktube/test_hydro_shocktube.cpp
@@ -179,7 +179,7 @@ template <> void QuokkaSimulation<ShocktubeProblem>::refineGrid(int lev, amrex::
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 
 	// read in exact solution

--- a/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
+++ b/src/problems/HydroShuOsher/test_hydro_shuosher.cpp
@@ -139,7 +139,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 
 	// read in exact solution

--- a/src/problems/HydroVacuum/test_hydro_vacuum.cpp
+++ b/src/problems/HydroVacuum/test_hydro_vacuum.cpp
@@ -142,7 +142,7 @@ AMRSimulation<ShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVec
 
 template <>
 void QuokkaSimulation<ShocktubeProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 
 	auto const box = geom[0].Domain();

--- a/src/problems/ParticleCreation/particle_creation_from_cell.cpp
+++ b/src/problems/ParticleCreation/particle_creation_from_cell.cpp
@@ -237,7 +237,7 @@ template <> void QuokkaSimulation<TestParticle>::setInitialConditionsOnGrid(quok
 	});
 }
 
-template <> void QuokkaSimulation<TestParticle>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) {}
+template <> void QuokkaSimulation<TestParticle>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real /*time*/) {}
 
 auto problem_main() -> int
 {

--- a/src/problems/PassiveScalar/test_scalars.cpp
+++ b/src/problems/PassiveScalar/test_scalars.cpp
@@ -92,7 +92,7 @@ template <> void QuokkaSimulation<ScalarProblem>::setInitialConditionsOnGrid(quo
 
 template <>
 void QuokkaSimulation<ScalarProblem>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<Real, AMREX_SPACEDIM> const &dx,
-							       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo)
+							       amrex::GpuArray<Real, AMREX_SPACEDIM> const &prob_lo, amrex::Real /*time*/)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -241,7 +241,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 #endif // AMREX_SPACEDIM == 3
 	virtual void computeBeforeTimestep() = 0;
 	virtual void computeAfterTimestep() = 0;
-	virtual void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) = 0;
+	virtual void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons, amrex::Real time) = 0;
 	virtual void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) = 0;
 	virtual void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) = 0;
 	virtual void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf,
@@ -1264,7 +1264,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	amrex::Real elapsed_sec = getWalltime();
 
 	// compute reference solution (if it's a test problem)
-	computeAfterEvolve(init_sum_cons);
+	computeAfterEvolve(init_sum_cons, cur_time);
 
 	// compute conservation error
 	for (int n = 0; n < ncomp_cc; ++n) {


### PR DESCRIPTION
### Description
This PR modifies computeReferenceSolution and computeAfterEvolve to accept the current simulation time, which allows the reference solution to be evaluated at the actual end time, making the final comparison correct for time-dependent problems.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
