### PR TITLE
[WIP] use expression templates for valarray

### DIFF
--- a/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
+++ b/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
@@ -20,8 +20,20 @@ RUN zypper --non-interactive refresh && \
         python311-pip \
         python311-devel \
         python311-setuptools \
-        python311-wheel && \
+        python311-wheel \
+        gcc12 \
+        gcc12-c++ \
+        libstdc++6-devel-gcc12 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 30 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 30 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 30 && \
+    update-alternatives --set gcc /usr/bin/gcc-12 && \
+    update-alternatives --set g++ /usr/bin/g++-12 && \
+    update-alternatives --set c++ /usr/bin/g++-12 && \
     zypper clean --all
+
+ENV CC=/usr/bin/gcc
+ENV CXX=/usr/bin/g++
 
 # Set Python 3.11 as the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \

--- a/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
+++ b/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
@@ -20,20 +20,8 @@ RUN zypper --non-interactive refresh && \
         python311-pip \
         python311-devel \
         python311-setuptools \
-        python311-wheel \
-        gcc12 \
-        gcc12-c++ \
-        libstdc++6-devel-gcc12 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 30 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 30 && \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 30 && \
-    update-alternatives --set gcc /usr/bin/gcc-12 && \
-    update-alternatives --set g++ /usr/bin/g++-12 && \
-    update-alternatives --set c++ /usr/bin/g++-12 && \
+        python311-wheel && \
     zypper clean --all
-
-ENV CC=/usr/bin/gcc
-ENV CXX=/usr/bin/g++
 
 # Set Python 3.11 as the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 && \

--- a/.devcontainer/rocm-container/Dockerfile
+++ b/.devcontainer/rocm-container/Dockerfile
@@ -25,7 +25,28 @@ RUN if ! zypper repos -E | grep devel_languages_perl; then \
 ENV PATH="/opt/rocm/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}"
 
-RUN zypper --non-interactive install wget tar gzip gcc gcc-fortran file gcc-c++ make && zypper clean --all && \
+RUN zypper --non-interactive install \
+        wget \
+        tar \
+        gzip \
+        file \
+        make \
+        gcc \
+        gcc-c++ \
+        gcc-fortran \
+        gcc12 \
+        gcc12-c++ \
+        gcc12-fortran \
+        libstdc++6-devel-gcc12 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 30 && \
+    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 30 && \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-12 30 && \
+    update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-12 30 && \
+    update-alternatives --set gcc /usr/bin/gcc-12 && \
+    update-alternatives --set g++ /usr/bin/g++-12 && \
+    update-alternatives --set c++ /usr/bin/g++-12 && \
+    update-alternatives --set gfortran /usr/bin/gfortran-12 && \
+    zypper clean --all && \
     if [ ! -z "$(gcc --version | grep -Eo -m 1 [0-9][0-9]+\.[0-9]+\.[0-9]+ | grep -m 1 [0-9])" ]; then \
     export FFLAGS=-fallow-argument-mismatch; \
     fi && \

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -24,7 +24,7 @@ jobs:
       workflow_file: '.github/workflows/hip.yml'
 
   tests-hip:
-    name: HIP ROCm C++17
+    name: HIP ROCm
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
@@ -70,7 +70,6 @@ jobs:
             -DAMReX_ROCTX=ON                              \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
-            -DCMAKE_CXX_STANDARD=17                       \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache          \
             -DCMAKE_CXX_FLAGS="-ffp-exception-behavior=strict -stdlib=libc++"
         cmake --build build -j 2

