### PR TITLE
Update setonix slurm scripts

### DIFF
--- a/scripts/slurm/setonix-1node.submit
+++ b/scripts/slurm/setonix-1node.submit
@@ -6,10 +6,9 @@
 #SBATCH -t 00:10:00
 #SBATCH -p gpu
 #SBATCH --exclusive
-#SBATCH --ntasks-per-node=8
-#SBATCH --gpus-per-node=8
-##SBATCH --core-spec=8
 #SBATCH -N 1
+##SBATCH --ntasks-per-node=8
+##SBATCH --gpus-per-node=8
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
 . scripts/hpc_profiles/setonix-gpu.profile
@@ -20,20 +19,37 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 # use correct NIC-to-GPU binding
 export MPICH_OFI_NIC_POLICY=NUMA
 
+# OpenMP threads (pure MPI => 1)
+# QUOKKA does not use OpenMP, but it's good practice on Setonix to avoid accidental thread oversubscription
+export OMP_NUM_THREADS=1
+
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
 INPUTS="inputs/benchmark_unigrid_512.in"
 
-srun bash -c "
-    case \$((SLURM_LOCALID)) in
-      0) GPU=4;;
-      1) GPU=5;;
-      2) GPU=2;;
-      3) GPU=3;;
-      4) GPU=6;;
-      5) GPU=7;;
-      6) GPU=0;;
-      7) GPU=1;;
-    esac
-    export ROCR_VISIBLE_DEVICES=\$((GPU));
-    ${EXE} ${INPUTS}"
+# Wrapper that sets ROCR_VISIBLE_DEVICES per task
+# Create it in the working directory
+cat > selectGPU_X.sh << 'EOF'
+#!/bin/bash
+# Set the visible GPU for this task to its local task ID on the node
+export ROCR_VISIBLE_DEVICES="$SLURM_LOCALID"
+exec "$@"
+EOF
+chmod 755 ./selectGPU_X.sh
+
+# Generate optimal CPU binding list for 8 tasks on the GPUs allocated to this job
+CPU_BIND=$(generate_CPU_BIND.sh map_cpu)
+echo -e "\n# CPU_BIND=${CPU_BIND}"
+
+echo -e "\n# Run: 8 MPI tasks, manual GPU + CPU binding"
+# Notes:
+# -N 1, -n 8: 8 ranks on this node
+# -c 8: reserve one full chiplet per rank (actual threads controlled by OMP_NUM_THREADS)
+# --gres=gpu:8: expose 8 GPUs per node to this step
+# --cpu-bind=${CPU_BIND}: bind each rank to the chiplet matching its GPU
+# No --gpus-per-task, no --gpu-bind (manual binding avoids ROCm IPC attach error)
+srun -N 1 -n 8 -c 8 --gres=gpu:8 --cpu-bind=${CPU_BIND} ./selectGPU_X.sh ${EXE} ${INPUTS}
+
+echo -e "\n# sacct summary"
+sacct -j ${SLURM_JOBID} -o jobid%20,Start%20,elapsed%20
+echo -e "\n# Done"

--- a/scripts/slurm/setonix-64nodes.submit
+++ b/scripts/slurm/setonix-64nodes.submit
@@ -6,9 +6,6 @@
 #SBATCH -t 00:10:00
 #SBATCH -p gpu
 #SBATCH --exclusive
-#SBATCH --ntasks-per-node=8
-#SBATCH --gpus-per-node=8
-##SBATCH --core-spec=8
 #SBATCH -N 64
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
@@ -20,20 +17,42 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 # use correct NIC-to-GPU binding
 export MPICH_OFI_NIC_POLICY=NUMA
 
+# OpenMP threads (pure MPI => 1)
+# QUOKKA does not use OpenMP, but it's good practice on Setonix to avoid accidental thread oversubscription
+export OMP_NUM_THREADS=1
+
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
-INPUTS="inputs/benchmark_unigrid_2048.in"
+INPUTS="inputs/benchmark_unigrid_1024.in"
 
-srun bash -c "
-    case \$((SLURM_LOCALID)) in
-      0) GPU=4;;
-      1) GPU=5;;
-      2) GPU=2;;
-      3) GPU=3;;
-      4) GPU=6;;
-      5) GPU=7;;
-      6) GPU=0;;
-      7) GPU=1;;
-    esac
-    export ROCR_VISIBLE_DEVICES=\$((GPU));
-    ${EXE} ${INPUTS}"
+# Wrapper that sets ROCR_VISIBLE_DEVICES per task
+# Create it in the working directory
+cat > selectGPU_X.sh << 'EOF'
+#!/bin/bash
+# Set the visible GPU for this task to its local task ID on the node
+export ROCR_VISIBLE_DEVICES="$SLURM_LOCALID"
+exec "$@"
+EOF
+chmod 755 ./selectGPU_X.sh
+
+# Generate optimal CPU binding list for 8 tasks on the GPUs allocated to this job
+CPU_BIND=$(generate_CPU_BIND.sh map_cpu)
+echo -e "\n# CPU_BIND=${CPU_BIND}"
+
+echo -e "\n# Run: 8 MPI tasks, manual GPU + CPU binding"
+# Notes:
+# -N 1, -n 8: 8 ranks on this node
+# -c 8: reserve one full chiplet per rank (actual threads controlled by OMP_NUM_THREADS)
+# --gres=gpu:8: expose 8 GPUs per node to this step
+# --cpu-bind=${CPU_BIND}: bind each rank to the chiplet matching its GPU
+# No --gpus-per-task, no --gpu-bind (manual binding avoids ROCm IPC attach error)
+NODES=${SLURM_NNODES}
+TASKS_PER_NODE=8                 # one task per GPU
+TOTAL_TASKS=$((NODES * TASKS_PER_NODE))
+
+srun -N $NODES -n ${TOTAL_TASKS} -c 8 --gres=gpu:8 --cpu-bind=${CPU_BIND} ./selectGPU_X.sh ${EXE} ${INPUTS}
+
+echo -e "\n# sacct summary"
+sacct -j ${SLURM_JOBID} -o jobid%20,Start%20,elapsed%20
+echo -e "\n# Done"
+

