### PR TITLE
Fix PLM convergence

### DIFF
--- a/scripts/python/hydro_wave_convergence_analysis.py
+++ b/scripts/python/hydro_wave_convergence_analysis.py
@@ -32,6 +32,13 @@ class FitResult:
     sse: float
 
 
+@dataclass
+class ConvergenceRun:
+    label: str
+    data: Sequence[ConvergenceDatum]
+    fit: FitResult
+
+
 def read_convergence_csv(path: Path) -> List[ConvergenceDatum]:
     if not path.exists():
         raise FileNotFoundError(f"Could not find convergence file: {path}")
@@ -161,39 +168,32 @@ def geometric_space(x_min: float, x_max: float, num: int) -> List[float]:
     return [math.exp(log_min + (log_max - log_min) * i / (num - 1)) for i in range(num)]
 
 
-def make_plot(
-    data: Sequence[ConvergenceDatum],
-    fit: FitResult,
-    output_path: Path,
-) -> None:
+def make_plot(runs: Sequence[ConvergenceRun], output_path: Path) -> None:
     import matplotlib
 
     matplotlib.use("Agg")
 
     import matplotlib.pyplot as plt
 
-    nx_values = [item.nx for item in data]
-    error_values = [item.error for item in data]
-
-    nx_min = min(nx_values)
-    nx_max = max(nx_values)
-    nx_plot = geometric_space(nx_min, nx_max, 200)
-
-    model_values = []
-    asymptotic_values = []
-    for nx in nx_plot:
-        asymptotic = fit.amplitude * (nx ** (-fit.order))
-        model_values.append(math.sqrt(asymptotic * asymptotic + fit.floor * fit.floor))
-        asymptotic_values.append(asymptotic)
-
     fig, ax = plt.subplots(figsize=(6.0, 4.0))
-    ax.loglog(nx_values, error_values, "o", label="Simulation data")
-    ax.loglog(nx_plot, model_values, "-", label="Power law + floor fit")
-    ax.loglog(nx_plot, asymptotic_values, "--", label="Asymptotic power law")
+    color_cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    for run_index, run in enumerate(runs):
+        color = color_cycle[run_index % len(color_cycle)]
+        nx_values = [item.nx for item in run.data]
+        error_values = [item.error for item in run.data]
 
-    x_lo, x_hi = ax.get_xlim()
-    ax.axhline(fit.floor, color="gray", linestyle="--", label="Roundoff floor")
-    ax.set_xlim(x_lo, x_hi)
+        nx_plot = geometric_space(min(nx_values), max(nx_values), 200)
+        model_values = []
+        asymptotic_values = []
+        for nx in nx_plot:
+            asymptotic = run.fit.amplitude * (nx ** (-run.fit.order))
+            model_values.append(math.sqrt(asymptotic * asymptotic + run.fit.floor * run.fit.floor))
+            asymptotic_values.append(asymptotic)
+
+        ax.loglog(nx_values, error_values, "o", color=color, label="_nolegend_")
+        ax.loglog(nx_plot, model_values, "-", color=color, label=f"{run.label} fit")
+        ax.loglog(nx_plot, asymptotic_values, "--", color=color, label="_nolegend_")
+        ax.axhline(run.fit.floor, color=color, linestyle=":", alpha=0.5, label="_nolegend_")
 
     ax.set_xlabel("Cells per wavelength (N_x)")
     ax.set_ylabel("L1 error norm")
