### PR TITLE
[WIP] modernize code to use C++20 features

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -26,6 +26,7 @@ namespace filesystem = experimental::filesystem;
 }
 #endif
 #include <limits>
+#include <numbers>
 #include <string>
 #include <tuple>
 #include <unordered_map>
@@ -1044,7 +1045,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAt
 	amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 		// *add* density to rhs_mf
 		// (N.B. particles **will not work** if you overwrite the density here!)
-		rhs[bx](i, j, k) += 4.0 * M_PI * G * state[bx](i, j, k, HydroSystem<problem_t>::density_index);
+		rhs[bx](i, j, k) += 4.0 * std::numbers::pi * G * state[bx](i, j, k, HydroSystem<problem_t>::density_index);
 	});
 	amrex::Gpu::streamSynchronizeAll();
 }

--- a/src/math/quadrature.hpp
+++ b/src/math/quadrature.hpp
@@ -3,6 +3,7 @@
 
 // system headers
 #include <cmath>
+#include <numbers>
 
 // library headers
 #include <AMReX.H>
@@ -16,7 +17,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto kernel_wendland_c2(const amrex::Real r)
 	if (r > 1.0) {
 		val = 0;
 	} else {
-		val = (21. / (2. * M_PI)) * std::pow((1.0 - r), 4) * (4.0 * r + 1.0);
+		val = (21. / (2. * std::numbers::pi)) * std::pow((1.0 - r), 4) * (4.0 * r + 1.0);
 	}
 	return val;
 }

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -10,6 +10,7 @@
 #include "particles/particle_types.hpp"
 #include "particles/particle_utils.hpp"
 #include <limits>
