### PR TITLE
changed way error is calculated in quokkasimulation

### DIFF
--- a/inputs/FastWave.in
+++ b/inputs/FastWave.in
@@ -29,7 +29,7 @@ do_subcycle = 0
 plotfile_interval = 100
 checkpoint_interval = -1
 cfl = 0.3
-stop_time = 10.0
+stop_time = 0.7071068
 max_timesteps = 2000
 
 hydro.rk_integrator_order = 2

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -243,8 +243,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
 	auto computeErrorNorm() -> amrex::Real;
-	auto computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref,amrex::Vector<std::string> const &componentNames) 
-					  -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
+	auto computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref, amrex::Vector<std::string> const &componentNames)
+	    -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 
@@ -846,29 +846,30 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 	    mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { printf("%f\n", mf_fc[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex)); });
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref, amrex::Vector<std::string> const &componentNames)
--> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> 
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref,
+							 amrex::Vector<std::string> const &componentNames)
+    -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
 {
 	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> component_errors{};
 	const int ncomp = state_new.nComp();
-	
+
 	// Use the BoxArray from state_ref instead of boxArray(0)!
 	amrex::MultiFab residual(state_ref.boxArray(), state_ref.DistributionMap(), ncomp, 0);
 	amrex::MultiFab::Copy(residual, state_ref, 0, 0, ncomp, 0);
 	amrex::MultiFab::Saxpy(residual, -1., state_new, 0, 0, ncomp, 0);
-	
+
 	const auto n_cells = static_cast<amrex::Real>(residual.boxArray().numPts());
-	
-	for (int icomp = 0; icomp < ncomp; ++icomp)
-	{
+
+	for (int icomp = 0; icomp < ncomp; ++icomp) {
 		const amrex::Real abs_err = residual.norm1(icomp) / n_cells;
 		const amrex::Real ref_norm = state_ref.norm1(icomp) / n_cells;
-		
-		amrex::Real rel_err = NAN;		
+
+		amrex::Real rel_err = NAN;
 		if (ref_norm > 0.0) {
 			rel_err = abs_err / ref_norm;
 		}
-		
+
 		component_errors.push_back(std::make_tuple(componentNames[icomp], abs_err, rel_err));
 	}
 	return component_errors;
@@ -878,7 +879,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 	amrex::Real errorNorm = 0.0;
-	
+
 	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
@@ -896,14 +897,13 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 			// Create both MultiFabs with shrunk BoxArray
 			amrex::MultiFab state_ref_fc_level0(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
-			
+
 			// Fill reference solution
-			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), 
-										geom[0].ProbLoArray(), quokka::direction{idim});
-			
+			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
+
 			// Copy shrunk data (removes the last face in direction idim)
 			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
-			
+
 			auto fc_comp_errors = computeComponentErrors(state_new_fc_shrunk, state_ref_fc_level0, componentNames_fc_[idim]);
 			comp_errors.insert(comp_errors.end(), fc_comp_errors.begin(), fc_comp_errors.end());
 			ncomp_tot += ncomp_fc;
@@ -913,21 +913,19 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	if (this->suppress_output == 0) {
 		amrex::Print() << "\nComponent Errors:\n";
 		amrex::Print() << std::string(70, '=') << "\n";
-		amrex::Print() << std::setw(25) << std::left << "Component" 
-					<< std::setw(20) << std::right << "Absolute Error" 
-					<< std::setw(20) << std::right << "Relative Error" << "\n";
+		amrex::Print() << std::setw(25) << std::left << "Component" << std::setw(20) << std::right << "Absolute Error" << std::setw(20) << std::right
+			       << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
-	}	
+	}
 
-	for (int icomp = 0; icomp < ncomp_tot; ++icomp)
-	{
+	for (int icomp = 0; icomp < ncomp_tot; ++icomp) {
 		auto [name, abs_err, rel_err] = comp_errors[icomp];
 		rms_err += abs_err * abs_err;
-			// Print each component
+		// Print each component
 		if (this->suppress_output == 0) {
-			amrex::Print() << std::setw(25) << std::left << name
-						<< std::setw(20) << std::right << std::scientific << std::setprecision(4) << abs_err;
-			
+			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
+				       << abs_err;
+
 			if (std::isnan(rel_err)) {
 				amrex::Print() << std::setw(20) << std::right << "N/A" << "\n";
 			} else {
@@ -936,7 +934,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 		}
 	}
 	amrex::Print() << std::string(70, '=') << "\n";
-	rms_err = std::sqrt(rms_err/static_cast<amrex::Real>(ncomp_tot));
+	rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
 	if (this->suppress_output == 0) {
 		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
 	}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -959,61 +959,60 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	return comp_errors;
 }
 
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
-    // use_rel_err: if true, compute relative error norm; else compute absolute error norm
-    // default: true
+	// use_rel_err: if true, compute relative error norm; else compute absolute error norm
+	// default: true
 
-    auto comp_errors = computeComponentErrors();
-if (comp_errors.empty()) {
-	if (this->suppress_output == 0) {
-		amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
+	auto comp_errors = computeComponentErrors();
+	if (comp_errors.empty()) {
+		if (this->suppress_output == 0) {
+			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
+		}
+		return NAN;
 	}
-	return NAN;
-}
 
-// Get number of cells to convert back from normalized errors to L1 norms
-const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
-amrex::Real sum_sq_err = 0.0;
-amrex::Real sum_sq_ref = 0.0;
+	// Get number of cells to convert back from normalized errors to L1 norms
+	const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
+	amrex::Real sum_sq_err = 0.0;
+	amrex::Real sum_sq_ref = 0.0;
 
-for (const auto &[name, abs_err, rel_err] : comp_errors) {
-	// Convert normalized errors back to L1 norms
-	amrex::Real L1_err = abs_err * n_cells;
-	sum_sq_err += L1_err * L1_err;
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+		// Convert normalized errors back to L1 norms
+		amrex::Real L1_err = abs_err * n_cells;
+		sum_sq_err += L1_err * L1_err;
 
-	// Reconstruct reference L1 norm
-	if (!std::isnan(rel_err) && rel_err != 0.0) {
-		amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
-		sum_sq_ref += L1_ref * L1_ref;
+		// Reconstruct reference L1 norm
+		if (!std::isnan(rel_err) && rel_err != 0.0) {
+			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
+			sum_sq_ref += L1_ref * L1_ref;
+		}
+		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
 	}
-	// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
-}
 
-const amrex::Real err_norm = std::sqrt(sum_sq_err);
-const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
+	const amrex::Real err_norm = std::sqrt(sum_sq_err);
+	const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
 
-amrex::Real error_norm = 0.0;
-if (use_rel_err && sol_norm > 0.0) {
-	error_norm = err_norm / sol_norm;
-	if (this->suppress_output == 0) {
-		amrex::Print() << std::string(70, '=') << "\n";
-		amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
-	}
-} else {
-	error_norm = err_norm;
-	if (this->suppress_output == 0) {
-		amrex::Print() << std::string(70, '=') << "\n";
-		if (sol_norm == 0.0) {
-			amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
-		} else {
-			amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
+	amrex::Real error_norm = 0.0;
+	if (use_rel_err && sol_norm > 0.0) {
+		error_norm = err_norm / sol_norm;
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::string(70, '=') << "\n";
+			amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
+		}
+	} else {
+		error_norm = err_norm;
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::string(70, '=') << "\n";
+			if (sol_norm == 0.0) {
+				amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
+			} else {
+				amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
+			}
 		}
 	}
-}
 
-return error_norm;
+	return error_norm;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -959,7 +959,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
-	BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 	
 	auto comp_errors = computeComponentErrors();
 	if (comp_errors.empty()) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -938,6 +938,17 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			       << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
 	}
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::setw(25) << std::left << name 
+			               << std::setw(20) << std::right << std::scientific << std::setprecision(4) << abs_err;
+			if (std::isnan(rel_err)) {
+				amrex::Print() << std::setw(20) << std::right << "N/A" << "\n";
+			} else {
+				amrex::Print() << std::setw(20) << std::right << std::scientific << std::setprecision(4) << rel_err << "\n";
+			}
+		}
+	}
 	return comp_errors;
 }
 
@@ -946,58 +957,49 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 
 	auto comp_errors = computeComponentErrors();
