### PR TITLE
Enable ccache for GitHub actions

### DIFF
--- a/.github/workflows/checkpoint-restart-refine.yml
+++ b/.github/workflows/checkpoint-restart-refine.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,15 +46,31 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Build PlotfileTools
       shell: bash
       working-directory: ${{github.workspace}}/extern/amrex/Tools/Plotfile
-      run: make -j4
+      run: make -j4 CC="ccache gcc-11" CXX="ccache g++-11"
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DAMReX_SPACEDIM=3
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=3
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -65,6 +85,12 @@ jobs:
         BUILD_DIR: ${{runner.workspace}}/build
         PLOTFILETOOLS_DIR: ${{github.workspace}}/extern/amrex/Tools/Plotfile
       run: ../inputs/checkpoint_restart_refine_test.sh
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload output
       if: always()

--- a/.github/workflows/checkpoint-restart.yml
+++ b/.github/workflows/checkpoint-restart.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,15 +46,31 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Build PlotfileTools
       shell: bash
       working-directory: ${{github.workspace}}/extern/amrex/Tools/Plotfile
-      run: make -j4
+      run: make -j4 CC="ccache gcc-11" CXX="ccache g++-11"
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DAMReX_SPACEDIM=3
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=3
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -65,6 +85,12 @@ jobs:
         BUILD_DIR: ${{runner.workspace}}/build
         PLOTFILETOOLS_DIR: ${{github.workspace}}/extern/amrex/Tools/Plotfile
       run: ../inputs/checkpoint_restart_test.sh
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload output
       if: always()

--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,13 +46,29 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DAMReX_SPACEDIM=1
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -62,6 +82,12 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: canary run --output-on-failure --workers=4 -k 'not RadhydroPulseMG' .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-arm64-hwasan.yml
+++ b/.github/workflows/cmake-arm64-hwasan.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,16 +46,32 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
     - name: Install Clang 20.x
       run: sudo mkdir -m 0755 -p /etc/apt/keyrings/ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/llvm-snapshot.gpg.key && sudo echo "deb [signed-by=/etc/apt/keyrings/llvm-snapshot.gpg.key] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null && sudo apt-get clean && sudo apt-get update -y && sudo apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev libclang-rt-20-dev clangd-20 lld-20
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
 
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release -DENABLE_HWASAN=ON -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 -DAMReX_SPACEDIM=1
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release -DENABLE_HWASAN=ON -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_EXE_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_SHARED_LINKER_FLAGS="-fuse-ld=lld" -DCMAKE_C_COMPILER=clang-20 -DCMAKE_CXX_COMPILER=clang++-20 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -65,6 +85,12 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0:leak_check_at_exit=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=detect_leaks=0:leak_check_at_exit=0 canary run --output-on-failure --workers=4 .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-arm64-release.yml
+++ b/.github/workflows/cmake-arm64-release.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,13 +46,29 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DAMReX_SPACEDIM=1
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=1
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -62,6 +82,12 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: canary run --output-on-failure --workers=4 .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -28,6 +28,11 @@ jobs:
     runs-on: macos-14
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
+      CCACHE_SLOPPINESS: time_macros
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -47,7 +52,7 @@ jobs:
 
     - name: Install Homebrew dependencies
       run: |
-        brew install openmpi hdf5@1.10 || true
+        brew install ccache openmpi hdf5@1.10 || true
         brew link --force hdf5@1.10
 
     - name: Output HDF5 configuration (verbose)
@@ -62,13 +67,26 @@ jobs:
     - name: Install Canary
       run: python3 -m pip install --user "canary-wm @ git+https://github.com/sandialabs/canary"
 
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/Library/Caches/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
       env: {CXXFLAGS: "-ffp-exception-behavior=strict"}
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -85,6 +103,12 @@ jobs:
       run: |
         export PATH="$HOME/Library/Python/3.11/bin:$PATH"
         canary run --output-on-failure --workers=3 .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        du -hs ~/Library/Caches/ccache
