### PR TITLE
Abort simulation when max signal speed becomes unphysically large

### DIFF
--- a/inputs/DiskGalaxy.in
+++ b/inputs/DiskGalaxy.in
@@ -36,7 +36,7 @@ cooling.cooling_table_type = resampled
 cooling.hdf5_data_file = "./CloudyData_UVB=HM2012_resampled.h5"
 temperature_floor = 100
 density_floor = 1e-30
-signal_speed_abort_kms = 6000
+signal_speed_abort = 6e8
 
 checkpoint_interval = 100
 plotfile_interval = 10

--- a/inputs/DiskGalaxy.in
+++ b/inputs/DiskGalaxy.in
@@ -36,6 +36,7 @@ cooling.cooling_table_type = resampled
 cooling.hdf5_data_file = "./CloudyData_UVB=HM2012_resampled.h5"
 temperature_floor = 100
 density_floor = 1e-30
+signal_speed_abort_kms = 6000
 
 checkpoint_interval = 100
 plotfile_interval = 10

--- a/inputs/SN.in
+++ b/inputs/SN.in
@@ -41,3 +41,7 @@ particles.verbose = 1
 max_timesteps = 10
 plotfile_interval = -1
 checkpoint_interval = -1
+
+#temperature_floor = 10
+density_floor = 1e-26
+signal_speed_abort_kms = 4000

--- a/inputs/SN.in
+++ b/inputs/SN.in
@@ -44,4 +44,4 @@ checkpoint_interval = -1
 
 #temperature_floor = 10
 density_floor = 1e-26
-signal_speed_abort_kms = 4000
+signal_speed_abort = 4e8

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -179,8 +179,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real stopTime_ = 1.0;	      // default
 	amrex::Real cflNumber_ = 0.3;	        // default
 	amrex::Real particleCflNumber_ = 0.5;   // default
-	amrex::Real signalSpeedAbortThreshold_ = 5.0e8;	 // default 5000 km/s in cm/s; <=0 disables
-	amrex::Real particleSpeedAbortThreshold_ = 5.0e8; // default 5000 km/s in cm/s; <=0 disables
+	amrex::Real signalSpeedAbortThreshold_ = -1.0;
+	amrex::Real particleSpeedAbortThreshold_ = -1.0;
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Real dtCutoff_ = 0.0;	      // default: no cutoff (disabled when 0)
 	amrex::Long cycleCount_ = 0;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -177,8 +177,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<amrex::Real> tOld_;     // for state_old_cc_
 	amrex::Vector<amrex::Real> dt_;	      // timestep for each level
 	amrex::Real stopTime_ = 1.0;	      // default
-	amrex::Real cflNumber_ = 0.3;	      // default
-	amrex::Real particleCflNumber_ = 0.5; // default
+	amrex::Real cflNumber_ = 0.3;	        // default
+	amrex::Real particleCflNumber_ = 0.5;   // default
+	amrex::Real signalSpeedAbortThreshold_ = 5.0e8;	 // default 5000 km/s in cm/s; <=0 disables
+	amrex::Real particleSpeedAbortThreshold_ = 5.0e8; // default 5000 km/s in cm/s; <=0 disables
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Real dtCutoff_ = 0.0;	      // default: no cutoff (disabled when 0)
 	amrex::Long cycleCount_ = 0;
@@ -738,6 +740,26 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default CFL number for particles == 0.5, set to whatever is in the file
 	pp.query("particle_cfl", particleCflNumber_);
 
+	// Abort when signal speed exceeds this threshold (specified in km/s, CGS only)
+	constexpr amrex::Real cm_per_km = 1.0e5;
+	amrex::Real signalSpeedAbortKms = signalSpeedAbortThreshold_ / cm_per_km;
+	if (pp.query("signal_speed_abort_kms", signalSpeedAbortKms) != 0) {
+		if (signalSpeedAbortKms <= 0.0) {
+			signalSpeedAbortThreshold_ = -1.0; // disable safety check
+		} else {
+			signalSpeedAbortThreshold_ = signalSpeedAbortKms * cm_per_km;
+		}
+	}
+	// Abort when particle speed exceeds this threshold (specified in km/s, CGS only)
+	amrex::Real particleSpeedAbortKms = particleSpeedAbortThreshold_ / cm_per_km;
+	if (pp.query("particle_speed_abort_kms", particleSpeedAbortKms) != 0) {
+		if (particleSpeedAbortKms <= 0.0) {
+			particleSpeedAbortThreshold_ = -1.0; // disable safety check
+		} else {
+			particleSpeedAbortThreshold_ = particleSpeedAbortKms * cm_per_km;
+		}
+	}
+
 	// Default AMR interpolation method == lincc_interp
 	pp.query("amr_interpolation_method", amrInterpMethod_);
 
