### PR TITLE
Add runtime parameter to toggle particle splitting on restart

### DIFF
--- a/inputs/BinaryOrbit_refactor_splitparticle.in
+++ b/inputs/BinaryOrbit_refactor_splitparticle.in
@@ -34,4 +34,4 @@ max_timesteps = 40
 plotfile_interval = -1
 restartfile = chk00020
 
-particles.split_particles_on_restart_refine = false
+particles.split_particles_on_restart_refine = true

--- a/src/problems/BinaryOrbitCIC/CMakeLists.txt
+++ b/src/problems/BinaryOrbitCIC/CMakeLists.txt
@@ -9,9 +9,13 @@ if (AMReX_SPACEDIM EQUAL 3)
     add_test(NAME BinaryOrbitCICSplit COMMAND ${JOB_NAME} ../inputs/BinaryOrbit_split.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
     add_test(NAME BinaryOrbitCICRefactorInit COMMAND ${JOB_NAME} ../inputs/BinaryOrbit_refactor_init.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
     add_test(NAME BinaryOrbitCICRefactor COMMAND ${JOB_NAME} ../inputs/BinaryOrbit_refactor.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    add_test(NAME BinaryOrbitCICRefactorInit2 COMMAND ${JOB_NAME} ../inputs/BinaryOrbit_refactor_init.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    add_test(NAME BinaryOrbitCICRefactor2 COMMAND ${JOB_NAME} ../inputs/BinaryOrbit_refactor_splitparticle.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
     add_test(NAME ${JOB_NAME} COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
     add_test(NAME BinaryOrbitCICAMR COMMAND ${JOB_NAME} ../inputs/BinaryOrbitAMR.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 
     # BinaryOrbitCICRefactor runs after BinaryOrbitCICRefactorInit, even if it fails
     set_tests_properties(BinaryOrbitCICRefactor PROPERTIES DEPENDS "BinaryOrbitCICRefactorInit")
+    set_tests_properties(BinaryOrbitCICRefactorInit2 PROPERTIES DEPENDS "BinaryOrbitCICRefactor")
+    set_tests_properties(BinaryOrbitCICRefactor2 PROPERTIES DEPENDS "BinaryOrbitCICRefactorInit2")
 endif()

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -150,6 +150,15 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 	++cycle;
 }
 
+template <> void QuokkaSimulation<BinaryOrbit>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+{
+	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
+		const amrex::Box &box = mfi.validbox();
+		const auto tag = tags.array(mfi);
+		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { tag(i, j, k) = amrex::TagBox::SET; });
+	}
+}
+
 auto problem_main() -> int
 {
 	// read in runtiem parameter geometry.is_periodic
@@ -190,6 +199,7 @@ auto problem_main() -> int
 	amrex::ParmParse const amr_pp("amr");
 	amr_pp.query("n_cell", n_cell);
 	const bool is_refactor = n_cell[0] == 64;
+	const bool is_refactor_splitparticle = is_refactor && sim.splitParticlesOnRestartRefine_;
 
 	// get the number of particles
 	const int n_particles = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getNumParticles();
@@ -233,7 +243,7 @@ auto problem_main() -> int
 				amrex::Print() << "Test failed\n";
 			}
 		} else {
-			const double max_err_tol = 2.0; // max error tol in cell widths
+			const double max_err_tol = (is_refactor_splitparticle) ? 2.0 : 0.05; // max error tol in cell widths
 			if (max_err < max_err_tol) {
 				status = 0;
 				amrex::Print() << "Test passed\n";

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -150,15 +150,6 @@ template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 	++cycle;
 }
 
-template <> void QuokkaSimulation<BinaryOrbit>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
-{
-	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
-		const amrex::Box &box = mfi.validbox();
-		const auto tag = tags.array(mfi);
-		amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { tag(i, j, k) = amrex::TagBox::SET; });
-	}
-}
-
 auto problem_main() -> int
 {
 	// read in runtiem parameter geometry.is_periodic

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -234,16 +234,21 @@ auto problem_main() -> int
 				amrex::Print() << "Test failed\n";
 			}
 		} else {
-			const double max_err_tol = (is_refactor_splitparticle) ? 2.0 : 0.05; // max error tol in cell widths
+			double max_err_tol = 0.05;
+			int n_particles_expected = 2;
+			if (is_refactor_splitparticle) {
+				max_err_tol = 2.0;
+				n_particles_expected = 2 * 8; // 8 = 2^3 is the split factor and is hard-coded
+			}
 			if (max_err < max_err_tol) {
 				status = 0;
 				amrex::Print() << "Test passed\n";
 			} else {
 				amrex::Print() << "Test failed\n";
 			}
-			if (n_particles != 2 * 8) {
+			if (n_particles != n_particles_expected) {
 				status = 1;
-				amrex::Print() << "Test failed (refactor, number of particles is not 2 * 8)\n";
+				amrex::Print() << "Test failed (refactor, number of particles is not " << n_particles_expected << ")\n";
 			}
 		}
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -199,7 +199,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
 	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
 	int poissonSupercycleInterval_ = 1;			     // number of coarse steps between Poisson solves (default: 1)
-	bool splitParticlesOnRestartRefine_ = true; // whether to split particles when restarting with refinement
+	bool splitParticlesOnRestartRefine_ = true;		     // whether to split particles when restarting with refinement
 	amrex::Vector<amrex::MultiFab> phi;
 
 	amrex::Real densityFloor_ = 0.0; // default

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -455,6 +455,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	bool useLuminosityTable_ = true;
 	std::string luminosityTableFilename_;
 	quokka::SpacingType rad_table_output_spacing_ = quokka::SpacingType::fast_log;
+	bool splitParticlesOnRestartRefine_ = true; // whether to split particles when restarting with refinement
 
 #if AMREX_SPACEDIM == 3
 	quokka::LuminosityTables<Physics_Traits<problem_t>::nGroups> luminosityTables_;
@@ -847,6 +848,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 		ppp.query("use_luminosity_table", useLuminosityTable_);
 		ppp.query("rad_table", luminosityTableFilename_);
 		ppp.query("rad_table_output_spacing", rad_table_output_spacing_);
+		ppp.query("split_particles_on_restart_refine", splitParticlesOnRestartRefine_);
 
 #if AMREX_SPACEDIM == 3
 		// if particle and radiation are enabled
@@ -3967,7 +3969,7 @@ void AMRSimulation<problem_t>::initializeParticleContainerFromCheckpoint(std::un
 
 	// Split particles
 #if AMREX_SPACEDIM == 3
-	if (restartRefineFactor_ > 1) {
+	if (restartRefineFactor_ > 1 && splitParticlesOnRestartRefine_) {
 		const int split_factor = gcem::pow(restartRefineFactor_, AMREX_SPACEDIM);
 		amrex::Print() << fmt::format("Splitting {} using split_factor = {}\n", particleRegister_.getParticleTypeName(particle_type), split_factor);
 		auto descriptor = particleRegister_.getParticleDescriptor(particle_type);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -199,6 +199,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real reltolPoisson_ = 1.0e-5;			     // default
 	amrex::Real abstolPoisson_ = 1.0e-5;			     // default (scaled by minimum RHS value)
 	int poissonSupercycleInterval_ = 1;			     // number of coarse steps between Poisson solves (default: 1)
+	bool splitParticlesOnRestartRefine_ = true; // whether to split particles when restarting with refinement
 	amrex::Vector<amrex::MultiFab> phi;
 
 	amrex::Real densityFloor_ = 0.0; // default
@@ -455,7 +456,6 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	bool useLuminosityTable_ = true;
 	std::string luminosityTableFilename_;
 	quokka::SpacingType rad_table_output_spacing_ = quokka::SpacingType::fast_log;
-	bool splitParticlesOnRestartRefine_ = true; // whether to split particles when restarting with refinement
 
 #if AMREX_SPACEDIM == 3
 	quokka::LuminosityTables<Physics_Traits<problem_t>::nGroups> luminosityTables_;


### PR DESCRIPTION
Add a new runtime parameter `particles.split_particles_on_restart_refine` to control whether particles are split when restarting with refinement. It makes sense to split dark matter particles, but it doesn't make sense to split individual stellar particles.

### Changes
- Add boolean member variable `splitParticlesOnRestartRefine_` (defaults to true)
- Add runtime parameter `particles.split_particles_on_restart_refine`
- Modify particle splitting logic to check this parameter
- When false, particles are not split during restart with refinement
- Maintains backward compatibility with default behavior

Related to #1100

Generated with [Claude Code](https://claude.ai/code)