--- a/src/radiation/radiation_dust_system.hpp
+++ b/src/radiation/radiation_dust_system.hpp
@@ -53,7 +53,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDust(
 	// I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption
 	// only affects the convergence rate of the Newton-Raphson iteration and does not affect the converged solution at all.
 
-	auto dEg_dT = kappaPoverE * d_fourpiboverc_d_t;
+	quokka::valarray<double, nGroups_> dEg_dT = kappaPoverE * d_fourpiboverc_d_t;
 
 	result.J00 = 1.0 + sum(cooling_derivative) / c_v;
 	result.J0g.fillin(cscale);
@@ -164,7 +164,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeJacobianForGasAndDustWithPE(
 	// I assume (kappaPVec / kappaEVec) is constant here. This is usually a reasonable assumption. Note that this assumption
 	// only affects the convergence rate of the Newton-Raphson iteration and does not affect the converged solution at all.
 
-	auto d_Eg_d_Rg = -1.0 * kappaPoverE;
+	quokka::valarray<double, nGroups_> d_Eg_d_Rg = -1.0 * kappaPoverE;
 	for (int g = 0; g < nGroups_; ++g) {
 		if (tau[g] <= 0.0) {
 			d_Eg_d_Rg[g] = -LARGE;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -525,7 +525,7 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationMultiGro
 {
 	const double power = radiation_constant_ * std::pow(temperature, 4);
 	const auto radEnergyFractions = ComputePlanckEnergyFractions(boundaries, temperature);
-	auto Erad_g = power * radEnergyFractions;
+	quokka::valarray<amrex::Real, nGroups_> Erad_g = power * radEnergyFractions;
 	// set floor
 	for (int g = 0; g < nGroups_; ++g) {
 		if (Erad_g[g] < Erad_floor_) {

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -146,8 +146,8 @@ template <typename T, int d> class valarray
 		}
 	}
 
-template <detail::CompatibleExpr<T, d> Expr>
-requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit valarray(Expr const &expr)
+	template <detail::CompatibleExpr<T, d> Expr>
+	requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit valarray(Expr const &expr)
 	{
 		assign_from(expr);
 	}

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -129,7 +129,7 @@ template <typename T, int d> class valarray
 	// (although not cppcore-compliant)
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(std::initializer_list<T> list) // NOLINT
 	{
-		const size_t max_count = std::min(list.size(), static_cast<size_t>(d));
+		const size_t max_count = std::min(list.size(), extent_size);
 
 		T const *input = std::data(list); // requires nvcc to be in C++17 mode (or newer)! (if it fails, the
 						  // compiler flags are wrong, probably due to a CMake issue.)
@@ -147,7 +147,8 @@ template <typename T, int d> class valarray
 	}
 
 template <detail::CompatibleExpr<T, d> Expr>
-requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit valarray(Expr const &expr)
+// NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
+requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(Expr const &expr)
 	{
 		assign_from(expr);
 	}

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -327,6 +327,18 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(v
 	return min_val;
 }
 
+template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(Expr const &expr) -> typename detail::expr_value_t<Expr>
+{
+	using value_type = typename detail::expr_value_t<Expr>;
+	constexpr int extent = detail::expr_extent_v<Expr>;
+	static_assert(extent >= 1);
+	value_type min_val = static_cast<value_type>(expr[0]);
+	for (int i = 1; i < extent; ++i) {
+		min_val = std::min(min_val, static_cast<value_type>(expr[static_cast<size_t>(i)]));
+	}
+	return min_val;
+}
+
 template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(valarray<T, d> const &v) -> T
 {
 	static_assert(d >= 1);
@@ -334,6 +346,18 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(v
 
 	for (size_t i = 0; i < v.size(); ++i) {
 		max_val = std::max(max_val, v[i]);
+	}
+	return max_val;
+}
+
+template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(Expr const &expr) -> typename detail::expr_value_t<Expr>
+{
+	using value_type = typename detail::expr_value_t<Expr>;
+	constexpr int extent = detail::expr_extent_v<Expr>;
+	static_assert(extent >= 1);
+	value_type max_val = static_cast<value_type>(expr[0]);
+	for (int i = 1; i < extent; ++i) {
+		max_val = std::max(max_val, static_cast<value_type>(expr[static_cast<size_t>(i)]));
 	}
 	return max_val;
 }

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -11,8 +11,8 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <concepts>
+#include <cstddef>
 #include <iterator>
 #include <type_traits>
 #include <utility>
@@ -27,11 +27,11 @@ namespace detail
 {
 template <typename T> using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
-template <typename Expr>
-concept Expression = requires(Expr const &expr, size_t idx) {
+template <typename Expr> concept Expression = requires(Expr const &expr, size_t idx)
+{
 	typename remove_cvref_t<Expr>::value_type;
-	{ remove_cvref_t<Expr>::extent } -> std::convertible_to<int>;
-	{ expr[idx] } -> std::convertible_to<typename remove_cvref_t<Expr>::value_type>;
+	{remove_cvref_t<Expr>::extent}->std::convertible_to<int>;
+	{expr[idx]}->std::convertible_to<typename remove_cvref_t<Expr>::value_type>;
 };
 
 template <typename Expr> constexpr int expr_extent_v = static_cast<int>(remove_cvref_t<Expr>::extent);
@@ -41,8 +41,7 @@ template <typename Expr> using expr_value_t = typename remove_cvref_t<Expr>::val
 template <typename Expr, typename T, int d>
 concept CompatibleExpr = Expression<Expr> && std::convertible_to<expr_value_t<Expr>, T> && (expr_extent_v<Expr> == d);
 
-template <typename LHS, typename RHS>
-concept BinaryCompatible = Expression<LHS> && Expression<RHS> && (expr_extent_v<LHS> == expr_extent_v<RHS>);
+template <typename LHS, typename RHS> concept BinaryCompatible = Expression<LHS> && Expression<RHS> && (expr_extent_v<LHS> == expr_extent_v<RHS>);
 
 struct AddOp {
 	template <typename L, typename R> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto apply(L const &lhs, R const &rhs) -> decltype(lhs + rhs)
@@ -69,8 +68,7 @@ struct DivOp {
 	}
 };
 
-template <typename T, int d> struct ScalarExpr
-{
+template <typename T, int d> struct ScalarExpr {
 	using value_type = T;
 	static constexpr int extent = d;
 
@@ -82,14 +80,11 @@ template <typename T, int d> struct ScalarExpr
 	T value;
 };
 
-template <typename Op, Expression LHS, Expression RHS>
-requires BinaryCompatible<LHS, RHS> struct BinaryExpr
-{
+template <typename Op, Expression LHS, Expression RHS> requires BinaryCompatible<LHS, RHS> struct BinaryExpr {
 	using lhs_type = remove_cvref_t<LHS>;
 	using rhs_type = remove_cvref_t<RHS>;
 
-	using value_type =
-	    std::decay_t<decltype(Op::apply(std::declval<typename lhs_type::value_type>(), std::declval<typename rhs_type::value_type>()))>;
+	using value_type = std::decay_t<decltype(Op::apply(std::declval<typename lhs_type::value_type>(), std::declval<typename rhs_type::value_type>()))>;
 	static constexpr int extent = expr_extent_v<LHS>;
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE BinaryExpr(LHS lhs_in, RHS rhs_in) : lhs(lhs_in), rhs(rhs_in) {}
@@ -107,8 +102,7 @@ requires BinaryCompatible<LHS, RHS> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE aut
 }
 
 template <Expression Expr, typename Scalar>
-requires std::convertible_to<Scalar, expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto make_scalar_expr(Scalar const &scalar)
+requires std::convertible_to<Scalar, expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto make_scalar_expr(Scalar const &scalar)
 {
 	using value_type = expr_value_t<Expr>;
 	return ScalarExpr<value_type, expr_extent_v<Expr>>(static_cast<value_type>(scalar));
@@ -150,14 +144,12 @@ template <typename T, int d> class valarray
 	}
 
 	template <detail::CompatibleExpr<T, d> Expr>
-	requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>)
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(Expr const &expr)
+	requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(Expr const &expr)
 	{
 		assign_from(expr);
 	}
 
-	template <detail::CompatibleExpr<T, d> Expr>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(Expr const &expr) -> valarray &
+	template <detail::CompatibleExpr<T, d> Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(Expr const &expr) -> valarray &
 	{
 		assign_from(expr);
 		return *this;
@@ -186,8 +178,7 @@ template <typename T, int d> class valarray
 		return false;
 	}
 
-	template <detail::CompatibleExpr<T, d> Expr>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+=(Expr const &expr) -> valarray &
+	template <detail::CompatibleExpr<T, d> Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+=(Expr const &expr) -> valarray &
 	{
 		for (size_t i = 0; i < d; ++i) {
 			values[i] += static_cast<T>(expr[i]);
@@ -195,8 +186,7 @@ template <typename T, int d> class valarray
 		return *this;
 	}
 
-	template <detail::CompatibleExpr<T, d> Expr>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-=(Expr const &expr) -> valarray &
+	template <detail::CompatibleExpr<T, d> Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-=(Expr const &expr) -> valarray &
 	{
 		for (size_t i = 0; i < d; ++i) {
 			values[i] -= static_cast<T>(expr[i]);
@@ -205,8 +195,7 @@ template <typename T, int d> class valarray
 	}
 
 	template <typename Scalar>
-	requires std::convertible_to<Scalar, T>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*=(Scalar const &scalar) -> valarray &
+	requires std::convertible_to<Scalar, T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*=(Scalar const &scalar) -> valarray &
 	{
 		for (size_t i = 0; i < d; ++i) {
 			values[i] *= static_cast<T>(scalar);
@@ -215,8 +204,7 @@ template <typename T, int d> class valarray
 	}
 
 	template <typename Scalar>
-	requires std::convertible_to<Scalar, T>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/=(Scalar const &scalar) -> valarray &
+	requires std::convertible_to<Scalar, T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/=(Scalar const &scalar) -> valarray &
 	{
 		for (size_t i = 0; i < d; ++i) {
 			values[i] /= static_cast<T>(scalar);
@@ -225,8 +213,7 @@ template <typename T, int d> class valarray
 	}
 
       private:
-	template <typename Expr>
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void assign_from(Expr const &expr)
+	template <typename Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void assign_from(Expr const &expr)
 	{
 		for (size_t i = 0; i < d; ++i) {
 			values[i] = static_cast<T>(expr[i]);
@@ -238,100 +225,87 @@ template <typename T, int d> class valarray
 };
 
 template <detail::Expression Expr1, detail::Expression Expr2>
-	requires detail::BinaryCompatible<Expr1, Expr2>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr1 const &lhs, Expr2 const &rhs)
+requires detail::BinaryCompatible<Expr1, Expr2> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr1 const &lhs, Expr2 const &rhs)
 {
 	return detail::make_binary_expr<detail::AddOp>(lhs, rhs);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr const &expr, Scalar const &scalar)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr const &expr, Scalar const &scalar)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::AddOp>(expr, scalar_expr);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Scalar const &scalar, Expr const &expr)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Scalar const &scalar, Expr const &expr)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::AddOp>(scalar_expr, expr);
 }
 
 template <detail::Expression Expr1, detail::Expression Expr2>
-	requires detail::BinaryCompatible<Expr1, Expr2>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr1 const &lhs, Expr2 const &rhs)
+requires detail::BinaryCompatible<Expr1, Expr2> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr1 const &lhs, Expr2 const &rhs)
 {
 	return detail::make_binary_expr<detail::SubOp>(lhs, rhs);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr const &expr, Scalar const &scalar)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr const &expr, Scalar const &scalar)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::SubOp>(expr, scalar_expr);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Scalar const &scalar, Expr const &expr)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Scalar const &scalar, Expr const &expr)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::SubOp>(scalar_expr, expr);
 }
 
 template <detail::Expression Expr1, detail::Expression Expr2>
-	requires detail::BinaryCompatible<Expr1, Expr2>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr1 const &lhs, Expr2 const &rhs)
+requires detail::BinaryCompatible<Expr1, Expr2> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr1 const &lhs, Expr2 const &rhs)
 {
 	return detail::make_binary_expr<detail::MulOp>(lhs, rhs);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr const &expr, Scalar const &scalar)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr const &expr, Scalar const &scalar)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::MulOp>(expr, scalar_expr);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Scalar const &scalar, Expr const &expr)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Scalar const &scalar, Expr const &expr)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::MulOp>(scalar_expr, expr);
 }
 
 template <detail::Expression Expr1, detail::Expression Expr2>
