### PR TITLE
Add runtime param tol and relative convergence check

### DIFF
--- a/inputs/RadTube.in
+++ b/inputs/RadTube.in
@@ -22,3 +22,5 @@ do_subcycle = 0
 suppress_output = 1
 
 plotfile_interval = 10000000
+
+radiation.iteration_tolerance = 1.0e-13

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -161,7 +161,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	bool use_wavespeed_correction_ = false;
 	bool print_rad_counter_ = false;
-	amrex::Real radiation_iteration_tolerance_ = 1e-11; // tolerance for the Newton-Raphson iteration residuals
+	amrex::Real radiation_iteration_tolerance_ = 1e-11;    // tolerance for the Newton-Raphson iteration residuals
 	amrex::Real radiation_iteration_tolerance_rel_ = -1.0; // tolerance for the relative change between two consecutive Newton-Raphson iterations
 
 	int lowLevelDebuggingOutput_ = 0;	// 0 == do nothing; 1 == output intermediate multifabs used in hydro each timestep (ONLY USE FOR DEBUGGING)
@@ -2279,11 +2279,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				// hydro properties get to t + IMEX_a32 dt in terms of matter-radiation exchange.
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
 					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
-											dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
-											p_iteration_failure_counter);
+											dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor,
+											p_iteration_counter, p_iteration_failure_counter);
 				} else {
 					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
-										       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
+										       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor,
+										       p_iteration_counter, p_iteration_failure_counter);
 				}
 			}
 		}
@@ -2312,10 +2313,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			// include cell-centered source terms; will update state_new_cc_[lev] in place (updates both radiation and hydro vars)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
 				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
-										dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
+										dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
+										p_iteration_failure_counter);
 			} else {
 				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
-									       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
+									       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
+									       p_iteration_failure_counter);
 			}
 		}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2279,7 +2279,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				// hydro properties get to t + IMEX_a32 dt in terms of matter-radiation exchange.
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
 					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
-											dustGasInteractionCoeff_, p_iteration_counter,
+											dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
 											p_iteration_failure_counter);
 				} else {
 					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
@@ -2312,7 +2312,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			// include cell-centered source terms; will update state_new_cc_[lev] in place (updates both radiation and hydro vars)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
 				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
-										dustGasInteractionCoeff_, p_iteration_counter, p_iteration_failure_counter);
+										dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
 			} else {
 				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
 									       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -161,6 +161,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	bool use_wavespeed_correction_ = false;
 	bool print_rad_counter_ = false;
+	amrex::Real radiation_iteration_tolerance_ = 1e-11; // tolerance for the Newton-Raphson iteration residuals
+	amrex::Real radiation_iteration_tolerance_rel_ = -1.0; // tolerance for the relative change between two consecutive Newton-Raphson iterations
 
 	int lowLevelDebuggingOutput_ = 0;	// 0 == do nothing; 1 == output intermediate multifabs used in hydro each timestep (ONLY USE FOR DEBUGGING)
 	int integratorOrder_ = 2;		// 1 == forward Euler; 2 == RK2-SSP (default)
@@ -536,6 +538,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		rpp.query("cfl", radiationCflNumber_);
 		rpp.query("dust_gas_interaction_coeff", dustGasInteractionCoeff_);
 		rpp.query("print_iteration_counts", print_rad_counter_);
+		rpp.query("iteration_tolerance", radiation_iteration_tolerance_);
+		rpp.query("iteration_tolerance_rel", radiation_iteration_tolerance_rel_);
 	}
 }
 
@@ -2187,6 +2191,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 	// compute radiation timestep
 	int nsubSteps = 0;
 	amrex::Real dt_radiation = NAN;
+	auto const rad_tol = radiation_iteration_tolerance_;
+	auto const rad_tol_rel = radiation_iteration_tolerance_rel_;
+	auto const tempFloor = tempFloor_;
 
 	if (Physics_Traits<problem_t>::is_hydro_enabled && !(constantDt_ > 0.)) {
 		// adjust to get integer number of substeps
@@ -2276,8 +2283,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 											p_iteration_failure_counter);
 				} else {
 					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 1,
-										       dustGasInteractionCoeff_, p_iteration_counter,
-										       p_iteration_failure_counter);
+										       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
 				}
 			}
 		}