-	const int ncomp_tot = static_cast<int>(comp_errors.size());
-
-	if (ncomp_tot == 0) {
+	if (comp_errors.empty()) {
 		if (this->suppress_output == 0) {
 			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
 		}
 		return NAN;
 	}
 
-	amrex::Real rms_err = 0.0;
-	auto N = static_cast<amrex::Real>(ncomp_tot);
-
-	for (const auto &[name, abs_err, rel_err] : comp_errors) {
-		amrex::Real err = abs_err;
-		if (use_rel_err) {
-			// Use relative error if valid, otherwise fall back to abs_err
-			if (!std::isnan(rel_err) && rel_err != 0.0) {
-				err = rel_err;
+	auto compute_rms = [](const auto &errors, auto selector) {
+		amrex::Real sum_sq = 0.0;
+		int count = 0;
+		for (const auto &e : errors) {
+			amrex::Real val = selector(e);
+			if (val != 0.0 && !std::isnan(val)) {
+				sum_sq += val * val;
+				++count;
 			}
 		}
-		if (err == 0.0 || std::isnan(err)) {
-			N -= 1.0; // exclude this component from RMS
-		} else {
-			rms_err += err * err;
-		}
-		// Optional printing
-		if (this->suppress_output == 0) {
-			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
-				       << abs_err;
+		return std::make_pair(std::sqrt(sum_sq), count);
+	};
 
-			if (std::isnan(rel_err)) {
-				amrex::Print() << std::setw(20) << "N/A\n";
-			} else {
-				amrex::Print() << std::setw(20) << std::scientific << std::setprecision(4) << rel_err << "\n";
-			}
-		}
-	}
+	auto [rms_abs, abs_count] = compute_rms(comp_errors, [](const auto &e) { return std::get<1>(e); });
+	auto [rms_rel, rel_count] = compute_rms(comp_errors, [](const auto &e) { return std::get<2>(e); });
 
-	// Final RMS
-	if (N == 0.0) {
+	if (abs_count == 0) {
 		if (this->suppress_output == 0) {
 			amrex::Print() << "\nNo non-zero errors found. RMS error is zero.\n\n";
 		}
 		return 0.0;
 	}
-	rms_err = std::sqrt(rms_err / N);
+
+	amrex::Real rms_err = rms_abs;
+	if (use_rel_err) {
+		if (rel_count > 0) {
+			rms_err = rms_rel;
+		} else if (this->suppress_output == 0) {
+			amrex::Print() << "\nNo valid relative errors found. Falling back to absolute errors.\n";
+		}
+	}
 
 	if (this->suppress_output == 0) {
 		amrex::Print() << std::string(70, '=') << "\n";
 		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
 	}
-
 	return rms_err;
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -898,7 +898,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
 			bool has_valid_data = true;
 			for (int icomp = 0; icomp < ncomp_fc; ++icomp) {
-				if (!std::isfinite(state_ref_level0.norm0(icomp))) {
+				if (!std::isfinite(state_ref_fc_level0.norm0(icomp))) {
 					has_valid_data = false;
 					break;
 				}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -845,8 +845,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 	    mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { printf("%f\n", mf_fc[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex)); });
 }
 
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
 {
 	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> comp_errors{};
 
@@ -929,8 +928,8 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	if (this->suppress_output == 0) {
 		amrex::Print() << "\nComponent Errors:\n";
 		amrex::Print() << std::string(70, '=') << "\n";
-		amrex::Print() << std::setw(25) << std::left << "Component" << std::setw(20) << std::right << "Absolute Error" << std::setw(20)
-			       << std::right << "Relative Error" << "\n";
+		amrex::Print() << std::setw(25) << std::left << "Component" << std::setw(20) << std::right << "Absolute Error" << std::setw(20) << std::right
+			       << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
 	}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -959,60 +959,61 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	return comp_errors;
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 
-	// use_rel_err: if true, compute relative error norm; else compute absolute error norm
-	// default: true
+    // use_rel_err: if true, compute relative error norm; else compute absolute error norm
+    // default: true
 
-	auto comp_errors = computeComponentErrors();
-	if (comp_errors.empty()) {
-		if (this->suppress_output == 0) {
-			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
-		}
-		return NAN;
+    auto comp_errors = computeComponentErrors();
+if (comp_errors.empty()) {
+	if (this->suppress_output == 0) {
+		amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
 	}
+	return NAN;
+}
 
-	// Get number of cells to convert back from normalized errors to L1 norms
-	const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
-	amrex::Real sum_sq_err = 0.0;
-	amrex::Real sum_sq_ref = 0.0;
+// Get number of cells to convert back from normalized errors to L1 norms
+const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
+amrex::Real sum_sq_err = 0.0;
+amrex::Real sum_sq_ref = 0.0;
 
-	for (const auto &[name, abs_err, rel_err] : comp_errors) {
-		// Convert normalized errors back to L1 norms
-		amrex::Real L1_err = abs_err * n_cells;
-		sum_sq_err += L1_err * L1_err;
+for (const auto &[name, abs_err, rel_err] : comp_errors) {
+	// Convert normalized errors back to L1 norms
+	amrex::Real L1_err = abs_err * n_cells;
+	sum_sq_err += L1_err * L1_err;
 
-		// Reconstruct reference L1 norm
-		if (!std::isnan(rel_err) && rel_err != 0.0) {
-			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
-			sum_sq_ref += L1_ref * L1_ref;
-		}
-		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
+	// Reconstruct reference L1 norm
+	if (!std::isnan(rel_err) && rel_err != 0.0) {
+		amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
+		sum_sq_ref += L1_ref * L1_ref;
 	}
+	// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
+}
 
-	const amrex::Real err_norm = std::sqrt(sum_sq_err);
-	const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
+const amrex::Real err_norm = std::sqrt(sum_sq_err);
+const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
 
-	amrex::Real error_norm = 0.0;
-	if (use_rel_err && sol_norm > 0.0) {
-		error_norm = err_norm / sol_norm;
-		if (this->suppress_output == 0) {
-			amrex::Print() << std::string(70, '=') << "\n";
-			amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
-		}
-	} else {
-		error_norm = err_norm;
-		if (this->suppress_output == 0) {
-			amrex::Print() << std::string(70, '=') << "\n";
-			if (sol_norm == 0.0) {
-				amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
-			} else {
-				amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
-			}
+amrex::Real error_norm = 0.0;
+if (use_rel_err && sol_norm > 0.0) {
+	error_norm = err_norm / sol_norm;
+	if (this->suppress_output == 0) {
+		amrex::Print() << std::string(70, '=') << "\n";
+		amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
+	}
+} else {
+	error_norm = err_norm;
+	if (this->suppress_output == 0) {
+		amrex::Print() << std::string(70, '=') << "\n";
+		if (sol_norm == 0.0) {
+			amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
+		} else {
+			amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
 		}
 	}
+}
 
-	return error_norm;
+return error_norm;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -958,7 +958,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-	
+
 	auto comp_errors = computeComponentErrors();
 	if (comp_errors.empty()) {
 		if (this->suppress_output == 0) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -943,61 +943,58 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	return comp_errors;
 }
 
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
-    const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 
-    auto comp_errors = computeComponentErrors();
-    const int ncomp_tot = static_cast<int>(comp_errors.size());
+	auto comp_errors = computeComponentErrors();
+	const int ncomp_tot = static_cast<int>(comp_errors.size());
 
-    if (ncomp_tot == 0) {
-        if (this->suppress_output == 0) {
-            amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
-        }
-        return NAN;
-    }
+	if (ncomp_tot == 0) {
+		if (this->suppress_output == 0) {
+			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
+		}
+		return NAN;
+	}
 
-    amrex::Real rms_err = 0.0;
-    auto N = static_cast<amrex::Real>(ncomp_tot);
+	amrex::Real rms_err = 0.0;
+	auto N = static_cast<amrex::Real>(ncomp_tot);
 
-    for (const auto &[name, abs_err, rel_err] : comp_errors) {
-        amrex::Real err = abs_err;
-        if (use_rel_err) {
-            // Use relative error if valid, otherwise fall back to abs_err
-            if (!std::isnan(rel_err) && rel_err != 0.0) {
-                err = rel_err;
-            }
-        }
-        if (err == 0.0 || std::isnan(err)) {
-            N -= 1.0;   // exclude this component from RMS
-        } else {
-            rms_err += err * err;
-        }
-        // Optional printing
-        if (this->suppress_output == 0) {
-            amrex::Print() << std::setw(25) << std::left << name
-                           << std::setw(20) << std::right << std::scientific
-                           << std::setprecision(4) << abs_err;
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+		amrex::Real err = abs_err;
+		if (use_rel_err) {
+			// Use relative error if valid, otherwise fall back to abs_err
+			if (!std::isnan(rel_err) && rel_err != 0.0) {
+				err = rel_err;
+			}
+		}
+		if (err == 0.0 || std::isnan(err)) {
+			N -= 1.0; // exclude this component from RMS
+		} else {
+			rms_err += err * err;
+		}
+		// Optional printing
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
+				       << abs_err;
 
-            if (std::isnan(rel_err)) {
-                amrex::Print() << std::setw(20) << "N/A\n";
-            } else {
-                amrex::Print() << std::setw(20) << std::scientific
-                               << std::setprecision(4) << rel_err << "\n";
-            }
-        }
-    }
+			if (std::isnan(rel_err)) {
+				amrex::Print() << std::setw(20) << "N/A\n";
+			} else {
+				amrex::Print() << std::setw(20) << std::scientific << std::setprecision(4) << rel_err << "\n";
+			}
+		}
+	}
 
-    // Final RMS
-    rms_err = std::sqrt(rms_err / N);
+	// Final RMS
+	rms_err = std::sqrt(rms_err / N);
 
-    if (this->suppress_output == 0) {
-        amrex::Print() << std::string(70, '=') << "\n";
-        amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
-    }
+	if (this->suppress_output == 0) {
+		amrex::Print() << std::string(70, '=') << "\n";
+		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
+	}
 
-    return rms_err;
+	return rms_err;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -940,8 +940,8 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	}
 	for (const auto &[name, abs_err, rel_err] : comp_errors) {
 		if (this->suppress_output == 0) {
-			amrex::Print() << std::setw(25) << std::left << name 
-			               << std::setw(20) << std::right << std::scientific << std::setprecision(4) << abs_err;
+			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
+				       << abs_err;
 			if (std::isnan(rel_err)) {
 				amrex::Print() << std::setw(20) << std::right << "N/A" << "\n";
 			} else {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -872,6 +872,7 @@ auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_
 
 		component_errors.push_back(std::make_tuple(componentNames[icomp], abs_err, rel_err));
 	}
+));emplace_back
 	return component_errors;
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -879,7 +879,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 
-	    const int ncomp = state_new_cc_[0].nComp();
+	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -987,8 +987,8 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
 	}
 
-	amrex::Real err_norm = std::sqrt(sum_sq_err);
-	amrex::Real sol_norm = std::sqrt(sum_sq_ref);
+	const amrex::Real err_norm = std::sqrt(sum_sq_err);
+	const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
 
 	amrex::Real error_norm = 0.0;
 	if (use_rel_err && sol_norm > 0.0) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -897,7 +897,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
 			bool has_valid_data = true;
-			for (int icomp = 0; icomp < ncomp; ++icomp) {
+			for (int icomp = 0; icomp < ncomp_fc; ++icomp) {
 				if (!std::isfinite(state_ref_level0.norm0(icomp))) {
 					has_valid_data = false;
 					break;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -873,7 +873,6 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
 
 	const auto n_cells = static_cast<amrex::Real>(residual.boxArray().numPts());
-	std::cout << "\nChecking n_cells: " << n_cells << "\n";
 
 	for (int icomp = 0; icomp < ncomp; ++icomp) {
 		const amrex::Real abs_err = residual.norm1(icomp) / n_cells;
@@ -922,7 +921,6 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			for (int icomp_fc = 0; icomp_fc < ncomp_fc; ++icomp_fc) {
 				const amrex::Real abs_err = residual_fc.norm1(icomp_fc) / n_cells_fc;
 				const amrex::Real ref_norm = state_ref_fc_level0.norm1(icomp_fc) / n_cells_fc;
-				std::cout << "\nChecking n_cells_fc: " << n_cells_fc << "\n";
 
 				amrex::Real rel_err = NAN;
 				if (ref_norm > 0.0) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -879,9 +879,9 @@ emplace_back return component_errors;
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-");const 
+	");const 
 
-	const int ncomp = state_new_cc_[0].nComp();
+	    const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -243,8 +243,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
 	auto computeErrorNorm() -> amrex::Real;
-	auto computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref, amrex::Vector<std::string> const &componentNames)
-	    -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
+	auto computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 
@@ -847,45 +846,35 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 }
 
 template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref,
-							 amrex::Vector<std::string> const &componentNames)
-    -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
+auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
 {
-	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> component_errors{};
-	const int ncomp = state_new.nComp();
+	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> comp_errors{};
 
-	// Use the BoxArray from state_ref instead of boxArray(0)!
-	amrex::MultiFab residual(state_ref.boxArray(), state_ref.DistributionMap(), ncomp, 0);
-	amrex::MultiFab::Copy(residual, state_ref, 0, 0, ncomp, 0);
-	amrex::MultiFab::Saxpy(residual, -1., state_new, 0, 0, ncomp, 0);
+	// Compute cell-centered errors
+	const int ncomp = state_new_cc_[0].nComp();
+	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
+	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
+
+	// Compute residual
+	amrex::MultiFab residual(state_ref_level0.boxArray(), state_ref_level0.DistributionMap(), ncomp, 0);
+	amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
+	amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
 
 	const auto n_cells = static_cast<amrex::Real>(residual.boxArray().numPts());
 
 	for (int icomp = 0; icomp < ncomp; ++icomp) {
 		const amrex::Real abs_err = residual.norm1(icomp) / n_cells;
-		const amrex::Real ref_norm = state_ref.norm1(icomp) / n_cells;
+		const amrex::Real ref_norm = state_ref_level0.norm1(icomp) / n_cells;
 
 		amrex::Real rel_err = NAN;
 		if (ref_norm > 0.0) {
 			rel_err = abs_err / ref_norm;
 		}
 
-		component_errors.emplace_back(componentNames[icomp], abs_err, rel_err);
+		comp_errors.emplace_back(componentNames_cc_[icomp], abs_err, rel_err);
 	}
-	return component_errors;
-}
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
-{
-	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-
-	    const int ncomp = state_new_cc_[0].nComp();
-	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
-	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
-
-	auto comp_errors = computeComponentErrors(state_new_cc_[0], state_ref_level0, componentNames_cc_);
-
-	int ncomp_tot = ncomp;
+	// Compute face-centered errors (if MHD is enabled)
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			const int ncomp_fc = state_new_fc_[0][idim].nComp();
@@ -903,22 +892,49 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 			// Copy shrunk data (removes the last face in direction idim)
 			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
 
-			auto fc_comp_errors = computeComponentErrors(state_new_fc_shrunk, state_ref_fc_level0, componentNames_fc_[idim]);
-			comp_errors.insert(comp_errors.end(), fc_comp_errors.begin(), fc_comp_errors.end());
-			ncomp_tot += ncomp_fc;
+			// Compute residual
+			amrex::MultiFab residual_fc(state_ref_fc_level0.boxArray(), state_ref_fc_level0.DistributionMap(), ncomp_fc, 0);
+			amrex::MultiFab::Copy(residual_fc, state_ref_fc_level0, 0, 0, ncomp_fc, 0);
+			amrex::MultiFab::Saxpy(residual_fc, -1., state_new_fc_shrunk, 0, 0, ncomp_fc, 0);
+
+			const auto n_cells_fc = static_cast<amrex::Real>(residual_fc.boxArray().numPts());
+
+			for (int icomp_fc = 0; icomp_fc < ncomp_fc; ++icomp_fc) {
+				const amrex::Real abs_err = residual_fc.norm1(icomp_fc) / n_cells_fc;
+				const amrex::Real ref_norm = state_ref_fc_level0.norm1(icomp_fc) / n_cells_fc;
+
+				amrex::Real rel_err = NAN;
+				if (ref_norm > 0.0) {
+					rel_err = abs_err / ref_norm;
+				}
+
+				comp_errors.emplace_back(componentNames_fc_[idim][icomp_fc], abs_err, rel_err);
+			}
 		}
 	}
+
+	return comp_errors;
+}
+
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
+{
+	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+
+	// Compute all component errors
+	auto comp_errors = computeComponentErrors();
+	const int ncomp_tot = static_cast<int>(comp_errors.size());
+
+	// Compute RMS error and print results
 	amrex::Real rms_err = 0.0;
 	if (this->suppress_output == 0) {
 		amrex::Print() << "\nComponent Errors:\n";
 		amrex::Print() << std::string(70, '=') << "\n";
-		amrex::Print() << std::setw(25) << std::left << "Component" << std::setw(20) << std::right << "Absolute Error" << std::setw(20) << std::right
-			       << "Relative Error" << "\n";
+		amrex::Print() << std::setw(25) << std::left << "Component" << std::setw(20) << std::right << "Absolute Error" << std::setw(20)
+			       << std::right << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
 	}
 
-	for (int icomp = 0; icomp < ncomp_tot; ++icomp) {
-		auto [name, abs_err, rel_err] = comp_errors[icomp];
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
 		rms_err += abs_err * abs_err;
 		// Print each component
 		if (this->suppress_output == 0) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -909,7 +909,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 					amrex::Print() << "\nWARNING: Face-centered reference solution was not properly set.\n";
 					amrex::Print() << "Please implement computeReferenceSolution_fc() for your problem.\n\n";
 				}
-				return comp_errors; // Return empty vector
+				continue; // Return empty vector
 			}
 			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
 			amrex::MultiFab residual_fc(state_ref_fc_level0.boxArray(), state_ref_fc_level0.DistributionMap(), ncomp_fc, 0);
@@ -942,6 +942,12 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	// Compute all component errors
 	auto comp_errors = computeComponentErrors();
 	const int ncomp_tot = static_cast<int>(comp_errors.size());
+	if (ncomp_tot == 0) {  // ADDED: Check for empty results
+		if (this->suppress_output == 0) {
+			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
+		}
+		return NAN;
+	}
 
 	// Compute RMS error and print results
 	amrex::Real rms_err = 0.0;
@@ -967,10 +973,12 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 			}
 		}
 	}
-	amrex::Print() << std::string(70, '=') << "\n";
-	rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
-	if (this->suppress_output == 0) {
+	if (this->suppress_output == 0) {  // MOVED: inside conditional to avoid dividing by zero
+		amrex::Print() << std::string(70, '=') << "\n";
+		rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
 		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
+	} else {
+		rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
 	}
 	return rms_err;
 }

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -242,6 +242,9 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo);
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
+	auto computeErrorNorm() -> amrex::Real;
+	auto computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref,amrex::Vector<std::string> const &componentNames) 
+					  -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 
@@ -843,6 +846,103 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 	    mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { printf("%f\n", mf_fc[bx](i, j, k, Physics_Indices<problem_t>::mhdFirstIndex)); });
 }
 
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_new, amrex::MultiFab &state_ref, amrex::Vector<std::string> const &componentNames)
+-> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> 
+{
+	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> component_errors{};
+	const int ncomp = state_new.nComp();
+	
+	// Use the BoxArray from state_ref instead of boxArray(0)!
+	amrex::MultiFab residual(state_ref.boxArray(), state_ref.DistributionMap(), ncomp, 0);
+	amrex::MultiFab::Copy(residual, state_ref, 0, 0, ncomp, 0);
+	amrex::MultiFab::Saxpy(residual, -1., state_new, 0, 0, ncomp, 0);
+	
+	const auto n_cells = static_cast<amrex::Real>(residual.boxArray().numPts());
+	
+	for (int icomp = 0; icomp < ncomp; ++icomp)
+	{
+		const amrex::Real abs_err = residual.norm1(icomp) / n_cells;
+		const amrex::Real ref_norm = state_ref.norm1(icomp) / n_cells;
+		
+		amrex::Real rel_err = NAN;		
+		if (ref_norm > 0.0) {
+			rel_err = abs_err / ref_norm;
+		}
+		
+		component_errors.push_back(std::make_tuple(componentNames[icomp], abs_err, rel_err));
+	}
+	return component_errors;
+}
+
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
+{
+	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+	amrex::Real errorNorm = 0.0;
+	
+	const int ncomp = state_new_cc_[0].nComp();
+	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
+	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
+
+	auto comp_errors = computeComponentErrors(state_new_cc_[0], state_ref_level0, componentNames_cc_);
+
+	int ncomp_tot = ncomp;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			const int ncomp_fc = state_new_fc_[0][idim].nComp();
+			// Start with face-centered BoxArray
+			amrex::BoxArray ba_fc = amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim));
+			// Shrink by 1 in the face-normal direction (idim)
+			ba_fc.growHi(idim, -1);
+			// Create both MultiFabs with shrunk BoxArray
+			amrex::MultiFab state_ref_fc_level0(ba_fc, DistributionMap(0), ncomp_fc, 0);
+			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
+			
+			// Fill reference solution
+			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), 
+										geom[0].ProbLoArray(), quokka::direction{idim});
+			
+			// Copy shrunk data (removes the last face in direction idim)
+			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
+			
+			auto fc_comp_errors = computeComponentErrors(state_new_fc_shrunk, state_ref_fc_level0, componentNames_fc_[idim]);
+			comp_errors.insert(comp_errors.end(), fc_comp_errors.begin(), fc_comp_errors.end());
+			ncomp_tot += ncomp_fc;
+		}
+	}
+	amrex::Real rms_err = 0.0;
+	if (this->suppress_output == 0) {
+		amrex::Print() << "\nComponent Errors:\n";
+		amrex::Print() << std::string(70, '=') << "\n";
+		amrex::Print() << std::setw(25) << std::left << "Component" 
+					<< std::setw(20) << std::right << "Absolute Error" 
+					<< std::setw(20) << std::right << "Relative Error" << "\n";
+		amrex::Print() << std::string(70, '-') << "\n";
+	}	
+
+	for (int icomp = 0; icomp < ncomp_tot; ++icomp)
+	{
+		auto [name, abs_err, rel_err] = comp_errors[icomp];
+		rms_err += abs_err * abs_err;
+			// Print each component
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::setw(25) << std::left << name
+						<< std::setw(20) << std::right << std::scientific << std::setprecision(4) << abs_err;
+			
+			if (std::isnan(rel_err)) {
+				amrex::Print() << std::setw(20) << std::right << "N/A" << "\n";
+			} else {
+				amrex::Print() << std::setw(20) << std::right << std::scientific << std::setprecision(4) << rel_err << "\n";
+			}
+		}
+	}
+	amrex::Print() << std::string(70, '=') << "\n";
+	rms_err = std::sqrt(rms_err/static_cast<amrex::Real>(ncomp_tot));
+	if (this->suppress_output == 0) {
+		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
+	}
+	return rms_err;
+}
+
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
@@ -884,77 +984,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvol
 		amrex::Print() << '\n';
 	}
 