-	requires detail::BinaryCompatible<Expr1, Expr2>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr1 const &lhs, Expr2 const &rhs)
+requires detail::BinaryCompatible<Expr1, Expr2> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr1 const &lhs, Expr2 const &rhs)
 {
 	return detail::make_binary_expr<detail::DivOp>(lhs, rhs);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr const &expr, Scalar const &scalar)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr const &expr, Scalar const &scalar)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::DivOp>(expr, scalar_expr);
 }
 
 template <detail::Expression Expr, typename Scalar>
-	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Scalar const &scalar, Expr const &expr)
+requires std::convertible_to<Scalar, detail::expr_value_t<Expr>> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Scalar const &scalar, Expr const &expr)
 {
 	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
 	return detail::make_binary_expr<detail::DivOp>(scalar_expr, expr);
 }
 
 template <detail::Expression Expr>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto abs(Expr const &expr)
-    -> valarray<typename detail::expr_value_t<Expr>, detail::expr_extent_v<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto abs(Expr const &expr) -> valarray<typename detail::expr_value_t<Expr>, detail::expr_extent_v<Expr>>
 {
 	using value_type = typename detail::expr_value_t<Expr>;
 	constexpr int extent = detail::expr_extent_v<Expr>;
@@ -342,8 +316,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto abs(Expr const &expr)
 	return abs_v;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(valarray<T, d> const &v) -> T
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(valarray<T, d> const &v) -> T
 {
 	static_assert(d >= 1);
 	T min_val = v[0]; // v must have at least 1 element
@@ -354,8 +327,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(valarray<T, d> const &v) -> T
 	return min_val;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(valarray<T, d> const &v) -> T
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(valarray<T, d> const &v) -> T
 {
 	static_assert(d >= 1);
 	T max_val = v[0]; // v must have at least 1 element
@@ -366,8 +338,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(valarray<T, d> const &v) -> T
 	return max_val;
 }
 
-template <detail::Expression Expr>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto sum(Expr const &expr) -> typename detail::expr_value_t<Expr>
+template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto sum(Expr const &expr) -> typename detail::expr_value_t<Expr>
 {
 	using value_type = typename detail::expr_value_t<Expr>;
 	constexpr int extent = detail::expr_extent_v<Expr>;
@@ -378,8 +349,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto sum(Expr const &expr) -> typename 
 	return sum_val;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
 {
 	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
@@ -388,8 +358,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a,
 	return comp;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
 {
 	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
@@ -398,8 +367,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a,
 	return comp;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
 {
 	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
@@ -408,8 +376,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a,
 	return comp;
 }
 
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
+template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
 {
 	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -74,7 +74,7 @@ template <typename T, int d> struct ScalarExpr {
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit ScalarExpr(T scalar) : value(scalar) {}
 
-	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[](size_t) const -> T { return value; }
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[]([[maybe_unused]] size_t index) const -> T { return value; }
 
       private:
 	T value;
@@ -115,12 +115,15 @@ template <typename T, int d> class valarray
       public:
 	using value_type = T;
 	static constexpr int extent = d;
+	static_assert(d >= 0, "valarray extent must be non-negative");
+	static constexpr size_t extent_size = static_cast<size_t>(extent);
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray() = default;
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(valarray const &) = default;
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(valarray &&) noexcept = default;
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(valarray const &) -> valarray & = default;
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(valarray &&) noexcept -> valarray & = default;
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE ~valarray() = default;
 
 	// we *want* implicit construction from initializer lists for valarrays,
 	// (although not cppcore-compliant)
@@ -138,13 +141,13 @@ template <typename T, int d> class valarray
 		// it is undefined behavior to not fully initialize an object!
 		// (this does happen in practice with gcc 10+, which optimizes out ctor
 		//  calls if an object is unused before a subsequent assignment.)
-		for (size_t i = max_count; i < d; ++i) {
+		for (size_t i = max_count; i < extent_size; ++i) {
 			values[i] = default_value;
 		}
 	}
 
-	template <detail::CompatibleExpr<T, d> Expr>
-	requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(Expr const &expr)
+template <detail::CompatibleExpr<T, d> Expr>
+requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>) AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit valarray(Expr const &expr)
 	{
 		assign_from(expr);
 	}
@@ -159,18 +162,18 @@ template <typename T, int d> class valarray
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[](size_t i) const -> T { return values[i]; }
 
-	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr auto size() const -> size_t { return d; }
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE constexpr auto size() const -> size_t { return extent_size; }
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void fillin(T const &scalar)
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] = scalar;
 		}
 	}
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto hasnan() const -> bool
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			if (std::isnan(values[i])) {
 				return true;
 			}
@@ -180,7 +183,7 @@ template <typename T, int d> class valarray
 
 	template <detail::CompatibleExpr<T, d> Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+=(Expr const &expr) -> valarray &
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] += static_cast<T>(expr[i]);
 		}
 		return *this;
@@ -188,7 +191,7 @@ template <typename T, int d> class valarray
 
 	template <detail::CompatibleExpr<T, d> Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-=(Expr const &expr) -> valarray &
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] -= static_cast<T>(expr[i]);
 		}
 		return *this;
