### PR TITLE
Add ccache to GPU CI

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -48,15 +48,22 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
-        if ! command -v ccache >/dev/null 2>&1; then
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        if command -v ccache >/dev/null 2>&1; then
+          echo "ccache available on agent."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        else
+          echo "ccache not found; proceeding without compiler cache."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]"
         fi
-      displayName: Ensure ccache
+      displayName: Detect ccache
 
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
-        ccache --zero-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --zero-stats || true
+        else
+          echo "ccache not installed; skipping zero-stats."
+        fi
       displayName: Prepare ccache
       env:
         CCACHE_DIR: $(Pipeline.Workspace)/ccache
@@ -68,7 +75,7 @@ jobs:
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
         CCACHE_NOHASHDIR: 1
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_FLAGS=-ffp-exception-behavior=strict -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_FLAGS=-ffp-exception-behavior=strict $(cmakeLauncherArgs)'
     
     - task: CMake@1
       displayName: 'Build Quokka'
@@ -93,7 +100,11 @@ jobs:
       displayName: Publish test results
 
     - script: |
-        ccache --show-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+        else
+          echo "ccache not installed; no statistics to report."
+        fi
       displayName: Report ccache statistics
       condition: succeededOrFailed()
       env:

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -36,13 +36,36 @@ jobs:
     pool: amdgpu
     timeoutInMinutes: 120
     steps:
+    - task: Cache@2
+      displayName: Restore ccache
+      inputs:
+        key: 'ccache | HIP | $(Agent.OS) | $(Build.SourceBranch)'
+        restoreKeys: |
+          ccache | HIP | $(Agent.OS)
+        path: $(Pipeline.Workspace)/ccache
+
+    - script: |
+        mkdir -p $(Pipeline.Workspace)/ccache
+        ccache --zero-stats || true
+      displayName: Prepare ccache
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+
     - task: CMake@1
       displayName: 'Configure CMake'
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+        CCACHE_BASEDIR: $(Build.SourcesDirectory)
+        CCACHE_NOHASHDIR: 1
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_FLAGS=-ffp-exception-behavior=strict'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=HIP -DCMAKE_CXX_FLAGS=-ffp-exception-behavior=strict -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
     
     - task: CMake@1
       displayName: 'Build Quokka'
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+        CCACHE_BASEDIR: $(Build.SourcesDirectory)
+        CCACHE_NOHASHDIR: 1
       inputs:
         cmakeArgs: '--build . --parallel 16'
     
@@ -58,3 +81,10 @@ jobs:
         testRunTitle: $(Agent.JobName)
       condition: succeededOrFailed()
       displayName: Publish test results
+
+    - script: |
+        ccache --show-stats || true
+      displayName: Report ccache statistics
+      condition: succeededOrFailed()
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -48,6 +48,13 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
+        if ! command -v ccache >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        fi
+      displayName: Ensure ccache
+
+    - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         ccache --zero-stats || true
       displayName: Prepare ccache

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -31,6 +31,9 @@ pr:
     - '*.rst'
     - '*.txt'
 
+variables:
+  cacheKeySuffix: $[replace(variables['Build.SourceBranch'], '/', '_')]
+
 jobs:
   - job: HIP_Build_Test
     pool: amdgpu
@@ -39,7 +42,7 @@ jobs:
     - task: Cache@2
       displayName: Restore ccache
       inputs:
-        key: 'ccache | HIP | $(Agent.OS) | $(Build.SourceBranch)'
+        key: 'ccache | HIP | $(Agent.OS) | $(cacheKeySuffix)'
         restoreKeys: |
           ccache | HIP | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -32,6 +32,13 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
+        if ! command -v ccache >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        fi
+      displayName: Ensure ccache
+
+    - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         ccache --zero-stats || true
       displayName: Prepare ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -11,6 +11,9 @@ schedules:
     include:
     - development
 
+variables:
+  cacheKeySuffix: $[replace(variables['Build.SourceBranch'], '/', '_')]
+
 # NOTE: several Python packages are needed for regression_testing to run properly:
 #   https://github.com/AMReX-Codes/regression_testing/blob/main/requirements.txt
 # ALSO NEEDED: bokeh
@@ -23,7 +26,7 @@ jobs:
     - task: Cache@2
       displayName: Restore ccache
       inputs:
-        key: 'ccache | regression | $(Agent.OS) | $(Build.SourceBranch)'
+        key: 'ccache | regression | $(Agent.OS) | $(cacheKeySuffix)'
         restoreKeys: |
           ccache | regression | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -20,8 +20,27 @@ jobs:
     pool: avatar
     timeoutInMinutes: 300
     steps:
+    - task: Cache@2
+      displayName: Restore ccache
+      inputs:
+        key: 'ccache | regression | $(Agent.OS) | $(Build.SourceBranch)'
+        restoreKeys: |
+          ccache | regression | $(Agent.OS)
+        path: $(Pipeline.Workspace)/ccache
+
+    - script: |
+        mkdir -p $(Pipeline.Workspace)/ccache
+        ccache --zero-stats || true
+      displayName: Prepare ccache
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+
     - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+        CCACHE_BASEDIR: $(Build.SourcesDirectory)
+        CCACHE_NOHASHDIR: 1
     - publish: /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
       condition: succeededOrFailed()
       artifact: regressionHTMLOutput
@@ -29,3 +48,9 @@ jobs:
     - script: cd /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'
+    - script: |
+        ccache --show-stats || true
+      displayName: Report ccache statistics
+      condition: succeededOrFailed()
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -32,15 +32,22 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
-        if ! command -v ccache >/dev/null 2>&1; then
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        if command -v ccache >/dev/null 2>&1; then
+          echo "ccache available on agent."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        else
+          echo "ccache not found; proceeding without compiler cache."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]"
         fi
-      displayName: Ensure ccache
+      displayName: Detect ccache
 
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
-        ccache --zero-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --zero-stats || true
+        else
+          echo "ccache not installed; skipping zero-stats."
+        fi
       displayName: Prepare ccache
       env:
         CCACHE_DIR: $(Pipeline.Workspace)/ccache
@@ -59,7 +66,11 @@ jobs:
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'
     - script: |
-        ccache --show-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+        else
+          echo "ccache not installed; no statistics to report."
+        fi
       displayName: Report ccache statistics
       condition: succeededOrFailed()
       env:

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -34,7 +34,7 @@ jobs:
     - script: |
         if command -v ccache >/dev/null 2>&1; then
           echo "ccache available on agent."
-          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache"
         else
           echo "ccache not found; proceeding without compiler cache."
           echo "##vso[task.setvariable variable=cmakeLauncherArgs]"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -30,6 +30,9 @@ pr:
     - '*.rst'
     - '*.txt'
 
+variables:
+  cacheKeySuffix: $[replace(variables['Build.SourceBranch'], '/', '_')]
+
 jobs:
   - job: CUDA_Build_Test
     pool: avatar
@@ -38,7 +41,7 @@ jobs:
     - task: Cache@2
       displayName: Restore ccache
       inputs:
-        key: 'ccache | CUDA | $(Agent.OS) | $(Build.SourceBranch)'
+        key: 'ccache | CUDA | $(Agent.OS) | $(cacheKeySuffix)'
         restoreKeys: |
           ccache | CUDA | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -35,13 +35,36 @@ jobs:
     pool: avatar
     timeoutInMinutes: 120
     steps:
+    - task: Cache@2
+      displayName: Restore ccache
+      inputs:
+        key: 'ccache | CUDA | $(Agent.OS) | $(Build.SourceBranch)'
+        restoreKeys: |
+          ccache | CUDA | $(Agent.OS)
+        path: $(Pipeline.Workspace)/ccache
+
+    - script: |
+        mkdir -p $(Pipeline.Workspace)/ccache
+        ccache --zero-stats || true
+      displayName: Prepare ccache
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+
     - task: CMake@1
       displayName: 'Configure CMake'
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+        CCACHE_BASEDIR: $(Build.SourcesDirectory)
+        CCACHE_NOHASHDIR: 1
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
     
     - task: CMake@1
       displayName: 'Build Quokka'
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+        CCACHE_BASEDIR: $(Build.SourcesDirectory)
+        CCACHE_NOHASHDIR: 1
       inputs:
         cmakeArgs: '--build . --parallel 16'
     
@@ -57,3 +80,10 @@ jobs:
         testRunTitle: $(Agent.JobName)
       condition: succeededOrFailed()
       displayName: Publish test results