@@ -983,6 +1005,18 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	computeMaxSignalLocal(lev);
 	const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
+	if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
+		if (signalSpeedAbortThreshold_ > 0.0 && domain_signal_max > signalSpeedAbortThreshold_) {
+			constexpr amrex::Real cm_per_km = 1.0e5;
+			const amrex::Real measured_speed_kms = domain_signal_max / cm_per_km;
+			const amrex::Real threshold_speed_kms = signalSpeedAbortThreshold_ / cm_per_km;
+			const std::string abort_msg = fmt::format(
+			    "[FATAL] Maximum signal speed ({:.3f} km/s) exceeded abort threshold ({:.3f} km/s) on level {} at cell {}",
+			    measured_speed_kms, threshold_speed_kms, lev, domain_signal_maxloc);
+			amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
+			amrex::Abort(abort_msg.c_str());
+		}
+	}
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
 	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
 	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
@@ -1002,6 +1036,18 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		const amrex::ValLocPair<amrex::Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
 		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
+		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
+			if (particleSpeedAbortThreshold_ > 0.0 && max_particle_speed.value > particleSpeedAbortThreshold_) {
+				constexpr amrex::Real cm_per_km = 1.0e5;
+				const amrex::Real measured_speed_kms = max_particle_speed.value / cm_per_km;
+				const amrex::Real threshold_speed_kms = particleSpeedAbortThreshold_ / cm_per_km;
+				const std::string abort_msg =
+				    fmt::format("[FATAL] Maximum particle speed ({:.3f} km/s) exceeded abort threshold ({:.3f} km/s) on level {} at position {::e}",
+						measured_speed_kms, threshold_speed_kms, lev, max_particle_speed.index);
+				amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
+				amrex::Abort(abort_msg.c_str());
+			}
+		}
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1007,12 +1007,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 		if (signalSpeedAbortThreshold_ > 0.0 && domain_signal_max > signalSpeedAbortThreshold_) {
-			constexpr amrex::Real cm_per_km = 1.0e5;
-			const amrex::Real measured_speed_kms = domain_signal_max / cm_per_km;
-			const amrex::Real threshold_speed_kms = signalSpeedAbortThreshold_ / cm_per_km;
 			const std::string abort_msg = fmt::format(
-			    "[FATAL] Maximum signal speed ({:.3f} km/s) exceeded abort threshold ({:.3f} km/s) on level {} at cell {}",
-			    measured_speed_kms, threshold_speed_kms, lev, domain_signal_maxloc);
+			    "[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+			    domain_signal_max, signalSpeedAbortThreshold_, lev, domain_signal_maxloc);
 			amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
 			amrex::Abort(abort_msg.c_str());
 		}
@@ -1038,12 +1035,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			if (particleSpeedAbortThreshold_ > 0.0 && max_particle_speed.value > particleSpeedAbortThreshold_) {
-				constexpr amrex::Real cm_per_km = 1.0e5;
-				const amrex::Real measured_speed_kms = max_particle_speed.value / cm_per_km;
-				const amrex::Real threshold_speed_kms = particleSpeedAbortThreshold_ / cm_per_km;
 				const std::string abort_msg =
-				    fmt::format("[FATAL] Maximum particle speed ({:.3f} km/s) exceeded abort threshold ({:.3f} km/s) on level {} at position {::e}",
-						measured_speed_kms, threshold_speed_kms, lev, max_particle_speed.index);
+				    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at position {::e}",
+						max_particle_speed.value, particleSpeedAbortThreshold_, lev, max_particle_speed.index);
 				amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
 				amrex::Abort(abort_msg.c_str());
 			}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -740,7 +740,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default CFL number for particles == 0.5, set to whatever is in the file
 	pp.query("particle_cfl", particleCflNumber_);
 
-	// Abort when signal speed exceeds this threshold (specified in km/s, CGS only)
+	// Abort when signal speed exceeds this threshold (in code units)
 	pp.query("signal_speed_abort", signalSpeedAbort_);
 	pp.query("particle_speed_abort", particleSpeedAbort_);
 
