### PR TITLE
Add timestep control runtime options

### DIFF
--- a/inputs/DustDamping.in
+++ b/inputs/DustDamping.in
@@ -21,6 +21,7 @@ do_subcycle = 0
 suppress_output = 0
 
 max_timesteps = 1000
+constant_dt = 0.005
 
 dust.omega = 1.0
 

--- a/inputs/HydroLeblanc.in
+++ b/inputs/HydroLeblanc.in
@@ -19,3 +19,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 
 do_reflux = 0
 do_subcycle = 0
+initial_dt = 1.0e-5

--- a/inputs/HydroSMS.in
+++ b/inputs/HydroSMS.in
@@ -19,3 +19,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 
 do_reflux = 0
 do_subcycle = 0
+constant_dt = 1.0e-3

--- a/inputs/HydroShuOsher.in
+++ b/inputs/HydroShuOsher.in
@@ -19,3 +19,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 
 do_reflux = 0
 do_subcycle = 0
+constant_dt = 1.0e-4

--- a/inputs/MarshakAsymptoticCorr.in
+++ b/inputs/MarshakAsymptoticCorr.in
@@ -24,3 +24,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+initial_dt = 5.0e-12

--- a/inputs/ParticleCreation.in
+++ b/inputs/ParticleCreation.in
@@ -29,6 +29,7 @@ particles.verbose = 1
 particles.disable_SN_feedback = true
 
 stop_time = 1.0
+initial_dt = 0.001
 max_timesteps = 4
 plotfile_interval = -1
 plottime_interval = 0.003

--- a/inputs/ParticleCreationAMR.in
+++ b/inputs/ParticleCreationAMR.in
@@ -29,6 +29,7 @@ particles.verbose = 1
 particles.disable_SN_feedback = true
 
 stop_time = 1.0
+initial_dt = 0.001
 max_timesteps = 4
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/inputs/ParticleRadiation.in
+++ b/inputs/ParticleRadiation.in
@@ -30,6 +30,7 @@ particles.rad_table = ../inputs/lum_demo_2groups.csv
 particles.rad_table_output_spacing = linear
 
 stop_time = 8.0e20
+initial_dt = 3.15576e6
 max_timesteps = 3
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/inputs/ParticleRadiationFastlog.in
+++ b/inputs/ParticleRadiationFastlog.in
@@ -30,6 +30,7 @@ particles.rad_table = ../inputs/lum_demo_2groups_fastlog.csv
 particles.rad_table_output_spacing = fast_log
 
 stop_time = 8.0e20
+initial_dt = 3.15576e6
 max_timesteps = 3
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/inputs/ParticleRadiationLog.in
+++ b/inputs/ParticleRadiationLog.in
@@ -30,6 +30,7 @@ particles.rad_table = ../inputs/lum_demo_2groups_log.csv
 particles.rad_table_output_spacing = log
 
 stop_time = 8.0e20
+initial_dt = 3.15576e6
 max_timesteps = 3
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/inputs/ParticleSF.in
+++ b/inputs/ParticleSF.in
@@ -36,6 +36,7 @@ problem.n0 = 1.0e5
 problem.Tamb = 1.0e1
 
 max_timesteps = 10
+initial_dt = 3.15576e12
 plotfile_interval = 5
 checkpoint_interval = 5
 

--- a/inputs/ParticleSF2.in
+++ b/inputs/ParticleSF2.in
@@ -37,6 +37,7 @@ problem.Tamb = 1.0e1
 
 restartfile = chk00010
 max_timesteps = 20
+initial_dt = 3.15576e12
 plotfile_interval = 5
 checkpoint_interval = 5
 

--- a/inputs/ParticleSink.in
+++ b/inputs/ParticleSink.in
@@ -30,6 +30,7 @@ particles.verbose = 1
 particles.sink_particle_use_uniform_kernel = true
 
 max_timesteps = 1
+initial_dt = 9.46728e7
 particle_interval = 1
 
 tiny_profiler.enabled = 0

--- a/inputs/ParticleSinkFormation.in
+++ b/inputs/ParticleSinkFormation.in
@@ -26,6 +26,7 @@ do_tracers = 0      # turn on tracer particles
 
 particles.verbose = 1
 
+initial_dt = 3.15576e12
 plotfile_interval = -1
 
 tiny_profiler.enabled = 0