@@ -211,8 +211,15 @@ def main() -> None:
     parser.add_argument(
         "--csv",
         type=Path,
-        default=Path("tests") / "hydro_wave_convergence.csv",
-        help="Path to the hydro wave convergence CSV file (default: tests/hydro_wave_convergence.csv).",
+        action="append",
+        default=[],
+        help="Path to a hydro wave convergence CSV file (repeatable).",
+    )
+    parser.add_argument(
+        "--label",
+        action="append",
+        default=[],
+        help="Optional label for a CSV file (repeatable, matches --csv order).",
     )
     parser.add_argument(
         "--output",
@@ -227,29 +234,38 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    data = read_convergence_csv(args.csv)
-    fit = fit_power_law_with_floor(data)
-    orders = compute_observed_orders(data)
+    csv_paths = args.csv or [Path("tests") / "hydro_wave_convergence.csv"]
+    if args.label and len(args.label) != len(csv_paths):
+        raise ValueError("Provide the same number of --label entries as --csv entries.")
 
-    print("Hydro wave convergence statistics:\n")
-    print(f"{'nx':>8} {'dx':>14} {'error':>16}")
-    for row in data:
-        print(f"{row.nx:8d} {row.dx:14.6e} {row.error:16.6e}")
+    labels = args.label or [path.stem for path in csv_paths]
+    runs: List[ConvergenceRun] = []
 
-    print("\nObserved refinement ratios and orders (successive levels):")
-    print(f"{'nx':>8} {'ratio':>10} {'order':>10}")
-    for nx, ratio, order in orders:
-        print(f"{nx:8d} {ratio:10.3f} {order:10.3f}")
+    for label, csv_path in zip(labels, csv_paths):
+        data = read_convergence_csv(csv_path)
+        fit = fit_power_law_with_floor(data)
+        orders = compute_observed_orders(data)
+        runs.append(ConvergenceRun(label=label, data=data, fit=fit))
 
-    print("\nPower-law + floor fit parameters:")
-    print(f"  amplitude (A): {fit.amplitude:.6e}")
-    print(f"  order (p):     {fit.order:.3f}")
-    print(f"  floor (f):     {fit.floor:.6e}")
+        print(f"Hydro wave convergence statistics for {label} ({csv_path}):\n")
+        print(f"{'nx':>8} {'dx':>14} {'error':>16}")
+        for row in data:
+            print(f"{row.nx:8d} {row.dx:14.6e} {row.error:16.6e}")
+
+        print("\nObserved refinement ratios and orders (successive levels):")
+        print(f"{'nx':>8} {'ratio':>10} {'order':>10}")
+        for nx, ratio, order in orders:
+            print(f"{nx:8d} {ratio:10.3f} {order:10.3f}")
+
+        print("\nPower-law + floor fit parameters:")
+        print(f"  amplitude (A): {fit.amplitude:.6e}")
+        print(f"  order (p):     {fit.order:.3f}")
+        print(f"  floor (f):     {fit.floor:.6e}\n")
 
     if args.no_plot:
         print("\nSkipping plot generation (per --no-plot).")
     else:
-        make_plot(data, fit, args.output)
+        make_plot(runs, args.output)
         print(f"\nSaved log-log plot to {args.output}")
 
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2652,10 +2652,10 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 											ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 2) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(cc_bfield_perp_comps_mf, leftState_bfield,
-													      rightState_bfield, ng_reconstruct, 2);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(cc_bfield_perp_comps_mf, leftState_bfield,
+													   rightState_bfield, ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
@@ -3151,7 +3151,7 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 										x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 2) {
 		// PLM and donor cell are interface-centered kernels
-		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::MC>(primVar.array(), x1LeftState.array(), x1RightState.array(),
+		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(primVar.array(), x1LeftState.array(), x1RightState.array(),
 												  x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(),

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2655,7 +2655,7 @@ void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf,
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(cc_bfield_perp_comps_mf, leftState_bfield,
-													   rightState_bfield, ng_reconstruct, 2);
+													     rightState_bfield, ng_reconstruct, 2);
 		}
 	} else if (reconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
@@ -3152,7 +3152,7 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 	} else if (radiationReconstructionOrder_ == 2) {
 		// PLM and donor cell are interface-centered kernels
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(primVar.array(), x1LeftState.array(), x1RightState.array(),
-												  x1ReconstructRange, nvars);
+												     x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(),
 										     x1ReconstructRange, nvars);

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -911,13 +911,13 @@ void MHDSystem<problem_t>::ReconstructTo(FluxDir dir, arrayconst_t &cState, arra
 	} else if (reconstructionOrder == 2) {
 		switch (dir) {
 			case FluxDir::X1:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X1, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X1, SlopeLimiter::sweby>(cState, lState, rState, box_r, 1);
 				break;
 			case FluxDir::X2:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X2, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X2, SlopeLimiter::sweby>(cState, lState, rState, box_r, 1);
 				break;
 			case FluxDir::X3:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X3, SlopeLimiter::minmod>(cState, lState, rState, box_r, 1);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X3, SlopeLimiter::sweby>(cState, lState, rState, box_r, 1);
 				break;
 		}
 	} else if (reconstructionOrder == 1) {

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -36,7 +36,7 @@ enum redoFlag { none = 0, redo = 1 };
 } // namespace quokka
 
 // Define enum for slope limiter type
-enum SlopeLimiter { minmod = 0, MC };
+enum SlopeLimiter { minmod = 0, sweby, MC };
 
 using array_t = amrex::Array4<amrex::Real> const;
 using arrayconst_t = amrex::Array4<const amrex::Real> const;
@@ -47,23 +47,43 @@ template <typename problem_t> class HyperbolicSystem
       public:
 	template <SlopeLimiter limiter> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto SlopeFunc(amrex::Real x, amrex::Real y) -> amrex::Real
 	{
-		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::MC, "Invalid slope limiter specified.");
+		static_assert(limiter == SlopeLimiter::minmod || limiter == SlopeLimiter::sweby || limiter == SlopeLimiter::MC,
+			      "Invalid slope limiter specified.");
 		if constexpr (limiter == SlopeLimiter::minmod) {
-			return minmod(x, y);
+			return Sweby(x, y, 1.0);
+		}
+		if constexpr (limiter == SlopeLimiter::sweby) {
+			return Sweby(x, y, 1.5);
 		}
 		if constexpr (limiter == SlopeLimiter::MC) {
-			return MC(x, y);
+			return Sweby(x, y, 2.0);
 		}
 	}
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(double a, double b) -> double
 	{
-		return 0.5 * (sgn(a) + sgn(b)) * std::min({0.5 * std::abs(a + b), 2.0 * std::abs(a), 2.0 * std::abs(b)});
+		return Sweby(a, b, 2.0);
 	}
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod(double a, double b) -> double
 	{
 		return 0.5 * (sgn(a) + sgn(b)) * std::min(std::abs(a), std::abs(b));
+	}
+
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod3(double a, double b, double c) -> double
+	{
+		if ((sgn(a) == sgn(b)) && (sgn(a) == sgn(c))) {
+			return sgn(a) * std::min({std::abs(a), std::abs(b), std::abs(c)});
+		}
+		return 0.0;
+	}
+
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto Sweby(double a, double b, double sigma) -> double
+	{
+		const double sigma_a = sigma * a;
+		const double sigma_b = sigma * b;
+		const double centered = 0.5 * (a + b);
+		return minmod3(sigma_a, centered, sigma_b);
 	}
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto median(double a, double b, double c) -> double
@@ -255,7 +275,7 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 	// permute array indices according to dir
 	auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