@@ -991,7 +991,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	if (signalSpeedAbort_ > 0.0 && domain_signal_max > signalSpeedAbort_) {
 		const std::string abort_msg =
-		    fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}", domain_signal_max,
+		    fmt::format("[FATAL] Maximum signal speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}", domain_signal_max,
 				signalSpeedAbort_, lev, domain_signal_maxloc);
 		printCellProperties(lev, domain_signal_maxloc);
 		amrex::Abort(abort_msg.c_str());
@@ -1023,7 +1023,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		}
 		if (particleSpeedAbort_ > 0.0 && max_particle_speed.value > particleSpeedAbort_) {
 			const std::string abort_msg =
-			    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+			    fmt::format("[FATAL] Maximum particle speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}",
 					max_particle_speed.value, particleSpeedAbort_, lev, particle_cell_idx);
 			// printCellProperties(lev, particle_cell_idx);
 			amrex::Abort(abort_msg.c_str());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -991,8 +991,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	if (signalSpeedAbort_ > 0.0 && domain_signal_max > signalSpeedAbort_) {
 		const std::string abort_msg =
-				fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
-				domain_signal_max, signalSpeedAbort_, lev, domain_signal_maxloc);
+		    fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}", domain_signal_max,
+				signalSpeedAbort_, lev, domain_signal_maxloc);
 		printCellProperties(lev, domain_signal_maxloc);
 		amrex::Abort(abort_msg.c_str());
 	}
@@ -1023,7 +1023,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		}
 		if (particleSpeedAbort_ > 0.0 && max_particle_speed.value > particleSpeedAbort_) {
 			const std::string abort_msg =
-					fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+			    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
 					max_particle_speed.value, particleSpeedAbort_, lev, particle_cell_idx);
 			// printCellProperties(lev, particle_cell_idx);
 			amrex::Abort(abort_msg.c_str());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -991,8 +991,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	if (signalSpeedAbort_ > 0.0 && domain_signal_max > signalSpeedAbort_) {
 		const std::string abort_msg =
-		    fmt::format("[FATAL] Maximum signal speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}", domain_signal_max,
-				signalSpeedAbort_, lev, domain_signal_maxloc);
+		    fmt::format("[FATAL] Maximum signal speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}",
+				domain_signal_max, signalSpeedAbort_, lev, domain_signal_maxloc);
 		printCellProperties(lev, domain_signal_maxloc);
 		amrex::Abort(abort_msg.c_str());
 	}
@@ -1022,9 +1022,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			particle_cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
 		}
 		if (particleSpeedAbort_ > 0.0 && max_particle_speed.value > particleSpeedAbort_) {
-			const std::string abort_msg =
-			    fmt::format("[FATAL] Maximum particle speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}",
-					max_particle_speed.value, particleSpeedAbort_, lev, particle_cell_idx);
+			const std::string abort_msg = fmt::format(
+			    "[FATAL] Maximum particle speed ({:.3e} code units) exceeded abort threshold ({:.3e} code units) on level {} at cell {}",
+			    max_particle_speed.value, particleSpeedAbort_, lev, particle_cell_idx);
 			// printCellProperties(lev, particle_cell_idx);
 			amrex::Abort(abort_msg.c_str());
 		}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -179,8 +179,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real stopTime_ = 1.0;	      // default
 	amrex::Real cflNumber_ = 0.3;	      // default
 	amrex::Real particleCflNumber_ = 0.5; // default
-	amrex::Real signalSpeedAbortThreshold_ = -1.0;
-	amrex::Real particleSpeedAbortThreshold_ = -1.0;
+	amrex::Real signalSpeedAbort_ = -1.0;
+	amrex::Real particleSpeedAbort_ = -1.0;
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Real dtCutoff_ = 0.0;	      // default: no cutoff (disabled when 0)
 	amrex::Long cycleCount_ = 0;
@@ -741,24 +741,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	pp.query("particle_cfl", particleCflNumber_);
 
 	// Abort when signal speed exceeds this threshold (specified in km/s, CGS only)
