### PR TITLE
de-duplicate TUs before invoking clang-tidy

### DIFF
--- a/scripts/bash/tidy.sh
+++ b/scripts/bash/tidy.sh
@@ -64,6 +64,29 @@ if [ ! -d "$BUILD_DIR" ]; then
     exit 1
 fi
 
+compile_commands_path="$BUILD_DIR/compile_commands.json"
+if [ ! -f "$compile_commands_path" ]; then
+    echo "Error: $compile_commands_path not found. Please generate it with CMake."
+    exit 1
+fi
+
+cleanup_tmp_cdb() {
+    if [ -n "$tmp_cdb_dir" ] && [ -d "$tmp_cdb_dir" ]; then
+        rm -rf "$tmp_cdb_dir"
+    fi
+}
+trap cleanup_tmp_cdb EXIT
+
+# Deduplicate compile_commands entries so clang-tidy runs each file once
+cdb_dir="$BUILD_DIR"
+if command -v jq >/dev/null 2>&1; then
+    tmp_cdb_dir=$(mktemp -d)
+    jq 'unique_by(.file)' "$compile_commands_path" > "$tmp_cdb_dir/compile_commands.json"
+    cdb_dir="$tmp_cdb_dir"
+else
+    echo "Warning: jq not found; using compile_commands.json as-is (may repeat files)."
+fi
+
 # Get the name of the current git branch
 CURRENT_BRANCH=$(git branch --show-current)
 
@@ -102,5 +125,5 @@ echo
 
 # Only run clang-tidy if there are files to process
 if [ ${#files_select[@]} -gt 0 ]; then
-    clang-tidy --extra-arg="-isysroot$(xcrun --show-sdk-path)" "${files_select[@]}" -p "$BUILD_DIR" $fix_flag
+    clang-tidy --extra-arg="-isysroot$(xcrun --show-sdk-path)" "${files_select[@]}" -p "$cdb_dir" $fix_flag
 fi


### PR DESCRIPTION
### Description
De-duplicate translation units (*.cpp files) before invoking `clang-tidy` in the `scripts/bash/tidy.sh` helper script.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