+#include <numbers>
 
 namespace quokka
 {
@@ -104,7 +105,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto compute_Mdot_and_r_K(const amrex::
 	// M_dot = 4 pi rho_infty r_BH^2 * sqrt(v_infty^2 + lambda^2 c_s^2), where lambda = exp(3/2) / 4
 	constexpr double lambda = gcem::exp(1.5) / 4.0;
 	AMREX_ASSERT(rho_infty > 0.0);
-	const double M_dot = 4.0 * M_PI * rho_infty * r_BH * r_BH * std::sqrt(v_infty_sqr + lambda * lambda * cs_infty * cs_infty);
+	const double M_dot = 4.0 * std::numbers::pi * rho_infty * r_BH * r_BH * std::sqrt(v_infty_sqr + lambda * lambda * cs_infty * cs_infty);
 	AMREX_ASSERT(M_dot >= 0.0);
 
 	// Compute accretion kernel radius,

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -11,6 +11,7 @@
 #include "stellarpop_data.hpp"
 #include <cmath>
 #include <limits>
+#include <numbers>
 
 namespace quokka
 {
@@ -377,7 +378,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 
 			const amrex::Real cs = HydroSystem<problem_t>::ComputeSoundSpeed(state_arr, i, j, k);
 			const amrex::Real LambdaJ = cs / std::sqrt(C::Gconst * cell_density);
-			const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * cell_density));
+			const amrex::Real t_ff = std::sqrt(3.0 * std::numbers::pi / (32.0 * C::Gconst * cell_density));
 			const amrex::Real prob_star_formation = (eps_ff_ / eps_star) * (dt / t_ff);
 			const amrex::Real random_draw = amrex::Random(engine);
 			int num_star = 0;
@@ -485,7 +486,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 						double const cos_theta_random =
 						    (2 * amrex::Random(engine) - 1.0); // Sample cos theta from a uniform distribution between -1 to 1.
 						double const phi_random =
-						    (1. - amrex::Random(engine)) * 2. * M_PI; // Sample phi from a uniform distribution between 0 and 2*pi
+						    (1. - amrex::Random(engine)) * 2. * std::numbers::pi; // Sample phi from a uniform distribution between 0 and 2*pi
 
 						double const vx_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::cos(phi_random);
 						double const vy_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::sin(phi_random);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -485,8 +485,8 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 
 						double const cos_theta_random =
 						    (2 * amrex::Random(engine) - 1.0); // Sample cos theta from a uniform distribution between -1 to 1.
-						double const phi_random =
-						    (1. - amrex::Random(engine)) * 2. * std::numbers::pi; // Sample phi from a uniform distribution between 0 and 2*pi
+						double const phi_random = (1. - amrex::Random(engine)) * 2. *
+									  std::numbers::pi; // Sample phi from a uniform distribution between 0 and 2*pi
 
 						double const vx_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::cos(phi_random);
 						double const vy_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::sin(phi_random);

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -1,8 +1,6 @@
 #ifndef PARTICLE_DEPOSITION_HPP_
 #define PARTICLE_DEPOSITION_HPP_
 
-#include <algorithm>
-
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
 #include "AMReX_BLProfiler.H"
@@ -13,6 +11,8 @@
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
 #include "particles/particle_utils.hpp"
+#include <algorithm>
+#include <numbers>
 
 namespace amrex::ParticleInterpolator
 {
@@ -108,7 +108,7 @@ struct MassDeposition {
 		const amrex::Real cellVolumeFactor = (AMREX_D_TERM(dxi[0], *dxi[1], *dxi[2]));
 		// Deposit mass weighted by 4 pi G
 		interp.ParticleToMesh(p, rho, start_part_comp, start_mesh_comp, num_comp, [=] AMREX_GPU_DEVICE(const ContainerType &part, int comp) {
-			return 4.0 * M_PI * gConstLocal * part.rdata(comp) * cellVolumeFactor;
+			return 4.0 * std::numbers::pi_v<amrex::Real> * gConstLocal * part.rdata(comp) * cellVolumeFactor;
 		});
 	}
 };
@@ -273,7 +273,7 @@ void depositToBuffer(ContainerType *container, amrex::MultiFab &state, amrex::Mu
 		     int evolutionStageIndex, int birthTimeIndex, const SNScheme SN_scheme_d)
 {
 	const BL_PROFILE("SNFeedbackUtils::depositToBuffer()");
-	constexpr amrex::Real stencil_volume = 4.0 / 3.0 * M_PI * SN_stencil_size * SN_stencil_size * SN_stencil_size;
+	constexpr amrex::Real stencil_volume = 4.0 / 3.0 * std::numbers::pi_v<amrex::Real> * SN_stencil_size * SN_stencil_size * SN_stencil_size;
 	constexpr amrex::GpuArray<amrex::GpuArray<amrex::GpuArray<amrex::Real, SN_stencil_array_size>, SN_stencil_array_size>, SN_stencil_array_size>
 	    stencil_weights_gpu = {{{{{0.00884198143074, 0.00884198143074, 0.00884198143074, 0.00416240696843},
 				      {0.00884198143074, 0.00884198143074, 0.00884198143074, 0.00262865918549},

--- a/src/particles/particle_utils.hpp
+++ b/src/particles/particle_utils.hpp
@@ -5,6 +5,7 @@
 #include "fundamental_constants.H"
 #include "math/FastMath.hpp"
 #include "particles/particle_types.hpp"
+#include <numbers>
 
 namespace quokka::ParticleUtils
 {
@@ -15,7 +16,7 @@ constexpr double jeansNo = 0.25; // Jeans number
 
 static_assert(stencil_size <= 3, "stencil_size must be <= 3");
 
-constexpr amrex::Real stencil_volume = 4.0 / 3.0 * M_PI * stencil_size * stencil_size * stencil_size;
+constexpr amrex::Real stencil_volume = 4.0 / 3.0 * std::numbers::pi_v<amrex::Real> * stencil_size * stencil_size * stencil_size;
 
 using kernel_weights_array_t =
     amrex::GpuArray<amrex::GpuArray<amrex::GpuArray<amrex::Real, SN_stencil_array_size>, SN_stencil_array_size>, SN_stencil_array_size>;
@@ -76,7 +77,7 @@ constexpr kernel_weights_array_t kernel_spherical_uniform_3_weights = {{{{{1.000
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto computeJeansDensity(double cs_cell, double dx) -> double
 {
-	return jeansNo * jeansNo * M_PI * cs_cell * cs_cell / (C::Gconst * (dx * dx));
+	return jeansNo * jeansNo * std::numbers::pi * cs_cell * cs_cell / (C::Gconst * (dx * dx));
 }
 
 inline void roundoffMultiFab(amrex::MultiFab &mf)

--- a/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
+++ b/src/problems/AlfvenWaveCircular/test_alfven_wave_circular.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cmath>
 #include <gcem.hpp>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -49,7 +50,7 @@ constexpr double gamma_gas = quokka::EOS_Traits<AlfvenWaveCircular>::gamma;
 // k = 2 pi / wave_length. note: wave_length should be an integer, because of periodic BCs + the requirement that the magnetic field be continuous. also, the
 // box length = 1, so |k| in [1, inf)
 constexpr double num_modes = 1;
-constexpr double k_amplitude = 2.0 * M_PI * num_modes;
+constexpr double k_amplitude = 2.0 * std::numbers::pi * num_modes;
 
 // background states
 constexpr double bg_density = 1.0;

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -388,7 +388,8 @@ auto problem_main() -> int
 	}
 
 	// we assume box length = 1.0
-	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_x), 2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_y),
+	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_x),
+						      2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};

--- a/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
+++ b/src/problems/AlfvenWaveLinear/test_alfven_wave_linear.cpp
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <cmath>
 #include <gcem.hpp>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -139,7 +140,7 @@ AMREX_GPU_MANAGED std::array<amrex::Real, 3> inplane_dir_prf{0.0, 1.0, 0.0};	// 
 AMREX_GPU_MANAGED std::array<amrex::Real, 3> outofplane_dir_prf{0.0, 0.0, 1.0}; // NOLINT
 
 // wavefront
-AMREX_GPU_MANAGED double k_magn = 2.0 * M_PI; // NOLINT
+AMREX_GPU_MANAGED double k_magn = 2.0 * std::numbers::pi; // NOLINT
 
 /// \brief Rotate a vector from PRF to MRF by multiplying with the rotation matrix R.
 /// \details Implements v_mrf = R * v_prf, where the rows of R are the
@@ -372,7 +373,7 @@ auto problem_main() -> int
 	double angle_between_k_b0_deg = 0.0;
 	hpp.query("angle_between_k_b0", angle_between_k_b0_deg);
 
-	constexpr double deg2rad = M_PI / 180.0;
+	constexpr double deg2rad = std::numbers::pi / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
 
 	int num_modes_x = 0;
@@ -387,8 +388,8 @@ auto problem_main() -> int
 	}
 
 	// we assume box length = 1.0
-	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
-						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
+	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_x), 2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_y),
+						      2.0 * std::numbers::pi * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};
 

--- a/src/problems/Cooling/test_cooling.cpp
+++ b/src/problems/Cooling/test_cooling.cpp
@@ -7,6 +7,7 @@
 /// \brief Defines a test problem for SUNDIALS cooling.
 ///
 #include <fmt/format.h>
+#include <numbers>
 #include <random>
 
 #include "AMReX_BC_TYPES.H"
@@ -67,7 +68,7 @@ template <> void QuokkaSimulation<CoolingTest>::preCalculateInitialConditions()
 
 	// 64-bit Mersenne Twister (do not use 32-bit version for sampling doubles!)
 	std::mt19937_64 rng(1); // NOLINT
-	std::uniform_real_distribution<double> sample_phase(0., 2.0 * M_PI);
+	std::uniform_real_distribution<double> sample_phase(0., 2.0 * std::numbers::pi);
 
 	// Initialize data on the host
 	for (int j = tlo[0]; j <= thi[0]; ++j) {
@@ -109,9 +110,9 @@ template <> void QuokkaSimulation<CoolingTest>::setInitialConditionsOnGrid(quokk
 					if ((ki == 0) && (kj == 0) && (kk == 0)) {
 						continue;
 					}
-					Real const kx = 2.0 * M_PI * static_cast<Real>(ki) / Lx;
-					Real const ky = 2.0 * M_PI * static_cast<Real>(kj) / Lx;
-					Real const kz = 2.0 * M_PI * static_cast<Real>(kk) / Lx;
+					Real const kx = 2.0 * std::numbers::pi * static_cast<Real>(ki) / Lx;
+					Real const ky = 2.0 * std::numbers::pi * static_cast<Real>(kj) / Lx;
+					Real const kz = 2.0 * std::numbers::pi * static_cast<Real>(kk) / Lx;
 					delta_rho += A * std::sin(x * kx + y * ky + z * kz + phase_table(ki, kj, kk));
 				}
 			}

--- a/src/problems/CurrentSheet/test_current_sheet.cpp
+++ b/src/problems/CurrentSheet/test_current_sheet.cpp
@@ -9,6 +9,7 @@
 ///
 
 #include <cmath>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -60,7 +61,7 @@ template <> void QuokkaSimulation<CurrentSheet>::setInitialConditionsOnGrid(quok
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
-		const double vx = A * std::sin(2.0 * M_PI * y);
+		const double vx = A * std::sin(2.0 * std::numbers::pi * y);
 
 		const double Ekin = 0.5 * rho0 * (vx * vx);
 		const double Eint = P0 / (gamma_gas - 1.0);

--- a/src/problems/DiskGalaxy/galaxy.cpp
+++ b/src/problems/DiskGalaxy/galaxy.cpp
@@ -7,9 +7,6 @@
 /// \brief Defines a simulation using the AGORA isolated galaxy initial conditions.
 ///
 
-#include <algorithm>
-#include <cmath>
-
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
 #include "AMReX_FabArrayBase.H"
@@ -17,6 +14,9 @@
 #include "AMReX_GpuDevice.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_REAL.H"
+#include <algorithm>
+#include <cmath>
+#include <numbers>
 
 #include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"
@@ -148,7 +148,7 @@ template <> void QuokkaSimulation<AgoraGalaxy>::setInitialConditionsOnGrid(quokk
 	const double R_d = disk_Rscale_kpc * (1.0e3 * C::parsec);
 	const double z_d = disk_zscale_kpc * (1.0e3 * C::parsec);
 	const double R_max_perturb = disk_perturb_Rmax_kpc * (1e3 * C::parsec);
-	const double rho_0 = disk_gas_mass / 4. / M_PI / (R_d * R_d) / z_d; // normalization constant
+	const double rho_0 = disk_gas_mass / (4. * std::numbers::pi) / (R_d * R_d) / z_d; // normalization constant
 
 	// halo parameters
 	double T_halo = 1.0e6;	    // K

--- a/src/problems/FCQuantities/test_fc_quantities.cpp
+++ b/src/problems/FCQuantities/test_fc_quantities.cpp
@@ -10,6 +10,7 @@
 #include "hydro/mhd_system.hpp"
 #include <cassert>
 #include <fmt/format.h>
+#include <numbers>
 #include <ostream>
 #include <stdexcept>
 #include <valarray>
@@ -59,7 +60,8 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
 	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<FCQuantities>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
-	const quokka::valarray<double, 3> dU = (A * R / (2.0 * M_PI * dx[0])) * (std::cos(2.0 * M_PI * x_L) - std::cos(2.0 * M_PI * x_R));
+	const quokka::valarray<double, 3> dU =
+	    (A * R / (2.0 * std::numbers::pi * dx[0])) * (std::cos(2.0 * std::numbers::pi * x_L) - std::cos(2.0 * std::numbers::pi * x_R));
 
 	double const rho = U_0[0] + dU[0];
 	double const xmom = U_0[1] + dU[1];

--- a/src/problems/FastWave/test_fast_wave.cpp
+++ b/src/problems/FastWave/test_fast_wave.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <gcem.hpp>
 #include <iostream>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -55,12 +56,12 @@ constexpr double bg_mag_amplitude = 1.;
 
 // theta is the angle between k and background magnetic field bg_mag
 constexpr double theta_degrees = 90.0; // degrees
-constexpr double cos_theta = gcem::cos(theta_degrees * M_PI / 180.0);
+constexpr double cos_theta = gcem::cos(theta_degrees * std::numbers::pi / 180.0);
 
 // k = 2 pi / wave length
 // box length = 1, so |k| in [1, inf)
 constexpr double num_modes = 1;
-constexpr double k_amplitude = 2 * M_PI * num_modes;
+constexpr double k_amplitude = 2 * std::numbers::pi * num_modes;
 
 // input perturbation: choose to do this via the relative density field in [0, 1]. remember, the linear regime is valid when this perturbation is small
 constexpr double delta_b = 1e-4;

--- a/src/problems/FieldLoop/test_field_loop.cpp
+++ b/src/problems/FieldLoop/test_field_loop.cpp
@@ -9,6 +9,7 @@
 ///
 
 #include <cmath>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -64,8 +65,8 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
 
 		//  Vx=sin(60 degrees) and Vy=cos(60 degrees)
-		const double vx = std::sin(M_PI / 3.0);
-		const double vy = std::cos(M_PI / 3.0);
+		const double vx = std::sin(std::numbers::pi / 3.0);
+		const double vy = std::cos(std::numbers::pi / 3.0);
 		const double vz = 1.0; // this should not affect the solution!
 
 		const double Ekin = 0.5 * rho0 * (vx * vx + vy * vy);

--- a/src/problems/HydroHighMach/test_hydro_highmach.cpp
+++ b/src/problems/HydroHighMach/test_hydro_highmach.cpp
@@ -17,6 +17,7 @@
 #include "math/interpolate.hpp"
 #include <fmt/format.h>
 #include <fstream>
+#include <numbers>
 
 #include "QuokkaSimulation.hpp"
 #include "hydro/hydro_system.hpp"
@@ -64,8 +65,8 @@ template <> void QuokkaSimulation<HighMachProblem>::setInitialConditionsOnGrid(q
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		Real const x = prob_lo[0] + (i + static_cast<Real>(0.5)) * dx[0];
 
-		double const norm = 1. / (2.0 * M_PI);
-		double const vx = norm * std::sin(2.0 * M_PI * x);
+		double const norm = 1. / (2.0 * std::numbers::pi);
+		double const vx = norm * std::sin(2.0 * std::numbers::pi * x);
 		double const rho = 1.0;
 		double const P = 1.0e-10;
 

--- a/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
+++ b/src/problems/HydroKelvinHelmholz/test_hydro2d_kh.cpp
@@ -14,6 +14,7 @@
 #include "math/interpolate.hpp"
 #include <cmath>
 #include <fstream>
+#include <numbers>
 
 #include "AMReX_BLassert.H"
 #include "AMReX_Config.H"
@@ -73,7 +74,7 @@ template <> void QuokkaSimulation<KelvinHelmholzProblem>::setInitialConditionsOn
 
 		double const rho = 1.5 - 0.5 * std::tanh(yy / L);
 		double const vx = 0.5 * std::tanh(yy / L);
-		double const vy = A * std::cos(4.0 * M_PI * (x - x0)) * std::exp(-(yy * yy) / (sigma * sigma));
+		double const vy = A * std::cos(4.0 * std::numbers::pi * (x - x0)) * std::exp(-(yy * yy) / (sigma * sigma));
 		double const vz = 0.;
 		double const P = 2.5;
 

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -12,6 +12,7 @@
 #endif
 #include "hydro/hydro_system.hpp"
 #include <fmt/format.h>
+#include <numbers>
 #include <valarray>
 
 #include "AMReX_Array.H"
@@ -58,7 +59,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
 	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<WaveProblem>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
-	const quokka::valarray<double, 3> dU = (A * R / (2.0 * M_PI * dx[0])) * (std::cos(2.0 * M_PI * x_L) - std::cos(2.0 * M_PI * x_R));
+	const quokka::valarray<double, 3> dU = (A * R / (2.0 * std::numbers::pi * dx[0])) * (std::cos(2.0 * std::numbers::pi * x_L) - std::cos(2.0 * std::numbers::pi * x_R));
 
 	double const rho = U_0[0] + dU[0];
 	double const xmom = U_0[1] + dU[1];

--- a/src/problems/HydroWave/test_hydro_wave.cpp
+++ b/src/problems/HydroWave/test_hydro_wave.cpp
@@ -59,7 +59,8 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
 	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<WaveProblem>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
-	const quokka::valarray<double, 3> dU = (A * R / (2.0 * std::numbers::pi * dx[0])) * (std::cos(2.0 * std::numbers::pi * x_L) - std::cos(2.0 * std::numbers::pi * x_R));
+	const quokka::valarray<double, 3> dU =
+	    (A * R / (2.0 * std::numbers::pi * dx[0])) * (std::cos(2.0 * std::numbers::pi * x_L) - std::cos(2.0 * std::numbers::pi * x_R));
 
 	double const rho = U_0[0] + dU[0];
 	double const xmom = U_0[1] + dU[1];

--- a/src/problems/OrszagTang/test_orszag_tang.cpp
+++ b/src/problems/OrszagTang/test_orszag_tang.cpp
@@ -10,12 +10,12 @@
 ///	  https://www.astro.princeton.edu/~jstone/Athena/tests/orszag-tang/pagesource.html)
 ///
 
-#include <cmath>
-
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
 #include "AMReX_GpuQualifiers.H"
 #include "AMReX_REAL.H"
+#include <cmath>
+#include <numbers>
 
 #include "QuokkaSimulation.hpp"
 #include "grid.hpp"
@@ -48,7 +48,7 @@ constexpr double B0 = 1.0 / gcem::sqrt(4.0 * PI);
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto A_z(double x, double y) -> double
 {
-	return B0 / (4.0 * M_PI) * (std::cos(4.0 * M_PI * x) - 2.0 * std::cos(2.0 * M_PI * y));
+	return B0 / (4.0 * std::numbers::pi) * (std::cos(4.0 * std::numbers::pi * x) - 2.0 * std::cos(2.0 * std::numbers::pi * y));
 };
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto B_x(double xL, double yL, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx) -> double
@@ -70,15 +70,15 @@ template <> void QuokkaSimulation<OrszagTang>::setInitialConditionsOnGrid(quokka
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 
 	constexpr double gamma_gas = quokka::EOS_Traits<OrszagTang>::gamma;
-	constexpr double rho0 = 25. / (36. * M_PI);
-	constexpr double P0 = 5. / (12. * M_PI);
+	constexpr double rho0 = 25. / (36. * std::numbers::pi);
+	constexpr double P0 = 5. / (12. * std::numbers::pi);
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
 		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
 
-		const double vx = std::sin(2 * M_PI * y);
-		const double vy = -std::sin(2 * M_PI * x);
+		const double vx = std::sin(2 * std::numbers::pi * y);
+		const double vy = -std::sin(2 * std::numbers::pi * x);
 
 		const double Bx = 0.5 * (B_x(x - 0.5 * dx[0], y - 0.5 * dx[1], dx) + B_x(x + 0.5 * dx[0], y - 0.5 * dx[1], dx));
 		const double By = 0.5 * (B_y(x - 0.5 * dx[0], y - 0.5 * dx[1], dx) + B_y(x - 0.5 * dx[0], y + 0.5 * dx[1], dx));

--- a/src/problems/ParticleAccretion/test_particle_accretion.cpp
+++ b/src/problems/ParticleAccretion/test_particle_accretion.cpp
@@ -17,6 +17,7 @@
 #include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include <gcem.hpp>
+#include <numbers>
 
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
@@ -537,7 +538,7 @@ auto problem_main() -> int
 		const Real r_BH = C::Gconst * M_star_in_g / (cs0 * cs0);
 		const Real lam = std::exp(1.5) / 4.0;
 		const Real rho_bg = uniform_density > 0.0 ? uniform_density : rho0;
-		const Real Mdot_exact = 4.0 * M_PI * rho_bg * r_BH * r_BH * (lam * cs0);
+		const Real Mdot_exact = 4.0 * std::numbers::pi * rho_bg * r_BH * r_BH * (lam * cs0);
 		amrex::Print() << "Mdot_exact = " << Mdot_exact << "\n";
 
 		// Estimate the accretion rate from the particle data

--- a/src/problems/ParticleSF/test_particle_SF.cpp
+++ b/src/problems/ParticleSF/test_particle_SF.cpp
@@ -15,6 +15,7 @@
 #include "fundamental_constants.H"
 #include "hydro/hydro_system.hpp"
 #include "particles/particle_types.hpp"
+#include <numbers>
 
 struct ParticleSFProblem {
 };
@@ -123,7 +124,7 @@ auto problem_main() -> int
 
 	const amrex::Real eps_star = 0.5;
 	const amrex::Real rho0 = n0 * mu;
-	const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * rho0));
+	const amrex::Real t_ff = std::sqrt(3.0 * std::numbers::pi / (32.0 * C::Gconst * rho0));
 	const amrex::Real prob_star_formation = (eps_ff / eps_star) * (sim.initDt_ / t_ff);
 	amrex::Print() << "Probability of star formation = " << prob_star_formation << "\n";
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(prob_star_formation < 1.0,

--- a/src/problems/PopIII/popiii.cpp
+++ b/src/problems/PopIII/popiii.cpp
@@ -12,6 +12,7 @@
 #include "util/BC.hpp"
 #include <array>
 #include <fstream>
+#include <numbers>
 
 #include "AMReX.H"
 #include "AMReX_BC_TYPES.H"
@@ -353,7 +354,7 @@ template <> void QuokkaSimulation<PopIII>::refineGrid(int lev, amrex::TagBoxArra
 
 			amrex::Real const cs = quokka::EOS<PopIII>::ComputeSoundSpeed(rho, pressure, massScalars);
 
-			const amrex::Real l_Jeans = cs * std::sqrt(M_PI / (G * rho));
+			const amrex::Real l_Jeans = cs * std::sqrt(std::numbers::pi / (G * rho));
 			// add a density criterion for refinement so that no initial refinement is ever triggered outside the core
 			// typically, a density threshold ~ initial core density works well
 			if (l_Jeans < (N_cells * dx) && rho > jeans_density_threshold) {

--- a/src/problems/RadhydroShell/test_radhydro_shell.cpp
+++ b/src/problems/RadhydroShell/test_radhydro_shell.cpp
@@ -19,6 +19,7 @@
 #include "math/interpolate.hpp"
 #include "util/BC.hpp"
 #include <fstream>
+#include <numbers>
 
 #include "QuokkaSimulation.hpp"
 #include "SimulationData.hpp"
@@ -81,7 +82,7 @@ constexpr amrex::Real sigma_star = 0.3 * r_0;	// cm
 constexpr amrex::Real H_shell = 0.3 * r_0;	// cm
 constexpr amrex::Real kappa0 = 20.0;		// specific opacity [cm^2 g^-1]
 
-constexpr amrex::Real rho_0 = M_shell / ((4. / 3.) * M_PI * r_0 * r_0 * r_0); // g cm^-3
+constexpr amrex::Real rho_0 = M_shell / ((4. / 3.) * std::numbers::pi_v<amrex::Real> * r_0 * r_0 * r_0); // g cm^-3
 constexpr amrex::Real c_v = k_B / ((2.2 * m_H) * (gamma_gas - 1.0));
 
 template <>
@@ -104,7 +105,7 @@ void RadSystem<ShellProblem>::SetRadEnergySource(array_t &radEnergy, const amrex
 		z0 = 0.;
 	}
 
-	const amrex::Real source_norm = L_star / std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5);
+	const amrex::Real source_norm = L_star / std::pow(2.0 * std::numbers::pi_v<amrex::Real> * sigma_star * sigma_star, 1.5);
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		amrex::Real const x = prob_lo[0] + (i + static_cast<amrex::Real>(0.5)) * dx[0];
@@ -214,7 +215,7 @@ template <> void QuokkaSimulation<ShellProblem>::setInitialConditionsOnGrid(quok
 		amrex::Real const rhat_z = (z - z0) / r;
 
 		double const sigma_sh = H_shell / (2.0 * std::sqrt(2.0 * std::log(2.0)));
-		double const rho_norm = M_shell / (4.0 * M_PI * r * r * std::sqrt(2.0 * M_PI * sigma_sh * sigma_sh));
+		double const rho_norm = M_shell / (4.0 * std::numbers::pi * r * r * std::sqrt(2.0 * std::numbers::pi * sigma_sh * sigma_sh));
 		double const rho_shell = rho_norm * std::exp(-std::pow(r - r_0, 2) / (2.0 * sigma_sh * sigma_sh));
 		double const rho = std::max(rho_shell, 1.0e-8 * rho_0);
 

--- a/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
+++ b/src/problems/RayleighTaylor2D/test_hydro2d_rt.cpp
@@ -14,6 +14,7 @@
 #include "math/interpolate.hpp"
 #include <cmath>
 #include <fstream>
+#include <numbers>
 
 #include "AMReX_BLassert.H"
 #include "AMReX_ParmParse.H"
@@ -78,7 +79,7 @@ template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka:
 		double const amp = A * amrex::Random(rng);
 
 		double const vx = 0;
-		double const vy = amp * (1.0 + std::cos(8.0 * M_PI * y / 3.0)) / 2.0;
+		double const vy = amp * (1.0 + std::cos(8.0 * std::numbers::pi * y / 3.0)) / 2.0;
 		double const vz = 0;
 		double const P0 = 2.5;
 		double const P = P0 + rho * g_y * y;

--- a/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
+++ b/src/problems/RayleighTaylor3D/test_hydro3d_rt.cpp
@@ -14,6 +14,7 @@
 #include "math/interpolate.hpp"
 #include <cmath>
 #include <fstream>
+#include <numbers>
 
 #include "AMReX_BLassert.H"
 #include "AMReX_ParallelDescriptor.H"
@@ -80,7 +81,7 @@ template <> void QuokkaSimulation<RTProblem>::setInitialConditionsOnGrid(quokka:
 
 		double const vx = 0;
 		double const vy = 0;
-		double const vz = amp * (1.0 + std::cos(8.0 * M_PI * z / 3.0)) / 2.0;
+		double const vz = amp * (1.0 + std::cos(8.0 * std::numbers::pi * z / 3.0)) / 2.0;
 		double const P0 = 2.5;
 		double const P = P0 + rho * g_z * z;
 

--- a/src/problems/StarCluster/star_cluster.cpp
+++ b/src/problems/StarCluster/star_cluster.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <limits>
 #include <memory>
+#include <numbers>
 #include <random>
 
 #include "AMReX.H"
@@ -99,7 +100,7 @@ template <> void QuokkaSimulation<StarCluster>::preCalculateInitialConditions()
 		const Real R_sphere = userData_.R_sphere;
 		const Real rho_sph = userData_.rho_sphere;
 		const Real alpha_vir = userData_.alpha_vir;
-		const Real M_sphere = (4. / 3.) * M_PI * std::pow(R_sphere, 3) * rho_sph;
+		const Real M_sphere = (4. / 3.) * std::numbers::pi * std::pow(R_sphere, 3) * rho_sph;
 		const Real rms_dv_target = std::sqrt(alpha_vir * (3. / 5.) * Gconst_ * M_sphere / R_sphere);
 		const Real rms_Mach_target = rms_dv_target / quokka::EOS_Traits<StarCluster>::cs_isothermal;
 		const Real rms_dv_actual = userData_.dv_rms_generated;
@@ -183,7 +184,7 @@ template <> void QuokkaSimulation<StarCluster>::refineGrid(int lev, amrex::TagBo
 
 	amrex::ParallelFor(tags, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 		Real const rho = state[bx](i, j, k, HydroSystem<StarCluster>::density_index);
-		const amrex::Real l_Jeans = cs * std::sqrt(M_PI / (G * rho));
+		const amrex::Real l_Jeans = cs * std::sqrt(std::numbers::pi / (G * rho));
 
 		if (l_Jeans < (N_cells * dx)) {
 			tag[bx](i, j, k) = amrex::TagBox::SET;

--- a/src/radiation/planck_integral.hpp
+++ b/src/radiation/planck_integral.hpp
@@ -9,6 +9,7 @@
 
 #include <cassert>
 #include <cmath>
+#include <numbers>
 
 #include "AMReX_Array.H"
 #include "AMReX_BLassert.H"
@@ -19,7 +20,7 @@
 using Real = amrex::Real;
 
 static constexpr bool USE_SECOND_ORDER = false;
-static constexpr double PI = M_PI;
+static constexpr double PI = std::numbers::pi;
 static constexpr Real gInf = PI * PI * PI * PI / 15.0;
 static constexpr int INTERP_SIZE = 1000;
 static constexpr Real LOG_X_MIN = -3.;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -26,7 +26,6 @@ namespace filesystem = experimental::filesystem;
 }
 #endif
 #include <algorithm>
-#include <ranges>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -34,6 +33,7 @@ namespace filesystem = experimental::filesystem;
 #include <memory>
 #include <optional>
 #include <ostream>
+#include <ranges>
 #include <stdexcept>
 #include <variant>
 
@@ -3020,9 +3020,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::createDiagnostics()
 	}
 
 	// Remove duplicates from m_diagVars and check that all the variables exist
-		std::ranges::sort(m_diagVars);
-		auto const new_end = std::ranges::unique(m_diagVars).begin();
-		m_diagVars.erase(new_end, m_diagVars.end());
+	std::ranges::sort(m_diagVars);
+	auto const new_end = std::ranges::unique(m_diagVars).begin();
+	m_diagVars.erase(new_end, m_diagVars.end());
 
 	auto isVarName = [this](std::string const &v) {
 		auto const varnames = GetPlotfileVarNames();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -26,6 +26,7 @@ namespace filesystem = experimental::filesystem;
 }
 #endif
 #include <algorithm>
+#include <ranges>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -3019,9 +3020,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::createDiagnostics()
 	}
 
 	// Remove duplicates from m_diagVars and check that all the variables exist
-	std::sort(m_diagVars.begin(), m_diagVars.end());
-	auto last = std::unique(m_diagVars.begin(), m_diagVars.end());
-	m_diagVars.erase(last, m_diagVars.end());
+		std::ranges::sort(m_diagVars);
+		auto const new_end = std::ranges::unique(m_diagVars).begin();
+		m_diagVars.erase(new_end, m_diagVars.end());
 
 	auto isVarName = [this](std::string const &v) {
 		auto const varnames = GetPlotfileVarNames();

--- a/src/util/ArrayView_2d.hpp
+++ b/src/util/ArrayView_2d.hpp
@@ -24,63 +24,31 @@ template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<Flux
 
 template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X2>(int i, int j, int k) { return std::make_tuple(j, i, k); }
 
-template <class T, FluxDir N, class Enable = void> struct Array4View {
+template <class T, FluxDir N> struct Array4View {
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = N;
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-};
 
-// X1-flux
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> decltype(auto)
+	{
+		if constexpr (N == FluxDir::X1) {
+			return arr_(i, j, k, n);
+		} else {
+			static_assert(N == FluxDir::X2, "Unsupported flux direction for Array4View");
+			return arr_(j, i, k, n);
+		}
+	}
 
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T & { return arr_(i, j, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T & { return arr_(i, j, k); }
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T { return arr_(i, j, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T { return arr_(i, j, k); }
-};
-
-// X2-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T & { return arr_(j, i, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T & { return arr_(j, i, k); }
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T { return arr_(j, i, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T { return arr_(j, i, k); }
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> decltype(auto)
+	{
+		if constexpr (N == FluxDir::X1) {
+			return arr_(i, j, k);
+		} else {
+			static_assert(N == FluxDir::X2, "Unsupported flux direction for Array4View");
+			return arr_(j, i, k);
+		}
+	}
 };
 
 } // namespace quokka

--- a/src/util/ArrayView_3d.hpp
+++ b/src/util/ArrayView_3d.hpp
@@ -27,89 +27,35 @@ template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<Flux
 
 template <> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto reorderMultiIndex<FluxDir::X3>(int i, int j, int k) { return std::make_tuple(k, i, j); }
 
-template <class T, FluxDir N, class Enable = void> struct Array4View {
+template <class T, FluxDir N> struct Array4View {
 	amrex::Array4<T> arr_;
 	constexpr static FluxDir indexOrder = N;
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-};
 
-// X1-flux
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> decltype(auto)
+	{
+		if constexpr (N == FluxDir::X1) {
+			return arr_(i, j, k, n);
+		} else if constexpr (N == FluxDir::X2) {
+			return arr_(k, i, j, n);
+		} else {
+			static_assert(N == FluxDir::X3, "Unsupported flux direction for Array4View");
+			return arr_(j, k, i, n);
+		}
+	}
 
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T & { return arr_(i, j, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T & { return arr_(i, j, k); }
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X1, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X1;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T { return arr_(i, j, k, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T { return arr_(i, j, k); }
-};
-
-// X2-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T & { return arr_(k, i, j, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T & { return arr_(k, i, j); }
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X2, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X2;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T { return arr_(k, i, j, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T { return arr_(k, i, j); }
-};
-
-// X3-flux
-
-// if T is non-const
-template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<!std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X3;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T & { return arr_(j, k, i, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T & { return arr_(j, k, i); }
-};
-
-// if T is const
-template <class T> struct Array4View<T, FluxDir::X3, std::enable_if_t<std::is_const_v<T>>> {
-	amrex::Array4<T> arr_;
-	constexpr static FluxDir indexOrder = FluxDir::X3;
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit Array4View(amrex::Array4<T> arr) : arr_(arr) {}
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k, int n) const noexcept -> T { return arr_(j, k, i, n); }
-
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> T { return arr_(j, k, i); }
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator()(int i, int j, int k) const noexcept -> decltype(auto)
+	{
+		if constexpr (N == FluxDir::X1) {
+			return arr_(i, j, k);
+		} else if constexpr (N == FluxDir::X2) {
+			return arr_(k, i, j);
+		} else {
+			static_assert(N == FluxDir::X3, "Unsupported flux direction for Array4View");
+			return arr_(j, k, i);
+		}
+	}
 };
 } // namespace quokka
 

--- a/src/util/DataTable.hpp
+++ b/src/util/DataTable.hpp
@@ -395,7 +395,8 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Backward compatibility constructor for single output (Nout = 1)
-	template <int N = Nout, typename = std::enable_if_t<N == 1>>
+	template <int N = Nout>
+	requires(N == 1)
 	DataTable(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const amrex::Vector<amrex::Vector<amrex::Real>> &data)
 	{
 		std::array<amrex::Vector<amrex::Vector<amrex::Real>>, 1> data_array = {data};
@@ -422,7 +423,8 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 1D interface
-	template <int N = Ndim, typename = std::enable_if_t<N == 1>>
+	template <int N = Ndim>
+	requires(N == 1)
 	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_1d_type &data)
 	{
 		static_assert(Ndim == 1, "This initialize overload is for 1D tables only");
@@ -443,7 +445,8 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 2D interface
-	template <int N = Ndim, typename = std::enable_if_t<N == 2>>
+	template <int N = Ndim>
+	requires(N == 2)
 	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_2d_type &data)
 	{
 		static_assert(Ndim == 2, "This initialize overload is for 2D tables only");
@@ -473,7 +476,8 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 3D interface
-	template <int N = Ndim, typename = std::enable_if_t<N == 3>>
+	template <int N = Ndim>
+	requires(N == 3)
 	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_3d_type &data)
 	{
 		static_assert(Ndim == 3, "This initialize overload is for 3D tables only");
@@ -508,7 +512,8 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 4D interface
-	template <int N = Ndim, typename = std::enable_if_t<N == 4>>
+	template <int N = Ndim>
+	requires(N == 4)
 	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_4d_type &data)
 	{
 		static_assert(Ndim == 4, "This initialize overload is for 4D tables only");

--- a/src/util/DataTable.hpp
+++ b/src/util/DataTable.hpp
@@ -396,8 +396,7 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 
 	// Backward compatibility constructor for single output (Nout = 1)
 	template <int N = Nout>
-	requires(N == 1)
-	DataTable(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const amrex::Vector<amrex::Vector<amrex::Real>> &data)
+	requires(N == 1) DataTable(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const amrex::Vector<amrex::Vector<amrex::Real>> &data)
 	{
 		std::array<amrex::Vector<amrex::Vector<amrex::Real>>, 1> data_array = {data};
 		initialize(coords, data_array);
@@ -423,9 +422,7 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 1D interface
-	template <int N = Ndim>
-	requires(N == 1)
-	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_1d_type &data)
+	template <int N = Ndim> requires(N == 1) void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_1d_type &data)
 	{
 		static_assert(Ndim == 1, "This initialize overload is for 1D tables only");
 
@@ -445,9 +442,7 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 2D interface
-	template <int N = Ndim>
-	requires(N == 2)
-	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_2d_type &data)
+	template <int N = Ndim> requires(N == 2) void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_2d_type &data)
 	{
 		static_assert(Ndim == 2, "This initialize overload is for 2D tables only");
 
@@ -476,9 +471,7 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 3D interface
-	template <int N = Ndim>
-	requires(N == 3)
-	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_3d_type &data)
+	template <int N = Ndim> requires(N == 3) void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_3d_type &data)
 	{
 		static_assert(Ndim == 3, "This initialize overload is for 3D tables only");
 
@@ -512,9 +505,7 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 	}
 
 	// Initialize from coordinate arrays - 4D interface
-	template <int N = Ndim>
-	requires(N == 4)
-	void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_4d_type &data)
+	template <int N = Ndim> requires(N == 4) void initialize(const std::array<amrex::Vector<amrex::Real>, Ndim> &coords, const data_4d_type &data)
 	{
 		static_assert(Ndim == 4, "This initialize overload is for 4D tables only");
 


### PR DESCRIPTION
### Description
Adopts some C++20 features:
  * `src/util/DataTable.hpp:398` now uses requires clauses instead of SFINAE for dimensional overloads.
  * `src/util/ArrayView_2d.hpp:19` and `src/util/ArrayView_3d.hpp:20` collapse the `const`/non-`const` specializations into single `decltype(auto)` implementations with direction-specific logic.
  * Replaced `M_PI` with `std::numbers::pi` (or `pi_v` when type-specific)

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