-	constexpr amrex::Real cm_per_km = 1.0e5;
-	amrex::Real signalSpeedAbortKms = signalSpeedAbortThreshold_ / cm_per_km;
-	if (pp.query("signal_speed_abort_kms", signalSpeedAbortKms) != 0) {
-		if (signalSpeedAbortKms <= 0.0) {
-			signalSpeedAbortThreshold_ = -1.0; // disable safety check
-		} else {
-			signalSpeedAbortThreshold_ = signalSpeedAbortKms * cm_per_km;
-		}
-	}
-	// Abort when particle speed exceeds this threshold (specified in km/s, CGS only)
-	amrex::Real particleSpeedAbortKms = particleSpeedAbortThreshold_ / cm_per_km;
-	if (pp.query("particle_speed_abort_kms", particleSpeedAbortKms) != 0) {
-		if (particleSpeedAbortKms <= 0.0) {
-			particleSpeedAbortThreshold_ = -1.0; // disable safety check
-		} else {
-			particleSpeedAbortThreshold_ = particleSpeedAbortKms * cm_per_km;
-		}
-	}
+	pp.query("signal_speed_abort", signalSpeedAbort_);
+	pp.query("particle_speed_abort", particleSpeedAbort_);
 
 	// Default AMR interpolation method == lincc_interp
 	pp.query("amr_interpolation_method", amrInterpMethod_);
@@ -1005,15 +989,12 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	computeMaxSignalLocal(lev);
 	const amrex::Real domain_signal_max = max_signal_speed_[lev].norminf();
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
-	if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
-		if (signalSpeedAbortThreshold_ > 0.0 && domain_signal_max > signalSpeedAbortThreshold_) {
-			const std::string abort_msg =
-			    fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
-					domain_signal_max, signalSpeedAbortThreshold_, lev, domain_signal_maxloc);
-			printCellProperties(lev, domain_signal_maxloc);
-			amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
-			amrex::Abort(abort_msg.c_str());
-		}
+	if (signalSpeedAbort_ > 0.0 && domain_signal_max > signalSpeedAbort_) {
+		const std::string abort_msg =
+				fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+				domain_signal_max, signalSpeedAbort_, lev, domain_signal_maxloc);
+		printCellProperties(lev, domain_signal_maxloc);
+		amrex::Abort(abort_msg.c_str());
 	}
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
 	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
@@ -1040,15 +1021,12 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
 			particle_cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
 		}
-		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
-			if (particleSpeedAbortThreshold_ > 0.0 && max_particle_speed.value > particleSpeedAbortThreshold_) {
-				const std::string abort_msg =
-				    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
-						max_particle_speed.value, particleSpeedAbortThreshold_, lev, particle_cell_idx);
-				// printCellProperties(lev, particle_cell_idx);
-				amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
-				amrex::Abort(abort_msg.c_str());
-			}
+		if (particleSpeedAbort_ > 0.0 && max_particle_speed.value > particleSpeedAbort_) {
+			const std::string abort_msg =
+					fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+					max_particle_speed.value, particleSpeedAbort_, lev, particle_cell_idx);
+			// printCellProperties(lev, particle_cell_idx);
+			amrex::Abort(abort_msg.c_str());
 		}
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -177,8 +177,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<amrex::Real> tOld_;     // for state_old_cc_
 	amrex::Vector<amrex::Real> dt_;	      // timestep for each level
 	amrex::Real stopTime_ = 1.0;	      // default
-	amrex::Real cflNumber_ = 0.3;	        // default
-	amrex::Real particleCflNumber_ = 0.5;   // default
+	amrex::Real cflNumber_ = 0.3;	      // default
+	amrex::Real particleCflNumber_ = 0.5; // default
 	amrex::Real signalSpeedAbortThreshold_ = -1.0;
 	amrex::Real particleSpeedAbortThreshold_ = -1.0;
 	amrex::Real dtToleranceFactor_ = 1.1; // default