+        ccache -s
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -45,8 +49,24 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
@@ -56,7 +76,7 @@ jobs:
       # Note the current convention is to use the -S and -B options here to specify source 
       # and build directories, but this is only available with CMake 3.13 and higher.  
       # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DENABLE_ASAN=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DENABLE_ASAN=ON
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -71,6 +91,12 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       run: ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1:detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=0 LSAN_OPTIONS=suppressions=$GITHUB_WORKSPACE/inputs/leak_suppress.txt canary run --output-on-failure --workers=2 .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/dependencies/dependencies_ccache.sh
+++ b/.github/workflows/dependencies/dependencies_ccache.sh
@@ -1,11 +1,47 @@
 #!/usr/bin/env bash
+#
+# Install ccache following the pattern used by AMReX CI.
+#  - Linux x86_64: download the upstream binary release.
+#  - Other Linux architectures: fall back to the system package manager.
+#  - macOS: rely on Homebrew.
 
-if [[ $# -eq 2 ]]; then
+set -euo pipefail
+
+if [[ $# -eq 1 ]]; then
   CVER=$1
 else
   CVER=4.8
 fi
 
-wget https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64.tar.xz
-tar xvf ccache-${CVER}-linux-x86_64.tar.xz
-sudo cp -f ccache-${CVER}-linux-x86_64/ccache /usr/local/bin/
+OS_NAME=$(uname -s)
+ARCH_NAME=$(uname -m)
+
+if command -v ccache >/dev/null 2>&1; then
+  exit 0
+fi
+
+case "${OS_NAME}" in
+  Linux)
+    if [[ "${ARCH_NAME}" == "x86_64" ]]; then
+      wget -q https://github.com/ccache/ccache/releases/download/v${CVER}/ccache-${CVER}-linux-x86_64.tar.xz
+      tar xJf ccache-${CVER}-linux-x86_64.tar.xz
+      sudo cp -f ccache-${CVER}-linux-x86_64/ccache /usr/local/bin/
+      rm -rf ccache-${CVER}-linux-x86_64 ccache-${CVER}-linux-x86_64.tar.xz
+    else
+      sudo apt-get update
+      sudo apt-get install -y ccache
+    fi
+    ;;
+  Darwin)
+    if command -v brew >/dev/null 2>&1; then
+      brew install ccache
+    else
+      echo "error: Homebrew is required to install ccache on macOS" >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "error: unsupported platform ${OS_NAME} for ccache installation" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/mhd-asan.yml
+++ b/.github/workflows/mhd-asan.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,13 +46,29 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
 
     - name: Configure CMake with ASAN
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3 -DENABLE_ASAN=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=3 -DENABLE_ASAN=ON
 
     - name: Get MHD test executables
       working-directory: ${{runner.workspace}}/build
@@ -83,6 +103,12 @@ jobs:
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       # Execute all tests with MHD label, excluding FastWave and BrioWuShockTube
       run: canary run --output-on-failure --workers=1 -k "MHD and not FastWave and not BrioWuShockTube and not MHDQuirk" .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/mhd.yml
+++ b/.github/workflows/mhd.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -42,13 +46,29 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
     - name: Install Canary
       run: python3 -m pip install "canary-wm @ git+https://github.com/sandialabs/canary"
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
 
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DAMReX_SPACEDIM=3
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DAMReX_SPACEDIM=3
 
     - name: Get MHD test executables
       working-directory: ${{runner.workspace}}/build
@@ -80,6 +100,12 @@ jobs:
       shell: bash
       # Execute all tests with MHD in their name
       run: canary run --output-on-failure --workers=2 -k MHD .
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/openpmd.yml
+++ b/.github/workflows/openpmd.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -44,12 +48,28 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev libadios2-mpi-c++11-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAMReX_SPACEDIM=3 -DQUOKKA_OPENPMD=ON
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DAMReX_SPACEDIM=3 -DQUOKKA_OPENPMD=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
@@ -61,6 +81,12 @@ jobs:
       working-directory: ${{github.workspace}}/tests
       shell: bash
       run: mpirun $RUNNER_WORKSPACE/build/src/problems/HydroBlast3D/test_hydro3d_blast ../inputs/blast_32.in max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=100
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache
 
     - name: Upload test output
       if: always()

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
-      CCACHE_COMPRESS: '1'
-      CCACHE_COMPRESSLEVEL: '10'
-      CCACHE_MAXSIZE: 450M
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
         with:
@@ -26,22 +23,6 @@ jobs:
           
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib libopenmpi-dev libhdf5-mpi-dev
-
-      - name: Install ccache
-        run: .github/workflows/dependencies/dependencies_ccache.sh
-
-      - name: Set Up Cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
-          restore-keys: |
-               ccache-${{ github.workflow }}-${{ github.job }}-git-
-
-      - name: Initialize ccache
-        run: |
-          ccache --version
-          ccache -z
         
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@44cc4d3d487fbc35e5c29b0a9d717be218d3a0e8 # v3.2.0
@@ -49,7 +30,7 @@ jobs:
       - name: Run build-wrapper
         run: |
           mkdir build
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -S . -B build
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config $BUILD_TYPE --parallel 1
           
       - name: Run sonar-scanner
@@ -58,8 +39,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
-      - name: ccache stats
-        if: always()
-        run: |
-          ccache -s
-          du -hs ~/.cache/ccache

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
     steps:
       - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
         with:
@@ -23,6 +26,22 @@ jobs:
           
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib libopenmpi-dev libhdf5-mpi-dev
+
+      - name: Install ccache
+        run: .github/workflows/dependencies/dependencies_ccache.sh
+
+      - name: Set Up Cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+          restore-keys: |
+               ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+      - name: Initialize ccache
+        run: |
+          ccache --version
+          ccache -z
         
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@44cc4d3d487fbc35e5c29b0a9d717be218d3a0e8 # v3.2.0
@@ -30,7 +49,7 @@ jobs:
       - name: Run build-wrapper
         run: |
           mkdir build
-          cmake -S . -B build
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config $BUILD_TYPE --parallel 1
           
       - name: Run sonar-scanner
@@ -39,3 +58,8 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+      - name: ccache stats
+        if: always()
+        run: |
+          ccache -s
+          du -hs ~/.cache/ccache

--- a/.github/workflows/warnings.yml
+++ b/.github/workflows/warnings.yml
@@ -30,6 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
+    env:
+      CCACHE_COMPRESS: '1'
+      CCACHE_COMPRESSLEVEL: '10'
+      CCACHE_MAXSIZE: 450M
 
     steps:
     - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
@@ -45,15 +49,37 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update && sudo apt-get install gcc g++ python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
+    - name: Install ccache
+      run: .github/workflows/dependencies/dependencies_ccache.sh
+
+    - name: Set Up Cache
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ github.workflow }}-${{ github.job }}-git-${{ github.sha }}
+        restore-keys: |
+             ccache-${{ github.workflow }}-${{ github.job }}-git-
+
+    - name: Initialize ccache
+      run: |
+        ccache --version
+        ccache -z
+
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable
       # access regardless of the host operating system
       shell: bash
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DWARNINGS_AS_ERRORS=ON -DAMReX_SPACEDIM=3
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DWARNINGS_AS_ERRORS=ON -DAMReX_SPACEDIM=3
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
       run: cmake --build . --config $BUILD_TYPE --parallel 4
+
+    - name: ccache stats
+      if: always()
+      run: |
+        ccache -s
+        du -hs ~/.cache/ccache


### PR DESCRIPTION
### Description
Adds support for `ccache` to all GitHub actions, so the compilation outputs are cached whenever they are run on GitHub. Subsequent CI actions will fetch the most recent version of the cache, eliminating compiles for everything except changed files.

GPU CI caching will be handled in a separate PR.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
