### PR TITLE
do not warn about trailing return type for lambdas

### DIFF
--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -309,6 +309,8 @@ CheckOptions:
     value:           '0'
   - key:             modernize-use-override.OverrideSpelling
     value:           override
+  - key:             modernize-use-trailing-return-type.TransformLambdas
+    value:           'none'
   - key:             modernize-use-transparent-functors.SafeMode
     value:           '0'
   - key:             modernize-use-using.IgnoreMacros
@@ -394,4 +396,3 @@ CheckOptions:
   - key:             zircon-temporary-objects.Names
     value:           ''
 ...
-


### PR DESCRIPTION
### Description
Turns off the "use a trailing return type" warning from clang-tidy about lambda functions (https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-trailing-return-type.html).

CUDA doesn't support this, so we can't use it. Also, it makes the code longer when the return type is void (applies to most lambdas in the code).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