@@ -1007,9 +1007,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	const amrex::IntVect domain_signal_maxloc = max_signal_speed_[lev].maxIndex(0);
 	if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 		if (signalSpeedAbortThreshold_ > 0.0 && domain_signal_max > signalSpeedAbortThreshold_) {
-			const std::string abort_msg = fmt::format(
-			    "[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
-			    domain_signal_max, signalSpeedAbortThreshold_, lev, domain_signal_maxloc);
+			const std::string abort_msg =
+			    fmt::format("[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+					domain_signal_max, signalSpeedAbortThreshold_, lev, domain_signal_maxloc);
 			printCellProperties(lev, domain_signal_maxloc);
 			amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
 			amrex::Abort(abort_msg.c_str());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1010,6 +1010,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			const std::string abort_msg = fmt::format(
 			    "[FATAL] Maximum signal speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
 			    domain_signal_max, signalSpeedAbortThreshold_, lev, domain_signal_maxloc);
+			printCellProperties(lev, domain_signal_maxloc);
 			amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
 			amrex::Abort(abort_msg.c_str());
 		}
@@ -1033,11 +1034,18 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		const amrex::ValLocPair<amrex::Real, amrex::RealVect> max_particle_speed = particleRegister_.computeMaxParticleSpeed(lev);
 		AMREX_ALWAYS_ASSERT(!std::isnan(max_particle_speed.value));
 		AMREX_ALWAYS_ASSERT(std::isfinite(max_particle_speed.value));
+		amrex::IntVect particle_cell_idx{AMREX_D_DECL(-1, -1, -1)};
+		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxinv = geom[lev].InvCellSizeArray();
+		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo = geom[lev].ProbLoArray();
+		for (int i = 0; i < AMREX_SPACEDIM; ++i) {
+			particle_cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
+		}
 		if constexpr (Physics_Traits<problem_t>::unit_system == UnitSystem::CGS) {
 			if (particleSpeedAbortThreshold_ > 0.0 && max_particle_speed.value > particleSpeedAbortThreshold_) {
 				const std::string abort_msg =
-				    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at position {::e}",
-						max_particle_speed.value, particleSpeedAbortThreshold_, lev, max_particle_speed.index);
+				    fmt::format("[FATAL] Maximum particle speed ({:.3e} cm/s) exceeded abort threshold ({:.3e} cm/s) on level {} at cell {}",
+						max_particle_speed.value, particleSpeedAbortThreshold_, lev, particle_cell_idx);
+				// printCellProperties(lev, particle_cell_idx);
 				amrex::Print() << abort_msg << std::endl; // NOLINT(performance-avoid-endl)
 				amrex::Abort(abort_msg.c_str());
 			}
@@ -1045,14 +1053,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
-			// compute IntVect from RealVect and geom[lev]
-			amrex::IntVect cell_idx;
-			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dxinv = geom[lev].InvCellSizeArray();
-			amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo = geom[lev].ProbLoArray();
-			for (int i = 0; i < AMREX_SPACEDIM; ++i) {
-				cell_idx[i] = static_cast<int>(dxinv[i] * (max_particle_speed.index[i] - prob_lo[i]));
-			}
-			particle_dt.index = cell_idx;
+			particle_dt.index = particle_cell_idx;
 		}
 		if (verbose) {
 			amrex::Print() << fmt::format("...[level {}] estimated particle timestep: {:e}\n", lev, particle_dt.value);


### PR DESCRIPTION
Simulations occasionally reach unphysically high velocities that stall execution, resulting in waste of computational resources and user time. To address this issue, this PR introduces an optional mechanism that aborts the simulation when the signal speed exceeds a user-specified threshold. 

A new runtime parameter, `signal_speed_abort`, defines the maximum allowable signal speed (in code unit). If the maximum signal speed at any timestep exceeds this threshold, the code will abort with the following message. By default, `signal_speed_abort = -1`, meaning no abort will be triggered regardless of the signal speed.

```
Coarse STEP 4 at t = 104455.656 (1.103333333e-06%) starts ...
...[level 0] estimated hydro timestep: 2.987793e+10
...[level 0]    hydro timestep limited at cell [16, 15, 14] with signal speed = 2.478628e+08
...[level 0]    cell density = 3.161355e-27, |v| = 2.088636e+03, cs = 2.478607e+08
...[level 0] estimated particle timestep: 1.797693e+308
...[level 0]    max particle velocity: 0.000000e+00
...[level 0]    particle timestep limited at position [nan, nan, nan]
...[level 0] timestep limited by HYDRO
...[level 1]    cell density = 6.469539e-32, |v| = 1.292989e+08, cs = 1.889988e+08
[FATAL] Maximum signal speed (3.183e+08 code unit) exceeded abort threshold (2.800e+08 code unit) on level 1 at cell [34, 28, 32]
amrex::Abort::0::[FATAL] Maximum signal speed (3.183e+08 code unit) exceeded abort threshold (2.800e+08 code unit) on level 1 at cell [34, 28, 32] !!!
SIGABRT
See Backtrace.0 file for details
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
  Proc: [[9078,0],0]
  Errorcode: 6
```

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