-	if (computeReferenceSolution_) {
-		// compute cc-reference solution
-		amrex::Print() << "Checking cc-quantities\n";
-		const int ncomp = state_new_cc_[0].nComp();
-		amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
-		computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
-
-		// compute error norm
-		amrex::MultiFab residual(boxArray(0), DistributionMap(0), ncomp, 0);
-		amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
-		amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
-
-		amrex::Real sol_norm = 0.;
-		amrex::Real err_norm = 0.;
-		for (int n = 0; n < ncomp; ++n) {
-			sol_norm += std::pow(state_ref_level0.norm1(n), 2);
-			err_norm += std::pow(residual.norm1(n), 2);
-		}
-		sol_norm = std::sqrt(sol_norm);
-		err_norm = std::sqrt(err_norm);
-
-		double rel_error = NAN;
-		if (sol_norm > 0.) {
-			rel_error = err_norm / sol_norm;
-			errorNorm_ = rel_error;
-			amrex::Print() << "Relative rms L1 error norm = " << rel_error << '\n';
-		} else {
-			// if the reference solution is identically zero -> only report absolute error instead
-			errorNorm_ = err_norm;
-			amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm << '\n';
-		}
-
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-
-				amrex::Print() << "Checking fc-quantities in the " << idim << " direction\n";
-				const int ncomp = state_new_fc_[0][idim].nComp();
-				const int nghost = state_new_fc_[0][idim].nGrow();
-				amrex::MultiFab state_ref_level0(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0),
-								 ncomp, nghost);
-
-				computeReferenceSolution_fc(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
-
-				// compute error norm
-				amrex::MultiFab residual(amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim)), DistributionMap(0), ncomp,
-							 nghost);
-				amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, nghost);
-				amrex::MultiFab::Saxpy(residual, -1., state_new_fc_[0][idim], 0, 0, ncomp, nghost);
-
-				amrex::Real sol_norm = 0.;
-				amrex::Real err_norm = 0.;
-				for (int n = 0; n < ncomp; ++n) {
-					sol_norm += std::pow(state_ref_level0.norm1(n), 2);
-					err_norm += std::pow(residual.norm1(n), 2);
-				}
-				sol_norm = std::sqrt(sol_norm);
-				err_norm = std::sqrt(err_norm);
-
-				double rel_error = NAN;
-				if (sol_norm > 0.) {
-					rel_error = err_norm / sol_norm;
-					errorNorm_ = rel_error;
-					amrex::Print() << "Relative rms L1 error norm = " << rel_error << ", with err_norm = " << err_norm
-						       << " and sol_norm = " << sol_norm << "\n";
-				} else {
-					errorNorm_ = err_norm;
-					amrex::Print() << "Reference norm is zero; reporting absolute L1 error norm = " << err_norm << " (sol_norm = 0)\n";
-				}
-			}
-		}
-	}
 	amrex::Print() << '\n';
 
 	// compute average number of radiation subcycles per timestep

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -241,7 +241,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo);
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
-	auto computeErrorNorm() -> amrex::Real;
+	auto computeErrorNorm(bool use_rel_err = true) -> amrex::Real;
 	auto computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