@@ -197,7 +200,7 @@ template <typename T, int d> class valarray
 	template <typename Scalar>
 	requires std::convertible_to<Scalar, T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*=(Scalar const &scalar) -> valarray &
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] *= static_cast<T>(scalar);
 		}
 		return *this;
@@ -206,7 +209,7 @@ template <typename T, int d> class valarray
 	template <typename Scalar>
 	requires std::convertible_to<Scalar, T> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/=(Scalar const &scalar) -> valarray &
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] /= static_cast<T>(scalar);
 		}
 		return *this;
@@ -215,7 +218,7 @@ template <typename T, int d> class valarray
       private:
 	template <typename Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void assign_from(Expr const &expr)
 	{
-		for (size_t i = 0; i < d; ++i) {
+		for (size_t i = 0; i < extent_size; ++i) {
 			values[i] = static_cast<T>(expr[i]);
 		}
 	}
@@ -332,7 +335,7 @@ template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 	using value_type = typename detail::expr_value_t<Expr>;
 	constexpr int extent = detail::expr_extent_v<Expr>;
 	static_assert(extent >= 1);
-	value_type min_val = static_cast<value_type>(expr[0]);
+	auto min_val = static_cast<value_type>(expr[0]);
 	for (int i = 1; i < extent; ++i) {
 		min_val = std::min(min_val, static_cast<value_type>(expr[static_cast<size_t>(i)]));
 	}
@@ -355,7 +358,7 @@ template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 	using value_type = typename detail::expr_value_t<Expr>;
 	constexpr int extent = detail::expr_extent_v<Expr>;
 	static_assert(extent >= 1);
-	value_type max_val = static_cast<value_type>(expr[0]);
+	auto max_val = static_cast<value_type>(expr[0]);
 	for (int i = 1; i < extent; ++i) {
 		max_val = std::max(max_val, static_cast<value_type>(expr[static_cast<size_t>(i)]));
 	}
@@ -366,7 +369,7 @@ template <detail::Expression Expr> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto
 {
 	using value_type = typename detail::expr_value_t<Expr>;
 	constexpr int extent = detail::expr_extent_v<Expr>;
-	value_type sum_val = static_cast<value_type>(0);
+	auto sum_val = static_cast<value_type>(0);
 	for (int i = 0; i < extent; ++i) {
 		sum_val += static_cast<value_type>(expr[i]);
 	}

--- a/src/util/valarray.hpp
+++ b/src/util/valarray.hpp
@@ -12,7 +12,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstddef>
+#include <concepts>
 #include <iterator>
+#include <type_traits>
+#include <utility>
 
 // library headers
 #include "AMReX_Extension.H"
@@ -20,10 +23,110 @@
 
 namespace quokka
 {
+namespace detail
+{
+template <typename T> using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+template <typename Expr>
+concept Expression = requires(Expr const &expr, size_t idx) {
+	typename remove_cvref_t<Expr>::value_type;
+	{ remove_cvref_t<Expr>::extent } -> std::convertible_to<int>;
+	{ expr[idx] } -> std::convertible_to<typename remove_cvref_t<Expr>::value_type>;
+};
+
+template <typename Expr> constexpr int expr_extent_v = static_cast<int>(remove_cvref_t<Expr>::extent);
+
+template <typename Expr> using expr_value_t = typename remove_cvref_t<Expr>::value_type;
+
+template <typename Expr, typename T, int d>
+concept CompatibleExpr = Expression<Expr> && std::convertible_to<expr_value_t<Expr>, T> && (expr_extent_v<Expr> == d);
+
+template <typename LHS, typename RHS>
+concept BinaryCompatible = Expression<LHS> && Expression<RHS> && (expr_extent_v<LHS> == expr_extent_v<RHS>);
+
+struct AddOp {
+	template <typename L, typename R> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto apply(L const &lhs, R const &rhs) -> decltype(lhs + rhs)
+	{
+		return lhs + rhs;
+	}
+};
+struct SubOp {
+	template <typename L, typename R> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto apply(L const &lhs, R const &rhs) -> decltype(lhs - rhs)
+	{
+		return lhs - rhs;
+	}
+};
+struct MulOp {
+	template <typename L, typename R> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto apply(L const &lhs, R const &rhs) -> decltype(lhs * rhs)
+	{
+		return lhs * rhs;
+	}
+};
+struct DivOp {
+	template <typename L, typename R> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto apply(L const &lhs, R const &rhs) -> decltype(lhs / rhs)
+	{
+		return lhs / rhs;
+	}
+};
+
+template <typename T, int d> struct ScalarExpr
+{
+	using value_type = T;
+	static constexpr int extent = d;
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE explicit ScalarExpr(T scalar) : value(scalar) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[](size_t) const -> T { return value; }
+
+      private:
+	T value;
+};
+
+template <typename Op, Expression LHS, Expression RHS>
+requires BinaryCompatible<LHS, RHS> struct BinaryExpr
+{
+	using lhs_type = remove_cvref_t<LHS>;
+	using rhs_type = remove_cvref_t<RHS>;
+
+	using value_type =
+	    std::decay_t<decltype(Op::apply(std::declval<typename lhs_type::value_type>(), std::declval<typename rhs_type::value_type>()))>;
+	static constexpr int extent = expr_extent_v<LHS>;
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE BinaryExpr(LHS lhs_in, RHS rhs_in) : lhs(lhs_in), rhs(rhs_in) {}
+
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[](size_t i) const -> value_type { return Op::apply(lhs[i], rhs[i]); }
+
+	LHS lhs;
+	RHS rhs;
+};
+
+template <typename Op, Expression LHS, Expression RHS>
+requires BinaryCompatible<LHS, RHS> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto make_binary_expr(LHS lhs, RHS rhs) -> BinaryExpr<Op, LHS, RHS>
+{
+	return BinaryExpr<Op, LHS, RHS>(lhs, rhs);
+}
+
+template <Expression Expr, typename Scalar>
+requires std::convertible_to<Scalar, expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto make_scalar_expr(Scalar const &scalar)
+{
+	using value_type = expr_value_t<Expr>;
+	return ScalarExpr<value_type, expr_extent_v<Expr>>(static_cast<value_type>(scalar));
+}
+
+} // namespace detail
+
 template <typename T, int d> class valarray
 {
       public:
+	using value_type = T;
+	static constexpr int extent = d;
+
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray() = default;
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(valarray const &) = default;
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(valarray &&) noexcept = default;
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(valarray const &) -> valarray & = default;
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(valarray &&) noexcept -> valarray & = default;
 
 	// we *want* implicit construction from initializer lists for valarrays,
 	// (although not cppcore-compliant)
@@ -44,6 +147,20 @@ template <typename T, int d> class valarray
 		for (size_t i = max_count; i < d; ++i) {
 			values[i] = default_value;
 		}
+	}
+
+	template <detail::CompatibleExpr<T, d> Expr>
+	requires(!std::same_as<detail::remove_cvref_t<Expr>, valarray>)
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE valarray(Expr const &expr)
+	{
+		assign_from(expr);
+	}
+
+	template <detail::CompatibleExpr<T, d> Expr>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator=(Expr const &expr) -> valarray &
+	{
+		assign_from(expr);
+		return *this;
 	}
 
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator[](size_t i) -> T & { return values[i]; }
@@ -69,152 +186,164 @@ template <typename T, int d> class valarray
 		return false;
 	}
 
+	template <detail::CompatibleExpr<T, d> Expr>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+=(Expr const &expr) -> valarray &
+	{
+		for (size_t i = 0; i < d; ++i) {
+			values[i] += static_cast<T>(expr[i]);
+		}
+		return *this;
+	}
+
+	template <detail::CompatibleExpr<T, d> Expr>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-=(Expr const &expr) -> valarray &
+	{
+		for (size_t i = 0; i < d; ++i) {
+			values[i] -= static_cast<T>(expr[i]);
+		}
+		return *this;
+	}
+
+	template <typename Scalar>
+	requires std::convertible_to<Scalar, T>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*=(Scalar const &scalar) -> valarray &
+	{
+		for (size_t i = 0; i < d; ++i) {
+			values[i] *= static_cast<T>(scalar);
+		}
+		return *this;
+	}
+
+	template <typename Scalar>
+	requires std::convertible_to<Scalar, T>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/=(Scalar const &scalar) -> valarray &
+	{
+		for (size_t i = 0; i < d; ++i) {
+			values[i] /= static_cast<T>(scalar);
+		}
+		return *this;
+	}
+
       private:
+	template <typename Expr>
+	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void assign_from(Expr const &expr)
+	{
+		for (size_t i = 0; i < d; ++i) {
+			values[i] = static_cast<T>(expr[i]);
+		}
+	}
+
 	T values[d]; // NOLINT
 	static constexpr T default_value = 0;
 };
-} // namespace quokka
 
