### PR TITLE
[WIP] limit slopes in NSCBC boundary conditions

### DIFF
--- a/src/hydro/NSCBC_inflow.hpp
+++ b/src/hydro/NSCBC_inflow.hpp
@@ -15,6 +15,7 @@
 #include "AMReX_REAL.H"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
+#include "hydro/NSCBC_utils.hpp"
 #include "util/valarray.hpp"
 
 namespace NSCBC
@@ -123,7 +124,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setInflowX1Lower(const amrex::IntVect &
 	quokka::valarray<amrex::Real, N> const Q_i = HydroSystem<problem_t>::ComputePrimVars(consVar, ilo, j, k);
 	quokka::valarray<amrex::Real, N> const Q_ip1 = HydroSystem<problem_t>::ComputePrimVars(consVar, ilo + 1, j, k);
 	quokka::valarray<amrex::Real, N> const Q_ip2 = HydroSystem<problem_t>::ComputePrimVars(consVar, ilo + 2, j, k);
-	quokka::valarray<amrex::Real, N> const dQ_dx_data = (-3. * Q_i + 4. * Q_ip1 - Q_ip2) / (2. * dx);
+	quokka::valarray<amrex::Real, N> const dQ_dx_high = (-3.0 * Q_i + 4.0 * Q_ip1 - Q_ip2) / (2.0 * dx);
+	quokka::valarray<amrex::Real, N> const dQ_dx_data = detail::limit_normal_gradient<problem_t>(dQ_dx_high, Q_ip2, Q_ip1, Q_i, dx);
 
 	// compute dQ/dx with modified characteristics
 	quokka::valarray<amrex::Real, N> const dQ_dx = detail::dQ_dx_inflow_x1_lower<problem_t>(Q_i, dQ_dx_data, T_t, u_t, v_t, w_t, s_t, Lx);

--- a/src/hydro/NSCBC_inflow.hpp
+++ b/src/hydro/NSCBC_inflow.hpp
@@ -14,8 +14,8 @@
 #include "AMReX_GpuQualifiers.H"
 #include "AMReX_REAL.H"
 #include "hydro/EOS.hpp"
-#include "hydro/hydro_system.hpp"
 #include "hydro/NSCBC_utils.hpp"
+#include "hydro/hydro_system.hpp"
 #include "util/valarray.hpp"
 
 namespace NSCBC

--- a/src/hydro/NSCBC_outflow.hpp
+++ b/src/hydro/NSCBC_outflow.hpp
@@ -14,6 +14,7 @@
 #include "AMReX_REAL.H"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
+#include "hydro/NSCBC_utils.hpp"
 #include "util/valarray.hpp"
 
 namespace NSCBC
@@ -117,6 +118,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_xdir_dQ_data(const amrex::In
 	const auto &boundary_idx = (SIDE == BoundarySide::Lower) ? box.loVect3d() : box.hiVect3d();
 	const int ibr = boundary_idx[0];
 
+	[[maybe_unused]] quokka::valarray<amrex::Real, N> const Q_center = HydroSystem<problem_t>::ComputePrimVars(consVar, ibr, j, k);
 	quokka::valarray<amrex::Real, N> dQ_dy_data{};
 	quokka::valarray<amrex::Real, N> dQ_dz_data{};
 
@@ -125,7 +127,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_xdir_dQ_data(const amrex::In
 		if (consVar.contains(ibr, j + 1, k) && consVar.contains(ibr, j - 1, k)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, ibr, j + 1, k);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, ibr, j - 1, k);
-			dQ_dy_data = (Qp - Qm) / (2.0 * geom.CellSize(1));
+			dQ_dy_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(1));
 		}
 	}
 	// dQ/dz
@@ -133,7 +135,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_xdir_dQ_data(const amrex::In
 		if (consVar.contains(ibr, j, k + 1) && consVar.contains(ibr, j, k - 1)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, ibr, j, k + 1);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, ibr, j, k - 1);
-			dQ_dy_data = (Qp - Qm) / (2.0 * geom.CellSize(2));
+			dQ_dz_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(2));
 		}
 	}
 
