### PR TITLE
Fix the carbuncle problem in the HLLD solver

### DIFF
--- a/.github/workflows/mhd-asan.yml
+++ b/.github/workflows/mhd-asan.yml
@@ -75,7 +75,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0:print_stats=1:check_initialization_order=1:strict_string_checks=1:detect_stack_use_after_return=1
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       # Execute all tests with MHD label, excluding FastWave and BrioWuShockTube
-      run: canary run --output-on-failure --workers=1 -k "MHD and not FastWave and not BrioWuShockTube" .
+      run: canary run --output-on-failure --workers=1 -k "MHD and not FastWave and not BrioWuShockTube and not MHDQuirk" .
 
     - name: Upload test output
       if: always()

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -125,8 +125,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// tp := shock anisotropy, clamped to [0, 1], with theta = tp^4
 	const double denom_tp = std::max(1e-14, max_spd - std::min(perp_v_jump, 0.0));
 	double tp = (max_spd - std::min(para_v_jump, 0.0)) / denom_tp;
-	tp = std::max(tp, 0.0); // for completeness, but not strictly mathematically necessary
-	tp = std::min(tp, 1.0);
+	tp = std::clamp(tp, 0.0, 1.0);
 	theta = SQUARE(SQUARE(tp));
 	// modified middle speed S_M
 	const double sm_denom = (siui_R * u_R.rho - siui_L * u_L.rho);

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -5,6 +5,7 @@
 #include "AMReX_GpuQualifiers.H"
 #include <AMReX.H>
 #include <AMReX_REAL.H>
+#include <algorithm>
 
 #include "hydro/HydroState.hpp"
 #include "util/ArrayView.hpp"
@@ -17,7 +18,7 @@ constexpr double DELTA = 1.0e-4;
 // HLLD solver following Miyoshi and Kusano (2005), hereafter MK5.
 template <typename problem_t, int N_scalars, int N_mscalars, int fluxdim>
 AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_mscalars> const &sL, quokka::HydroState<N_scalars, N_mscalars> const &sR,