@@ -2309,7 +2315,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 										dustGasInteractionCoeff_, p_iteration_counter, p_iteration_failure_counter);
 			} else {
 				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_radiation, 2,
-									       dustGasInteractionCoeff_, p_iteration_counter, p_iteration_failure_counter);
+									       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter);
 			}
 		}
 

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -230,7 +230,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
     double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const coeff_n, double const dt,
     amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
     quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/,
+		int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 
@@ -328,15 +329,31 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
 	double Egas_guess = Egas0;
 	auto EradVec_guess = Erad0Vec;
 
+	double Egas_guess_prev = Egas_guess;
+	auto EradVec_guess_prev = EradVec_guess;
+
 	const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 
 	T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 	AMREX_ASSERT(T_gas >= 0.);
 
-	const double resid_tol = 1.0e-11; // 1.0e-15;
 	const int maxIter = 100;
 	int n = 0;
 	for (; n < maxIter; ++n) {
+		// if relative change is within tol, break
+		if (rel_change_tol > 0.0 && n > 0) {
+			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
+			const auto Erad_rel_diff = abs(EradVec_guess - EradVec_guess_prev);
+			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
+
+			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
+				break;
+			}
+		}
+
+		Egas_guess_prev = Egas_guess;
+		EradVec_guess_prev = EradVec_guess;
+
 		// 1. Compute dust temperature
 		// If the dust model is turned off, ComputeDustTemperature should be a function that returns T_gas.
 
@@ -581,7 +598,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
     double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const coeff_n, double const dt,
     amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
     quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/,
+		int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 
@@ -678,6 +696,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 	double Egas_guess = Egas0;
 	auto EradVec_guess = Erad0Vec;
 
+	double Egas_guess_prev = Egas_guess;
+	auto EradVec_guess_prev = EradVec_guess;
+
 	T_gas = quokka::EOS<problem_t>::ComputeTgasFromEint(rho, Egas_guess, massScalars);
 	AMREX_ASSERT(T_gas >= 0.);
 
@@ -685,10 +706,23 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 	const double H_num_den = ComputeNumberDensityH(rho, massScalars);
 	const double PE_heating_energy_derivative = dt * DefinePhotoelectricHeatingE1Derivative(T_gas, H_num_den);
 
-	const double resid_tol = 1.0e-11; // 1.0e-15;
 	const int maxIter = 100;
 	int n = 0;
 	for (; n < maxIter; ++n) {
+		// if relative change is within tol, break
+		if (rel_change_tol > 0.0 && n > 0) {
+			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
+			const auto Erad_rel_diff = abs(EradVec_guess - EradVec_guess_prev);
+			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
+
+			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
+				break;
+			}
+		}
+
+		Egas_guess_prev = Egas_guess;
+		EradVec_guess_prev = EradVec_guess;
+
 		// 1. Compute dust temperature
 		// If the dust model is turned off, ComputeDustTemperature should be a function that returns T_gas.
 

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -233,7 +233,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 							  quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
 							  amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol,
 							  double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
-    -> NewtonIterationResult<problem_t>
+    -> NewtonIterationResult<problem_t> // NOSONAR: High cognitive complexity is expected for this numerical solver
 {
 	// 1. Compute energy exchange
 
@@ -341,7 +341,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 
 	const int maxIter = 100;
 	int n = 0;
-	for (; n < maxIter; ++n) {
+	for (; n < maxIter; ++n) { // NOSONAR
 		// if relative change is within tol, break
 		if (rel_change_tol > 0.0 && n > 0) {
 			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
@@ -349,7 +349,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break; // NOSONAR
+				break;
 			}
 		}
 
@@ -470,7 +470,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break; // NOSONAR
+			break;
 		}
 
 #if 0
@@ -601,7 +601,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
     amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
     quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
     amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/, int *p_iteration_counter,
-    int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+    int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t> // NOSONAR: Numerical solver with inherently high complexity
 {
 	// 1. Compute energy exchange
 
@@ -710,7 +710,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 
 	const int maxIter = 100;
 	int n = 0;
-	for (; n < maxIter; ++n) {
+	for (; n < maxIter; ++n) { // NOSONAR
 		// if relative change is within tol, break
 		if (rel_change_tol > 0.0 && n > 0) {
 			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
@@ -718,7 +718,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break; // NOSONAR
+				break;
 			}
 		}
 
@@ -839,7 +839,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break; // NOSONAR
+			break;
 		}
 
 #if 0

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -349,7 +349,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break;
+				break; // NOSONAR
 			}
 		}
 
