### PR TITLE
Automatically download CloudyData_UVB=HM2012.h5 in resample_grackle_cooling_tables.py

### DIFF
--- a/docs/markdown/parameters.md
+++ b/docs/markdown/parameters.md
@@ -85,7 +85,7 @@ These parameters are read in the ``QuokkaSimulation<problem_t>::readParmParse()`
 | cooling.enabled | Integer | If set to 1, turns on optically-thin radiative cooling as a Strang-split source term. Default: 0 (disabled). |
 | cooling.cooling_table_type | String | Specifies the type of cooling table to use. The only supported option is "resampled". |
 | cooling.read_tables_even_if_disabled | Integer | If set to 1, reads the cooling tables even if the cooling module is disabled. |
-| cooling.hdf5_data_file | String | The path to the cooling tables in HDF5 format. |
+| cooling.hdf5_data_file | String | The path to the cooling tables in HDF5 format. We recommend using extern/cooling/CloudyData_UVB=HM2012_resampled.h5 for ISM at solar metallicity. |
 
 ## Chemistry
 

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -488,6 +488,7 @@ def main():
             try:
                 os.unlink(cleanup_path)
             except FileNotFoundError:
+                # It is safe to ignore if the file is already deleted or was never created.
                 pass
 
 

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -2,12 +2,27 @@
 # ABOUTME: Resample cooling tables from grackle_tables.py as a function of specific
 # ABOUTME: internal energy and mass density on a logarithmic 2D grid, including sound speeds.
 
+# By default, the Grackle data used is input/CloudyData_UVB=HM2012.h5 and is automatically 
+# downloaded from this url, if not specified:
+# https://github.com/grackle-project/grackle_data_files/raw/928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB=HM2012.h5
+
+import os
+import shutil
+import subprocess
+import tempfile
+
 import numpy as np
 import h5py
 
 from grackle_tables import (
     read_tables, cooling_rate, interpolate_mu, compute_temperature_from_nH_e,
     m_H, boltzmann_constant_cgs_, cloudy_H_mass_fraction, specific_energy_from_temperature
+)
+
+
+DEFAULT_GRACKLE_DATA_URL = (
+    "https://github.com/grackle-project/grackle_data_files/raw/"
+    "928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB=HM2012.h5"
 )
 
 
@@ -180,7 +195,7 @@ def find_eint_range(tables):
 
 def resample_cooling_tables(grackle_file, n_rho=100, n_eint=100, zmet=1.0,
                             output_file='resampled_cooling_tables.h5'):
-    """Resample cooling tables on a not-quite-logarithmic grid of density and specific internal energy.    
+    """Resample cooling tables on a not-quite-logarithmic grid of density and specific internal energy.
     Uses the fast logarithm approximation from https://arxiv.org/pdf/2206.08957 for grid spacing.
     
     Computes and stores:
@@ -389,19 +404,40 @@ def test_inverse_fast_log2():
     return max_error < eps * tolerance_factor
 
 
+def download_default_grackle_tables(url: str = DEFAULT_GRACKLE_DATA_URL) -> str:
+    """Download the default Grackle tables via wget and return the temporary file path."""
+    if shutil.which('wget') is None:
+        raise RuntimeError("wget is required to download default Grackle tables automatically.")
+
+    temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.h5')
+    temp_path = temp_file.name
+    temp_file.close()
+
+    print(f"Downloading default Grackle tables from {url}")
+    try:
+        subprocess.run(['wget', '-O', temp_path, url], check=True)
+    except subprocess.CalledProcessError as exc:
+        os.unlink(temp_path)
+        raise RuntimeError("Failed to download default Grackle tables via wget.") from exc
+
+    return temp_path
+
+
 def main():
     """Main function to run the resampling."""
     import argparse
-    
+    import sys
+
     parser = argparse.ArgumentParser(description='Resample Grackle cooling tables on (rho, e_int) grid')
-    
+
     parser.add_argument('grackle_file', type=str, nargs='?',
-                        help='Path to Grackle HDF5 cooling table file')
-    
+                        help=('Path to Grackle HDF5 cooling table file. '
+                              'If omitted, downloads the default HM2012 tables automatically.'))
+
     # Mode selection
     parser.add_argument('--test', action='store_true',
                         help='Test the inverse_fast_log2 function')
-    
+
     # Parameters for resampling
     parser.add_argument('--n_rho', type=int, default=30,
                         help='Number of density points (default: 30)')
@@ -412,27 +448,37 @@ def main():
 
     parser.add_argument('--zmet', type=float, default=1.0,
                         help='Gas Metallicity scaled to Solar (default: 1.0)')
-    
+
     args = parser.parse_args()
-    
+
     if args.test:
         # Run the test
         success = test_inverse_fast_log2()
-        import sys
         sys.exit(0 if success else 1)
-    
-    # For other modes, grackle_file is required
-    if not args.grackle_file:
-        parser.error("grackle_file is required unless using --test mode")    
-    else:
-        # Resampling mode
+
+    cleanup_path = None
+    grackle_file = args.grackle_file
+    if not grackle_file:
+        try:
+            cleanup_path = download_default_grackle_tables()
+            grackle_file = cleanup_path
+        except RuntimeError as err:
+            parser.error(str(err))
+
+    try:
         resample_cooling_tables(
-            args.grackle_file,
+            grackle_file,
             n_rho=args.n_rho,
             n_eint=args.n_eint,
-            zmet = args.zmet,
+            zmet=args.zmet,
             output_file=args.output
         )
+    finally:
+        if cleanup_path:
+            try:
+                os.unlink(cleanup_path)
+            except FileNotFoundError:
+                pass
 
 
 if __name__ == '__main__':

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 # ABOUTME: Resample cooling tables from grackle_tables.py as a function of specific
 # ABOUTME: internal energy and mass density on a logarithmic 2D grid, including sound speeds.
-
-# By default, the Grackle data used is input/CloudyData_UVB=HM2012.h5 and is automatically 
-# downloaded from this url, if not specified:
-# https://github.com/grackle-project/grackle_data_files/raw/928696482fbe15d9bac4382de6134d95568f099c/input/CloudyData_UVB=HM2012.h5
+"""
+Example usage:
+Resample using the default CloudyData_UVB=HM2012.h5 data (auto-downloaded via wget) at solar metallicity
+    ./resample_grackle_cooling_tables.py
+The CloudyData_UVB=HM2012_resampled.h5 file in this folder was generated via this command:
+    ./resample_grackle_cooling_tables.py --output CloudyData_UVB=HM2012_resampled.h5
+Resample using the default CloudyData_UVB=HM2012.h5 data (auto-downloaded via wget) at 0.5 solar metallicity
+    ./resample_grackle_cooling_tables.py --zmet 0.5
+Resample with user-provided tables and non-default spacing parameters
+    ./resample_grackle_cooling_tables.py /path/to/CloudyData.h5 --n_rho 50 --n_eint 400 --output my_tables.h5
+Validate fast_log2 <-> inverse_fast_log2
+    ./resample_grackle_cooling_tables.py --test
+"""
 
 import os
 import shutil

--- a/extern/cooling/resample_grackle_cooling_tables.py
+++ b/extern/cooling/resample_grackle_cooling_tables.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-# ABOUTME: Resample cooling tables from grackle_tables.py as a function of specific
-# ABOUTME: internal energy and mass density on a logarithmic 2D grid, including sound speeds.
 """
+Resample Grackle cooling tables as a function of specific internal energy and mass density on a logarithmic 2D grid.
+Outputs include cooling rates, temperatures, sound speeds, pressures, and entropies.
+
 Example usage:
 Resample using the default CloudyData_UVB=HM2012.h5 data (auto-downloaded via wget) at solar metallicity
     ./resample_grackle_cooling_tables.py


### PR DESCRIPTION
### Description
It was not clear how to generate new cooling tables using `resample_grackle_cooling_tables.py`. It required a Grackle data table like CloudyData_UVB=HM2012.h5, but the data was not provided. This h5 file is large (5 MB), so, instead of including it in the source code, we let the Python script download it from the official Grackle website. I also updated the file documentation to include example usage. 

### Related
#1126 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