@@ -873,6 +873,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
 
 	const auto n_cells = static_cast<amrex::Real>(residual.boxArray().numPts());
+	std::cout << "\nChecking n_cells: " << n_cells << "\n";
 
 	for (int icomp = 0; icomp < ncomp; ++icomp) {
 		const amrex::Real abs_err = residual.norm1(icomp) / n_cells;
@@ -921,6 +922,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			for (int icomp_fc = 0; icomp_fc < ncomp_fc; ++icomp_fc) {
 				const amrex::Real abs_err = residual_fc.norm1(icomp_fc) / n_cells_fc;
 				const amrex::Real ref_norm = state_ref_fc_level0.norm1(icomp_fc) / n_cells_fc;
+				std::cout << "\nChecking n_cells_fc: " << n_cells_fc << "\n";
 
 				amrex::Real rel_err = NAN;
 				if (ref_norm > 0.0) {
@@ -931,26 +933,6 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			}
 		}
 	}
-
-	return comp_errors;
-}
-
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
-{
-	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-
-	// Compute all component errors
-	auto comp_errors = computeComponentErrors();
-	const int ncomp_tot = static_cast<int>(comp_errors.size());
-	if (ncomp_tot == 0) {  // ADDED: Check for empty results
-		if (this->suppress_output == 0) {
-			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
-		}
-		return NAN;
-	}
-
-	// Compute RMS error and print results
-	amrex::Real rms_err = 0.0;
 	if (this->suppress_output == 0) {
 		amrex::Print() << "\nComponent Errors:\n";
 		amrex::Print() << std::string(70, '=') << "\n";
@@ -958,29 +940,64 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 			       << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
 	}
+	return comp_errors;
+}
 