@@ -470,7 +470,7 @@ RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, qu
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break;
+			break; // NOSONAR
 		}
 
 #if 0
@@ -718,7 +718,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break;
+				break; // NOSONAR
 			}
 		}
 
@@ -839,7 +839,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break;
+			break; // NOSONAR
 		}
 
 #if 0

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -226,12 +226,14 @@ AMREX_GPU_HOST_DEVICE void RadSystem<problem_t>::SolveLinearEqsWithLastColumn(Ja
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(
-    double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const coeff_n, double const dt,
-    amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
-    quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/,
-		int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+AMREX_GPU_DEVICE auto
+RadSystem<problem_t>::SolveGasDustRadiationEnergyExchange(double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho,
+							  double const coeff_n, double const dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
+							  int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
+							  quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
+							  amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol,
+							  double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
+    -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 
@@ -598,8 +600,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasDustRadiationEnergyExchangeW
     double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const coeff_n, double const dt,
     amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
     quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/,
-		int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double /*tempFloor*/, int *p_iteration_counter,
+    int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -294,7 +294,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 					     double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					      double dustGasCoeff, double tol, double tol_rel, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
+					      double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
 
@@ -427,7 +427,8 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	SolveGasRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double dt,
 					amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
 					quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double tol, double tol_rel, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter)
+					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double tempFloor, 
+					int *p_iteration_counter, int *p_iteration_failure_counter)
 	    -> NewtonIterationResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho,
@@ -435,14 +436,15 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 									 int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
 									 quokka::valarray<double, nGroups_> const &vel_times_F,
 									 quokka::valarray<double, nGroups_> const &Src,
-									 amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter,
-									 int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
+									 amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double tempFloor,
+									 int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto
 	SolveGasDustRadiationEnergyExchangeWithPE(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double coeff_n, double dt,
 						  amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter,
 						  quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
 						  quokka::valarray<double, nGroups_> const &Src, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
+							double resid_tol, double rel_change_tol, double tempFloor,
 						  int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	template <FluxDir DIR>

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -291,7 +291,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					     double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
+					     double dustGasCoeff, double tol_h, double tol_rel_h, double const tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
 					      double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
@@ -427,7 +427,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	SolveGasRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double dt,
 					amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
 					quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter)
+					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double tol, double tol_rel, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter)
 	    -> NewtonIterationResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho,

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -291,10 +291,10 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					     double dustGasCoeff, double tol_h, double tol_rel_h, double const tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
+					     double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					      double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter);
+					      double dustGasCoeff, double tol, double tol_rel, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -291,10 +291,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						double gas_update_factor, double Ekin0) -> FluxUpdateResult<problem_t>;
 
 	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					     double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
+					     double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter,
+					     int *p_iteration_failure_counter);
 
 	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt, int stage,
-					      double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter);
+					      double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor, int *p_iteration_counter,
+					      int *p_iteration_failure_counter);
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
 
@@ -427,25 +429,26 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	SolveGasRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double dt,
 					amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
 					quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double tempFloor, 
