### PR TITLE
Update docs

### DIFF
--- a/docs/markdown/amr_grid_refinement.md
+++ b/docs/markdown/amr_grid_refinement.md
@@ -1,134 +1,42 @@
-# Grid Refinement in Berger-Collela AMR
+# Adaptive Mesh Refinement Guidelines
 
-This document explains how Adaptive Mesh Refinement (AMR) works in Quokka, which uses the Berger-Collela AMR algorithm implemented in AMReX. Understanding these concepts is crucial for setting up AMR simulations effectively and avoiding common pitfalls.
+Quokka relies on the Berger-Collela AMR algorithm [@berger1989local] provided by AMReX to create a hierarchy of nested grids. This page distills practical advice for planning and tuning AMR runs so the mesh tracks the physics you care about without wasting resolution elsewhere.
 
-## Overview of Berger-Collela AMR
+## Understanding the Refinement Workflow
 
-Quokka uses the Berger-Collela AMR algorithm [@berger1989local] as implemented in the AMReX library. This algorithm automatically creates and manages a hierarchy of nested grids with different spatial resolutions to efficiently resolve features of interest while maintaining computational efficiency.
+AMReX walks through a predictable sequence each time it builds or adjusts the mesh hierarchy. Cells are tagged inside `ErrorEst`, those tags are coarsened according to `blocking_factor/ref_ratio`, clustered by the Berger-Rigoutsos algorithm [@berger1991algorithm], and then promoted to new grids that honor `blocking_factor` and `max_grid_size`. The resulting hierarchy is averaged down so coarse levels remain consistent with fine ones. Keeping this loop in mind helps interpret why the mesh responds the way it does when the problem evolves or when you revisit the `ErrorEst` logic.
 
-### Key Concepts
+## Setting AMR Parameters
 
-The AMR algorithm works by:
-
-1. **Tagging cells** for refinement based on user-defined criteria (implemented in the `ErrorEst` function)
-2. **Clustering tagged cells** into rectangular boxes using the Berger-Rigoutsos algorithm [@berger1991algorithm]
-3. **Creating new grids** at the next refinement level based on these clusters
-4. **Managing the grid hierarchy** across multiple refinement levels
-
-## AMR Parameters
-
-Several key parameters control the grid generation process:
+Several inputs shape how aggressively the hierarchy responds to refinement tags:
 
 | Parameter | Description | Typical Values | Performance Impact |
 |-----------|-------------|----------------|-------------------|
-| `blocking_factor` | Minimum grid size; grids must be divisible by this value | 8-32 | Higher values improve GPU performance but may cause over-refinement |
-| `grid_efficiency` | Minimum fraction of refined cells in each grid | 0.7-1.0 | Higher values create more efficient grids but may increase memory usage |
-| `max_grid_size` | Maximum size of individual grids | 64-128 | Affects load balancing and memory locality |
-| `ref_ratio` | Refinement ratio between levels | 2 or 4 | Factor by which resolution increases at each level |
+| `blocking_factor` | Minimum grid dimension; grids must be integer multiples of this value | 8-32 | Large values improve GPU throughput but can force broad refinement |
+| `grid_efficiency` | Minimum fraction of tagged cells in each grid | 0.7-1.0 | Higher values reduce wasted work yet may spawn extra boxes |
+| `max_grid_size` | Maximum dimension of a grid patch | 64-128 | Smaller sizes improve load balance; larger sizes cut communication |
+| `ref_ratio` | Refinement ratio between adjacent levels | 2 or 4 | Larger ratios sharpen features faster but deepen the hierarchy |
 
-## Common Unintuitive Behaviors
+Choose these controls as a set: a generous `blocking_factor` demands tighter tagging or higher `grid_efficiency` to avoid carpet refinement, while a smaller blocking factor allows surgical meshes but can stress GPUs. When in doubt, run short experiments that sweep one parameter at a time and compare the resulting plotfile headers to see how many grids are created per level.
 
-### Whole Domain Refinement
+## Performance and Scaling Considerations
 
-**Problem**: When setting `amr.max_level = 1`, you may observe that the entire computational domain gets refined to level 1, even when only a small region should be refined according to your refinement criteria.
+GPU runs typically favor `blocking_factor ≥ 32` so each patch keeps SMs busy; values below 32 almost always break memory coalescing across a warp and leave expensive kernels underutilized even when occupancy looks fine. CPU multigrid solves prefer at least 8. If you push those limits, guard your memory footprint by trimming the number of refinement levels or enlarging `max_grid_size` so patches do not proliferate. Also watch how frequently you trigger `regrid` calls—rapid regridding magnifies the cost of tag evaluation and repartitioning, so coarse control logic or hysteresis in `ErrorEst` can pay dividends on very dynamic problems.
 