-// array + array
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<T, d>
+template <detail::Expression Expr1, detail::Expression Expr2>
+	requires detail::BinaryCompatible<Expr1, Expr2>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr1 const &lhs, Expr2 const &rhs)
 {
-	quokka::valarray<T, d> sum;
-	for (size_t i = 0; i < a.size(); ++i) {
-		sum[i] = a[i] + b[i];
-	}
-	return sum;
+	return detail::make_binary_expr<detail::AddOp>(lhs, rhs);
 }
 
-// array + scalar
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(quokka::valarray<T, d> const &v, T const &scalar) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Expr const &expr, Scalar const &scalar)
 {
-	quokka::valarray<T, d> scalarsum;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalarsum[i] = v[i] + scalar;
-	}
-	return scalarsum;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::AddOp>(expr, scalar_expr);
 }
 
-// scalar + array
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator+(Scalar const &scalar, Expr const &expr)
 {
-	quokka::valarray<T, d> scalarsum;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalarsum[i] = scalar + v[i];
-	}
-	return scalarsum;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::AddOp>(scalar_expr, expr);
 }
 
-// array - array
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<T, d>
+template <detail::Expression Expr1, detail::Expression Expr2>
+	requires detail::BinaryCompatible<Expr1, Expr2>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr1 const &lhs, Expr2 const &rhs)
 {
-	quokka::valarray<T, d> diff;
-	for (size_t i = 0; i < a.size(); ++i) {
-		diff[i] = a[i] - b[i];
-	}
-	return diff;
+	return detail::make_binary_expr<detail::SubOp>(lhs, rhs);
 }
 