-					int *p_iteration_counter, int *p_iteration_failure_counter)
-	    -> NewtonIterationResult<problem_t>;
+					amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double tempFloor,
+					int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchange(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho,
 									 double coeff_n, double dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
 									 int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
 									 quokka::valarray<double, nGroups_> const &vel_times_F,
 									 quokka::valarray<double, nGroups_> const &Src,
-									 amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol, double rel_change_tol, double tempFloor,
-									 int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
+									 amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol,
+									 double rel_change_tol, double tempFloor, int *p_iteration_counter,
+									 int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
-	AMREX_GPU_DEVICE static auto
-	SolveGasDustRadiationEnergyExchangeWithPE(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho, double coeff_n, double dt,
-						  amrex::GpuArray<Real, nmscalars_> const &massScalars, int n_outer_iter,
-						  quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
-						  quokka::valarray<double, nGroups_> const &Src, amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries,
-							double resid_tol, double rel_change_tol, double tempFloor,
-						  int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
+	AMREX_GPU_DEVICE static auto SolveGasDustRadiationEnergyExchangeWithPE(double Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double rho,
+									       double coeff_n, double dt, amrex::GpuArray<Real, nmscalars_> const &massScalars,
+									       int n_outer_iter, quokka::valarray<double, nGroups_> const &work,
+									       quokka::valarray<double, nGroups_> const &vel_times_F,
+									       quokka::valarray<double, nGroups_> const &Src,
+									       amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double resid_tol,
+									       double rel_change_tol, double tempFloor, int *p_iteration_counter,
+									       int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>;
 
 	template <FluxDir DIR>
 	AMREX_GPU_DEVICE static auto ComputeCellOpticalDepth(const quokka::Array4View<const amrex::Real, DIR> &consVar,

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -147,14 +147,12 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGas(double /*T_d*/
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto
-RadSystem<problem_t>::SolveGasRadiationEnergyExchange(double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const dt,
-						      amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter,
-						      quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
-						      quokka::valarray<double, nGroups_> const &Src,
-						      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double const resid_tol, double const rel_change_tol,
-						      double const /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
-    -> NewtonIterationResult<problem_t>
+AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
+    double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const dt,
+    amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
+    quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
+    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double const resid_tol, double const rel_change_tol, double const /*tempFloor*/,
+    int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 
@@ -737,13 +735,13 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 					if constexpr (!enable_photoelectric_heating_) {
 						// gas + radiation + dust
 						updated_energy = SolveGasDustRadiationEnergyExchange(
-						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy,
-								tol, tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
+						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy, tol,
+						    tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
 					} else {
 						// gas + radiation + dust + photoelectric heating
 						updated_energy = SolveGasDustRadiationEnergyExchangeWithPE(
-						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy,
-								tol, tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
+						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy, tol,
+						    tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
 					}
 				}
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -233,7 +233,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 
 	const int maxIter = 100;
 	int n = 0;
-	for (; n < maxIter; ++n) {
+	for (; n < maxIter; ++n) { // NOSONAR
 		// if relative change is within tol, break
 		if (rel_change_tol > 0.0 && n > 0) {
 			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
@@ -241,7 +241,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break; // NOSONAR
+				break;
 			}
 		}
 
@@ -337,7 +337,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break; // NOSONAR
+			break;
 		}
 
 #if 0 // NOLINT

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -152,7 +152,7 @@ RadSystem<problem_t>::SolveGasRadiationEnergyExchange(double const Egas0, quokka
 						      amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter,
 						      quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
 						      quokka::valarray<double, nGroups_> const &Src,
-						      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double const tol, double const tol_rel,
+						      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double const resid_tol, double const rel_change_tol,
 						      double const /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
     -> NewtonIterationResult<problem_t>
 {
@@ -233,18 +233,16 @@ RadSystem<problem_t>::SolveGasRadiationEnergyExchange(double const Egas0, quokka
 	double Egas_guess_prev = Egas_guess;
 	auto EradVec_guess_prev = EradVec_guess;
 
-	const double resid_tol = tol;
-	const double resid_tol_rel = tol_rel;
 	const int maxIter = 100;
 	int n = 0;
 	for (; n < maxIter; ++n) {
 		// if relative change is within tol, break
-		if (resid_tol_rel > 0.0 && n > 0) {
+		if (rel_change_tol > 0.0 && n > 0) {
 			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
 			const auto Erad_rel_diff = abs(EradVec_guess - EradVec_guess_prev);
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
-			if ((sum(Erad_rel_diff) <= resid_tol_rel * Erad_tot_guess_prev) && (Egas_rel_diff <= resid_tol_rel * Egas_guess_prev)) {
+			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
 				break;
 			}
 		}
@@ -740,12 +738,12 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 						// gas + radiation + dust
 						updated_energy = SolveGasDustRadiationEnergyExchange(
 						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy,
-						    p_iteration_counter_local, p_iteration_failure_counter_local);
+								tol, tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
 					} else {
 						// gas + radiation + dust + photoelectric heating
 						updated_energy = SolveGasDustRadiationEnergyExchangeWithPE(
 						    Egas0, Erad0Vec, rho, coeff_n, dt, massScalars, iter, work, vel_times_F, Src, radBoundaries_g_copy,
-						    p_iteration_counter_local, p_iteration_failure_counter_local);
+								tol, tol_rel, tempFloor, p_iteration_counter_local, p_iteration_failure_counter_local);
 					}
 				}
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -241,7 +241,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
 
 			if ((sum(Erad_rel_diff) <= rel_change_tol * Erad_tot_guess_prev) && (Egas_rel_diff <= rel_change_tol * Egas_guess_prev)) {
-				break;
+				break; // NOSONAR
 			}
 		}
 
@@ -337,7 +337,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 
 		// check relative convergence of the residuals
 		if ((std::abs(jacobian.F0 / Etot0) < resid_tol) && (cscale * jacobian.Fg_abs_sum / Etot0 < resid_tol)) {
-			break;
+			break; // NOSONAR
 		}
 
 #if 0 // NOLINT

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -147,11 +147,14 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGas(double /*T_d*/
 }
 
 template <typename problem_t>
-AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
-    double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const dt,
-    amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter, quokka::valarray<double, nGroups_> const &work,
-    quokka::valarray<double, nGroups_> const &vel_times_F, quokka::valarray<double, nGroups_> const &Src,
-    amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, int *p_iteration_counter, int *p_iteration_failure_counter) -> NewtonIterationResult<problem_t>
+AMREX_GPU_DEVICE auto
+RadSystem<problem_t>::SolveGasRadiationEnergyExchange(double const Egas0, quokka::valarray<double, nGroups_> const &Erad0Vec, double const rho, double const dt,
+						      amrex::GpuArray<Real, nmscalars_> const &massScalars, int const n_outer_iter,
+						      quokka::valarray<double, nGroups_> const &work, quokka::valarray<double, nGroups_> const &vel_times_F,
+						      quokka::valarray<double, nGroups_> const &Src,
+						      amrex::GpuArray<double, nGroups_ + 1> const &rad_boundaries, double const tol, double const tol_rel,
+						      double const /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
+    -> NewtonIterationResult<problem_t>
 {
 	// 1. Compute energy exchange
 
@@ -227,10 +230,28 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 	double Egas_guess = Egas0;
 	auto EradVec_guess = Erad0Vec;
 
-	const double resid_tol = 1.0e-11; // 1.0e-15;
+	double Egas_guess_prev = Egas_guess;
+	auto EradVec_guess_prev = EradVec_guess;
+
+	const double resid_tol = tol;
+	const double resid_tol_rel = tol_rel;
 	const int maxIter = 100;
 	int n = 0;
 	for (; n < maxIter; ++n) {
+		// if relative change is within tol, break
+		if (resid_tol_rel > 0.0 && n > 0) {
+			const double Erad_tot_guess_prev = sum(EradVec_guess_prev);
+			const auto Erad_rel_diff = abs(EradVec_guess - EradVec_guess_prev);
+			const auto Egas_rel_diff = std::abs(Egas_guess - Egas_guess_prev);
+
+			if ((sum(Erad_rel_diff) <= resid_tol_rel * Erad_tot_guess_prev) && (Egas_rel_diff <= resid_tol_rel * Egas_guess_prev)) {
+				break;
+			}
+		}
+
+		Egas_guess_prev = Egas_guess;
+		EradVec_guess_prev = EradVec_guess;
+
 		// 1. Compute dust temperature
 		// If the dust model is turned off, ComputeDustTemperature should be a function that returns T_gas.
 
@@ -570,7 +591,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 
 template <typename problem_t>
 void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt_radiation,
-						    const int stage, double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter)
+						    const int stage, double dustGasCoeff, double const tol_h, double const tol_rel_h,
+						    double const tempFloor_local, int *p_iteration_counter, int *p_iteration_failure_counter)
 {
 	static_assert(beta_order_ == 0 || beta_order_ == 1);
 
@@ -582,6 +604,7 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 	}
 
 	amrex::GpuArray<amrex::Real, nGroups_ + 1> radBoundaries_g = radBoundaries_;
+	const double tempFloor_h = tempFloor_local;
 
 	// Add source terms
 
@@ -593,6 +616,10 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		// make a local reference
 		auto p_iteration_counter_local = p_iteration_counter;		      // NOLINT
 		auto p_iteration_failure_counter_local = p_iteration_failure_counter; // NOLINT
+
+		const double tol = tol_h;
+		const double tol_rel = tol_rel_h;
+		const double tempFloor = tempFloor_h;
 
 		const double c = c_light_;
 		const double chat = c_hat_;
@@ -705,9 +732,9 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 
 				if constexpr (!enable_dust_gas_thermal_coupling_model_) {
 					// gas + radiation
-					updated_energy =
-					    SolveGasRadiationEnergyExchange(Egas0, Erad0Vec, rho, dt, massScalars, iter, work, vel_times_F, Src,
-									    radBoundaries_g_copy, p_iteration_counter_local, p_iteration_failure_counter_local);
+					updated_energy = SolveGasRadiationEnergyExchange(Egas0, Erad0Vec, rho, dt, massScalars, iter, work, vel_times_F, Src,
+											 radBoundaries_g_copy, tol, tol_rel, tempFloor,
+											 p_iteration_counter_local, p_iteration_failure_counter_local);
 				} else {
 					if constexpr (!enable_photoelectric_heating_) {
 						// gas + radiation + dust

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -8,7 +8,8 @@
 
 template <typename problem_t>
 void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt_radiation,
-						     const int stage, double dustGasCoeff, double tol_h, double /*tol_rel_h*/, double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
+						     const int stage, double dustGasCoeff, double tol_h, double /*tol_rel_h*/, double /*tempFloor*/,
+						     int *p_iteration_counter, int *p_iteration_failure_counter)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
 	array_t &consNew = consVar;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -8,7 +8,7 @@
 
 template <typename problem_t>
 void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt_radiation,
-						     const int stage, double dustGasCoeff, int *p_iteration_counter, int *p_iteration_failure_counter)
+						     const int stage, double dustGasCoeff, double tol, double /*tol_rel*/, double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
 	array_t &consNew = consVar;
@@ -156,7 +156,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				double deltaR = NAN;
 				double F_D = NAN;
 
-				const double resid_tol = 1.0e-11; // 1.0e-15;
+				const double resid_tol = tol;
 				const int maxIter = 100;
 				int n = 0;
 				for (; n < maxIter; ++n) {

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -8,7 +8,7 @@
 
 template <typename problem_t>
 void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt_radiation,
-						     const int stage, double dustGasCoeff, double tol, double /*tol_rel*/, double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
+						     const int stage, double dustGasCoeff, double tol_h, double /*tol_rel_h*/, double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
 	array_t &consNew = consVar;
@@ -156,7 +156,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				double deltaR = NAN;
 				double F_D = NAN;
 
-				const double resid_tol = tol;
+				const double resid_tol = tol_h;
 				const int maxIter = 100;
 				int n = 0;
 				for (; n < maxIter; ++n) {

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -18,6 +18,8 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		dt = (1.0 - IMEX_a32) * dt_radiation;
 	}
 
+	const auto tol = tol_h;
+
 	// don't need radBoundaries_g for single-group
 
 	// Add source terms
@@ -157,7 +159,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				double deltaR = NAN;
 				double F_D = NAN;
 
-				const double resid_tol = tol_h;
+				const double resid_tol = tol;
 				const int maxIter = 100;
 				int n = 0;
 				for (; n < maxIter; ++n) {

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -18,8 +18,6 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		dt = (1.0 - IMEX_a32) * dt_radiation;
 	}
 
-	const auto tol = tol_h;
-
 	// don't need radBoundaries_g for single-group
 
 	// Add source terms
@@ -36,6 +34,7 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		const double c = c_light_;
 		const double chat = c_hat_;
 		const double dustGasCoeff_ = dustGasCoeff;
+		const double resid_tol = tol_h;
 
 		// load fluid properties
 		const double rho = consPrev(i, j, k, gasDensity_index);
@@ -159,7 +158,6 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 				double deltaR = NAN;
 				double F_D = NAN;
 
-				const double resid_tol = tol;
 				const int maxIter = 100;
 				int n = 0;
 				for (; n < maxIter; ++n) {


### PR DESCRIPTION
### Description
1. Make residual tolenrance for Newton-Raphason iteration a runtime parameter `radiation.iteration_tolerance`
2. Add a parameter `radiation.iteration_tolerance_rel` for relative convergence check. This can be useful in some problems. Default is '-1' (disabled). 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