--- a/inputs/PopIII.in
+++ b/inputs/PopIII.in
@@ -24,6 +24,7 @@ hydro.reconstruction_order = 3  # PPM
 cfl = 0.15
 max_timesteps = 10
 stop_time = 1e16
+initial_dt = 1.0e6
 
 do_reflux = 1
 do_subcycle = 0

--- a/inputs/RadLineCooling.in
+++ b/inputs/RadLineCooling.in
@@ -24,3 +24,4 @@ radiation.dust_gas_interaction_coeff = 1e-20
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+initial_dt = 1.0e-2

--- a/inputs/RadLineCoolingCoupled.in
+++ b/inputs/RadLineCoolingCoupled.in
@@ -24,3 +24,4 @@ radiation.dust_gas_interaction_coeff = 1e20
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+initial_dt = 1.0e-2

--- a/inputs/RadLineCoolingMG.in
+++ b/inputs/RadLineCoolingMG.in
@@ -24,3 +24,4 @@ radiation.dust_gas_interaction_coeff = 1e-20
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+initial_dt = 1.0e-2

--- a/inputs/RadMarshak.in
+++ b/inputs/RadMarshak.in
@@ -20,3 +20,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 0
+initial_dt = 1.0e-9

--- a/inputs/RadMarshakAsymptotic.in
+++ b/inputs/RadMarshakAsymptotic.in
@@ -22,3 +22,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+initial_dt = 5.0e-12

--- a/inputs/RadMatterCoupling.in
+++ b/inputs/RadMatterCoupling.in
@@ -21,3 +21,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+constant_dt = 1.0e-8

--- a/inputs/RadMatterCouplingRSLA.in
+++ b/inputs/RadMatterCouplingRSLA.in
@@ -21,3 +21,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 1
+constant_dt = 1.0e-8

--- a/inputs/RadSuOlson.in
+++ b/inputs/RadSuOlson.in
@@ -20,3 +20,4 @@ amr.blocking_factor = 8     # grid size must be divisible by this
 do_reflux = 0
 do_subcycle = 0
 suppress_output = 0
+initial_dt = 1.0e-9

--- a/inputs/SN.in
+++ b/inputs/SN.in
@@ -39,6 +39,7 @@ particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 10
+initial_dt = 3.15576e4
 plotfile_interval = -1
 checkpoint_interval = -1
 

--- a/inputs/SN_long_grackle.in
+++ b/inputs/SN_long_grackle.in
@@ -39,5 +39,6 @@ particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 400
+initial_dt = 3.15576e4
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/inputs/SN_long_resampled.in
+++ b/inputs/SN_long_resampled.in
@@ -39,5 +39,6 @@ particles.SN_scheme = SN_thermal_or_thermal_momentum
 particles.verbose = 1
 
 max_timesteps = 400
+initial_dt = 3.15576e4
 plotfile_interval = -1
 checkpoint_interval = -1

--- a/src/problems/DustDamping/testDustDamping.cpp
+++ b/src/problems/DustDamping/testDustDamping.cpp
@@ -270,7 +270,6 @@ auto problem_main() -> int
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.plotfileInterval_ = -1;
 	sim.cflNumber_ = CFL_number;
-	sim.constantDt_ = 0.005; // usually 0.005 for test B, 0.05 for test C
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -349,7 +349,6 @@ auto problem_main() -> int
 	const double CFL_number = 0.1;
 	const double max_time = 6.0;
 	const double max_dt = 1e-3;
-	const double initial_dt = 1e-5;
 	const int max_timesteps = 50000;
 
 	auto BCs_cc = quokka::BC<ShocktubeProblem>(quokka::BCType::foextrap, quokka::BCType::int_dir, quokka::BCType::int_dir);
@@ -360,7 +359,6 @@ auto problem_main() -> int
 	sim.maxDt_ = max_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
-	sim.initDt_ = initial_dt;
 
 	sim.plotfileInterval_ = -1;
 

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -269,13 +269,11 @@ auto problem_main() -> int
 	// const double Lx = 1.0;
 	const double CFL_number = 0.2;
 	const double max_time = 1.0;
-	const double fixed_dt = 1e-3;
 	const int max_timesteps = 20000;
 
 	QuokkaSimulation<ShocktubeProblem> sim;
 
 	sim.cflNumber_ = CFL_number;
-	sim.constantDt_ = fixed_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.integratorOrder_ = 2;     // use forward Euler

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -288,7 +288,6 @@ auto problem_main() -> int
 	// const double Lx = 10.0;
 	const double CFL_number = 0.2;
 	const double max_time = 1.8;