-	for (const auto &[name, abs_err, rel_err] : comp_errors) {
-		rms_err += abs_err * abs_err;
-		// Print each component
-		if (this->suppress_output == 0) {
-			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
-				       << abs_err;
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+{
+    const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 
-			if (std::isnan(rel_err)) {
-				amrex::Print() << std::setw(20) << std::right << "N/A" << "\n";
-			} else {
-				amrex::Print() << std::setw(20) << std::right << std::scientific << std::setprecision(4) << rel_err << "\n";
-			}
-		}
-	}
-	if (this->suppress_output == 0) {  // MOVED: inside conditional to avoid dividing by zero
-		amrex::Print() << std::string(70, '=') << "\n";
-		rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
-		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
-	} else {
-		rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
-	}
-	return rms_err;
+    auto comp_errors = computeComponentErrors();
+    const int ncomp_tot = static_cast<int>(comp_errors.size());
+
+    if (ncomp_tot == 0) {
+        if (this->suppress_output == 0) {
+            amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
+        }
+        return NAN;
+    }
+
+    amrex::Real rms_err = 0.0;
+    auto N = static_cast<amrex::Real>(ncomp_tot);
+
+    for (const auto &[name, abs_err, rel_err] : comp_errors) {
+        amrex::Real err = abs_err;
+        if (use_rel_err) {
+            // Use relative error if valid, otherwise fall back to abs_err
+            if (!std::isnan(rel_err) && rel_err != 0.0) {
+                err = rel_err;
+            }
+        }
+        if (err == 0.0 || std::isnan(err)) {
+            N -= 1.0;   // exclude this component from RMS
+        } else {
+            rms_err += err * err;
+        }
+        // Optional printing
+        if (this->suppress_output == 0) {
+            amrex::Print() << std::setw(25) << std::left << name
+                           << std::setw(20) << std::right << std::scientific
+                           << std::setprecision(4) << abs_err;
+
+            if (std::isnan(rel_err)) {
+                amrex::Print() << std::setw(20) << "N/A\n";
+            } else {
+                amrex::Print() << std::setw(20) << std::scientific
+                               << std::setprecision(4) << rel_err << "\n";
+            }
+        }
+    }
+
+    // Final RMS
+    rms_err = std::sqrt(rms_err / N);
+
+    if (this->suppress_output == 0) {
+        amrex::Print() << std::string(70, '=') << "\n";
+        amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
+    }
+
+    return rms_err;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -985,6 +985,12 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	}
 
 	// Final RMS
+	if (N == 0.0) {
+		if (this->suppress_output == 0) {
+			amrex::Print() << "\nNo non-zero errors found. RMS error is zero.\n\n";
+		}
+		return 0.0;
+	}
 	rms_err = std::sqrt(rms_err / N);
 
 	if (this->suppress_output == 0) {

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -846,10 +846,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
 {
-	//returns a vector of tuples: (component name, absolute error, relative error)
-	//absolute error is normalized by number of cells
-	//relative error is NAN if reference norm is zero
-	
+	// returns a vector of tuples: (component name, absolute error, relative error)
+	// absolute error is normalized by number of cells
+	// relative error is NAN if reference norm is zero
+
 	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> comp_errors{};
 
 	// Compute cell-centered errors

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -963,38 +963,19 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 		}
 		return NAN;
 	}
-
-	auto compute_rms = [](const auto &errors, auto selector) {
-		amrex::Real sum_sq = 0.0;
-		int count = 0;
-		for (const auto &e : errors) {
-			amrex::Real val = selector(e);
-			if (val != 0.0 && !std::isnan(val)) {
-				sum_sq += val * val;
-				++count;
+	amrex::Real rms_err = 0.0;
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+		if (use_rel_err) {
+			if (!std::isnan(rel_err)) {
+				rms_err += rel_err * rel_err;
+			} else {
+				rms_err += abs_err * abs_err;
 			}
-		}
-		return std::make_pair(std::sqrt(sum_sq), count);
-	};
-
-	auto [rms_abs, abs_count] = compute_rms(comp_errors, [](const auto &e) { return std::get<1>(e); });
-	auto [rms_rel, rel_count] = compute_rms(comp_errors, [](const auto &e) { return std::get<2>(e); });
-
-	if (abs_count == 0) {
-		if (this->suppress_output == 0) {
-			amrex::Print() << "\nNo non-zero errors found. RMS error is zero.\n\n";
-		}
-		return 0.0;
-	}
-
-	amrex::Real rms_err = rms_abs;
-	if (use_rel_err) {
-		if (rel_count > 0) {
-			rms_err = rms_rel;
-		} else if (this->suppress_output == 0) {
-			amrex::Print() << "\nNo valid relative errors found. Falling back to absolute errors.\n";
+		} else {
+			rms_err += abs_err * abs_err;
 		}
 	}
+	rms_err = std::sqrt(rms_err);
 
 	if (this->suppress_output == 0) {
 		amrex::Print() << std::string(70, '=') << "\n";

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -854,7 +854,6 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
 
-	// Compute residual
 	amrex::MultiFab residual(state_ref_level0.boxArray(), state_ref_level0.DistributionMap(), ncomp, 0);
 	amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
 	amrex::MultiFab::Saxpy(residual, -1., state_new_cc_[0], 0, 0, ncomp, 0);
@@ -877,21 +876,13 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			const int ncomp_fc = state_new_fc_[0][idim].nComp();
-			// Start with face-centered BoxArray
 			amrex::BoxArray ba_fc = amrex::convert(boxArray(0), amrex::IntVect::TheDimensionVector(idim));
-			// Shrink by 1 in the face-normal direction (idim)
+			// Shrink by 1 in the face-normal direction (idim) so that identical cell numbers are used for error calculation
 			ba_fc.growHi(idim, -1);
-			// Create both MultiFabs with shrunk BoxArray
 			amrex::MultiFab state_ref_fc_level0(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
-
-			// Fill reference solution
 			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
-
-			// Copy shrunk data (removes the last face in direction idim)
 			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
-
-			// Compute residual
 			amrex::MultiFab residual_fc(state_ref_fc_level0.boxArray(), state_ref_fc_level0.DistributionMap(), ncomp_fc, 0);
 			amrex::MultiFab::Copy(residual_fc, state_ref_fc_level0, 0, 0, ncomp_fc, 0);
 			amrex::MultiFab::Saxpy(residual_fc, -1., state_new_fc_shrunk, 0, 0, ncomp_fc, 0);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -155,7 +155,6 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	int maxSubsteps_ = 10;				// maximum number of radiation subcycles per hydro step
 	amrex::Real dustGasInteractionCoeff_ = 2.5e-34; // erg cm^3 s^−1 K^−3/2
 
-	bool computeReferenceSolution_ = false;
 	amrex::Real errorNorm_ = NAN;
 	amrex::Real pressureFloor_ = 0.;
 
@@ -853,6 +852,21 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
+		bool has_valid_data = true;
+	for (int icomp = 0; icomp < ncomp; ++icomp) {
+		if (!std::isfinite(state_ref_level0.norm0(icomp))) {
+			has_valid_data = false;
+			break;
+		}
+	}
+
+	if (!has_valid_data) {
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::Print() << "\nWARNING: Cell-centered reference solution was not properly set.\n";
+			amrex::Print() << "Please implement computeReferenceSolution() for your problem.\n\n";
+		}
+		return comp_errors; // Return empty vector
+	}
 
 	amrex::MultiFab residual(state_ref_level0.boxArray(), state_ref_level0.DistributionMap(), ncomp, 0);
 	amrex::MultiFab::Copy(residual, state_ref_level0, 0, 0, ncomp, 0);
@@ -882,6 +896,21 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			amrex::MultiFab state_ref_fc_level0(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
+				bool has_valid_data = true;
+			for (int icomp = 0; icomp < ncomp; ++icomp) {
+				if (!std::isfinite(state_ref_level0.norm0(icomp))) {
+					has_valid_data = false;
+					break;
+				}
+			}
+
+			if (!has_valid_data) {
+				if (amrex::ParallelDescriptor::IOProcessor()) {
+					amrex::Print() << "\nWARNING: Face-centered reference solution was not properly set.\n";
+					amrex::Print() << "Please implement computeReferenceSolution_fc() for your problem.\n\n";
+				}
+				return comp_errors; // Return empty vector
+			}
 			amrex::MultiFab::Copy(state_new_fc_shrunk, state_new_fc_[0][idim], 0, 0, ncomp_fc, 0);
 			amrex::MultiFab residual_fc(state_ref_fc_level0.boxArray(), state_ref_fc_level0.DistributionMap(), ncomp_fc, 0);
 			amrex::MultiFab::Copy(residual_fc, state_ref_fc_level0, 0, 0, ncomp_fc, 0);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -852,7 +852,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);
 	computeReferenceSolution(state_ref_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray());
-		bool has_valid_data = true;
+	bool has_valid_data = true;
 	for (int icomp = 0; icomp < ncomp; ++icomp) {
 		if (!std::isfinite(state_ref_level0.norm0(icomp))) {
 			has_valid_data = false;
@@ -896,7 +896,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			amrex::MultiFab state_ref_fc_level0(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			amrex::MultiFab state_new_fc_shrunk(ba_fc, DistributionMap(0), ncomp_fc, 0);
 			computeReferenceSolution_fc(state_ref_fc_level0, geom[0].CellSizeArray(), geom[0].ProbLoArray(), quokka::direction{idim});
-				bool has_valid_data = true;
+			bool has_valid_data = true;
 			for (int icomp = 0; icomp < ncomp; ++icomp) {
 				if (!std::isfinite(state_ref_level0.norm0(icomp))) {
 					has_valid_data = false;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -942,7 +942,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	// Compute all component errors
 	auto comp_errors = computeComponentErrors();
 	const int ncomp_tot = static_cast<int>(comp_errors.size());
-	if (ncomp_tot == 0) {  // ADDED: Check for empty results
+	if (ncomp_tot == 0) { // ADDED: Check for empty results
 		if (this->suppress_output == 0) {
 			amrex::Print() << "\nNo valid reference solution found. Cannot compute error norm.\n\n";
 		}
@@ -973,7 +973,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 			}
 		}
 	}
-	if (this->suppress_output == 0) {  // MOVED: inside conditional to avoid dividing by zero
+	if (this->suppress_output == 0) { // MOVED: inside conditional to avoid dividing by zero
 		amrex::Print() << std::string(70, '=') << "\n";
 		rms_err = std::sqrt(rms_err / static_cast<amrex::Real>(ncomp_tot));
 		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -846,6 +846,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::print_multifab_f
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
 {
+	//returns a vector of tuples: (component name, absolute error, relative error)
+	//absolute error is normalized by number of cells
+	//relative error is NAN if reference norm is zero
+	
 	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> comp_errors{};
 
 	// Compute cell-centered errors
@@ -958,6 +962,8 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+	// use_rel_err: if true, compute relative error norm; else compute absolute error norm
+	// default: true
 
 	auto comp_errors = computeComponentErrors();
 	if (comp_errors.empty()) {
@@ -969,8 +975,6 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 
 	// Get number of cells to convert back from normalized errors to L1 norms
 	const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
-
-	// Compute aggregate norms (old code approach)
 	amrex::Real sum_sq_err = 0.0;
 	amrex::Real sum_sq_ref = 0.0;
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -872,8 +872,8 @@ auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_
 
 		component_errors.push_back(std::make_tuple(componentNames[icomp], abs_err, rel_err));
 	}
-));emplace_back
-	return component_errors;
+));
+emplace_back return component_errors;
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -961,7 +961,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 
 template <typename problem_t>
 auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
-
+{
     // use_rel_err: if true, compute relative error norm; else compute absolute error norm
     // default: true
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -870,16 +870,14 @@ auto QuokkaSimulation<problem_t>::computeComponentErrors(amrex::MultiFab &state_
 			rel_err = abs_err / ref_norm;
 		}
 
-		component_errors.push_back(std::make_tuple(componentNames[icomp], abs_err, rel_err));
+		component_errors.emplace_back(componentNames[icomp], abs_err, rel_err);
 	}
-));
-emplace_back return component_errors;
+	return component_errors;
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-	");const 
 
 	    const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -950,17 +950,15 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 		}
 	}
 	if (this->suppress_output == 0) {
-    	amrex::Print() << std::string(70, '-') << "\n";
+		amrex::Print() << std::string(70, '-') << "\n";
 	}
 	return comp_errors;
 }
 
-
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
 {
 	BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-	
+
 	auto comp_errors = computeComponentErrors();
 	if (comp_errors.empty()) {
 		if (this->suppress_output == 0) {
@@ -971,16 +969,16 @@ auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::R
 
 	// Get number of cells to convert back from normalized errors to L1 norms
 	const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
-	
+
 	// Compute aggregate norms (old code approach)
 	amrex::Real sum_sq_err = 0.0;
 	amrex::Real sum_sq_ref = 0.0;
-	
+
 	for (const auto &[name, abs_err, rel_err] : comp_errors) {
 		// Convert normalized errors back to L1 norms
 		amrex::Real L1_err = abs_err * n_cells;
 		sum_sq_err += L1_err * L1_err;
-		
+
 		// Reconstruct reference L1 norm
 		if (!std::isnan(rel_err) && rel_err != 0.0) {
 			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
@@ -988,10 +986,10 @@ auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::R
 		}
 		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
 	}
-	
+
 	amrex::Real err_norm = std::sqrt(sum_sq_err);
 	amrex::Real sol_norm = std::sqrt(sum_sq_ref);
-	
+
 	amrex::Real error_norm = 0.0;
 	if (use_rel_err && sol_norm > 0.0) {
 		error_norm = err_norm / sol_norm;
@@ -1010,7 +1008,7 @@ auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::R
 			}
 		}
 	}
-	
+
 	return error_norm;
 }
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -960,8 +960,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
-{
-	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+
 	// use_rel_err: if true, compute relative error norm; else compute absolute error norm
 	// default: true
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -949,13 +949,18 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			}
 		}
 	}
