### PR TITLE
avoid using libc++ for ROCm

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -39,7 +39,7 @@ else
   rocm_suite="jammy"
 fi
 
-for ver in 7.0; do
+for ver in 7.1; do
   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver ${rocm_suite} main" \
       | sudo tee --append /etc/apt/sources.list.d/rocm.list
 done
@@ -62,13 +62,13 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev7.0.0        \
-    roctracer-dev7.0.0   \
-    rocprofiler-dev7.0.0 \
-    rocrand-dev7.0.0     \
-    hiprand-dev7.0.0     \
-    rocprim-dev7.0.0     \
-    rocsparse-dev7.0.0
+    rocm-dev7.1.0        \
+    roctracer-dev7.1.0   \
+    rocprofiler-dev7.1.0 \
+    rocrand-dev7.1.0     \
+    hiprand-dev7.1.0     \
+    rocprim-dev7.1.0     \
+    rocsparse-dev7.1.0
 
 # activate
 #

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -24,7 +24,7 @@ jobs:
       workflow_file: '.github/workflows/hip.yml'
 
   tests-hip:
-    name: HIP ROCm C++17
+    name: HIP ROCm C++20
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
@@ -70,9 +70,9 @@ jobs:
             -DAMReX_ROCTX=ON                              \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which clang++)         \
-            -DCMAKE_CXX_STANDARD=17                       \
+            -DCMAKE_CXX_STANDARD=20                       \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache          \
-            -DCMAKE_CXX_FLAGS="-ffp-exception-behavior=strict -stdlib=libc++"
+            -DCMAKE_CXX_FLAGS="-ffp-exception-behavior=strict"
         cmake --build build -j 2
 
         ccache -s


### PR DESCRIPTION
### Description
Avoid using libc++, since it is not fully compatible with ROCm with C++20.

Also, update to ROCm 7.1 for good measure.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