-					      const double gamma, const double bx) -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
+					      const double gamma, const double bx, const double perp_v_jump) -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
 {
 	//--- Step 1. Compute L/R states
 
@@ -116,9 +117,21 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// MK5: S_i - u_i (for i=L or R)
 	double siui_L = spds[0] - sL.u;
 	double siui_R = spds[4] - sR.u;
-	// MK5: S_M from eqn (38)
-	// group ptot terms for floating-point associativity symmetry
-	spds[2] = (siui_R * u_R.mx - siui_L * u_L.mx + (ptot_L - ptot_R)) / (siui_R * u_R.rho - siui_L * u_L.rho);
+	// carbuncle detector
+	const double max_spd = std::max(fspd_L, fspd_R);
+	const double para_v_jump = sL.u - sR.u; // negative -> compression
+	double theta = 1.0;
+	if (para_v_jump < 0.0) {
+		// tp := shock anisotropy, clamped to [0, 1], with theta = tp^4
+		const double denom_tp = std::max(1e-14, max_spd - std::min(perp_v_jump, 0.0));
+		double tp = (max_spd - std::min(para_v_jump, 0.0)) / denom_tp;
+		tp = std::max(tp, 0.0); // for completeness, but not strictly mathematically necessary
+		tp = std::min(tp, 1.0);
+		theta = SQUARE(SQUARE(tp));
+	}
+	// modified middle speed S_M
+	const double sm_denom = (siui_R * u_R.rho - siui_L * u_L.rho);
+	spds[2] = (siui_R * u_R.mx - siui_L * u_L.mx + theta * (ptot_L - ptot_R)) / sm_denom;
 	// S_i - S_M (for i=L or R)
 	double sism_L = spds[0] - spds[2];
 	double sism_R = spds[4] - spds[2];

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -127,7 +127,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	double tp = (max_spd - std::min(para_v_jump, 0.0)) / denom_tp;
 	tp = std::clamp(tp, 0.0, 1.0);
 	theta = SQUARE(SQUARE(tp));
-	// modified middle speed S_M
+	// modified middle speed S_M from MK5 eqn (38)
 	const double sm_denom = (siui_R * u_R.rho - siui_L * u_L.rho);
 	spds[2] = (siui_R * u_R.mx - siui_L * u_L.mx + theta * (ptot_L - ptot_R)) / sm_denom;
 	// S_i - S_M (for i=L or R)

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -18,7 +18,8 @@ constexpr double DELTA = 1.0e-4;
 // HLLD solver following Miyoshi and Kusano (2005), hereafter MK5.
 template <typename problem_t, int N_scalars, int N_mscalars, int fluxdim>
 AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_mscalars> const &sL, quokka::HydroState<N_scalars, N_mscalars> const &sR,
-					      const double gamma, const double bx, const double perp_v_jump) -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
+					      const double gamma, const double bx, const double perp_v_jump)
+    -> std::tuple<quokka::valarray<double, fluxdim>, double, double>
 {
 	//--- Step 1. Compute L/R states
 

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -121,14 +121,12 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	const double max_spd = std::max(fspd_L, fspd_R);
 	const double para_v_jump = sL.u - sR.u; // negative -> compression
 	double theta = 1.0;
-	if (para_v_jump < 0.0) {
-		// tp := shock anisotropy, clamped to [0, 1], with theta = tp^4
-		const double denom_tp = std::max(1e-14, max_spd - std::min(perp_v_jump, 0.0));
-		double tp = (max_spd - std::min(para_v_jump, 0.0)) / denom_tp;
-		tp = std::max(tp, 0.0); // for completeness, but not strictly mathematically necessary
-		tp = std::min(tp, 1.0);
-		theta = SQUARE(SQUARE(tp));
-	}
+	// tp := shock anisotropy, clamped to [0, 1], with theta = tp^4
+	const double denom_tp = std::max(1e-14, max_spd - std::min(perp_v_jump, 0.0));
+	double tp = (max_spd - std::min(para_v_jump, 0.0)) / denom_tp;
+	tp = std::max(tp, 0.0); // for completeness, but not strictly mathematically necessary
+	tp = std::min(tp, 1.0);
+	theta = SQUARE(SQUARE(tp));
 	// modified middle speed S_M
 	const double sm_denom = (siui_R * u_R.rho - siui_L * u_L.rho);
 	spds[2] = (siui_R * u_R.mx - siui_L * u_L.mx + theta * (ptot_L - ptot_R)) / sm_denom;

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1205,7 +1205,7 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 			x1FSpds(i, j, k, 1) = fspd_p;
 		} else if constexpr (RIEMANN == RiemannSolver::HLLD) {
 			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
-			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1);
+			auto [F_canonical_tmp, fspd_m, fspd_p] = quokka::Riemann::HLLD<problem_t, nscalars_, nmscalars_, nvar_>(sL, sR, gamma_, bx1, dw);
 			F_canonical = F_canonical_tmp;
 			x1FSpds(i, j, k, 0) = fspd_m;
 			x1FSpds(i, j, k, 1) = fspd_p;

--- a/src/problems/CMakeLists.txt
+++ b/src/problems/CMakeLists.txt
@@ -71,6 +71,7 @@ add_subdirectory(FastWave)
 add_subdirectory(FieldLoop)
 add_subdirectory(MHDBlast)
 add_subdirectory(BrioWuShockTube)
+add_subdirectory(MHDQuirk)
 
 add_subdirectory(DiskGalaxy)
 add_subdirectory(BinaryOrbitCIC)

--- a/src/problems/HydroQuirk/CMakeLists.txt
+++ b/src/problems/HydroQuirk/CMakeLists.txt
@@ -1,8 +1,8 @@
 if (AMReX_SPACEDIM GREATER_EQUAL 2)