+	if (this->suppress_output == 0) {
+    	amrex::Print() << std::string(70, '-') << "\n";
+	}
 	return comp_errors;
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
-{
-	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
 
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeErrorNorm(bool use_rel_err) -> amrex::Real
+{
+	BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
+	
 	auto comp_errors = computeComponentErrors();
 	if (comp_errors.empty()) {
 		if (this->suppress_output == 0) {
@@ -963,25 +968,50 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 		}
 		return NAN;
 	}
-	amrex::Real rms_err = 0.0;
+
+	// Get number of cells to convert back from normalized errors to L1 norms
+	const auto n_cells = static_cast<amrex::Real>(state_new_cc_[0].boxArray().numPts());
+	
+	// Compute aggregate norms (old code approach)
+	amrex::Real sum_sq_err = 0.0;
+	amrex::Real sum_sq_ref = 0.0;
+	
 	for (const auto &[name, abs_err, rel_err] : comp_errors) {
-		if (use_rel_err) {
-			if (!std::isnan(rel_err)) {
-				rms_err += rel_err * rel_err;
+		// Convert normalized errors back to L1 norms
+		amrex::Real L1_err = abs_err * n_cells;
+		sum_sq_err += L1_err * L1_err;
+		
+		// Reconstruct reference L1 norm
+		if (!std::isnan(rel_err) && rel_err != 0.0) {
+			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
+			sum_sq_ref += L1_ref * L1_ref;
+		}
+		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
+	}
+	
+	amrex::Real err_norm = std::sqrt(sum_sq_err);
+	amrex::Real sol_norm = std::sqrt(sum_sq_ref);
+	
+	amrex::Real error_norm = 0.0;
+	if (use_rel_err && sol_norm > 0.0) {
+		error_norm = err_norm / sol_norm;
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::string(70, '=') << "\n";
+			amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
+		}
+	} else {
+		error_norm = err_norm;
+		if (this->suppress_output == 0) {
+			amrex::Print() << std::string(70, '=') << "\n";
+			if (sol_norm == 0.0) {
+				amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
 			} else {
-				rms_err += abs_err * abs_err;
+				amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
 			}
-		} else {
-			rms_err += abs_err * abs_err;
 		}
 	}
-	rms_err = std::sqrt(rms_err);
-
-	if (this->suppress_output == 0) {
-		amrex::Print() << std::string(70, '=') << "\n";
-		amrex::Print() << "\nRMS of errors across all components = " << rms_err << "\n\n";
-	}
-	return rms_err;
+	
+	return error_norm;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -879,7 +879,7 @@ emplace_back return component_errors;
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm() -> amrex::Real
 {
 	const BL_PROFILE("QuokkaSimulation::computeErrorNorm()");
-	amrex::Real errorNorm = 0.0;
+");const 
 
 	const int ncomp = state_new_cc_[0].nComp();
 	amrex::MultiFab state_ref_level0(boxArray(0), DistributionMap(0), ncomp, 0);

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -238,7 +238,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.003;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -231,7 +231,7 @@ auto problem_main() -> int
 	}
 
 	QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
-	sim.computeReferenceSolution_ = true;
+
 	sim.setInitialConditions();
 	sim.evolve();
 

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -238,7 +238,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.003;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -239,7 +239,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.003;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
+++ b/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
@@ -428,7 +428,7 @@ auto problem_main() -> int
 
 	int status = 1;
 	const double error_tol = 0.005;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 0;
 		amrex::Print() << "Error norm = " << error_norm << "\n";

--- a/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
+++ b/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
@@ -422,7 +422,7 @@ auto problem_main() -> int
 	}
 
 	QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
-	sim.computeReferenceSolution_ = true;
+
 	sim.setInitialConditions();
 	sim.evolve();
 

--- a/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
+++ b/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
@@ -428,12 +428,13 @@ auto problem_main() -> int
 
 	int status = 1;
 	const double error_tol = 0.005;
-	if (sim.errorNorm_ < error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 0;
-		amrex::Print() << "Error norm = " << sim.errorNorm_ << "\n";
+		amrex::Print() << "Error norm = " << error_norm << "\n";
 		amrex::Print() << "test passed\n";
 	} else {
-		amrex::Print() << "Error norm = " << sim.errorNorm_ << "\n";
+		amrex::Print() << "Error norm = " << error_norm << "\n";
 		amrex::Print() << "test failed\n";
 	}
 

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -274,7 +274,7 @@ auto problem_main() -> int
 
 	amrex::Real error_norm = 0.0;
 	if (sol_norm > 0.0) {
-		error_norm = err_norm / sol_norm;	
+		error_norm = err_norm / sol_norm;
 		amrex::Print() << std::string(70, '=') << "\n";
 		amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
 	} else {
@@ -286,7 +286,6 @@ auto problem_main() -> int
 			amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
 		}
 	}
-	
 
 	if (error_norm > error_tol) {
 		status = 1;

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -143,9 +143,11 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 				      dx[1]);
 
 		if (dir == quokka::direction::x) {
-			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
+			//state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
+			state(i, j, k, MHDSystem<FastWave>::bfield_index + 1) = 0.0;
 		} else if (dir == quokka::direction::y) {
-			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
+			//state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = 0.0;
 		} else if (dir == quokka::direction::z) {
 			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x3mag;
 		}
@@ -249,7 +251,14 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	auto error_norm = sim.computeErrorNorm(false);
+	//auto comp_errors = sim.computeComponentErrors();
+
+	// error norm must be manually computed since B fields that should be 0 may have small non-zero values due to numerical precision
+
+	double error_norm = 0.0;
+	error_norm = sim.computeErrorNorm();
+
+
 	if (error_norm > error_tol) {
 		status = 1;
 	}

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -242,7 +242,7 @@ auto problem_main() -> int
 	}
 
 	QuokkaSimulation<FastWave> sim(BCs_cc, BCs_fc);