+
+    - script: |
+        ccache --show-stats || true
+      displayName: Report ccache statistics
+      condition: succeededOrFailed()
+      env:
+        CCACHE_DIR: $(Pipeline.Workspace)/ccache

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -47,15 +47,22 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
-        if ! command -v ccache >/dev/null 2>&1; then
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        if command -v ccache >/dev/null 2>&1; then
+          echo "ccache available on agent."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+        else
+          echo "ccache not found; proceeding without compiler cache."
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]"
         fi
-      displayName: Ensure ccache
+      displayName: Detect ccache
 
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
-        ccache --zero-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --zero-stats || true
+        else
+          echo "ccache not installed; skipping zero-stats."
+        fi
       displayName: Prepare ccache
       env:
         CCACHE_DIR: $(Pipeline.Workspace)/ccache
@@ -67,7 +74,7 @@ jobs:
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
         CCACHE_NOHASHDIR: 1
       inputs:
-        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache'
+        cmakeArgs: '.. -DCMAKE_BUILD_TYPE=Release -DAMReX_SPACEDIM=3 -DAMReX_GPU_BACKEND=CUDA -DQUOKKA_PYTHON=OFF $(cmakeLauncherArgs)'
     
     - task: CMake@1
       displayName: 'Build Quokka'
@@ -92,7 +99,11 @@ jobs:
       displayName: Publish test results
 
     - script: |
-        ccache --show-stats || true
+        if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+        else
+          echo "ccache not installed; no statistics to report."
+        fi
       displayName: Report ccache statistics
       condition: succeededOrFailed()
       env:

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -49,7 +49,7 @@ jobs:
     - script: |
         if command -v ccache >/dev/null 2>&1; then
           echo "ccache available on agent."
-          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          echo "##vso[task.setvariable variable=cmakeLauncherArgs]-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache"
         else
           echo "ccache not found; proceeding without compiler cache."
           echo "##vso[task.setvariable variable=cmakeLauncherArgs]"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -47,6 +47,13 @@ jobs:
         path: $(Pipeline.Workspace)/ccache
 
     - script: |
+        if ! command -v ccache >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ccache
+        fi
+      displayName: Ensure ccache
+
+    - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         ccache --zero-stats || true
       displayName: Prepare ccache

--- a/.devcontainer/cuda-azp-agent-in-docker/Dockerfile
+++ b/.devcontainer/cuda-azp-agent-in-docker/Dockerfile
@@ -5,7 +5,7 @@ ENV TARGETARCH="linux/amd64"
 USER root
 RUN apt update && \
   apt upgrade -y && \
-  apt install -y curl git jq libicu74 python3-h5py gfortran
+  apt install -y curl git jq libicu74 python3-h5py gfortran ccache
 
 # Install h5py
 # RUN pip3 install h5py 

--- a/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
+++ b/.devcontainer/rocm-azp-agent-in-docker/Dockerfile
@@ -8,6 +8,7 @@ USER root
 RUN zypper --non-interactive refresh && \
     zypper --non-interactive update && \
     zypper --non-interactive install \
+        ccache \
         curl \
         git \
         jq \

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -67,7 +67,7 @@ buildDir = .
 target = test_hydro3d_blast
 inputFile = inputs/blast_unigrid_128_regression.in
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -84,7 +84,7 @@ buildDir = .
 target = test_hydro3d_blast
 inputFile = inputs/blast_unigrid_128_AMR_regression.in
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -102,7 +102,7 @@ target = shock_cloud
 inputFile = inputs/ShockCloud_64_regression.in
 link1File = extern/cooling/CloudyData_UVB=HM2012_resampled.h5
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -119,7 +119,7 @@ buildDir = .
 target = spherical_collapse
 inputFile = inputs/SphericalCollapse_regression.in
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -135,7 +135,7 @@ target = test_radhydro3d_shell
 inputFile = inputs/radhydro_shell_regression.in
 link1File = extern/dust_shell/initial_conditions.txt
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -150,7 +150,7 @@ buildDir = .
 target = test_mhd_blast
 inputFile = inputs/blast_mhd.in
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1
@@ -167,7 +167,7 @@ buildDir = .
 target = test_alfven_wave_linear
 inputFile = inputs/alfven_wave_linear_regression.in
 dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA
+cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
 restartTest = 0
 useMPI = 1
 numprocs = 1


### PR DESCRIPTION
### Description
This updates the GPU CI so that they cache compiles using ccache and upload the cache to Azure Pipelines. This means only changed files will be recompiled when running the GPU CI.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
