### PR TITLE
Improve reference solution checks (handle zero-norm cases)

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -940,11 +940,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 					rel_error = err_norm / sol_norm;
 					errorNorm_ = rel_error;
 					amrex::Print() << "Relative rms L1 error norm = " << rel_error << ", with err_norm = " << err_norm
-					               << " and sol_norm = " << sol_norm << "\n";
+						       << " and sol_norm = " << sol_norm << "\n";
 				} else {
 					errorNorm_ = err_norm;
-					amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm
-					               << " (sol_norm = 0)\n";
+					amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm << " (sol_norm = 0)\n";
 				}
 			}
 		}
@@ -961,7 +960,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::Print() << '\n';
 	}
 }
-
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
 {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -891,7 +891,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 
 		amrex::Real sol_norm = 0.;
 		amrex::Real err_norm = 0.;
-		// compute rms of each component
 		for (int n = 0; n < ncomp; ++n) {
 			sol_norm += std::pow(state_ref_level0.norm1(n), 2);
 			err_norm += std::pow(residual.norm1(n), 2);
@@ -899,9 +898,17 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		sol_norm = std::sqrt(sol_norm);
 		err_norm = std::sqrt(err_norm);
 
-		const double rel_error = err_norm / sol_norm;
-		errorNorm_ = rel_error;
-		amrex::Print() << "Relative rms L1 error norm = " << rel_error << '\n';
+		double rel_error = NAN;
+		if (sol_norm > 0.) {
+			rel_error = err_norm / sol_norm;
+			errorNorm_ = rel_error;
+			amrex::Print() << "Relative rms L1 error norm = " << rel_error << '\n';
+		} else {
+			// if the reference solution is identically zero -> only report absolute error instead
+			errorNorm_ = err_norm;
+			amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm << '\n';
+		}
+
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 
@@ -921,7 +928,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 
 				amrex::Real sol_norm = 0.;
 				amrex::Real err_norm = 0.;
-				// compute rms of each component
 				for (int n = 0; n < ncomp; ++n) {
 					sol_norm += std::pow(state_ref_level0.norm1(n), 2);
 					err_norm += std::pow(residual.norm1(n), 2);
@@ -929,10 +935,17 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 				sol_norm = std::sqrt(sol_norm);
 				err_norm = std::sqrt(err_norm);
 
-				const double rel_error = err_norm / sol_norm;
-				errorNorm_ = rel_error;
-				amrex::Print() << "Relative rms L1 error norm = " << rel_error << ", with err_norm = " << err_norm
-					       << " and sol_norm = " << sol_norm << "\n";
+				double rel_error = NAN;
+				if (sol_norm > 0.) {
+					rel_error = err_norm / sol_norm;
+					errorNorm_ = rel_error;
+					amrex::Print() << "Relative rms L1 error norm = " << rel_error << ", with err_norm = " << err_norm
+					               << " and sol_norm = " << sol_norm << "\n";
+				} else {
+					errorNorm_ = err_norm;
+					amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm
+					               << " (sol_norm = 0)\n";
+				}
 			}
 		}
 	}
@@ -948,6 +961,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::Print() << '\n';
 	}
 }
+
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTimestepAtLevel(int lev, amrex::Real time, amrex::Real dt_lev, int ncycle)
 {


### PR DESCRIPTION
### Description
This PR fixes the correctness checks for both cell-centred and face-centred quantities. When `sol_norm` is zero, the code now reports `err_norm` directly instead of computing `rel_error = err_norm / sol_norm` (which produced infinite values). This prevents spurious failures from round-off in identically zero fields (e.g., in the linear Alfvén wave test), while still using relative error where `sol_norm > 0` to catch real differences.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