-	sim.computeReferenceSolution_ = true;
+
 	sim.setInitialConditions();
 	sim.evolve();
 

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -249,7 +249,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	auto error_norm = sim.computeErrorNorm();
+	auto error_norm = sim.computeErrorNorm(false);
 	if (error_norm > error_tol) {
 		status = 1;
 	}

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -122,20 +122,19 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 		state(i, j, k, HydroSystem<FastWave>::energy_index) = Etot;
 		state(i, j, k, HydroSystem<FastWave>::internalEnergy_index) = Eint;
 	} else if (cen == quokka::centering::fc) {
-		// commented out so that xmag1 and xmag2 can be explicitly set to 0.0, but needed later when Fast wave is set to run at an angle
 
-		// const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2, time) -
-		// 		      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
-		// 			 dx[1] -
-		// 		     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L + dx[2], time) -
-		// 		      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L, time)) /
-		// 			 dx[2];
-		// const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L + dx[2], time) -
-		// 		      computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L, time)) /
-		// 			 dx[2] -
-		// 		     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2, time) -
-		// 		      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
-		// 			 dx[0];
+		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+					 dx[1] -
+				     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L, time)) /
+					 dx[2];
+		const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L + dx[2], time) -
+				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L, time)) /
+					 dx[2] -
+				     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2, time) -
+				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+					 dx[0];
 
 		const double x3mag = ((computeMagneticVectorPotential_y(x1_L + dx[0], x2_L + (dx[1] / 2), x3_L, time) -
 				       computeMagneticVectorPotential_y(x1_L, x2_L + (dx[1] / 2), x3_L, time)) /
@@ -145,11 +144,9 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 				      dx[1]);
 
 		if (dir == quokka::direction::x) {
-			// state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
-			state(i, j, k, MHDSystem<FastWave>::bfield_index + 1) = 0.0;
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
 		} else if (dir == quokka::direction::y) {
-			// state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
-			state(i, j, k, MHDSystem<FastWave>::bfield_index) = 0.0;
+			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
 		} else if (dir == quokka::direction::z) {
 			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x3mag;
 		}
@@ -253,13 +250,29 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	// auto comp_errors = sim.computeComponentErrors();
+	 auto comp_errors = sim.computeComponentErrors();
 
 	// error norm must be manually computed since B fields that should be 0 may have small non-zero values due to numerical precision
 
 	double error_norm = 0.0;
-	error_norm = sim.computeErrorNorm();
 
+	const auto n_cells = static_cast<amrex::Real>(sim.state_new_cc_[0].boxArray().numPts());
+	amrex::Real sum_sq_err = 0.0;
+	amrex::Real sum_sq_ref = 0.0;
+	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+		// Convert normalized errors back to L1 norms
+		amrex::Real L1_err = abs_err * n_cells;
+		sum_sq_err += L1_err * L1_err;
+
+		// Reconstruct reference L1 norm
+		if (!std::isnan(rel_err) && rel_err != 0.0 && abs_err > 10E-15) {
+			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
+			sum_sq_ref += L1_ref * L1_ref;
+		}
+		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
+	}
+
+	
 	if (error_norm > error_tol) {
 		status = 1;
 	}

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -250,7 +250,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	 auto comp_errors = sim.computeComponentErrors();
+	auto comp_errors = sim.computeComponentErrors();
 
 	// error norm must be manually computed since B fields that should be 0 may have small non-zero values due to numerical precision
 
@@ -272,7 +272,6 @@ auto problem_main() -> int
 		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
 	}
 