-	const double fixed_dt = 1e-4;
 	const int max_timesteps = 20000;
 
 	// Problem initialization
@@ -306,7 +305,6 @@ auto problem_main() -> int
 	QuokkaSimulation<ShocktubeProblem> sim(BCs_cc);
 
 	sim.cflNumber_ = CFL_number;
-	sim.constantDt_ = fixed_dt;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 

--- a/src/problems/ParticleCreation/testParticleCreation.cpp
+++ b/src/problems/ParticleCreation/testParticleCreation.cpp
@@ -260,7 +260,6 @@ auto problem_main() -> int
 {
 	// Problem initialization
 	QuokkaSimulation<TestParticle> sim;
-	sim.initDt_ = dt_;
 	sim.maxDt_ = dt_;
 
 	// Read parameters from input file

--- a/src/problems/ParticleRadiation/testParticleRadiation.cpp
+++ b/src/problems/ParticleRadiation/testParticleRadiation.cpp
@@ -153,7 +153,6 @@ auto problem_main() -> int
 {
 	// Problem initialization
 	QuokkaSimulation<ParticleRadiationProblem> sim;
-	sim.initDt_ = dt_;
 	sim.maxDt_ = dt_;
 
 	// Read parameters from input file

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -233,7 +233,6 @@ auto problem_main() -> int
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 	sim.stopTime_ = 1.0e7 * year; // 10 Myr
-	sim.initDt_ = 1.0e5 * year;   // 0.1 Myr
 
 	// set random state
 	const int seed = 42;

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -138,7 +138,6 @@ auto problem_main() -> int
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 	sim.stopTime_ = 10.0 * dt_init;
-	sim.initDt_ = dt_init;
 	sim.tempFloor_ = 10.0; // K
 
 	// initialize

--- a/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
+++ b/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
@@ -131,7 +131,6 @@ auto problem_main() -> int
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.cflNumber_ = 0.3;	      // *must* be less than 1/3 in 3D!
 	sim.stopTime_ = 1.0e7 * year; // 1 Myr
-	sim.initDt_ = 1.0e5 * year;   // 0.1 Myr
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/PopIII/testPopIII.cpp
+++ b/src/problems/PopIII/testPopIII.cpp
@@ -452,8 +452,6 @@ auto problem_main() -> int
 	sim.userData_.numdens_init = numdens_init;
 	sim.userData_.omega_sphere = omega_sphere;
 
-	sim.initDt_ = 1e6;
-
 	// initialize
 	sim.setInitialConditions();
 

--- a/src/problems/RadLineCooling/testRadLineCooling.cpp
+++ b/src/problems/RadLineCooling/testRadLineCooling.cpp
@@ -209,7 +209,6 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number_rad;
 	sim.cflNumber_ = CFL_number_gas;
-	sim.initDt_ = the_dt;
 	sim.maxDt_ = the_dt;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.plotfileInterval_ = -1;

--- a/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
+++ b/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
@@ -209,7 +209,6 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number_rad;
 	sim.cflNumber_ = CFL_number_gas;
-	sim.initDt_ = the_dt;
 	sim.maxDt_ = the_dt;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.plotfileInterval_ = -1;

--- a/src/problems/RadMarshak/testRadMarshak.cpp
+++ b/src/problems/RadMarshak/testRadMarshak.cpp
@@ -202,15 +202,15 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 	const double CFL_number = 0.4;
 
-	const double max_dtau = 1e-3;	  // dimensionless time
-	const double max_tau = 10.0;	  // dimensionless time
+	const double max_dtau = 1e-3; // dimensionless time
+	const double max_tau = 10.0;  // dimensionless time
 	// const double Lz = 20.0;	  // dimensionless length
 
 	// Su & Olson (1997) parameters
 	const double chi = rho0 * kappa; // cm^-1 (total matter opacity)
 	// const double Lx = Lz / chi;	// cm
-	const double max_time = max_tau / (eps_SuOlson * c * chi);	  // s
-	const double max_dt = max_dtau / (eps_SuOlson * c * chi);	  // s
+	const double max_time = max_tau / (eps_SuOlson * c * chi); // s
+	const double max_dt = max_dtau / (eps_SuOlson * c * chi);  // s
 
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_; // NOLINT(cppcoreguidelines-init-variables)
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);

--- a/src/problems/RadMarshak/testRadMarshak.cpp
+++ b/src/problems/RadMarshak/testRadMarshak.cpp
@@ -202,7 +202,6 @@ auto problem_main() -> int
 	const int max_timesteps = 2e4;
 	const double CFL_number = 0.4;
 
-	const double initial_dtau = 1e-9; // dimensionless time
 	const double max_dtau = 1e-3;	  // dimensionless time
 	const double max_tau = 10.0;	  // dimensionless time
 	// const double Lz = 20.0;	  // dimensionless length
@@ -212,7 +211,6 @@ auto problem_main() -> int
 	// const double Lx = Lz / chi;	// cm
 	const double max_time = max_tau / (eps_SuOlson * c * chi);	  // s
 	const double max_dt = max_dtau / (eps_SuOlson * c * chi);	  // s
-	const double initial_dt = initial_dtau / (eps_SuOlson * c * chi); // s
 
 	constexpr int nvars = RadSystem<SuOlsonProblem>::nvar_; // NOLINT(cppcoreguidelines-init-variables)
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
@@ -230,7 +228,6 @@ auto problem_main() -> int
 
 	sim.stopTime_ = max_time;
 	sim.radiationCflNumber_ = CFL_number;
-	sim.initDt_ = initial_dt;
 	sim.maxDt_ = max_dt;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.plotfileInterval_ = -1;

--- a/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
@@ -207,8 +207,8 @@ auto problem_main() -> int
 	// Problem parameters
 	const int max_timesteps = 1e6;
 	const double CFL_number = 10.0;
-	const double max_dt = 5.0;	   // s
-	const double max_time = 10.0e-9;   // s
+	const double max_dt = 5.0;	 // s
+	const double max_time = 10.0e-9; // s
 	// const int nx = 60; // [18 == matches resolution of McClarren & Lowrie (2008)]
 	// const double Lx = 0.66; // cm
 

--- a/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
@@ -207,7 +207,6 @@ auto problem_main() -> int
 	// Problem parameters
 	const int max_timesteps = 1e6;
 	const double CFL_number = 10.0;
-	const double initial_dt = 5.0e-12; // s
 	const double max_dt = 5.0;	   // s
 	const double max_time = 10.0e-9;   // s
 	// const int nx = 60; // [18 == matches resolution of McClarren & Lowrie (2008)]
@@ -230,7 +229,6 @@ auto problem_main() -> int
 
 	sim.radiationReconstructionOrder_ = 3; // PPM
 	sim.stopTime_ = max_time;
-	sim.initDt_ = initial_dt;
 	sim.maxDt_ = max_dt;
 	sim.radiationCflNumber_ = CFL_number;
 	sim.maxTimesteps_ = max_timesteps;

--- a/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
+++ b/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
@@ -157,13 +157,11 @@ auto problem_main() -> int
 	const double CFL_number = 1.0;
 	const double max_time = 1.0e-2; // s
 	const int max_timesteps = 1e6;
-	const double constant_dt = 1.0e-8; // s
 
 	QuokkaSimulation<CouplingProblem> sim;
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;
-	sim.constantDt_ = constant_dt;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.stopTime_ = max_time;
 	sim.plotfileInterval_ = -1;

--- a/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
+++ b/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
@@ -160,13 +160,11 @@ auto problem_main() -> int
 	const double CFL_number = 1.0;
 	const double max_time = 1.0e-2; // s
 	const int max_timesteps = 1e6;
-	const double constant_dt = 1.0e-8; // s
 
 	QuokkaSimulation<CouplingProblem> sim;
 
 	sim.cflNumber_ = CFL_number;
 	sim.radiationCflNumber_ = CFL_number;
-	sim.constantDt_ = constant_dt;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.stopTime_ = max_time;
 	sim.plotfileInterval_ = -1;

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -187,8 +187,8 @@ auto problem_main() -> int
 	// const int nx = 1500;
 	const int max_timesteps = 12000;
 	const double CFL_number = 0.4;
-	const double max_dt = 1e-2;	// dimensionless time
-	const double max_time = 10.0;	// dimensionless time
+	const double max_dt = 1e-2;   // dimensionless time
+	const double max_time = 10.0; // dimensionless time
 	// const double max_time = 3.16228;	  // dimensionless time
 
 	QuokkaSimulation<MarshakProblem> sim;

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -188,7 +188,6 @@ auto problem_main() -> int
 	const int max_timesteps = 12000;
 	const double CFL_number = 0.4;
 	const double max_dt = 1e-2;	// dimensionless time
-	const double initial_dt = 1e-9; // dimensionless time
 	const double max_time = 10.0;	// dimensionless time
 	// const double max_time = 3.16228;	  // dimensionless time
 
@@ -199,7 +198,6 @@ auto problem_main() -> int
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.maxDt_ = max_dt;
-	sim.initDt_ = initial_dt;
 	sim.plotfileInterval_ = -1;
 
 	// evolve

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -185,7 +185,6 @@ auto problem_main() -> int
 	sim.reconstructionOrder_ = 3; // 2=PLM, 3=PPM
 	sim.stopTime_ = t_stop * year;
 	sim.cflNumber_ = 0.3; // *must* be less than 1/3 in 3D!
-	sim.initDt_ = 0.001 * year;
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -787,8 +787,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	const int dt_override_count =
 	    static_cast<int>(pp.contains("init_shrink")) + static_cast<int>(pp.contains("initial_dt")) + static_cast<int>(pp.contains("constant_dt"));
-	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_override_count <= 1,
-					 "Specify at most one of init_shrink, initial_dt, or constant_dt in the inputs.");
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_override_count <= 1, "Specify at most one of init_shrink, initial_dt, or constant_dt in the inputs.");
 
 	// Abort when signal speed exceeds this threshold (in code units)
 	pp.query("signal_speed_abort", signalSpeedAbort_);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -785,6 +785,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	pp.query("constant_dt", constantDt_);
 	pp.query("initial_dt", initDt_);
 