-**Cause**: This happens due to the interaction between several AMR parameters:
+## Observing and Adjusting the Hierarchy
 
-1. **Blocking Factor Constraint**: All grids must have dimensions that are multiples of `blocking_factor`. If your `blocking_factor` is large (e.g., 32 or 64), and you have scattered refinement tags, the algorithm may need to create grids that cover most of the domain to satisfy this constraint.
+Inspect the grid structure early in a run by opening the plotfile header or by enabling verbose regridding logs in AMReX. When the layout diverges from expectations, compare the tagged volume to the resulting grid inventory—discrepancies usually trace back to either tag dilution during coarsening or to efficiency limits that extend each patch. The spherical collapse study documented in [GitHub issue #978](https://github.com/quokka-astro/quokka/issues/978) is a useful reminder that large blocking factors can still trigger whole-domain refinement if tags are sparse, so monitor that scenario whenever you upscale a production run.
 
-2. **Grid Efficiency**: The algorithm tries to maintain a minimum `grid_efficiency` (fraction of tagged cells in each grid). Low efficiency may cause the algorithm to include many untagged cells.
+### Example: Berger-Rigoutsos in Practice
 
-3. **Coarsening Effect**: The AMReX algorithm first coarsens the tag list by `blocking_factor/ref_ratio` before applying the Berger-Rigoutsos clustering algorithm. This can cause small, isolated regions to merge into larger blocks.
+![Tagged cells and Berger-Rigoutsos boxes](amr_grid_refinement.svg)
 
-**Example**: In the SphericalCollapse test problem, when `blocking_factor = 64` and the domain is 128³ cells, even a small spherical region requiring refinement can result in the entire domain being refined because the algorithm cannot create efficient grids smaller than the blocking factor.
+Compile Quokka with `-DAMReX_SPACEDIM=2`, then run the HydroBlast2D driver with the bundled `inputs/blast2d_amr_example.in`. That input sets `amr.n_cell = 128 128 4`, `amr.ref_ratio = 2 2 1`, `amr.blocking_factor = 32 32 4`, `amr.grid_eff = 0.8`, and `amr.n_error_buf = 1`. The third entry in each list is ignored in 2D, so the effective blocking factor is 32. The pressure-gradient trigger in `ErrorEst` tags a thin ring around the blast front. AMReX coarsens those tags by 16 cells before clustering, so the Berger-Rigoutsos pass finds four rectangles that tile the annulus: two long bands `(lo, hi) = (64,96)→(191,127)` and `(64,128)→(191,159)` plus two shorter bridges `(96,64)→(159,95)` and `(96,160)→(159,191)`. Running `amrex_fboxinfo --full plt00040` on the resulting plotfile shows the same coordinates, confirming that the level-one patches are multiples of 32 cells in each direction and fully envelop the tagged region after refinement. Comparing those boxes with the tags in the plotfile (as sketched above) is a quick way to verify that the clustering step is behaving the way you expect.
 
-**Solutions**:
-- Reduce `blocking_factor` to allow finer control (minimum value is typically 4, constrained by `n_ghost`)
-- Increase `grid_efficiency` closer to 1.0 to avoid including many untagged cells
-- Consider the trade-off between refinement precision and computational performance
+## Troubleshooting Patterns
 
-### Performance vs. Precision Trade-offs
-
-**GPU Performance**: On GPUs, `blocking_factor` should typically be ≥32 for good performance. This conflicts with the desire for precise refinement.
-
-**CPU Performance**: Even on CPUs, `blocking_factor` should be ≥8 for efficient multigrid operations in the Poisson solver.
-
-**Memory Efficiency**: Large blocking factors can lead to significant memory overhead when refinement is only needed in small regions.
-
-### Grid Efficiency Interactions
-
-The `grid_efficiency` parameter can cause unexpected behavior:
-
-- **Low efficiency** (< 0.8): May include many untagged cells, leading to unnecessary computation
-- **High efficiency** (> 0.95): May create many small, inefficient grids that hurt performance
-- **Default value** (0.7): Usually provides a good balance but may still cause over-refinement in some cases
-
-## Understanding the Refinement Process
-
-### Error Estimation and Tagging
-
-The refinement process begins with the `ErrorEst` function, which is called by AMReX to determine which cells should be tagged for refinement. This is a virtual function that gets called indirectly through the AMReX grid management routines:
-
-- `AmrCore::InitFromScratch()` during initialization
-- `AmrCore::regrid()` during runtime regridding
-- `AmrMesh::MakeNewGrids()` as part of the grid generation process
-
-### Grid Generation Algorithm
-
-1. **Tag Collection**: Cells meeting refinement criteria are tagged
-2. **Coarsening**: Tags are coarsened by `blocking_factor/ref_ratio`
-3. **Clustering**: The Berger-Rigoutsos algorithm groups tagged cells into rectangular boxes
-4. **Grid Creation**: New grids are created from these boxes, respecting `blocking_factor` and `max_grid_size` constraints
-5. **Efficiency Check**: Grids not meeting `grid_efficiency` requirements may be merged or extended
-
-### Averaging Down Effects
-
-After creating refined grids, the solution is averaged down from fine to coarse levels. This can improve the solution on coarse grids, potentially changing the refinement criteria on subsequent regridding steps. This feedback effect can lead to expanding or contracting refinement regions over time.
-
-## Best Practices
-
-### For Test Problems
-
-- Use `blocking_factor = 4` or `blocking_factor = 8` to demonstrate proper refinement behavior
-- Set `grid_efficiency = 1.0` for maximum precision when performance is not critical
-- Monitor the actual grid structure in output files to verify expected refinement patterns
-
-### For Production Runs
-
-- Balance `blocking_factor` based on your computational platform:
-  - GPU: ≥32 for performance
-  - CPU: ≥8 for multigrid efficiency
-- Test different `grid_efficiency` values to find the optimal balance for your problem
-- Consider the memory and computational overhead of over-refinement
-
-### Debugging Refinement Issues
-
-When debugging unexpected refinement behavior:
-
-1. **Check grid structure**: Examine plotfile headers or use visualization tools to see actual grid layout
-2. **Reduce blocking_factor**: Temporarily use smaller values to verify refinement criteria
-3. **Monitor efficiency**: Check if grids meet your `grid_efficiency` requirements
-4. **Visualize tags**: Output refinement tags to understand what the `ErrorEst` function is actually selecting
-
-## Detection and Warnings
-
-Consider implementing detection for whole-domain refinement scenarios, especially during initialization. When the entire domain is refined to level 1, it often indicates:
-
-- `blocking_factor` is too large for the problem size
-- Refinement criteria are too broad
-- Grid efficiency settings are suboptimal
-
-Such detection can help users identify and correct these parameter mismatches early in their simulations.
+Start with the simplest levers. Reduce `blocking_factor` temporarily to verify the tagging logic, then restore the larger production value once you confirm the tags are reasonable. Next, nudge `grid_efficiency` upward until the refined region stabilizes without spawning many more boxes. If the hierarchy thrashes between steps, consider caching diagnostic arrays that record why cells were tagged; a quick visualization of those masks often pinpoints whether gradients, thresholds, or boundary effects are misbehaving.
 
 ## Further Reading
 
-For more detailed information about the Berger-Collela algorithm:
-
-- Berger & Colella (1989): "Local adaptive mesh refinement for shock hydrodynamics" [@berger1989local]
-- Berger & Rigoutsos (1991): "An Algorithm for Point Clustering and Grid Generation" [@berger1991algorithm]
-- [AMReX-Astro Castro documentation on regridding](https://amrex-astro.github.io/Castro/docs/regridding.html)
-- [AMReX source code documentation](https://github.com/AMReX-Codes/amrex)
-
-## References
-
-The behavior described in this document was identified and discussed in [GitHub issue #978](https://github.com/quokka-astro/quokka/issues/978).
+For deeper dives into refinement theory and AMReX implementation details, consult the original Berger & Colella paper [@berger1989local], the Berger-Rigoutsos clustering method [@berger1991algorithm], and the [AMReX-Astro Castro regridding notes](https://amrex-astro.github.io/Castro/docs/regridding.html). The [AMReX source documentation](https://github.com/AMReX-Codes/amrex) also clarifies lower-level options that Quokka exposes through its input files.

--- a/docs/markdown/amr_grid_refinement.md
+++ b/docs/markdown/amr_grid_refinement.md
@@ -27,6 +27,21 @@ GPU runs typically favor `blocking_factor ≥ 32` so each patch keeps SMs busy; 
 
 Inspect the grid structure early in a run by opening the plotfile header or by enabling verbose regridding logs in AMReX. When the layout diverges from expectations, compare the tagged volume to the resulting grid inventory—discrepancies usually trace back to either tag dilution during coarsening or to efficiency limits that extend each patch. The spherical collapse study documented in [GitHub issue #978](https://github.com/quokka-astro/quokka/issues/978) is a useful reminder that large blocking factors can still trigger whole-domain refinement if tags are sparse, so monitor that scenario whenever you upscale a production run.
 
+### Inspecting grids with `amrex_fboxinfo`
+
+AMReX ships a lightweight reporter named `amrex_fboxinfo` that prints the box layout stored in a plotfile. Make sure your CMake cache was configured with `-DAMReX_PLOTFILE_TOOLS=ON`, then build the utility once per build tree with `cmake --build build --target fboxinfo`. The resulting executable lives at `build/extern/amrex/Tools/Plotfile/amrex_fboxinfo`. Point it at any plotfile to see how much of the domain each AMR level occupies and how many boxes AMReX created:
+
+```
+$ build/extern/amrex/Tools/Plotfile/amrex_fboxinfo plt00040
+ plotfile: plt00040
+ level   0: number of boxes =      1, volume = 100.00%, number of cells = 16384
+          maximum zones =     128 x     128
+ level   1: number of boxes =      4, volume =  12.50%, number of cells =  8192
+          maximum zones =     256 x     256
+```
+
+The summary lines are the quickest health check: `volume` reports the percentage of the level-`ℓ` domain covered by refined grids, so values creeping toward 100% warn that your refinement criteria are effectively forcing a uniform mesh. The `maximum zones` line prints the physical extents of each level’s valid domain; large jumps confirm that refinement ratios and blocking factors coarsen or refine by the factors you expect. Add `--full` to list every box and verify the coordinates land on multiples of `blocking_factor`, or `--gridfile` to emit a grid-description file for AMReX regression tools. When you only need the number of active refinement levels (for log parsing, for example), pass `--levels` to suppress the rest of the report.
+
 ### Example: Berger-Rigoutsos in Practice
 
 ![Tagged cells and Berger-Rigoutsos boxes](amr_grid_refinement.svg)

--- a/docs/markdown/amr_grid_refinement.svg
+++ b/docs/markdown/amr_grid_refinement.svg
@@ -7,18 +7,22 @@
       <rect width="8" height="8" fill="#ffe8cc" />
       <rect x="0" y="0" width="8" height="4" fill="#ffd1a6" />
     </pattern>
+    <mask id="ring-mask">
+      <rect width="480" height="480" fill="#ffffff" />
+      <circle cx="240" cy="240" r="110" fill="#000000" />
+    </mask>
   </defs>
   <rect x="30" y="30" width="420" height="420" fill="#f8f8f8" stroke="#1d1d1d" stroke-width="2" />
-  <circle cx="240" cy="240" r="150" fill="url(#tagged)" stroke="#f0a25b" stroke-width="18" stroke-opacity="0.75" />
-  <circle cx="240" cy="240" r="110" fill="#f8f8f8" stroke="#f8f8f8" stroke-width="2" />
+  <circle cx="240" cy="240" r="150" fill="url(#tagged)" mask="url(#ring-mask)" />
+  <circle cx="240" cy="240" r="150" fill="none" stroke="#f0a25b" stroke-width="6" stroke-opacity="0.75" />
+  <circle cx="240" cy="240" r="110" fill="none" stroke="#f0a25b" stroke-width="4" stroke-opacity="0.35" />
   <rect x="187.5" y="135" width="105" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
   <rect x="135" y="187.5" width="210" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
   <rect x="135" y="240" width="210" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
   <rect x="187.5" y="292.5" width="105" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
   <rect x="60" y="60" width="72" height="32" fill="#f8f8f8" />
-  <rect x="310" y="360" width="110" height="60" fill="#f8f8f8" />
   <circle cx="84" cy="76" r="12" fill="#ffd1a6" stroke="#f0a25b" stroke-width="3" />
-  <rect x="332" y="380" width="20" height="20" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <rect x="305" y="405" width="20" height="20" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
   <text x="104" y="80" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="#3a2f20">Tagged cells</text>
-  <text x="360" y="395" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="#00335f">Level 1 grids</text>
+  <text x="335" y="427" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="#00335f">Level 1 grids</text>
 </svg>

--- a/docs/markdown/amr_grid_refinement.svg
+++ b/docs/markdown/amr_grid_refinement.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="480" height="480" viewBox="0 0 480 480" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Tagged cells and Berger-Rigoutsos boxes</title>
+  <desc id="desc">Tagged ring from the HydroBlast2D problem at t ≈ 0.004 and the four level-one grids produced by Berger-Rigoutsos clustering.</desc>
+  <defs>
+    <pattern id="tagged" width="8" height="8" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <rect width="8" height="8" fill="#ffe8cc" />
+      <rect x="0" y="0" width="8" height="4" fill="#ffd1a6" />
+    </pattern>
+  </defs>
+  <rect x="30" y="30" width="420" height="420" fill="#f8f8f8" stroke="#1d1d1d" stroke-width="2" />
+  <circle cx="240" cy="240" r="150" fill="url(#tagged)" stroke="#f0a25b" stroke-width="18" stroke-opacity="0.75" />
+  <circle cx="240" cy="240" r="110" fill="#f8f8f8" stroke="#f8f8f8" stroke-width="2" />
+  <rect x="187.5" y="135" width="105" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <rect x="135" y="187.5" width="210" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <rect x="135" y="240" width="210" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <rect x="187.5" y="292.5" width="105" height="52.5" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <rect x="60" y="60" width="72" height="32" fill="#f8f8f8" />
+  <rect x="310" y="360" width="110" height="60" fill="#f8f8f8" />
+  <circle cx="84" cy="76" r="12" fill="#ffd1a6" stroke="#f0a25b" stroke-width="3" />
+  <rect x="332" y="380" width="20" height="20" fill="none" stroke="#005bbb" stroke-width="3" stroke-dasharray="10 6" />
+  <text x="104" y="80" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="#3a2f20">Tagged cells</text>
+  <text x="360" y="395" font-family="Helvetica, Arial, sans-serif" font-size="18" fill="#00335f">Level 1 grids</text>
+</svg>

--- a/docs/markdown/citation.md
+++ b/docs/markdown/citation.md
@@ -29,6 +29,8 @@ If you use any of the following numerical methods or physical modules, please al
 
 - Multigroup Radiation-hydrodynamics: [@He_2024b]
 
+- Particle-mesh interactions: [@He_2025]
+
 ## Scientific applications with Quokka
 
 - Galactic outflows: [@Vijayan_2024], [@Huang_2025], [@Vijayan_2025]

--- a/docs/markdown/references.bib
+++ b/docs/markdown/references.bib
@@ -333,6 +333,23 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{He_2025,
+       author = {{He}, Chong-Chong and {Wibking}, Benjamin D. and {Vijayan}, Aditi and {Krumholz}, Mark R.},
+        title = "{A novel algorithm for GPU-accelerated particle-mesh interactions implemented in the QUOKKA code}",
+      journal = {arXiv e-prints},
+     keywords = {Instrumentation and Methods for Astrophysics, Astrophysics of Galaxies},
+         year = 2025,
+        month = sep,
+          eid = {arXiv:2509.18261},
+        pages = {arXiv:2509.18261},
+archivePrefix = {arXiv},
+       eprint = {2509.18261},
+ primaryClass = {astro-ph.IM},
+       doi = {10.48550/arXiv.2509.18261},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2025arXiv250918261H},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @ARTICLE{Vijayan_2024,
        author = {{Vijayan}, Aditi and {Krumholz}, Mark R. and {Wibking}, Benjamin D.},
         title = "{QUOKKA-based understanding of outflows (QED) - I. Metal loading, phase structure, and convergence testing for solar neighbourhood conditions}",

--- a/docs/markdown/references.bib
+++ b/docs/markdown/references.bib
@@ -32,6 +32,33 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{berger1989local,
+       author = {{Berger}, M.~J. and {Colella}, P.},
+        title = "{Local Adaptive Mesh Refinement for Shock Hydrodynamics}",
+      journal = {Journal of Computational Physics},
+         year = 1989,
+        month = mar,
+       volume = {82},
+       number = {1},
+        pages = {64-84},
+          doi = {10.1016/0021-9991(89)90035-1},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1989JCoPh..82...64B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{berger1991algorithm,
+       author = {{Berger}, M.~J. and {Rigoutsos}, I.},
+        title = "{An Algorithm for Point Clustering and Grid Generation}",
+      journal = {SIAM Journal on Scientific and Statistical Computing},
+         year = 1991,
+       volume = {13},
+       number = {6},
+        pages = {1341-1363},
+          doi = {10.1137/0913077},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/1991SJSSC..13.1341B},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 @article{AMReX_JOSS,
   doi = {10.21105/joss.01370},
   url = {https://doi.org/10.21105/joss.01370},

--- a/docs/markdown/star_formation.md
+++ b/docs/markdown/star_formation.md
@@ -1,29 +1,54 @@
-# Star Formation Recipe 
+# Star Formation
 
-## Checking for Jeans Violation
-The star formation recipe is implemented via the Stochastic Stellar Population specialisation. Every cell is checked for Jeans violation and star particles are added if $\lambda_J = c_s/\sqrt{G\rho} < J \cdot dx$, where J is $0.5$. 
+## Overview
 
-Adding a star particle to every Jeans violating cell can lead to a large number of small mass stars which can be cumbersome. To alleviate this issue, we control the star formation rate through $\epsilon_{\rm ff}$ and $\epsilon_{*}$. $\epsilon_{\rm ff}$ is the efficiency per freefall time given by $\frac{\dot{M}_{*} \cdot t_{\rm ff}}{M_{\rm cell} \cdot dt}$, while $\epsilon_{*}$ is the fraction of cell mass that gets converted into stars. 
+The star formation module adds star particles through a lightweight stochastic prescription that plugs into the Stochastic Stellar Population specialisation.
 
-We emulate the stochasticity of star formation in the following manner. We associate a probability P to the process of spawning a star in the cell. To set P, we note that the expectation value of the stellar mass formed is P multiplied by the mass of the star that will be inserted, $\epsilon_{*} M_{\rm cell}$, so $\langle M_{*} \rangle = P \epsilon_{*} M_{\rm cell} $. This must match the target mass determined by $\epsilon_{\rm ff}$, which is $\langle M_{*} \rangle = \epsilon_{\rm ff} M_{\rm cell} (dt/t_{\rm ff}), thereby requiring $P=(\epsilon_{\rm ff}/\epsilon_{*}) dt/t_{\rm ff}$. It should be noted that this is the probability for $\epsilon_{\rm ff}$ averaged over the timestep rather than for the instantaneous star formation rate, which should be integrated over the timestep dt. 
+- Runs once per hydro timestep and evaluates each cell independently.
+- Always spawns a low-mass star particle when a trial succeeds.
+- Adds high-mass particles probabilistically so the Chabrier initial mass function (IMF) is satisfied in expectation.
 
-Both the descriptions of P, from assuming a star formation rate averaged over timestep or an instantaneous star formation rate, lead to identical expression of P if $dt<t_{\rm ff}$. Because we operator-split the process of star formation from the hydrodynamic update, it is important to note that we should not expect to get exactly the correct star formation rate for time steps that are large compared to $t_{\rm ff}. We do not explicitly enforce this as a constraint on the time step, but in practice the CFL condition will almost always guarantee that $dt << t_{\rm ff}$.
+## Jeans instability filter
 
+Eligible cells are first identified through a Jeans-length check before any stochastic sampling occurs.
 
-## Estimating number and type of stars
+- Compute the Jeans length \(\lambda_J = c_s / \sqrt{G \rho}\) in every cell.
+- Mark the cell as eligible when \(\lambda_J < J \cdot \Delta x\) with \(J = 0.5\).
+- Only eligible cells continue to the sampling steps below.
 
-Once we establish that a star will form in a cell, we need to find out the stellar population looks like. In our implementation, the population comprises at least one particle representing the low mass star ($M<8M_{\odot}$) population plus a random number of particles, each representing a high mass star.
+## Controlling the formation rate
 
-The number of high mass stars is determined by the initial mass function, taken to be Chabrier03. The IMF is represented by a log normal for $M<M_{\odot}$ and a power law with a slope of $2.35$ above that. From the IMF, we can estimate the mass fraction of the high mass stars, $f_{*,\rm{high}}$, and the average mass of high mass stars, $\langle m \rangle _{*,\rm{high}}$. The expectation value of the number of high mass stars, *num_high_mass_stars*, then is the ratio of the total mass in high mass stars and $\langle m \rangle _{*,\rm{high}}$. 
+Two efficiency parameters tune how aggressively eligible gas is converted into star particles during each hydro step.
 
-The total number of star particles to be spawned in a cell is $1+$ Poission distribution with an expectation value of *num_high_mass_stars*. A fraction $1-f_{*,\rm{high}}$ goes into the particle representing low mass stars while the mass of the high mass star particles is randomly drawn from the high mass part of the IMF.
+- \(\epsilon_{ff}\): efficiency per free-fall time, defined through \(\epsilon_{ff} = (\dot M_{\star} \, t_{ff}) / (M_{cell} \, \Delta t)\).
+- \(\epsilon_{\star}\): fraction of the cell mass used when a particle is spawned.
+- The target stellar mass for the step is \(\epsilon_{ff} M_{cell} (\Delta t / t_{ff})\).
+- Bernoulli probability for spawning: \( P = \frac{\epsilon_{ff}}{\epsilon_{\star}} \frac{\Delta t}{t_{ff}} \).
+- The expectation value \(\langle M_{\star} \rangle = P \epsilon_{\star} M_{cell}\) matches the target mass provided \(\Delta t < t_{ff}\); the CFL condition typically enforces that inequality.
 
-In the case there are no high mass stars in the cell, the low mass star particle gets spawned at the centre of the cell with a velocity identical to the gas velocity. 
+## Sampling the stellar population
 
+Once a cell passes the filter and the Bernoulli draw succeeds, we construct the composite stellar population represented by the spawned particles.
 
+- Every accepted draw creates one low-mass particle that represents all stars with \(M < 8 M_{\odot}\).
+- High-mass stars follow the Chabrier (2003) IMF: log-normal below \(1 M_{\odot}\) and a slope of \(2.35\) above it.
+- Pre-computed IMF integrals provide the mass fraction \(f_{\star,high}\) and mean mass \(\langle m \rangle_{\star,high}\) of the high-mass component.
+- The expected number of massive stars is \(f_{\star,high} \epsilon_{\star} M_{cell} / \langle m \rangle_{\star,high}\); a Poisson variate with that mean sets the actual count.
+- Each massive star draws its mass from the high-mass end of the IMF, while the low-mass particle retains the remaining fraction \(1 - f_{\star,high}\) of the spawned mass.
+- If the Poisson draw returns zero, only the low-mass particle is inserted and it inherits the local gas velocity.
 
-## Estimating the Velocity of the High Mass Star(s)
+## Assigning particle velocities
 
-In the presence of high mass stars, we first assign momentum to these stars. The velocity of these particles is derived from a log normal distribution. The mean of this distribution is the cell velocity while its dispersion is obtained by mass-averaging over the neighbouring cells. 
+Sampled star particles receive velocities that combine the local bulk flow with an isotropic runaway kick.
 
-We track the total momentum of the high mass star particles in the three directions and in order to conserve momentum we impart an equal and opposite momentum to the low mass star. 
+- Each massive star draws a speed from a power-law distribution \(p(v) \propto v^{-1.8}\) truncated between 3 and 385 km s\(^{-1}\), then converts it to cgs units.
+- A random direction is chosen by sampling \(\cos \theta\) uniformly in \([-1, 1]\) and \(\phi\) in \([0, 2\pi)\); the resulting kick is added to the gas velocity of the parent cell.
+- The total momentum of all massive stars is accumulated, and the low-mass composite particle receives the opposite momentum so that the cell-level particle system conserves momentum.
+
+## Practical considerations
+
+A few implementation notes help interpret corner cases and limitations of the current recipe.
+
+- Star formation is operator-split from the hydrodynamics. Large timesteps compared with \(t_{ff}\) will therefore overshoot the desired rate; no explicit limiter is enforced beyond the CFL-controlled hydro step.
+- All spawned particles are inserted at the cell centre. The caller is responsible for any subsequent repositioning or feedback coupling.
+

--- a/docs/markdown/star_formation.md
+++ b/docs/markdown/star_formation.md
@@ -50,5 +50,5 @@ Sampled star particles receive velocities that combine the local bulk flow with 
 A few implementation notes help interpret corner cases and limitations of the current recipe.
 
 - Star formation is operator-split from the hydrodynamics. Large timesteps compared with \(t_{ff}\) will therefore overshoot the desired rate; no explicit limiter is enforced beyond the CFL-controlled hydro step.
-- All spawned particles are inserted at the cell centre. The caller is responsible for any subsequent repositioning or feedback coupling.
+- All spawned particles are inserted at the cell centre. Other physics modules are responsible for any subsequent repositioning or feedback coupling.
 

--- a/docs/markdown/star_formation.md
+++ b/docs/markdown/star_formation.md
@@ -6,7 +6,7 @@ The star formation module adds star particles through a lightweight stochastic p
 
 - Runs once per hydro timestep and evaluates each cell independently.
 - Always spawns a low-mass star particle when a trial succeeds.
-- Adds high-mass particles probabilistically so the Chabrier initial mass function (IMF) is satisfied in expectation.
+- Adds high-mass particles probabilistically so the Chabrier (2005) initial mass function (IMF) is satisfied in expectation.
 
 ## Jeans instability filter
 
@@ -31,7 +31,7 @@ Two efficiency parameters tune how aggressively eligible gas is converted into s
 Once a cell passes the filter and the Bernoulli draw succeeds, we construct the composite stellar population represented by the spawned particles.
 
 - Every accepted draw creates one low-mass particle that represents all stars with \(M < 8 M_{\odot}\).
-- High-mass stars follow the Chabrier (2003) IMF: log-normal below \(1 M_{\odot}\) and a slope of \(2.35\) above it.
+- High-mass stars follow the Chabrier (2005) IMF: log-normal below \(1 M_{\odot}\) and a slope of \(2.35\) above it.
 - Pre-computed IMF integrals provide the mass fraction \(f_{\star,high}\) and mean mass \(\langle m \rangle_{\star,high}\) of the high-mass component.
 - The expected number of massive stars is \(f_{\star,high} \epsilon_{\star} M_{cell} / \langle m \rangle_{\star,high}\); a Poisson variate with that mean sets the actual count.
 - Each massive star draws its mass from the high-mass end of the IMF, while the low-mass particle retains the remaining fraction \(1 - f_{\star,high}\) of the spawned mass.
@@ -49,6 +49,6 @@ Sampled star particles receive velocities that combine the local bulk flow with 
 
 A few implementation notes help interpret corner cases and limitations of the current recipe.
 
-- Star formation is operator-split from the hydrodynamics. Large timesteps compared with \(t_{ff}\) will therefore overshoot the desired rate; no explicit limiter is enforced beyond the CFL-controlled hydro step.
+- Star formation is operator-split from the hydrodynamics. When \(t_{ff}\) is unresolved (\(\Delta t \gtrsim t_{ff}\)), the true star formation rate is not captured, and this scheme provides one possible approximation; no explicit limiter is enforced beyond the CFL-controlled hydro step.
 - All spawned particles are inserted at the cell centre. Other physics modules are responsible for any subsequent repositioning or feedback coupling.
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -10,11 +10,11 @@ theme:
 nav:
   - About: about.md
   - Equations: equations.md
+  - Citation: citation.md
   - Physics Modules:
     - Star Formation: star_formation.md
-  - Citation: citation.md
   - Simulation gallery:
-    - Hydro : gallery.md
+    - Hydro: gallery.md
   - User guide:
     - Installation: installation.md
     - Running on HPC clusters: running_on_hpc_clusters.md

--- a/inputs/blast2d_amr_example.in
+++ b/inputs/blast2d_amr_example.in
@@ -1,0 +1,30 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  0.0  0.0  0.0 
+geometry.prob_hi     =  1.0  1.0  0.03125
+geometry.is_periodic =  0    0    0
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 0       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 128 128 4
+amr.max_level       = 1     # number of levels = max_level + 1
+amr.ref_ratio       = 2 2 1
+amr.blocking_factor = 32 32 4
+amr.n_error_buf     = 1     # reduced buffer to satisfy 2D blocking
+
+## grid_eff = 1 forces refinement to respect symmetries of the tagged cells
+amr.grid_eff        = 0.8   # encourage compact boxes without over-fragmenting
+
+do_reflux = 0
+do_subcycle = 0
+do_tracers = 1
+max_timesteps = 160
+stop_time = 0.08
+plotfile_interval = 20


### PR DESCRIPTION
### Description
  - Rewrote `docs/markdown/amr_grid_refinement.md` and added `docs/markdown/amr_grid_refinement.svg` to turn the page into a workflow-focused AMR tuning guide with an accompanying schematic.
  - Restructured `docs/markdown/star_formation.md` into a clearer, stepwise explanation of the stochastic recipe, including updated sections on sampling and velocity assignment.
  - Added the new `He_2025` particle-mesh citation to both `docs/markdown/references.bib` and `docs/markdown/citation.md`, and nudged the MkDocs nav (`docs/mkdocs.yml)` so the citation page is grouped with the introductory material.
  - Introduced `inputs/blast2d_amr_example.in` as a ready-to-run AMR configuration example.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
