### PR TITLE
add orphan docs to toctree

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,9 +31,11 @@ nav:
     - Postprocessing: postprocessing.md
     - Debugging simulation instability: instability.md
   - Developer Guide:
+    - Code Walkthrough: developer_onboarding.md
     - Contributing Guide: contributing.md
     - Flowchart: flowchart.md
     - Hydro Integrator: hydro_integrator.md
+    - Writing new problems: developing_problem_generators.md
     - Debugging: debugging.md
     - Assertions and error checking: error_checking.md
     - Performance tips: performance.md


### PR DESCRIPTION
### Description
Adds orphaned documentation pages to the left-hand-side navigation table of contents menu.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