+	const int dt_override_count =
+	    static_cast<int>(pp.contains("init_shrink")) + static_cast<int>(pp.contains("initial_dt")) + static_cast<int>(pp.contains("constant_dt"));
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_override_count <= 1,
+					 "Specify at most one of init_shrink, initial_dt, or constant_dt in the inputs.");
+
 	// Abort when signal speed exceeds this threshold (in code units)
 	pp.query("signal_speed_abort", signalSpeedAbort_);
 	pp.query("particle_speed_abort", particleSpeedAbort_);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -187,6 +187,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real particleSpeedAbort_ = -1.0;
 	amrex::Real dtToleranceFactor_ = 1.1; // default
 	amrex::Real dtCutoff_ = 0.0;	      // default: no cutoff (disabled when 0)
+	amrex::Real initShrink_ = 1.0;	      // default: no shrink
 	amrex::Long cycleCount_ = 0;
 	int printCycleTiming_ = 0;				     // default: don't print
 	amrex::Long maxTimesteps_ = std::numeric_limits<int>::max(); // default: no limit
@@ -780,6 +781,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default CFL number for particles == 0.5, set to whatever is in the file
 	pp.query("particle_cfl", particleCflNumber_);
 
+	// Optional fixed timestep controls
+	pp.query("constant_dt", constantDt_);
+	pp.query("initial_dt", initDt_);
+
 	// Abort when signal speed exceeds this threshold (in code units)
 	pp.query("signal_speed_abort", signalSpeedAbort_);
 	pp.query("particle_speed_abort", particleSpeedAbort_);
@@ -792,6 +797,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// Default timestep cutoff (safety feature)
 	pp.query("dt_cutoff", dtCutoff_);
+
+	// Default initial timestep shrink factor
+	pp.query("init_shrink", initShrink_);
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(initShrink_ > 0.0 && initShrink_ <= 1.0, "init_shrink must be in (0, 1].");
 
 	// Default ascent render interval
 	pp.query("ascent_interval", ascentInterval_);
@@ -1163,6 +1172,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 		if (constantDt_ > 0.0) { // use constant timestep if set
 			dt_0 = constantDt_;
 		}
+	}
+
+	if (tNew_[0] == 0.0) { // shrink the initial timestep if requested
+		dt_0 *= initShrink_;
 	}
 
 	if (verbose) {


### PR DESCRIPTION
### Description
Adds `init_shrink`, `initial_dt`, and `constant_dt` ParmParse options.
* `init_shrink`: shrinks the initial timestep by this factor
* `initial_dt`: sets the initial timestep to exactly this value
* `constant_dt`: sets *all* timesteps to exactly this value

This is inspired by the analogous Castro options: https://amrex-astro.github.io/Castro/docs/timestepping.html#additional-controls

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
