### PR TITLE
Remove grackle_data_files submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "extern/amrex"]
 	path = extern/amrex
 	url = https://github.com/AMReX-Codes/amrex.git
-[submodule "extern/grackle_data_files"]
-	path = extern/grackle_data_files
-	url = https://github.com/grackle-project/grackle_data_files.git
 [submodule "extern/Microphysics"]
 	path = extern/Microphysics
 	url = https://github.com/psharda/Microphysics


### PR DESCRIPTION
### Description
Removes the `grackle_data_files` submodule. Since we don't use Grackle tables directly anymore, this is not used for anything.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
