### PR TITLE
Fix small b-field degeneracy in HLLD solver

### DIFF
--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -209,49 +209,57 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// MK5: eqn (48)
 	u_star_R.E = (siui_R * u_R.E - ptot_R * sR.u + ptot_star * spds[2] + bx * (sR.u * bx + (sR.v * u_R.by + sR.w * u_R.bz) - vb_star_R)) * sism_inv_R;
 
-	// if Bx is near zero, then u_i^dstar = u_i^star
-	if (0.5 * bx_sq < DELTA * ptot_star) {
-		u_dstar_L = u_star_L;
-		u_dstar_R = u_star_R;
-	} else {
-		double rho_sum_inv = 1.0 / (rho_sqrt_L + rho_sqrt_R);
-		double bx_sign = (bx > 0.0 ? 1.0 : -1.0);
-		u_dstar_L.rho = u_star_L.rho;
-		u_dstar_R.rho = u_star_R.rho;
-		u_dstar_L.mx = u_star_L.mx;
-		u_dstar_R.mx = u_star_R.mx;
-		u_dstar_L.Eint = u_star_L.Eint;
-		u_dstar_R.Eint = u_star_R.Eint;
-		for (int n = 0; n < N_scalars; ++n) {
-			u_dstar_L.scalar[n] = u_star_L.scalar[n];
-			u_dstar_R.scalar[n] = u_star_R.scalar[n];
-		}
+	// if Bx is near zero, compute double-star states using MK5 eqns (59)–(63)
+	double rho_sum_inv = 1.0 / (rho_sqrt_L + rho_sqrt_R);
+	double bx_sign = (bx > 0.0 ? 1.0 : -1.0);
 
-		// MK5: eqn (59)
-		double tmp = rho_sum_inv * (rho_sqrt_L * (u_star_L.my * u_star_rho_inv_L) + rho_sqrt_R * (u_star_R.my * u_star_rho_inv_R) +
-					    bx_sign * (u_star_R.by - u_star_L.by));
-		u_dstar_L.my = u_dstar_L.rho * tmp;
-		u_dstar_R.my = u_dstar_R.rho * tmp;
-		// MK5: eqn (60)
-		tmp = rho_sum_inv *
-		      (rho_sqrt_L * (u_star_L.mz * u_star_rho_inv_L) + rho_sqrt_R * (u_star_R.mz * u_star_rho_inv_R) + bx_sign * (u_star_R.bz - u_star_L.bz));
-		u_dstar_L.mz = u_dstar_L.rho * tmp;
-		u_dstar_R.mz = u_dstar_R.rho * tmp;
-		// MK5: eqn (61)
-		tmp = rho_sum_inv * (rho_sqrt_L * u_star_R.by + rho_sqrt_R * u_star_L.by +
-				     bx_sign * rho_sqrt_L * rho_sqrt_R * ((u_star_R.my * u_star_rho_inv_R) - (u_star_L.my * u_star_rho_inv_L)));
-		u_dstar_L.by = tmp;
-		u_dstar_R.by = tmp;
-		// MK5: eqn (62)
-		tmp = rho_sum_inv * (rho_sqrt_L * u_star_R.bz + rho_sqrt_R * u_star_L.bz +
-				     bx_sign * rho_sqrt_L * rho_sqrt_R * ((u_star_R.mz * u_star_rho_inv_R) - (u_star_L.mz * u_star_rho_inv_L)));
-		u_dstar_L.bz = tmp;
-		u_dstar_R.bz = tmp;
-		// MK5: eqn (63)
-		tmp = spds[2] * bx + (u_dstar_L.my * u_dstar_L.by + u_dstar_L.mz * u_dstar_L.bz) / u_dstar_L.rho;
-		u_dstar_L.E = u_star_L.E - rho_sqrt_L * bx_sign * (vb_star_L - tmp);
-		u_dstar_R.E = u_star_R.E + rho_sqrt_R * bx_sign * (vb_star_R - tmp);
+	u_dstar_L.rho = u_star_L.rho;
+	u_dstar_R.rho = u_star_R.rho;
+	u_dstar_L.mx = u_star_L.mx;
+	u_dstar_R.mx = u_star_R.mx;
+	u_dstar_L.Eint = u_star_L.Eint;
+	u_dstar_R.Eint = u_star_R.Eint;
+	for (int n = 0; n < N_scalars; ++n) {
+		u_dstar_L.scalar[n] = u_star_L.scalar[n];
+		u_dstar_R.scalar[n] = u_star_R.scalar[n];
 	}
+
+	// MK5: eqn (59)
+	double tmp = rho_sum_inv *
+	             (rho_sqrt_L * (u_star_L.my * u_star_rho_inv_L) +
+	              rho_sqrt_R * (u_star_R.my * u_star_rho_inv_R) +
+	              bx_sign * (u_star_R.by - u_star_L.by));
+	u_dstar_L.my = u_dstar_L.rho * tmp;
+	u_dstar_R.my = u_dstar_R.rho * tmp;
+
+	// MK5: eqn (60)
+	tmp = rho_sum_inv *
+	      (rho_sqrt_L * (u_star_L.mz * u_star_rho_inv_L) +
+	       rho_sqrt_R * (u_star_R.mz * u_star_rho_inv_R) +
+	       bx_sign * (u_star_R.bz - u_star_L.bz));
+	u_dstar_L.mz = u_dstar_L.rho * tmp;
+	u_dstar_R.mz = u_dstar_R.rho * tmp;
+
+	// MK5: eqn (61)
+	tmp = rho_sum_inv *
+	      (rho_sqrt_L * u_star_R.by + rho_sqrt_R * u_star_L.by +
+	       bx_sign * rho_sqrt_L * rho_sqrt_R *
+	       ((u_star_R.my * u_star_rho_inv_R) - (u_star_L.my * u_star_rho_inv_L)));
+	u_dstar_L.by = tmp;
+	u_dstar_R.by = tmp;
+
+	// MK5: eqn (62)
+	tmp = rho_sum_inv *
+	      (rho_sqrt_L * u_star_R.bz + rho_sqrt_R * u_star_L.bz +
+	       bx_sign * rho_sqrt_L * rho_sqrt_R *
+	       ((u_star_R.mz * u_star_rho_inv_R) - (u_star_L.mz * u_star_rho_inv_L)));
+	u_dstar_L.bz = tmp;
+	u_dstar_R.bz = tmp;
+
+	// MK5: eqn (63)
+	tmp = spds[2] * bx + (u_dstar_L.my * u_dstar_L.by + u_dstar_L.mz * u_dstar_L.bz) / u_dstar_L.rho;
+	u_dstar_L.E = u_star_L.E - rho_sqrt_L * bx_sign * (vb_star_L - tmp);
+	u_dstar_R.E = u_star_R.E + rho_sqrt_R * bx_sign * (vb_star_R - tmp);
 
 	// Convert to arrays for simplified math
 

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -226,33 +226,25 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 
 	// MK5: eqn (59)
 	double tmp = rho_sum_inv *
-	             (rho_sqrt_L * (u_star_L.my * u_star_rho_inv_L) +
-	              rho_sqrt_R * (u_star_R.my * u_star_rho_inv_R) +
-	              bx_sign * (u_star_R.by - u_star_L.by));
+		     (rho_sqrt_L * (u_star_L.my * u_star_rho_inv_L) + rho_sqrt_R * (u_star_R.my * u_star_rho_inv_R) + bx_sign * (u_star_R.by - u_star_L.by));
 	u_dstar_L.my = u_dstar_L.rho * tmp;
 	u_dstar_R.my = u_dstar_R.rho * tmp;
 
 	// MK5: eqn (60)
 	tmp = rho_sum_inv *
-	      (rho_sqrt_L * (u_star_L.mz * u_star_rho_inv_L) +
-	       rho_sqrt_R * (u_star_R.mz * u_star_rho_inv_R) +
-	       bx_sign * (u_star_R.bz - u_star_L.bz));
+	      (rho_sqrt_L * (u_star_L.mz * u_star_rho_inv_L) + rho_sqrt_R * (u_star_R.mz * u_star_rho_inv_R) + bx_sign * (u_star_R.bz - u_star_L.bz));
 	u_dstar_L.mz = u_dstar_L.rho * tmp;
 	u_dstar_R.mz = u_dstar_R.rho * tmp;
 
 	// MK5: eqn (61)
-	tmp = rho_sum_inv *
-	      (rho_sqrt_L * u_star_R.by + rho_sqrt_R * u_star_L.by +
-	       bx_sign * rho_sqrt_L * rho_sqrt_R *
-	       ((u_star_R.my * u_star_rho_inv_R) - (u_star_L.my * u_star_rho_inv_L)));
+	tmp = rho_sum_inv * (rho_sqrt_L * u_star_R.by + rho_sqrt_R * u_star_L.by +
+			     bx_sign * rho_sqrt_L * rho_sqrt_R * ((u_star_R.my * u_star_rho_inv_R) - (u_star_L.my * u_star_rho_inv_L)));
 	u_dstar_L.by = tmp;
 	u_dstar_R.by = tmp;
 
 	// MK5: eqn (62)
-	tmp = rho_sum_inv *
-	      (rho_sqrt_L * u_star_R.bz + rho_sqrt_R * u_star_L.bz +
-	       bx_sign * rho_sqrt_L * rho_sqrt_R *
-	       ((u_star_R.mz * u_star_rho_inv_R) - (u_star_L.mz * u_star_rho_inv_L)));
+	tmp = rho_sum_inv * (rho_sqrt_L * u_star_R.bz + rho_sqrt_R * u_star_L.bz +
+			     bx_sign * rho_sqrt_L * rho_sqrt_R * ((u_star_R.mz * u_star_rho_inv_R) - (u_star_L.mz * u_star_rho_inv_L)));
 	u_dstar_L.bz = tmp;
 	u_dstar_R.bz = tmp;
 

--- a/src/hydro/HLLD.hpp
+++ b/src/hydro/HLLD.hpp
@@ -209,7 +209,7 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto HLLD(quokka::HydroState<N_scalars, N_ms
 	// MK5: eqn (48)
 	u_star_R.E = (siui_R * u_R.E - ptot_R * sR.u + ptot_star * spds[2] + bx * (sR.u * bx + (sR.v * u_R.by + sR.w * u_R.bz) - vb_star_R)) * sism_inv_R;
 
-	// if Bx is near zero, compute double-star states using MK5 eqns (59)–(63)
+	// compute double-star states using MK5 eqns (59)–(63)
 	double rho_sum_inv = 1.0 / (rho_sqrt_L + rho_sqrt_R);
 	double bx_sign = (bx > 0.0 ? 1.0 : -1.0);
 


### PR DESCRIPTION
### Description
This PR removes the ad-hoc "weak magnetic field" degeneracy branch in the HLLD MHD Riemann solver, where the double-star states were collapsed onto the single-star states when the normal field component was very weak. The double-star states are now always computed using the Miyoshi & Kusano (2005) eqs. (59)–(63), bringing Quokka’s HLLD implementation in line with the Athena++/Parthenon implementation (see [Athena++'s PR discussion](https://github.com/PrincetonUniversity/athena/pull/620)). This should avoid unphysical fluxes in non-smooth regions when the field is weak, while leaving the rest of the solver unchanged. I have not added a dedicated correctness test for this change, but the logic now follows the published HLLD derivation and the upstream Athena++ fix.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/746

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