-    add_executable(test_quirk test_quirk.cpp ${QuokkaObjSources})
+    add_executable(test_hydro_quirk test_hydro_quirk.cpp ${QuokkaObjSources})
     if(AMReX_GPU_BACKEND MATCHES "CUDA")
-        setup_target_for_cuda_compilation(test_quirk)
+        setup_target_for_cuda_compilation(test_hydro_quirk)
     endif()
 
-    add_test(NAME HydroQuirk COMMAND test_quirk ../inputs/quirk.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    add_test(NAME HydroQuirk COMMAND test_hydro_quirk ../inputs/quirk.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 endif()

--- a/src/problems/HydroQuirk/test_hydro_quirk.cpp
+++ b/src/problems/HydroQuirk/test_hydro_quirk.cpp
@@ -3,7 +3,7 @@
 // Copyright 2020 Benjamin Wibking.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
-/// \file test_quirk.cpp
+/// \file test_hydro_quirk.cpp
 /// \brief Defines a test problem for the odd-even decoupling instability.
 ///
 

--- a/src/problems/MHDQuirk/CMakeLists.txt
+++ b/src/problems/MHDQuirk/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (AMReX_SPACEDIM EQUAL 3)
+    add_executable(test_mhd_quirk test_mhd_quirk.cpp ${QuokkaObjSources})
+
+    if(AMReX_GPU_BACKEND MATCHES "CUDA")
+        setup_target_for_cuda_compilation(test_mhd_quirk)
+    endif()
+
+    add_test(NAME MHDQuirk COMMAND test_mhd_quirk ../inputs/quirk.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+		set_tests_properties(MHDQuirk PROPERTIES LABELS "MHD")
+endif()

--- a/src/problems/MHDQuirk/test_mhd_quirk.cpp
+++ b/src/problems/MHDQuirk/test_mhd_quirk.cpp
@@ -230,8 +230,8 @@ template <> void QuokkaSimulation<MHDQuirk>::computeAfterEvolve(amrex::Vector<am
 template <>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
 AMRSimulation<MHDQuirk>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/, int /*numcomp*/,
-							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec * /*bcr*/,
-							 int /*bcomp*/, int /*orig_comp*/)
+						     amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec * /*bcr*/, int /*bcomp*/,
+						     int /*orig_comp*/)
 {
 #if (AMREX_SPACEDIM == 1)
 	auto i = iv.toArray()[0];
@@ -273,9 +273,9 @@ AMRSimulation<MHDQuirk>::setCustomBoundaryConditions(const amrex::IntVect &iv, a
 auto problem_main() -> int
 {
 	// Boundary conditions: ext_dir in x, periodic in y and z
-	auto BCs_cc = quokka::BC<MHDQuirk>(quokka::BCType::ext_dir,	 // x: outflow
-					       quokka::BCType::int_dir,	 // y: periodic
-					       quokka::BCType::int_dir); // z: periodic
+	auto BCs_cc = quokka::BC<MHDQuirk>(quokka::BCType::ext_dir,  // x: outflow
+					   quokka::BCType::int_dir,  // y: periodic
+					   quokka::BCType::int_dir); // z: periodic
 
 	const int nvars_fc = Physics_Indices<MHDQuirk>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);

--- a/src/problems/MHDQuirk/test_mhd_quirk.cpp
+++ b/src/problems/MHDQuirk/test_mhd_quirk.cpp
@@ -34,7 +34,6 @@
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
-#include "hydro/hydro_system.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/BC.hpp"
 

--- a/src/problems/MHDQuirk/test_mhd_quirk.cpp
+++ b/src/problems/MHDQuirk/test_mhd_quirk.cpp
@@ -80,14 +80,12 @@ template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_fc = grid_elem.array_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
-	const quokka::centering cen = grid_elem.cen_;
-	const quokka::direction dir = grid_elem.dir_;
 
 	const int ncomp_fc = Physics_Indices<MHDQuirk>::nvarPerDim_fc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		for (int n = 0; n < ncomp_fc; ++n) {
-			state_fc(i, j, k, n) = 0; // fill unused quantities with zeros
+			state_fc(i, j, k, n) = 0; // fill all b-field quantities with zeros
 		}
 	});
 }

--- a/src/problems/MHDQuirk/test_mhd_quirk.cpp
+++ b/src/problems/MHDQuirk/test_mhd_quirk.cpp
@@ -75,8 +75,6 @@ constexpr int ishock_g = 0;
 template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
-	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
-	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_fc = grid_elem.array_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 

--- a/src/problems/MHDQuirk/test_mhd_quirk.cpp
+++ b/src/problems/MHDQuirk/test_mhd_quirk.cpp
@@ -1,0 +1,307 @@
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file test_mhd_quirk.cpp
+/// \brief Defines a test problem for the odd-even decoupling instability.
+///
+
+#ifdef HAVE_PYTHON
+#include "util/matplotlibcpp.h"
+#endif
+#include "hydro/hydro_system.hpp"
+#include "math/interpolate.hpp"
+#include <algorithm>
+#include <fmt/format.h>
+#include <fstream>
+#include <vector>
+
+#include "AMReX.H"
+#include "AMReX_Array.H"
+#include "AMReX_BCRec.H"
+#include "AMReX_BC_TYPES.H"
+#include "AMReX_BLassert.H"
+#include "AMReX_Box.H"
+#include "AMReX_FabArrayBase.H"
+#include "AMReX_GpuAsyncArray.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_IntVect.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_ParallelDescriptor.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Print.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+#include "hydro/hydro_system.hpp"
+#include "radiation/radiation_system.hpp"
+#include "util/BC.hpp"
+
+using Real = amrex::Real;
+
+struct MHDQuirk {
+};
+
+template <> struct quokka::EOS_Traits<MHDQuirk> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+};
+
+template <> struct HydroSystem_Traits<MHDQuirk> {
+	static constexpr bool reconstruct_eint = false;
+};
+
+template <> struct Physics_Traits<MHDQuirk> {
+	static constexpr bool is_self_gravity_enabled = false;
+	// cell-centred
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	// face-centred
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+};
+
+constexpr Real dl = 3.692;
+constexpr Real ul = -0.625;
+constexpr Real pl = 26.85;
+constexpr Real dr = 1.0;
+constexpr Real ur = -5.0;
+constexpr Real pr = 0.6;
+constexpr int ishock_g = 0;
+
+template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	// extract grid information
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::centering cen = grid_elem.cen_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	const int ncomp_fc = Physics_Indices<MHDQuirk>::nvarPerDim_fc;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < ncomp_fc; ++n) {
+			state_fc(i, j, k, n) = 0; // fill unused quantities with zeros
+		}
+	});
+}
+
+template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// extract variables required from the geom object
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
+	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	Real const xshock = 0.4;
+	int ishock = 0;
+	for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + static_cast<Real>(0.5))) < xshock; ++ishock) {
+	}
+	ishock--;
+	amrex::Print() << "ishock = " << ishock << "\n";
+
+	Real const dd = dl - 0.135;
+	Real const ud = ul + 0.219;
+	Real const pd = pl - 1.31;
+	// loop over the grid and set the initial condition
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		double vx = NAN;
+		double const vy = 0.;
+		double const vz = 0.;
+		double rho = NAN;
+		double P = NAN;
+
+		if (i <= ishock) {
+			rho = dl;
+			vx = ul;
+			P = pl;
+		} else {
+			rho = dr;
+			vx = ur;
+			P = pr;
+		}
+
+		if ((i == ishock) && (j % 2 == 0)) {
+			rho = dd;
+			vx = ud;
+			P = pd;
+		}
+
+		AMREX_ASSERT(!std::isnan(vx));
+		AMREX_ASSERT(!std::isnan(vy));
+		AMREX_ASSERT(!std::isnan(vz));
+		AMREX_ASSERT(!std::isnan(rho));
+		AMREX_ASSERT(!std::isnan(P));
+
+		const auto v_sq = vx * vx + vy * vy + vz * vz;
+
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::density_index) = rho;
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::x1Momentum_index) = rho * vx;
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::x2Momentum_index) = rho * vy;
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::x3Momentum_index) = rho * vz;
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::energy_index) = quokka::EOS<MHDQuirk>::ComputeEintFromPres(rho, P) + 0.5 * rho * v_sq;
+		state_cc(i, j, k, HydroSystem<MHDQuirk>::internalEnergy_index) = quokka::EOS<MHDQuirk>::ComputeEintFromPres(rho, P);
+	});
+}
+
+auto getDeltaEntropyVector() -> std::vector<Real> &
+{
+	static std::vector<Real> delta_s_vec;
+	return delta_s_vec;
+}
+
+template <> void QuokkaSimulation<MHDQuirk>::computeAfterTimestep()
+{
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		// it should be sufficient examine a single box on level 0
+		// (no AMR should be used for this problem, and the odd-even decoupling will
+		// manifest in every row along the shock, if it happens)
+
+		amrex::MultiFab const &mf_state = state_new_cc_[0];
+		int box_no = -1;
+		int const ilo = ishock_g;
+		int jlo = 0;
+		int klo = 0;
+		for (amrex::MFIter mfi(mf_state); mfi.isValid(); ++mfi) {
+			const amrex::Box &bx = mfi.validbox();
+			amrex::GpuArray<int, 3> box_lo = bx.loVect3d();
+			jlo = box_lo[1];
+			klo = box_lo[2];
+			amrex::IntVect const cell{AMREX_D_DECL(ilo, jlo, klo)};
+			if (bx.contains(cell)) {
+				box_no = mfi.index();
+				break;
+			}
+		}
+
+		AMREX_ALWAYS_ASSERT(box_no != -1);
+		auto const &state = mf_state.const_array(box_no);
+		amrex::Box const bx = amrex::makeSingleCellBox(ilo, jlo, klo);
+		Real host_s = NAN;
+		amrex::AsyncArray async_s(&host_s, 1);
+		Real *s = async_s.data();
+
+		amrex::launch(bx, [=] AMREX_GPU_DEVICE(amrex::Box const &tbx) {
+			amrex::GpuArray<int, 3> const idx = tbx.loVect3d();
+			int const i = idx[0];
+			int const j = idx[1];
+			int const k = idx[2];
+			Real const dodd = state(i, j + 1, k, HydroSystem<MHDQuirk>::density_index);
+			Real const podd = HydroSystem<MHDQuirk>::ComputePressure(state, i, j + 1, k);
+			Real const deven = state(i, j, k, HydroSystem<MHDQuirk>::density_index);
+			Real const peven = HydroSystem<MHDQuirk>::ComputePressure(state, i, j, k);
+
+			// the 'entropy function' s == P / rho^gamma
+			const Real gamma = quokka::EOS_Traits<MHDQuirk>::gamma;
+			Real const sodd = podd / std::pow(dodd, gamma);
+			Real const seven = peven / std::pow(deven, gamma);
+			s[0] = std::abs(sodd - seven);
+		});
+
+		async_s.copyToHost(&host_s, 1);
+		getDeltaEntropyVector().push_back(host_s);
+	}
+}
+
+template <> void QuokkaSimulation<MHDQuirk>::computeAfterEvolve(amrex::Vector<amrex::Real> & /*initSumCons*/)
+{
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		auto const &deltas_vec = getDeltaEntropyVector();
+		const Real deltas = *std::max_element(deltas_vec.begin(), deltas_vec.end());
+
+		if (deltas > 0.06) {
+			amrex::Print() << "The scheme suffers from the Carbuncle phenomenon : max delta s = " << deltas << "\n\n";
+			amrex::Abort("Carbuncle detected!");
+		} else {
+			amrex::Print() << "The scheme looks stable against the Carbuncle phenomenon : "
+					  "max delta s = "
+				       << deltas << "\n\n";
+		}
+	}
+}
+
+template <>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+AMRSimulation<MHDQuirk>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/, int /*numcomp*/,
+							 amrex::GeometryData const &geom, const amrex::Real /*time*/, const amrex::BCRec * /*bcr*/,
+							 int /*bcomp*/, int /*orig_comp*/)
+{
+#if (AMREX_SPACEDIM == 1)
+	auto i = iv.toArray()[0];
+	int j = 0;
+	int k = 0;
+#endif
+#if (AMREX_SPACEDIM == 2)
+	auto [i, j] = iv.toArray();
+	int k = 0;
+#endif
+#if (AMREX_SPACEDIM == 3)
+	auto [i, j, k] = iv.toArray();
+#endif
+
+	amrex::Box const &box = geom.Domain();
+	amrex::GpuArray<int, 3> lo = box.loVect3d();
+	amrex::GpuArray<int, 3> hi = box.hiVect3d();
+	const auto gamma = quokka::EOS_Traits<MHDQuirk>::gamma;
+
+	if (i < lo[0]) {
+		// x1 left side boundary
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasEnergy_index) = pl / (gamma - 1.) + 0.5 * dl * ul * ul;
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasInternalEnergy_index) = pl / (gamma - 1.);
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasDensity_index) = dl;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x1GasMomentum_index) = dl * ul;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x2GasMomentum_index) = 0.;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x3GasMomentum_index) = 0.;
+	} else if (i >= hi[0]) {
+		// x1 right-side boundary
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasEnergy_index) = pr / (gamma - 1.) + 0.5 * dr * ur * ur;
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasInternalEnergy_index) = pr / (gamma - 1.);
+		consVar(i, j, k, RadSystem<MHDQuirk>::gasDensity_index) = dr;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x1GasMomentum_index) = dr * ur;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x2GasMomentum_index) = 0.;
+		consVar(i, j, k, RadSystem<MHDQuirk>::x3GasMomentum_index) = 0.;
+	}
+}
+
+auto problem_main() -> int
+{
+	// Boundary conditions: ext_dir in x, periodic in y and z
+	auto BCs_cc = quokka::BC<MHDQuirk>(quokka::BCType::ext_dir,	 // x: outflow
+					       quokka::BCType::int_dir,	 // y: periodic
+					       quokka::BCType::int_dir); // z: periodic
+
+	const int nvars_fc = Physics_Indices<MHDQuirk>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir); // periodic
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	// Problem initialization
+	QuokkaSimulation<MHDQuirk> sim(BCs_cc, BCs_fc);
+
+	sim.reconstructionOrder_ = 2; // PLM
+	sim.stopTime_ = 0.4;
+	sim.cflNumber_ = 0.4;
+	sim.maxTimesteps_ = 2000;
+	sim.plotfileInterval_ = -1;
+
+	// initialize
+	sim.setInitialConditions();
+
+	// evolve
+	sim.evolve();
+
+	// Cleanup and exit
+	amrex::Print() << "Finished." << '\n';
+	return 0;
+}


### PR DESCRIPTION
### Description
This PR mirrors the HLLC carbuncle fix, but for the HLLD solver: we apply the same transverse vel jump detector and damp the middle-speed pressure jump accordingly, with no other changes to HLLD’s star/dstar states. To test that the fix works correctly, I've duplicated the Quirk test with MHD enabled and B=0 (so HLLD is used internally). With this, the post-shock instability disappears and matches the HLLC reference (see attached figure of the before/after solution + the reference HLLC solution). Note, the low-Mach pressure correction is intentionally deferred for a follow-up PR.

<img width="1230" height="885" alt="carbuncle-fix-HLLD" src="https://github.com/user-attachments/assets/8765cbb4-1cf7-4873-ac47-2a9cfbe6df76" />


### Related issues
Partially fixes https://github.com/quokka-astro/quokka/issues/528.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
