### PR TITLE
Fix Azure DevOps CI ccache timeout issues

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -134,9 +134,17 @@ jobs:
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          echo "=== Before cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cleanup ==="
           ccache --cleanup || true
+          echo ""
+          echo "=== After cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cache directory size ==="
+          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
         else
           echo "ccache not installed; no statistics to report."
         fi

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -63,7 +63,7 @@ variables:
 jobs:
   - job: HIP_Build_Test
     pool: amdgpu
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     steps:
     - task: Cache@2
       displayName: Restore ccache
@@ -72,6 +72,7 @@ jobs:
         restoreKeys: |
           ccache | HIP | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache
+        cacheHitVar: CACHE_RESTORED
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
@@ -86,7 +87,13 @@ jobs:
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         if command -v ccache >/dev/null 2>&1; then
+          ccache --set-config=max_size=5G
+          ccache --set-config=compression=true
+          ccache --set-config=compression_level=6
+          ccache --cleanup || true
           ccache --zero-stats || true
+          echo "ccache configuration:"
+          ccache --show-config | grep -E "(max_size|compression)" || true
         else
           echo "ccache not installed; skipping zero-stats."
         fi
@@ -127,6 +134,8 @@ jobs:
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+          ccache --cleanup || true
           ccache --show-stats || true
         else
           echo "ccache not installed; no statistics to report."

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -84,22 +84,7 @@ jobs:
         fi
       displayName: Detect ccache
 
-    - script: |
-        mkdir -p $(Pipeline.Workspace)/ccache
-        if command -v ccache >/dev/null 2>&1; then
-          ccache --set-config=max_size=5G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --cleanup || true
-          ccache --zero-stats || true
-          echo "ccache configuration:"
-          ccache --show-config | grep -E "(max_size|compression)" || true
-        else
-          echo "ccache not installed; skipping zero-stats."
-        fi
-      displayName: Prepare ccache
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-prepare.yml
 
     - task: CMake@1
       displayName: 'Configure CMake'
@@ -132,23 +117,4 @@ jobs:
       condition: succeededOrFailed()
       displayName: Publish test results
 
-    - script: |
-        if command -v ccache >/dev/null 2>&1; then
-          echo "=== Before cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cleanup ==="
-          ccache --cleanup || true
-          echo ""
-          echo "=== After cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cache directory size ==="
-          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
-        else
-          echo "ccache not installed; no statistics to report."
-        fi
-      displayName: Report ccache statistics
-      condition: succeededOrFailed()
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-stats.yml

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -42,22 +42,7 @@ jobs:
         fi
       displayName: Detect ccache
 
-    - script: |
-        mkdir -p $(Pipeline.Workspace)/ccache
-        if command -v ccache >/dev/null 2>&1; then
-          ccache --set-config=max_size=5G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --cleanup || true
-          ccache --zero-stats || true
-          echo "ccache configuration:"
-          ccache --show-config | grep -E "(max_size|compression)" || true
-        else
-          echo "ccache not installed; skipping zero-stats."
-        fi
-      displayName: Prepare ccache
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-prepare.yml
 
     - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
@@ -72,23 +57,4 @@ jobs:
     - script: cd /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'
-    - script: |
-        if command -v ccache >/dev/null 2>&1; then
-          echo "=== Before cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cleanup ==="
-          ccache --cleanup || true
-          echo ""
-          echo "=== After cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cache directory size ==="
-          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
-        else
-          echo "ccache not installed; no statistics to report."
-        fi
-      displayName: Report ccache statistics
-      condition: succeededOrFailed()
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-stats.yml

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -30,6 +30,7 @@ jobs:
         restoreKeys: |
           ccache | regression | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache
+        cacheHitVar: CACHE_RESTORED
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
@@ -44,7 +45,13 @@ jobs:
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         if command -v ccache >/dev/null 2>&1; then
+          ccache --set-config=max_size=5G
+          ccache --set-config=compression=true
+          ccache --set-config=compression_level=6
+          ccache --cleanup || true
           ccache --zero-stats || true
+          echo "ccache configuration:"
+          ccache --show-config | grep -E "(max_size|compression)" || true
         else
           echo "ccache not installed; skipping zero-stats."
         fi
@@ -67,6 +74,8 @@ jobs:
       displayName: 'Upload results to GitHub Pages'
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+          ccache --cleanup || true
           ccache --show-stats || true
         else
           echo "ccache not installed; no statistics to report."

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -74,9 +74,17 @@ jobs:
       displayName: 'Upload results to GitHub Pages'
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          echo "=== Before cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cleanup ==="
           ccache --cleanup || true
+          echo ""
+          echo "=== After cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cache directory size ==="
+          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
         else
           echo "ccache not installed; no statistics to report."
         fi

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -83,22 +83,7 @@ jobs:
         fi
       displayName: Detect ccache
 
-    - script: |
-        mkdir -p $(Pipeline.Workspace)/ccache
-        if command -v ccache >/dev/null 2>&1; then
-          ccache --set-config=max_size=5G
-          ccache --set-config=compression=true
-          ccache --set-config=compression_level=6
-          ccache --cleanup || true
-          ccache --zero-stats || true
-          echo "ccache configuration:"
-          ccache --show-config | grep -E "(max_size|compression)" || true
-        else
-          echo "ccache not installed; skipping zero-stats."
-        fi
-      displayName: Prepare ccache
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-prepare.yml
 
     - task: CMake@1
       displayName: 'Configure CMake'
