### PR TITLE
Add missing n_grow in fillPoissonRhsAtLevel

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -278,7 +278,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void ErrorEst(int lev, amrex::TagBoxArray &tags, amrex::Real time, int ngrow) override;
 
 	// fill rhs for Poisson solve
-	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;
+	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev, int n_ghost) override;
 
 	void print_multifab_fc(amrex::MultiFab &mf, std::string const &name, int lev, int idim);
 
@@ -1176,14 +1176,15 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 	AMREX_ASSERT(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()));
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs_mf, const int lev)
+template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs_mf, const int lev, const int n_ghost)
 {
 	// add hydro density to Poisson rhs
 	auto const &state = state_new_cc_[lev].const_arrays();
 	auto rhs = rhs_mf.arrays();
 	const Real G = Gconst_;
 
-	amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+	amrex::IntVect ng{AMREX_D_DECL(n_ghost, n_ghost, n_ghost)};
+	amrex::ParallelFor(rhs_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 		// *add* density to rhs_mf
 		// (N.B. particles **will not work** if you overwrite the density here!)
 		rhs[bx](i, j, k) += 4.0 * M_PI * G * state[bx](i, j, k, HydroSystem<problem_t>::density_index);

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -91,7 +91,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 				      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi);
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
-	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) override;
+	void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev, int n_ghost) override;
 	void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) override;
 
 	// compute derived variables
@@ -142,7 +142,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::printCellProp
 	// deliberately empty
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev)
+template <typename problem_t> void AdvectionSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev, int n_ghost)
 {
 	// deliberately empty
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -260,7 +260,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual void computeBeforeTimestep() = 0;
 	virtual void computeAfterTimestep() = 0;
 	virtual void computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons) = 0;
-	virtual void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev) = 0;
+	virtual void fillPoissonRhsAtLevel(amrex::MultiFab &rhs, int lev, int n_ghost) = 0;
 	virtual void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) = 0;
 	virtual void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf,
 							const amrex::Vector<std::string> &compNames, int lev, int interval) = 0;
@@ -1522,7 +1522,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::calculateGpotAllLev
 		}
 
 		for (int lev = 0; lev <= finest_level; ++lev) {
-			fillPoissonRhsAtLevel(rhs[lev], lev);
+			fillPoissonRhsAtLevel(rhs[lev], lev, nghost_rhs);
 			AMREX_ALWAYS_ASSERT(!rhs[lev].contains_nan());
 			rhs_min = std::min(rhs_min, rhs[lev].min(0));
 		}


### PR DESCRIPTION
### Description
This alone does not fix gravity+AMR reproducibility issue, but it's obviously a mistake. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