@@ -151,6 +153,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_ydir_dQ_data(const amrex::In
 	const auto &boundary_idx = (SIDE == BoundarySide::Lower) ? box.loVect3d() : box.hiVect3d();
 	const int jbr = boundary_idx[1];
 
+	[[maybe_unused]] quokka::valarray<amrex::Real, N> const Q_center = HydroSystem<problem_t>::ComputePrimVars(consVar, i, jbr, k);
 	quokka::valarray<amrex::Real, N> dQ_dz_data{};
 	quokka::valarray<amrex::Real, N> dQ_dx_data{};
 
@@ -159,7 +162,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_ydir_dQ_data(const amrex::In
 		if (consVar.contains(i, jbr, k + 1) && consVar.contains(i, jbr, k - 1)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, i, jbr, k + 1);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, i, jbr, k - 1);
-			dQ_dz_data = (Qp - Qm) / (2.0 * geom.CellSize(2));
+			dQ_dz_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(2));
 		}
 	}
 	// dQ/dx
@@ -167,7 +170,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_ydir_dQ_data(const amrex::In
 		if (consVar.contains(i + 1, jbr, k) && consVar.contains(i - 1, jbr, k)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, i + 1, jbr, k);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, i - 1, jbr, k);
-			dQ_dx_data = (Qp - Qm) / (2.0 * geom.CellSize(0));
+			dQ_dx_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(0));
 		}
 	}
 	return std::make_tuple(dQ_dz_data, dQ_dx_data);
@@ -184,6 +187,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_zdir_dQ_data(const amrex::In
 	const auto &boundary_idx = (SIDE == BoundarySide::Lower) ? box.loVect3d() : box.hiVect3d();
 	const int kbr = boundary_idx[2];
 
+	[[maybe_unused]] quokka::valarray<amrex::Real, N> const Q_center = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, kbr);
 	quokka::valarray<amrex::Real, N> dQ_dx_data{};
 	quokka::valarray<amrex::Real, N> dQ_dy_data{};
 
@@ -192,7 +196,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_zdir_dQ_data(const amrex::In
 		if (consVar.contains(i + 1, j, kbr) && consVar.contains(i - 1, j, kbr)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, i + 1, j, kbr);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, i - 1, j, kbr);
-			dQ_dx_data = (Qp - Qm) / (2.0 * geom.CellSize(0));
+			dQ_dx_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(0));
 		}
 	}
 	// dQ/dy
@@ -200,7 +204,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto transverse_zdir_dQ_data(const amrex::In
 		if (consVar.contains(i, j + 1, kbr) && consVar.contains(i, j - 1, kbr)) {
 			quokka::valarray<amrex::Real, N> const Qp = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j + 1, kbr);
 			quokka::valarray<amrex::Real, N> const Qm = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j - 1, kbr);
-			dQ_dy_data = (Qp - Qm) / (2.0 * geom.CellSize(1));
+			dQ_dy_data = centered_limited_gradient<problem_t>(Qm, Q_center, Qp, geom.CellSize(1));
 		}
 	}
 	return std::make_tuple(dQ_dx_data, dQ_dy_data);
@@ -295,7 +299,8 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void setOutflowBoundary(const amrex::IntVect
 		Q_im2 = HydroSystem<problem_t>::ComputePrimVars(consVar, i, j, im2);
 	}
 
-	quokka::valarray<amrex::Real, N> dQ_dx_data = (Q_im2 - 4.0 * Q_im1 + 3.0 * Q_i) / (2.0 * dx);
+	quokka::valarray<amrex::Real, N> const dQ_dx_high = (Q_im2 - 4.0 * Q_im1 + 3.0 * Q_i) / (2.0 * dx);
+	quokka::valarray<amrex::Real, N> dQ_dx_data = detail::limit_normal_gradient<problem_t>(dQ_dx_high, Q_im2, Q_im1, Q_i, dx);
 	dQ_dx_data *= (SIDE == BoundarySide::Lower) ? -1.0 : 1.0;
 
 	// compute dQ/dx with modified characteristics

--- a/src/hydro/NSCBC_outflow.hpp
+++ b/src/hydro/NSCBC_outflow.hpp
@@ -13,8 +13,8 @@
 #include "AMReX_GpuQualifiers.H"
 #include "AMReX_REAL.H"
 #include "hydro/EOS.hpp"