-	// Unlike PPM, PLM with MC or minmod limiters is TVD.
+	// Unlike PPM, PLM with Sweby limiters (sigma=1 midmod, sigma=1.5 Sweby, sigma=2 MC) is TVD.
 	// (There are no spurious oscillations, *except* in the slow-moving shock problem,
 	// which can produce unphysical oscillations even when using upwind Godunov fluxes.)
 	// However, most tests fail when using PLM reconstruction because
@@ -273,8 +293,8 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 	// (This converges at second order in spatial resolution.)
 	const auto lslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i, j, k, n) - q(i - 1, j, k, n), q(i - 1, j, k, n) - q(i - 2, j, k, n));
 	const auto rslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
-	leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.25 * lslope; // NOLINT
-	rightState(i, j, k, n) = q(i, j, k, n) - 0.25 * rslope;	   // NOLINT
+	leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.5 * lslope; // NOLINT
+	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * rslope;	   // NOLINT
 }
 
 template <typename problem_t>

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -60,10 +60,7 @@ template <typename problem_t> class HyperbolicSystem
 		}
 	}
 
-	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(double a, double b) -> double
-	{
-		return Sweby(a, b, 2.0);
-	}
+	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto MC(double a, double b) -> double { return Sweby(a, b, 2.0); }
 
 	[[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static auto minmod(double a, double b) -> double
 	{
@@ -294,7 +291,7 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 	const auto lslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i, j, k, n) - q(i - 1, j, k, n), q(i - 1, j, k, n) - q(i - 2, j, k, n));
 	const auto rslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
 	leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.5 * lslope; // NOLINT
-	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * rslope;	   // NOLINT
+	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * rslope;	  // NOLINT
 }
 
 template <typename problem_t>

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -36,7 +36,7 @@ enum redoFlag { none = 0, redo = 1 };
 } // namespace quokka
 
 // Define enum for slope limiter type
-enum SlopeLimiter { minmod = 0, sweby, MC };
+enum class SlopeLimiter { minmod = 0, sweby, MC };
 
 using array_t = amrex::Array4<amrex::Real> const;
 using arrayconst_t = amrex::Array4<const amrex::Real> const;

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -272,7 +272,7 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 	// permute array indices according to dir
 	auto [i, j, k] = quokka::reorderMultiIndex<DIR>(i_in, j_in, k_in);
 
-	// Unlike PPM, PLM with Sweby limiters (sigma=1 midmod, sigma=1.5 Sweby, sigma=2 MC) is TVD.
+	// Unlike PPM, PLM with Sweby limiters (sigma=1 minmod, sigma=1.5 Sweby, sigma=2 MC) is TVD.
 	// (There are no spurious oscillations, *except* in the slow-moving shock problem,
 	// which can produce unphysical oscillations even when using upwind Godunov fluxes.)
 	// However, most tests fail when using PLM reconstruction because


### PR DESCRIPTION
### Description
There was a factor-of-two bug in the PLM slopes that preventing PLM convergence at order 2.

I have also switched to use the Sweby $\beta=1.5$ limiter, which is sharper than minmod. (Minmod only converges at order ~1.5 due to severe extrema clipping. MC converges at almost exactly order 2.)

It now converges at nearly order 2, as it should:
```
Running Richardson convergence test for HydroWave:
Resolution      Error Norm
----------      ----------

       128      5.680154e-09
       256      1.544953e-09
       512      4.469956e-10
      1024      1.255872e-10
      2048      3.500900e-11

Reached maximum resolution (nx = 2048) without achieving the target error 2.000e-11

Convergence Rate Analysis:
Resolution Pair Observed Rate   Expected Rate
--------------- -------------   -------------
 128 ->  256             1.88             2.0
 256 ->  512             1.79             2.0
 512 -> 1024             1.83             2.0
1024 -> 2048             1.84             2.0

Overall convergence rate: 1.84
Expected rate: 2.0
```

<img width="1200" height="800" alt="hydro_wave_convergence_limiters" src="https://github.com/user-attachments/assets/361acc88-db5d-4682-a9f7-09dd64948b77" />

### Related issues
N/A
### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