-	
 	if (error_norm > error_tol) {
 		status = 1;
 	}

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -263,7 +263,7 @@ auto problem_main() -> int
 		sum_sq_err += L1_err * L1_err;
 		// Reconstruct reference L1 norm
 		if (!std::isnan(rel_err) && rel_err != 0.0 && abs_err > 10E-15) {
-			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
+			amrex::Real const L1_ref = (abs_err / rel_err) * n_cells;
 			sum_sq_ref += L1_ref * L1_ref;
 		}
 		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -143,10 +143,10 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 				      dx[1]);
 
 		if (dir == quokka::direction::x) {
-			//state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
+			// state(i, j, k, MHDSystem<FastWave>::bfield_index) = x1mag;
 			state(i, j, k, MHDSystem<FastWave>::bfield_index + 1) = 0.0;
 		} else if (dir == quokka::direction::y) {
-			//state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
+			// state(i, j, k, MHDSystem<FastWave>::bfield_index) = x2mag;
 			state(i, j, k, MHDSystem<FastWave>::bfield_index) = 0.0;
 		} else if (dir == quokka::direction::z) {
 			state(i, j, k, MHDSystem<FastWave>::bfield_index) = x3mag;
@@ -251,13 +251,12 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	//auto comp_errors = sim.computeComponentErrors();
+	// auto comp_errors = sim.computeComponentErrors();
 
 	// error norm must be manually computed since B fields that should be 0 may have small non-zero values due to numerical precision
 
 	double error_norm = 0.0;
 	error_norm = sim.computeErrorNorm();
-
 
 	if (error_norm > error_tol) {
 		status = 1;

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -122,18 +122,20 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 		state(i, j, k, HydroSystem<FastWave>::energy_index) = Etot;
 		state(i, j, k, HydroSystem<FastWave>::internalEnergy_index) = Eint;
 	} else if (cen == quokka::centering::fc) {
-		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2, time) -
-				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
-					 dx[1] -
-				     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L + dx[2], time) -
-				      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L, time)) /
-					 dx[2];
-		const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L + dx[2], time) -
-				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L, time)) /
-					 dx[2] -
-				     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2, time) -
-				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
-					 dx[0];
+		// commented out so that xmag1 and xmag2 can be explicitly set to 0.0, but needed later when Fast wave is set to run at an angle
+
+		// const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2, time) -
+		// 		      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+		// 			 dx[1] -
+		// 		     (computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L + dx[2], time) -
+		// 		      computeMagneticVectorPotential_y(x1_L, x2_L + dx[1] / 2, x3_L, time)) /
+		// 			 dx[2];
+		// const double x2mag = (computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L + dx[2], time) -
+		// 		      computeMagneticVectorPotential_x(x1_L + dx[0] / 2, x2_L, x3_L, time)) /
+		// 			 dx[2] -
+		// 		     (computeMagneticVectorPotential_z(x1_L + dx[0], x2_L, x3_L + dx[2] / 2, time) -
+		// 		      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2, time)) /
+		// 			 dx[0];
 
 		const double x3mag = ((computeMagneticVectorPotential_y(x1_L + dx[0], x2_L + (dx[1] / 2), x3_L, time) -
 				       computeMagneticVectorPotential_y(x1_L, x2_L + (dx[1] / 2), x3_L, time)) /

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -249,7 +249,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	if (sim.errorNorm_ > error_tol) {
+	auto error_norm = sim.computeErrorNorm();
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -259,7 +259,7 @@ auto problem_main() -> int
 	amrex::Real sum_sq_ref = 0.0;
 	for (const auto &[name, abs_err, rel_err] : comp_errors) {
 		// Convert normalized errors back to L1 norms
-		amrex::Real L1_err = abs_err * n_cells;
+		amrex::Real const L1_err = abs_err * n_cells;
 		sum_sq_err += L1_err * L1_err;
 		// Reconstruct reference L1 norm
 		if (!std::isnan(rel_err) && rel_err != 0.0 && abs_err > 10E-15) {

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -254,8 +254,6 @@ auto problem_main() -> int
 
 	// error norm must be manually computed since B fields that should be 0 may have small non-zero values due to numerical precision
 
-	double error_norm = 0.0;
-
 	const auto n_cells = static_cast<amrex::Real>(sim.state_new_cc_[0].boxArray().numPts());
 	amrex::Real sum_sq_err = 0.0;
 	amrex::Real sum_sq_ref = 0.0;
@@ -263,7 +261,6 @@ auto problem_main() -> int
 		// Convert normalized errors back to L1 norms
 		amrex::Real L1_err = abs_err * n_cells;
 		sum_sq_err += L1_err * L1_err;
-
 		// Reconstruct reference L1 norm
 		if (!std::isnan(rel_err) && rel_err != 0.0 && abs_err > 10E-15) {
 			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
@@ -271,6 +268,25 @@ auto problem_main() -> int
 		}
 		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
 	}
+
+	const amrex::Real err_norm = std::sqrt(sum_sq_err);
+	const amrex::Real sol_norm = std::sqrt(sum_sq_ref);
+
+	amrex::Real error_norm = 0.0;
+	if (sol_norm > 0.0) {
+		error_norm = err_norm / sol_norm;	
+		amrex::Print() << std::string(70, '=') << "\n";
+		amrex::Print() << "\nRelative RMS L1 error norm = " << error_norm << "\n\n";
+	} else {
+		error_norm = err_norm;
+		amrex::Print() << std::string(70, '=') << "\n";
+		if (sol_norm == 0.0) {
+			amrex::Print() << "\nReference norm is zero; reporting absolute L1 error norm = " << error_norm << "\n\n";
+		} else {
+			amrex::Print() << "\nAbsolute L1 error norm = " << error_norm << "\n\n";
+		}
+	}
+	
 
 	
 	if (error_norm > error_tol) {

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -211,7 +211,7 @@ auto problem_main() -> int
 	const double error_tol = 0.0; // this is not a typo
 	int status = 0;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -210,7 +210,8 @@ auto problem_main() -> int
 	// [See Section 10.7 and Figure 10.20 of Toro (1998).]
 	const double error_tol = 0.0; // this is not a typo
 	int status = 0;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -198,7 +198,7 @@ auto problem_main() -> int
 	sim.stopTime_ = 2.0;
 	sim.cflNumber_ = 0.8;
 	sim.maxTimesteps_ = 2000;
-	sim.computeReferenceSolution_ = true;
+
 	sim.plotfileInterval_ = -1;
 
 	// initialize and evolve

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -210,7 +210,7 @@ auto problem_main() -> int
 	// [See Section 10.7 and Figure 10.20 of Toro (1998).]
 	const double error_tol = 0.0; // this is not a typo
 	int status = 0;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -266,7 +266,7 @@ auto problem_main() -> int
 
 	const double error_tol = 0.26;
 	int status = 0;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol || std::isnan(error_norm)) {
 		status = 1;
 	}

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -258,8 +258,6 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<HighMachProblem> sim(BCs_cc);
 
-
-
 	// initialize and evolve
 	sim.setInitialConditions();
 	sim.evolve();

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -267,7 +267,7 @@ auto problem_main() -> int
 	const double error_tol = 0.26;
 	int status = 0;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol || std::isnan(error_norm)) {
+	if (error_norm > error_tol || std::isnan(error_norm)) {
 		status = 1;
 	}
 

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -258,7 +258,7 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<HighMachProblem> sim(BCs_cc);
 
-	sim.computeReferenceSolution_ = true;
+
 
 	// initialize and evolve
 	sim.setInitialConditions();

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -266,7 +266,8 @@ auto problem_main() -> int
 
 	const double error_tol = 0.26;
 	int status = 0;
-	if (sim.errorNorm_ > error_tol || std::isnan(sim.errorNorm_)) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol || std::isnan(error_norm)) {
 		status = 1;
 	}
 

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -369,7 +369,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -369,7 +369,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -359,7 +359,7 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.initDt_ = initial_dt;
-	sim.computeReferenceSolution_ = true;
+
 	sim.plotfileInterval_ = -1;
 
 	// Main time loop

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -370,7 +370,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.002;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -291,7 +291,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.005;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -281,7 +281,7 @@ auto problem_main() -> int
 	sim.maxTimesteps_ = max_timesteps;
 	sim.integratorOrder_ = 2;     // use forward Euler
 	sim.reconstructionOrder_ = 3; // use donor cell
-	sim.computeReferenceSolution_ = true;
+
 	sim.plotfileInterval_ = -1;
 
 	// Main time loop

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -291,7 +291,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.005;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -292,7 +292,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.005;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -375,7 +375,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.002;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 	return status;

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -366,7 +366,6 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 
-
 	// Main time loop
 	sim.setInitialConditions();
 	sim.evolve();

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -374,7 +374,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 	return status;

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -365,7 +365,7 @@ auto problem_main() -> int
 	// sim.initDt_ = initial_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
-	sim.computeReferenceSolution_ = true;
+
 
 	// Main time loop
 	sim.setInitialConditions();

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -374,7 +374,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.002;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -317,7 +317,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.01;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -317,7 +317,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.01;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -307,7 +307,7 @@ auto problem_main() -> int
 	sim.constantDt_ = fixed_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
-	sim.computeReferenceSolution_ = true;
+
 	sim.plotfileInterval_ = -1;
 
 	// Main time loop

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -318,7 +318,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.01;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -322,7 +322,7 @@ auto problem_main() -> int
 	sim.maxDt_ = max_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
-	sim.computeReferenceSolution_ = true;
+
 	sim.plotfileInterval_ = -1;
 
 	// Main time loop

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -332,7 +332,8 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.015;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -333,7 +333,7 @@ auto problem_main() -> int
 	int status = 0;
 	const double error_tol = 0.015;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -332,7 +332,7 @@ auto problem_main() -> int
 	// Compute test success condition
 	int status = 0;
 	const double error_tol = 0.015;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
+++ b/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
@@ -271,7 +271,7 @@ auto problem_main() -> int
 	num_diffs += verifyPeriodicBCs(fc_state[amr_level][2], "FC-z");
 	const bool diff_exist = (num_diffs != 0);
 
-	auto errornorm = sim.computeErrorNorm();
+	sim.computeErrorNorm();
 
 	return static_cast<int>(diff_exist);
 }

--- a/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
+++ b/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
@@ -256,7 +256,7 @@ auto problem_main() -> int
 	}
 
 	QuokkaSimulation<MHDBitwiseICs> sim(BCs_cc, BCs_fc);
-	sim.computeReferenceSolution_ = true;
+
 	sim.setInitialConditions();
 
 	amrex::Vector<amrex::MultiFab> const &cc_state = sim.getNewMF_cc();

--- a/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
+++ b/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
@@ -271,5 +271,7 @@ auto problem_main() -> int
 	num_diffs += verifyPeriodicBCs(fc_state[amr_level][2], "FC-z");
 	const bool diff_exist = (num_diffs != 0);
 
+	auto errornorm = sim.computeErrorNorm();
+
 	return static_cast<int>(diff_exist);
 }

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -260,7 +260,8 @@ auto problem_main() -> int
 
 	const double error_tol = 0.008;
 	int status = 0;
-	if (sim.errorNorm_ > error_tol) {
+	amrex::Real error_norm = sim.computeErrorNorm();
+	if (error_norm < error_tol) {
 		status = 1;
 	}
 

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -256,7 +256,7 @@ auto problem_main() -> int
 	sim.setInitialConditions();
 	sim.evolve();
 
-	const double error_tol = 0.008;
+	const double error_tol = 0.02;
 	int status = 0;
 	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm > error_tol) {

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -252,7 +252,7 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<ScalarProblem> sim(BCs_cc);
 
-	sim.computeReferenceSolution_ = true;
+
 
 	// initialize and evolve
 	sim.setInitialConditions();

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -252,8 +252,6 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<ScalarProblem> sim(BCs_cc);
 
-
-
 	// initialize and evolve
 	sim.setInitialConditions();
 	sim.evolve();

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -260,7 +260,7 @@ auto problem_main() -> int
 
 	const double error_tol = 0.008;
 	int status = 0;
-	amrex::Real error_norm = sim.computeErrorNorm();
+	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm < error_tol) {
 		status = 1;
 	}

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -256,7 +256,7 @@ auto problem_main() -> int
 	sim.setInitialConditions();
 	sim.evolve();
 
-	const double error_tol = 0.02;
+	const double error_tol = 0.008;
 	int status = 0;
 	amrex::Real const error_norm = sim.computeErrorNorm();
 	if (error_norm > error_tol) {

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -261,7 +261,7 @@ auto problem_main() -> int
 	const double error_tol = 0.008;
 	int status = 0;
 	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm < error_tol) {
+	if (error_norm > error_tol) {
 		status = 1;
 	}
 


### PR DESCRIPTION
### Description
Fixes the bug in calculating errors for face-centered quantites, and creates a table unless output is suppressed of the absolute and relative error (where applicable) for each component, as well as the rms error of the absolute error. 

### Related issues
Errors are required for regression testing (e.g., https://github.com/quokka-astro/quokka/pull/1434)

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
