### PR TITLE
add missing plotfile output for MHDBlast regression test

### DIFF
--- a/inputs/blast_mhd.in
+++ b/inputs/blast_mhd.in
@@ -24,5 +24,6 @@ do_reflux = 1
 do_subcycle = 1
 do_tracers = 1      # turn on tracer particles
 
+plotfile_interval = 500
 derived_vars = magnetic_divergence
 stop_time = 0.05


### PR DESCRIPTION
### Description
The MHDBlast regression test was missing plotfile outputs. This enables them, so now the regression test can work.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
