### PR TITLE
Rename ErrorEst to refineGrid

### DIFF
--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -284,7 +284,7 @@ template <> void QuokkaSimulation<AgoraGalaxy>::createInitialCICParticles()
 	amrex::Print() << "\n";
 }
 
-template <> void QuokkaSimulation<AgoraGalaxy>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<AgoraGalaxy>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// geometrical refinement
 	// tag cells within the cylinder defined by R < Rmax and abs(z) < zmax

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -123,7 +123,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 	});
 }
 
-template <> void QuokkaSimulation<FieldLoop>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	RefineOn refine_based_on{};
 	amrex::ParmParse const pp("field_loop");

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -72,7 +72,7 @@ template <> void QuokkaSimulation<ParticleSFProblem>::setInitialConditionsOnGrid
 	});
 }
 
-template <> void QuokkaSimulation<ParticleSFProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<ParticleSFProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement: static mesh refinement for the whole domain
 

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -88,7 +88,7 @@ template <> void QuokkaSimulation<SinkProblem>::setInitialConditionsOnGrid(quokk
 	});
 }
 
-template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<SinkProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement: static mesh refinement for the whole domain (if refine_half_domain is false) or for x > 0 (if refine_half_domain is true)
 

--- a/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
+++ b/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
@@ -93,7 +93,7 @@ template <> void QuokkaSimulation<SinkProblem>::setInitialConditionsOnGrid(quokk
 	});
 }
 
-template <> void QuokkaSimulation<SinkProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<SinkProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement: static mesh refinement for the whole domain
 

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -118,7 +118,7 @@ template <> void QuokkaSimulation<SNProblem>::setInitialConditionsOnGrid(quokka:
 	});
 }
 
-template <> void QuokkaSimulation<SNProblem>::ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<SNProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement: static mesh refinement for the whole domain (if refine_half_domain is false) or for x > 0 (if refine_half_domain is true)
 


### PR DESCRIPTION
### Description
There are some ErrorEst functions remaining in the problem folder. They need to be renamed to refineGrid. ErrorEst is a wrapper around refineGrid, and it also calls refineGridsAroundParticles to tag cells around particles, so the user should define refineGrid instead of ErrorEst. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
