### PR TITLE
set amr.n_error_buf = 0 for static mesh refinement

### DIFF
--- a/inputs/DiskGalaxy.in
+++ b/inputs/DiskGalaxy.in
@@ -17,7 +17,7 @@ amr.v              = 1       # verbosity in Amr
 amr.n_cell          = 128 128 128
 amr.blocking_factor = 16    # grid size must be divisible by this
 amr.max_grid_size   = 64    # at least 128 for GPUs
-amr.n_error_buf     = 3     # minimum 3 cell buffer around tagged cells
+amr.n_error_buf     = 0     # no cell buffer around tagged cells
 amr.grid_eff        = 0.7
 regrid_interval     = -1    # static refinement only (do not regrid)
 


### PR DESCRIPTION
### Description
I believe the correct value of `amr.n_error_buf` for static mesh refinement is 0. @BenWibking Do you agree?

I my tall-box simulations (1 kpc widt and 4 kpc tall), using `n_error_buf=3` causes the refinement tags to extend three cells beyond the intende region, which in turn creates an extra layer of `64^3` grids for refinement. For ths problem, I want a 1 kpc-tall box at level 2 and 2 kpc-tall box at level 1; however, the buffer expands the max-level box beyond these targets. Setting `n_error_buf=0` gives the correct grid geometry.

*Left: `n_error_buf=3`. Right: `n_error_buf=0`*
<img width="300" alt="plt00008 n_error_buf3" src="https://github.com/user-attachments/assets/24eab005-d1a5-433a-8d80-e183d0014784" /> <img width="300" alt="plt00008 n_error_buf0" src="https://github.com/user-attachments/assets/b039ccdf-36e1-41db-9adb-1412a4c2f522" />

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