-// array * array
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Expr const &expr, Scalar const &scalar)
 {
-	quokka::valarray<T, d> prod;
-	for (size_t i = 0; i < a.size(); ++i) {
-		prod[i] = a[i] * b[i];
-	}
-	return prod;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::SubOp>(expr, scalar_expr);
 }
 
-// array / array
-template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator-(Scalar const &scalar, Expr const &expr)
 {
-	quokka::valarray<T, d> div;
-	for (size_t i = 0; i < a.size(); ++i) {
-		div[i] = a[i] / b[i];
-	}
-	return div;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::SubOp>(scalar_expr, expr);
 }
 
-// scalar * array
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
+template <detail::Expression Expr1, detail::Expression Expr2>
+	requires detail::BinaryCompatible<Expr1, Expr2>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr1 const &lhs, Expr2 const &rhs)
 {
-	quokka::valarray<T, d> scalarprod;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalarprod[i] = scalar * v[i];
-	}
-	return scalarprod;
+	return detail::make_binary_expr<detail::MulOp>(lhs, rhs);
 }
 
-// array * scalar
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(quokka::valarray<T, d> const &v, T const &scalar) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Expr const &expr, Scalar const &scalar)
 {
-	quokka::valarray<T, d> scalarprod;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalarprod[i] = scalar * v[i];
-	}
-	return scalarprod;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::MulOp>(expr, scalar_expr);
 }
 