--- a/scripts/slurm/setonix-8nodes.submit
+++ b/scripts/slurm/setonix-8nodes.submit
@@ -6,9 +6,6 @@
 #SBATCH -t 00:10:00
 #SBATCH -p gpu
 #SBATCH --exclusive
-#SBATCH --ntasks-per-node=8
-#SBATCH --gpus-per-node=8
-##SBATCH --core-spec=8
 #SBATCH -N 8
 
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
@@ -20,20 +17,42 @@ export MPICH_GPU_SUPPORT_ENABLED=1
 # use correct NIC-to-GPU binding
 export MPICH_OFI_NIC_POLICY=NUMA
 
+# OpenMP threads (pure MPI => 1)
+# QUOKKA does not use OpenMP, but it's good practice on Setonix to avoid accidental thread oversubscription
+export OMP_NUM_THREADS=1
+
 ## run
 EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
 INPUTS="inputs/benchmark_unigrid_1024.in"
 
-srun bash -c "
-    case \$((SLURM_LOCALID)) in
-      0) GPU=4;;
-      1) GPU=5;;
-      2) GPU=2;;
-      3) GPU=3;;
-      4) GPU=6;;
-      5) GPU=7;;
-      6) GPU=0;;
-      7) GPU=1;;
-    esac
-    export ROCR_VISIBLE_DEVICES=\$((GPU));
-    ${EXE} ${INPUTS}"
+# Wrapper that sets ROCR_VISIBLE_DEVICES per task
+# Create it in the working directory
+cat > selectGPU_X.sh << 'EOF'
+#!/bin/bash
+# Set the visible GPU for this task to its local task ID on the node
+export ROCR_VISIBLE_DEVICES="$SLURM_LOCALID"
+exec "$@"
+EOF
+chmod 755 ./selectGPU_X.sh
+
+# Generate optimal CPU binding list for 8 tasks on the GPUs allocated to this job
+CPU_BIND=$(generate_CPU_BIND.sh map_cpu)
+echo -e "\n# CPU_BIND=${CPU_BIND}"
+
+echo -e "\n# Run: 8 MPI tasks, manual GPU + CPU binding"
+# Notes:
+# -N 1, -n 8: 8 ranks on this node
+# -c 8: reserve one full chiplet per rank (actual threads controlled by OMP_NUM_THREADS)
+# --gres=gpu:8: expose 8 GPUs per node to this step
+# --cpu-bind=${CPU_BIND}: bind each rank to the chiplet matching its GPU
+# No --gpus-per-task, no --gpu-bind (manual binding avoids ROCm IPC attach error)
+NODES=${SLURM_NNODES}
+TASKS_PER_NODE=8                 # one task per GPU
+TOTAL_TASKS=$((NODES * TASKS_PER_NODE))
+
+srun -N $NODES -n ${TOTAL_TASKS} -c 8 --gres=gpu:8 --cpu-bind=${CPU_BIND} ./selectGPU_X.sh ${EXE} ${INPUTS}
+
+echo -e "\n# sacct summary"
+sacct -j ${SLURM_JOBID} -o jobid%20,Start%20,elapsed%20
+echo -e "\n# Done"
+


### PR DESCRIPTION
### Description
The old Setonix slurm script causes Segfault:

```
 21 srun: error: nid002068: tasks 0-1: Segmentation fault (core dumped)
 22 srun: Terminating StepId=36584803.0
```
which is likely caused by this snippet:
```sh
 27 srun bash -c "
 28     case \$((SLURM_LOCALID)) in
 29       0) GPU=4;;
 30       1) GPU=5;;
 31       2) GPU=2;;
 32       3) GPU=3;;
 33       4) GPU=6;;
 34       5) GPU=7;;
 35       6) GPU=0;;
 36       7) GPU=1;;
 37     esac
 38     export ROCR_VISIBLE_DEVICES=\$((GPU));
 39     ${EXE} ${INPUTS}"
```

This PR modifies the scripts to use a more robust way suggested by [the official Setonix documentation](https://pawsey.atlassian.net/wiki/spaces/US/pages/51929056/Example+Slurm+Batch+Scripts+for+Setonix+on+GPU+Compute+Nodes#Methods-to-achieve-optimal-binding-of-GCDs%2FGPUs) to set `ROCR_VISIBLE_DEVICES` per task, and bind each rank to the chiplet matching its GPU. 

BTW, the "Method 1" `--gpus-per-task=1 --gpu-bind=closest` won't work -- it produces the error message `Fatal error in PMPI_Waitall: Invalid count, error stack:` described in the Setonix page. 

Note: this mapping suppresses this warning: (and improve performance?)
```
   29 0: Multiple GPUs are visible to each MPI rank. This is usually not an issue. But this may lead to incorrect or suboptimal rank-to-GPU mapping.!
   30 0: HIP initialized with 8 devices.
```

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