-#include "hydro/hydro_system.hpp"
 #include "hydro/NSCBC_utils.hpp"
+#include "hydro/hydro_system.hpp"
 #include "util/valarray.hpp"
 
 namespace NSCBC

--- a/src/hydro/NSCBC_utils.hpp
+++ b/src/hydro/NSCBC_utils.hpp
@@ -1,0 +1,53 @@
+#ifndef NSCBC_UTILS_HPP_ // NOLINT
+#define NSCBC_UTILS_HPP_
+//==============================================================================
+// Quokka -- two-moment radiation hydrodynamics on GPUs for astrophysics
+// Copyright 2024.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file NSCBC_utils.hpp
+/// \brief Shared helpers for NSCBC boundary condition implementations.
+
+#include "hydro/hydro_system.hpp"
+
+namespace NSCBC
+{
+namespace detail
+{
+template <typename problem_t, SlopeLimiter limiter = SlopeLimiter::minmod>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto limit_normal_gradient(
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &high_order_grad,
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QL,
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QC,
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QR, const amrex::Real dx)
+    -> quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_>
+{
+	quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> grad{};
+	for (int n = 0; n < HydroSystem<problem_t>::nvar_; ++n) {
+		const amrex::Real slopeL = (QC[n] - QL[n]) / dx;
+		const amrex::Real slopeR = (QR[n] - QC[n]) / dx;
+		const amrex::Real plm_slope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(slopeL, slopeR);
+		grad[n] = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(high_order_grad[n], plm_slope);
+	}
+	return grad;
+}
+
+template <typename problem_t, SlopeLimiter limiter = SlopeLimiter::minmod>
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto centered_limited_gradient(
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qm,
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qc,
+    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qp, const amrex::Real dx)
+    -> quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_>
+{
+	quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> grad{};
+	for (int n = 0; n < HydroSystem<problem_t>::nvar_; ++n) {
+		const amrex::Real slopeL = (Qc[n] - Qm[n]) / dx;
+		const amrex::Real slopeR = (Qp[n] - Qc[n]) / dx;
+		grad[n] = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(slopeL, slopeR);
+	}
+	return grad;
+}
+} // namespace detail
+} // namespace NSCBC
+
+#endif // NSCBC_UTILS_HPP_

--- a/src/hydro/NSCBC_utils.hpp
+++ b/src/hydro/NSCBC_utils.hpp
@@ -15,11 +15,10 @@ namespace NSCBC
 namespace detail
 {
 template <typename problem_t, SlopeLimiter limiter = SlopeLimiter::minmod>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto limit_normal_gradient(
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &high_order_grad,
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QL,
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QC,
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QR, const amrex::Real dx)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto limit_normal_gradient(quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &high_order_grad,
+							       quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QL,
+							       quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QC,
+							       quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &QR, const amrex::Real dx)
     -> quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_>
 {
 	quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> grad{};
@@ -33,10 +32,9 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto limit_normal_gradient(
 }
 
 template <typename problem_t, SlopeLimiter limiter = SlopeLimiter::minmod>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto centered_limited_gradient(
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qm,
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qc,
-    quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qp, const amrex::Real dx)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto centered_limited_gradient(quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qm,
+								   quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qc,
+								   quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> const &Qp, const amrex::Real dx)
     -> quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_>
 {
 	quokka::valarray<amrex::Real, HydroSystem<problem_t>::nvar_> grad{};

--- a/src/problems/NscbcChannel/testNscbcChannel.cpp
+++ b/src/problems/NscbcChannel/testNscbcChannel.cpp
@@ -291,7 +291,7 @@ auto problem_main() -> int
 
 	// Compute test success condition
 	int status = 0;
-	const double error_tol = 3.5e-5;
+	const double error_tol = 0.005; // minmod: rms of component-wise relative L1 error norms = 0.004027494839
 	if (epsilon > error_tol) {
 		status = 1;
 	}


### PR DESCRIPTION
### Description
Use a slope limiter in the NSCBC boundary condition implementation. This should make it more stable in real problems.

### Related issues
https://github.com/quokka-astro/quokka/issues/532

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