-// array *= scalar
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void operator*=(quokka::valarray<T, d> &v, T const &scalar)
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator*(Scalar const &scalar, Expr const &expr)
 {
-	for (size_t i = 0; i < v.size(); ++i) {
-		v[i] *= scalar;
-	}
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::MulOp>(scalar_expr, expr);
 }
 
-// array += array
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void operator+=(quokka::valarray<T, d> &a, quokka::valarray<T, d> const &b)
+template <detail::Expression Expr1, detail::Expression Expr2>
+	requires detail::BinaryCompatible<Expr1, Expr2>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr1 const &lhs, Expr2 const &rhs)
 {
-	for (size_t i = 0; i < a.size(); ++i) {
-		a[i] += b[i];
-	}
+	return detail::make_binary_expr<detail::DivOp>(lhs, rhs);
 }
 
-// array / scalar
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(quokka::valarray<T, d> const &v, T const &scalar) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Expr const &expr, Scalar const &scalar)
 {
-	quokka::valarray<T, d> scalardiv;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalardiv[i] = v[i] / scalar;
-	}
-	return scalardiv;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::DivOp>(expr, scalar_expr);
 }
 
-// scalar / array
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(T const &scalar, quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
+template <detail::Expression Expr, typename Scalar>
+	requires std::convertible_to<Scalar, detail::expr_value_t<Expr>>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator/(Scalar const &scalar, Expr const &expr)
 {
-	quokka::valarray<T, d> scalardiv;
-	for (size_t i = 0; i < v.size(); ++i) {
-		scalardiv[i] = scalar / v[i];
-	}
-	return scalardiv;
+	auto scalar_expr = detail::make_scalar_expr<Expr>(scalar);
+	return detail::make_binary_expr<detail::DivOp>(scalar_expr, expr);
 }
 
-// array /= scalar
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void operator/=(quokka::valarray<T, d> &v, T const &scalar)
+template <detail::Expression Expr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto abs(Expr const &expr)
+    -> valarray<typename detail::expr_value_t<Expr>, detail::expr_extent_v<Expr>>
 {
-	for (size_t i = 0; i < v.size(); ++i) {
-		v[i] /= scalar;
-	}
-}
-
-// abs(array)
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto abs(quokka::valarray<T, d> const &v) -> quokka::valarray<T, d>
-{
-	quokka::valarray<T, d> abs_v;
-	for (size_t i = 0; i < v.size(); ++i) {
-		abs_v[i] = std::abs(v[i]);
+	using value_type = typename detail::expr_value_t<Expr>;
+	constexpr int extent = detail::expr_extent_v<Expr>;
+	valarray<value_type, extent> abs_v;
+	for (size_t i = 0; i < abs_v.size(); ++i) {
+		abs_v[i] = std::abs(static_cast<value_type>(expr[i]));
 	}
 	return abs_v;
 }
 
-// min(array)
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(quokka::valarray<T, d> const &v) -> T
+template <typename T, int d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(valarray<T, d> const &v) -> T
 {
 	static_assert(d >= 1);
 	T min_val = v[0]; // v must have at least 1 element
@@ -225,8 +354,8 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto min(q
 	return min_val;
 }
 
-// max(array)
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(quokka::valarray<T, d> const &v) -> T
+template <typename T, int d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(valarray<T, d> const &v) -> T
 {
 	static_assert(d >= 1);
 	T max_val = v[0]; // v must have at least 1 element
@@ -237,58 +366,58 @@ template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto max(q
 	return max_val;
 }
 
-// sum(array)
-template <typename T, int d> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto sum(quokka::valarray<T, d> const &v) -> T
+template <detail::Expression Expr>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto sum(Expr const &expr) -> typename detail::expr_value_t<Expr>
 {
-	T sum_val = 0;
-	for (size_t i = 0; i < v.size(); ++i) {
-		sum_val += v[i];
+	using value_type = typename detail::expr_value_t<Expr>;
+	constexpr int extent = detail::expr_extent_v<Expr>;
+	value_type sum_val = static_cast<value_type>(0);
+	for (int i = 0; i < extent; ++i) {
+		sum_val += static_cast<value_type>(expr[i]);
 	}
 	return sum_val;
 }
 
-// array > array
 template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<bool, d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
 {
-	quokka::valarray<bool, d> comp;
+	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
 		comp[i] = a[i] > b[i];
 	}
 	return comp;
 }
 
-// array > scalar
 template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(quokka::valarray<T, d> const &a, T const &scalar) -> quokka::valarray<bool, d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator>(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
 {
-	quokka::valarray<bool, d> comp;
+	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
 		comp[i] = a[i] > scalar;
 	}
 	return comp;
 }
 
-// array < array
 template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(quokka::valarray<T, d> const &a, quokka::valarray<T, d> const &b) -> quokka::valarray<bool, d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, valarray<T, d> const &b) -> valarray<bool, d>
 {
-	quokka::valarray<bool, d> comp;
+	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
 		comp[i] = a[i] < b[i];
 	}
 	return comp;
 }
 
-// array < scalar
 template <typename T, int d>
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(quokka::valarray<T, d> const &a, T const &scalar) -> quokka::valarray<bool, d>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto operator<(valarray<T, d> const &a, T const &scalar) -> valarray<bool, d>
 {
-	quokka::valarray<bool, d> comp;
+	valarray<bool, d> comp;
 	for (size_t i = 0; i < a.size(); ++i) {
 		comp[i] = a[i] < scalar;
 	}
 	return comp;
 }
+
+} // namespace quokka
 
 #endif // VALARRAY_HPP_


### PR DESCRIPTION
### Description
Rewrites `quokka::valarray` to use expression templates. `valarray` is heavily used in the HLLC Riemann solver.

This PR makes the HydroBlast3D problem about 8% faster in total walltime on NVIDIA V100.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
