### PR TITLE
Write particle data in slice plots

### DIFF
--- a/inputs/ParticleSink.in
+++ b/inputs/ParticleSink.in
@@ -30,7 +30,22 @@ particles.verbose = 1
 particles.sink_particle_use_uniform_kernel = true
 
 max_timesteps = 1
-plotfile_interval = 1
 particle_interval = 1
 
 tiny_profiler.enabled = 0
+
+quokka.diagnostics = plt slice_z
+
+quokka.plt.type = PlotFile         # pltfile for the whole box
+quokka.plt.file = plt              # Output file prefix (default "plt", must end in "plt")
+quokka.plt.int  = 1                # Output cadence (in number of coarse steps)
+#quokka.plt.particles = # Default to all particle types
+
+quokka.slice_z.type = DiagFramePlane         # Diagnostic type
+quokka.slice_z.file = slicez_plt             # Output file prefix (must end in "plt")
+quokka.slice_z.normal = 2                    # Plane normal (0 == x, 1 == y, 2 == z)
+quokka.slice_z.center = 0.001                # Coordinate in the normal direction (cannot lie *exactly* on domain boundary)
+quokka.slice_z.int    = 1                   # Output cadence (in number of coarse steps)
+quokka.slice_z.interpolation = Linear        # (Optional, default is Linear) Interpolation type: Linear or Quadratic
+quokka.slice_z.field_names = gasDensity gasInternalEnergy x-GasMomentum y-GasMomentum z-GasMomentum # List of variables included in output
+quokka.slice_z.particles = Sink_particles

--- a/src/io/DiagFramePlane.H
+++ b/src/io/DiagFramePlane.H
@@ -1,9 +1,18 @@
 #ifndef DIAGFRAMEPLANE_H
 #define DIAGFRAMEPLANE_H
 
+#include <string>
+#include <vector>
+
 #include "AMReX_PlotFileUtil.H"
 #include "AMReX_VisMF.H"
 #include "DiagBase.H"
+
+// Forward declaration
+namespace quokka
+{
+template <typename problem_t> class PhysicsParticleRegister;
+} // namespace quokka
 
 class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 {
@@ -21,6 +30,9 @@ class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 	template <typename problem_t> void processDiag(int a_nstep, const amrex::Real &a_time);
 
 	void addVars(amrex::Vector<std::string> &a_varList) override;
+
+	// Get the list of particle types to include (empty means none)
+	[[nodiscard]] auto getParticleTypes() const -> const std::vector<std::string> & { return m_particleTypes; }
 
 	void Write2DMultiLevelPlotfile(const std::string &a_pltfile, int a_nlevels, const amrex::Vector<const amrex::MultiFab *> &a_slice,
 				       const amrex::Vector<std::string> &a_varnames, const amrex::Vector<amrex::Geometry> &a_geoms, const amrex::Real &a_time,
@@ -47,6 +59,9 @@ class DiagFramePlane : public DiagBase::Register<DiagFramePlane>
 	// Variables output
 	amrex::Vector<std::string> m_fieldNames;
 	amrex::Gpu::DeviceVector<int> m_fieldIndices_d;
+
+	// Particle types to include (default: empty)
+	std::vector<std::string> m_particleTypes;
 
 	// Plane definition
 	int m_normal;
@@ -140,6 +155,13 @@ template <typename problem_t> void DiagFramePlane::processDiag(int a_nstep, cons
 		amrex::Vector<int> const step_array(nlevs, a_nstep);
 		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio,
 					  simulationMetadata);
+
+		// If particles are requested, write them
+		if (!m_particleTypes.empty()) {
+			auto *sim = getSim<problem_t>();
+			sim->particleRegister_.writePlotFileFiltered(diagfile, m_particleTypes);
+			amrex::Print() << "  Wrote particles to frame plane " << diagfile << "\n";
+		}
 	}
 }
 

--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -1,8 +1,16 @@
-#include "DiagFramePlane.H"
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
 #include "AMReX_FPC.H"
+#include "AMReX_ParallelDescriptor.H"
 #include "AMReX_ParmParse.H"
 #include "AMReX_PlotFileUtil.H"
+#include "AMReX_Print.H"
 #include "AMReX_VisMF.H"
+#include "DiagFramePlane.H"
 #include "yaml-cpp/yaml.h"
 
 void printLowerDimIntVect(std::ostream &a_File, const amrex::IntVect &a_IntVect, int skipDim)
@@ -76,6 +84,23 @@ void DiagFramePlane::init(const std::string &a_prefix, std::string_view a_diagNa
 		m_interpType = Quadratic;
 	} else {
 		amrex::Abort("Unknown interpolation type for " + a_prefix);
+	}
+
+	// Read particle types to include (optional, default to empty = no particles)
+	int const nParticleTypes = pp.countval("particles");
+	if (nParticleTypes > 0) {
+		m_particleTypes.resize(nParticleTypes);
+		for (int n = 0; n < nParticleTypes; ++n) {
+			pp.get("particles", m_particleTypes[n], n);
+		}
+
+		amrex::Print() << "DiagFramePlane: Including particles: ";
+		for (const auto &ptype : m_particleTypes) {
+			amrex::Print() << ptype << " ";
+		}
+		amrex::Print() << "\n";
+	} else {
+		amrex::Print() << "DiagFramePlane: No particles will be included\n";
 	}
 }
 


### PR DESCRIPTION
### Description
Add support for writing particle data in DiagFramePlane. When `quokka.slice_z.particles` is left empty, default behavior is no particle types. 

This is helpful because in many simulations, slice plot and particle data is all the information i need to make animation figures. 

In the future, we will add support to extract slice plots with deposited particle fields. However, this won't completely replace the feature implemented in this PR, because it's not clear how to display particles in a temperature or velocity field using this approch.


### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
