### PR TITLE
Let SonarCloud use c++20 standard

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarcloud analysis
           
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install python3-dev python3-numpy python3-matplotlib libopenmpi-dev libhdf5-mpi-dev
+        run: sudo apt-get update && sudo apt-get install gcc-11 g++-11 python3-dev python3-numpy python3-matplotlib libopenmpi-dev libhdf5-mpi-dev
         
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@44cc4d3d487fbc35e5c29b0a9d717be218d3a0e8 # v3.2.0
@@ -30,7 +30,7 @@ jobs:
       - name: Run build-wrapper
         run: |
           mkdir build
-          cmake -S . -B build
+          cmake -S . -B build -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} cmake --build build/ --config $BUILD_TYPE --parallel 1
           
       - name: Run sonar-scanner
@@ -38,4 +38,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner \
+            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+            --define sonar.cfamily.reportingCppStandardOverride=c++20

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,6 @@
 //==============================================================================
 /// \file main.cpp
 /// \brief The main() function for simulations.
-///
 
 #include "AMReX.H"
 #include "AMReX_ParallelDescriptor.H"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 //==============================================================================
 /// \file main.cpp
 /// \brief The main() function for simulations.
+///
 
 #include "AMReX.H"
 #include "AMReX_ParallelDescriptor.H"


### PR DESCRIPTION
### Description
Use `gcc-11` and `sonar.cfamily.reportingCppStandardOverride=c++20` in sonarcloud.yml

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
