### PR TITLE
Updated build instructions for AMD GPUs in the installation guide

### DIFF
--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -91,7 +91,7 @@ which should end with output similar to the following:
 
 > *Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.*
 
-Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. This is typically `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
+Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. The typical AMD GPU aware compilers are `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
 
 ```shell
 rocminfo | grep gfx

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -91,7 +91,7 @@ which should end with output similar to the following:
 
 > *Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.*
 
-Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. The typical AMD GPU aware compilers are `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
+Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. The typical AMD GPU compilers are `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
 
 ```shell
 rocminfo | grep gfx

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -89,7 +89,26 @@ which should end with output similar to the following:
 
 ### AMD GPUs
 
-Compile with `-DAMReX_GPU_BACKEND=HIP`. Requires ROCm 6.3.0 or newer. Your MPI library **must** support GPU-aware MPI for AMD GPUs. Quokka has been tested on MI100 and MI250X GPUs.
+> **Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.**
+
+Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. This is typically `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` optons to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
+
+```shell
+rocminfo | grep gfx
+```
+
+A typical build command using a the `amdclang++` compiler and an AMD GPU with RDNA 2 (gfx1031) architecture will look like
+
+```shell
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+         -DCMAKE_CXX_COMPILER=amdclang++ \
+         -DCMAKE_C_COMPILER=amdclang \
+         -DAMReX_GPU_BACKEND=HIP \
+         -DAMReX_GPU_ARCH=gfx1031 \
+         -G Ninja
+```
+
+Quokka has been tested on MI100, MI250X and 6700XT GPUs.
 
 ### Intel GPUs *(does not compile)*
 

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -97,7 +97,7 @@ Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-awar
 rocminfo | grep gfx
 ```
 
-A typical build command using a the `amdclang++` compiler and an AMD GPU with RDNA 2 (gfx1031) architecture will look like
+A typical build command using the `amdclang++` compiler and an AMD GPU with RDNA 2 (gfx1031) architecture will look like
 
 ```shell
 cmake .. -DCMAKE_BUILD_TYPE=Release \

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -89,7 +89,7 @@ which should end with output similar to the following:
 
 ### AMD GPUs
 
-> **Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.**
+> *Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.*
 
 Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. This is typically `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` optons to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
 

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -91,7 +91,7 @@ which should end with output similar to the following:
 
 > *Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.*
 
-Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. This is typically `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` optons to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
+Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. This is typically `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
 
 ```shell
 rocminfo | grep gfx


### PR DESCRIPTION
### Description
The build instructions have been updated in the installation guide for AMD GPUs. Instructions regarding 3 additional build options have been added which may be required while building the code for AMD GPUs:

- DCMAKE_CXX_COMPILER
- DCMAKE_C_COMPILER
- DAMReX_AMD_ARCH

Additional information on adding the HIP binary path to the environment has also been added

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