@@ -131,23 +116,4 @@ jobs:
       condition: succeededOrFailed()
       displayName: Publish test results
 
-    - script: |
-        if command -v ccache >/dev/null 2>&1; then
-          echo "=== Before cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cleanup ==="
-          ccache --cleanup || true
-          echo ""
-          echo "=== After cleanup ==="
-          ccache --show-stats || true
-          echo ""
-          echo "=== Cache directory size ==="
-          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
-        else
-          echo "ccache not installed; no statistics to report."
-        fi
-      displayName: Report ccache statistics
-      condition: succeededOrFailed()
-      env:
-        CCACHE_DIR: $(Pipeline.Workspace)/ccache
+    - template: templates/ccache-stats.yml

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -133,9 +133,17 @@ jobs:
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          echo "=== Before cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cleanup ==="
           ccache --cleanup || true
+          echo ""
+          echo "=== After cleanup ==="
           ccache --show-stats || true
+          echo ""
+          echo "=== Cache directory size ==="
+          du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
         else
           echo "ccache not installed; no statistics to report."
         fi

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -62,7 +62,7 @@ variables:
 jobs:
   - job: CUDA_Build_Test
     pool: avatar
-    timeoutInMinutes: 120
+    timeoutInMinutes: 150
     steps:
     - task: Cache@2
       displayName: Restore ccache
@@ -71,6 +71,7 @@ jobs:
         restoreKeys: |
           ccache | CUDA | $(Agent.OS)
         path: $(Pipeline.Workspace)/ccache
+        cacheHitVar: CACHE_RESTORED
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
@@ -85,7 +86,13 @@ jobs:
     - script: |
         mkdir -p $(Pipeline.Workspace)/ccache
         if command -v ccache >/dev/null 2>&1; then
+          ccache --set-config=max_size=5G
+          ccache --set-config=compression=true
+          ccache --set-config=compression_level=6
+          ccache --cleanup || true
           ccache --zero-stats || true
+          echo "ccache configuration:"
+          ccache --show-config | grep -E "(max_size|compression)" || true
         else
           echo "ccache not installed; skipping zero-stats."
         fi
@@ -126,6 +133,8 @@ jobs:
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
+          ccache --show-stats || true
+          ccache --cleanup || true
           ccache --show-stats || true
         else
           echo "ccache not installed; no statistics to report."

--- a/.ci/templates/ccache-prepare.yml
+++ b/.ci/templates/ccache-prepare.yml
@@ -1,0 +1,18 @@
+# Reusable template for preparing and configuring ccache
+steps:
+- script: |
+    mkdir -p $(Pipeline.Workspace)/ccache
+    if command -v ccache >/dev/null 2>&1; then
+      ccache --set-config=max_size=5G
+      ccache --set-config=compression=true
+      ccache --set-config=compression_level=6
+      ccache --cleanup || true
+      ccache --zero-stats || true
+      echo "ccache configuration:"
+      ccache --show-config | grep -E "(max_size|compression)" || true
+    else
+      echo "ccache not installed; skipping zero-stats."
+    fi
+  displayName: Prepare ccache
+  env:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache

--- a/.ci/templates/ccache-stats.yml
+++ b/.ci/templates/ccache-stats.yml
@@ -1,0 +1,22 @@
+# Reusable template for reporting ccache statistics
+steps:
+- script: |
+    if command -v ccache >/dev/null 2>&1; then
+      echo "=== Before cleanup ==="
+      ccache --show-stats || true
+      echo ""
+      echo "=== Cleanup ==="
+      ccache --cleanup || true
+      echo ""
+      echo "=== After cleanup ==="
+      ccache --show-stats || true
+      echo ""
+      echo "=== Cache directory size ==="
+      du -sh $(Pipeline.Workspace)/ccache 2>/dev/null || echo "Could not measure directory size"
+    else
+      echo "ccache not installed; no statistics to report."
+    fi
+  displayName: Report ccache statistics
+  condition: succeededOrFailed()
+  env:
+    CCACHE_DIR: $(Pipeline.Workspace)/ccache


### PR DESCRIPTION
## Description

### Problem

The "Post-job: Restore ccache" step was timing out during cache save operations, causing CI builds to fail despite successful test execution. The cache directory had grown unbounded over time, making the automatic cache save operation exceed the job timeout.

### Solution
Implemented ccache size management and compression across all three Azure pipelines:

**Changes to all pipelines** (`.ci/azure-pipelines.yml`, `.ci/azure-pipelines-amdgpu.yml`, `.ci/azure-pipelines-regression.yml`):

- Added 5GB size limit for ccache (`max_size=5G`)
- Enabled compression with level 6 to reduce storage requirements
- Added cleanup operations before and after builds to prevent cache bloat
- Enhanced statistics reporting to monitor cache usage and hit rates
- Added `cacheHitVar` for better cache observability

**Timeout adjustments:**
- CUDA pipeline: 120 → 150 minutes
- AMD GPU pipeline: 120 → 150 minutes
- Regression pipeline: unchanged (300 minutes already sufficient)

### Validation
Monitor the "Report ccache statistics" step in CI runs to verify:
- Cache size stays well below 5GB limit
- Cache hit rate remains >80%
- No timeout errors during post-job cache save

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
