### PR TITLE
Use 7-digit plotfile and checkpoint numbering

### DIFF
--- a/inputs/BinaryOrbit_refactor.in
+++ b/inputs/BinaryOrbit_refactor.in
@@ -32,6 +32,6 @@ stop_time = 5.0e7   # s
 checkpoint_interval = 20
 max_timesteps = 40
 plotfile_interval = -1
-restartfile = chk00020
+restartfile = chk0000020
 
 particles.split_particles_on_restart_refine = false

--- a/inputs/BinaryOrbit_refactor_splitparticle.in
+++ b/inputs/BinaryOrbit_refactor_splitparticle.in
@@ -32,6 +32,6 @@ stop_time = 5.0e7   # s
 checkpoint_interval = 20
 max_timesteps = 40
 plotfile_interval = -1
-restartfile = chk00020
+restartfile = chk0000020
 
 particles.split_particles_on_restart_refine = true

--- a/inputs/ParticleSF2.in
+++ b/inputs/ParticleSF2.in
@@ -35,7 +35,7 @@ particles.stellar_velocity_limit = 1.0e8
 problem.n0 = 1.0e5
 problem.Tamb = 1.0e1
 
-restartfile = chk00010
+restartfile = chk0000010
 max_timesteps = 20
 initial_dt = 3.15576e12
 plotfile_interval = 5

--- a/inputs/RadMarshakDust.in
+++ b/inputs/RadMarshakDust.in
@@ -34,4 +34,4 @@ do_subcycle = 0
 suppress_output = 0
 stop_time = 5.0
 #checkpoint_interval = 1
-#restartfile = chk00006
+#restartfile = chk0000006

--- a/inputs/RadMarshakDustPE.in
+++ b/inputs/RadMarshakDustPE.in
@@ -34,4 +34,4 @@ do_subcycle = 0
 suppress_output = 0
 stop_time = 5.0
 #checkpoint_interval = 1
-#restartfile = chk00006
+#restartfile = chk0000006

--- a/inputs/RadMarshakDustPEdecoupled.in
+++ b/inputs/RadMarshakDustPEdecoupled.in
@@ -34,4 +34,4 @@ do_subcycle = 0
 suppress_output = 0
 stop_time = 5.0
 #checkpoint_interval = 1
-#restartfile = chk00006
+#restartfile = chk0000006

--- a/inputs/RadParticles1D.in
+++ b/inputs/RadParticles1D.in
@@ -24,4 +24,4 @@ suppress_output = 0
 stop_time = 0.4
 plotfile_interval = 100000
 checkpoint_interval = 100000
-#restartfile = "chk00086"
+#restartfile = "chk0000086"

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3297,7 +3297,7 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 // Save single-level plotfile
 // This is a wrapper around the WriteSingleLevelPlotfile function in the AMReX library.
 // The step number of the plotfile is set to istep[lev] and the time is set to the current time tNew_[lev].
-// Example usage: write debug_rhs00000 debug_rhs00001 etc with interval plotfileInterval_
+// Example usage: write debug_rhs0000000 debug_rhs0000001 etc with interval plotfileInterval_
 //   const int lev_debug = 0;
 //   amrex::Vector<std::string> flatCompNames{"rhs"};
 //   WriteSingleLevelPlotfileSimplified("debug_rhs", rhs[lev_debug], flatCompNames, lev_debug, plotfileInterval_);

--- a/src/io/DiagParticleTxt.H
+++ b/src/io/DiagParticleTxt.H
@@ -39,7 +39,7 @@ template <typename problem_t> void DiagParticleTxt::processDiag(int a_nstep, con
 	auto *sim = getSim<problem_t>();
 
 	// Generate filename using step number
-	const std::string plotfilename = amrex::Concatenate(m_diagfile, a_nstep, 5);
+	const std::string plotfilename = amrex::Concatenate(m_diagfile, a_nstep, 7);
 
 	// Create directory if it doesn't exist
 	if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/src/io/DiagPlotfile.H
+++ b/src/io/DiagPlotfile.H
@@ -65,7 +65,7 @@ template <typename problem_t> void DiagPlotfile::processDiag(int a_nstep, const 
 	auto *sim = getSim<problem_t>();
 
 	// Generate filename using step number (works for both step-based and time-based intervals)
-	const std::string plotfilename = amrex::Concatenate(m_diagfile, a_nstep, 5);
+	const std::string plotfilename = amrex::Concatenate(m_diagfile, a_nstep, 7);
 	amrex::Print() << "DiagPlotfile: Writing plotfile " << plotfilename << "\n";
 
 	// Prepare cell-centered data
@@ -119,7 +119,7 @@ template <typename problem_t> void DiagPlotfile::processDiag(int a_nstep, const 
 		std::vector<std::string> dimNames = {"x", "y", "z"};
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			auto plotfilename_base = plotfilename + "/fc_vars/" + dimNames[idim];
-			const std::string plotfilename_fc = amrex::Concatenate(plotfilename_base, sim->istep[0], 5);
+			const std::string plotfilename_fc = amrex::Concatenate(plotfilename_base, sim->istep[0], 7);
 			amrex::Vector<const amrex::MultiFab *> mf_fc_ptr = amrex::GetVecOfConstPtrs(mf_fc[idim]);
 			amrex::WriteMultiLevelPlotfile(plotfilename_fc, finest_level + 1, mf_fc_ptr, varnames_fc[idim], geoms, a_time, sim->istep, refRatio);
 			WriteMetadataFile(plotfilename_fc + "/metadata.yaml", sim->simulationMetadata_);

--- a/src/io/DiagProjectionPlot.H
+++ b/src/io/DiagProjectionPlot.H
@@ -72,7 +72,7 @@ template <typename problem_t> void DiagProjectionPlot::processDiag(int a_nstep, 
 
 		// If particles are requested, write them
 		if (!m_particleTypes.empty()) {
-			const std::string filename = amrex::Concatenate(basename, a_nstep, 5);
+			const std::string filename = amrex::Concatenate(basename, a_nstep, 7);
 			sim->particleRegister_.writePlotFileFiltered(filename, m_particleTypes);
 			amrex::Print() << "  Wrote particles to projection " << filename << "\n";
 		}

--- a/src/io/projection.cpp
+++ b/src/io/projection.cpp
@@ -570,7 +570,7 @@ void WriteProjection(amrex::Direction dir, std::unordered_map<std::string, amrex
 	}
 
 	// write mf_all to disk
-	const std::string filename = amrex::Concatenate(basename, istep, 5);
+	const std::string filename = amrex::Concatenate(basename, istep, 7);
 	const amrex::Vector<const amrex::MultiFab *> mfs = {&mf_all};
 	amrex::Print() << "Writing projection " << filename << "\n";
 

--- a/src/io/projection.hpp
+++ b/src/io/projection.hpp
@@ -136,7 +136,7 @@ void WriteProjection(amrex::Direction dir, std::unordered_map<std::string, amrex
 	}
 
 	// Construct the plotfile name (same directory as field data)
-	const std::string filename = amrex::Concatenate(basename, istep, 5);
+	const std::string filename = amrex::Concatenate(basename, istep, 7);
 
 	// Write particles using the filtered method
 	particleRegister.writePlotFileFiltered(filename, particleTypes);

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -463,7 +463,7 @@ void AdvectionSimulation<problem_t>::fluxFunction(amrex::MultiFab const &consSta
 // Save single-level plotfile
 // This is a wrapper around the WriteSingleLevelPlotfile function in the AMReX library.
 // The step number of the plotfile is set to istep[lev] and the time is set to the current time tNew_[lev].
-// Example usage: write debug_rhs00000 debug_rhs00001 etc with interval plotfileInterval_
+// Example usage: write debug_rhs0000000 debug_rhs0000001 etc with interval plotfileInterval_
 //   const int lev_debug = 0;
 //   amrex::Vector<std::string> flatCompNames{"rhs"};
 //   WriteSingleLevelPlotfileSimplified("debug_rhs", rhs[lev_debug], flatCompNames, lev_debug, plotfileInterval_);

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -147,7 +147,7 @@ auto problem_main() -> int
 	amrex::Print() << "\n";
 
 	QuokkaSimulation<FCQuantities> sim_restart;
-	sim_restart.setChkFile("chk00000");
+	sim_restart.setChkFile("chk0000000");
 	sim_restart.setInitialConditions();
 	amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> const &state_new_fc_restart = sim_restart.getNewMF_fc();
 	amrex::Print() << "\n";

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2984,13 +2984,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 }
 
 // get plotfile name
-template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileName(int lev) const -> std::string { return amrex::Concatenate(plot_file, lev, 5); }
+template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileName(int lev) const -> std::string { return amrex::Concatenate(plot_file, lev, 7); }
 
 // get plotfile name
 template <typename problem_t> auto AMRSimulation<problem_t>::CustomPlotFileName(const char *base, int lev) const -> std::string
 {
 	const std::string base_str(base);
-	return amrex::Concatenate(base_str, lev, 5);
+	return amrex::Concatenate(base_str, lev, 7);
 }
 
 template <typename problem_t>
@@ -3594,17 +3594,17 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 {
 	BL_PROFILE("AMRSimulation::WriteCheckpointFile()"); // NOLINT(misc-const-correctness)
 
-	// chk00010            write a checkpoint file with this root directory
-	// chk00010/Header     this contains information you need to save (e.g.,
+	// chk0000010            write a checkpoint file with this root directory
+	// chk0000010/Header     this contains information you need to save (e.g.,
 	// finest_level, t_new, etc.) and also
 	//                     the BoxArrays at each level
-	// chk00010/Level_0/
-	// chk00010/Level_1/
+	// chk0000010/Level_0/
+	// chk0000010/Level_1/
 	// etc.                these subdirectories will hold the MultiFab data at
 	// each level of refinement
 
-	// checkpoint file name, e.g., chk00010
-	const std::string &checkpointname = amrex::Concatenate(chk_file, istep[0]);
+	// checkpoint file name, e.g., chk0000010
+	const std::string &checkpointname = amrex::Concatenate(chk_file, istep[0], 7);
 
 	amrex::Print() << "Writing checkpoint " << checkpointname << "\n";
 
@@ -3672,13 +3672,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	// set the maximum number of binary files per MultiFab
 	quokka::ScopedVisMFNOutFiles scoped_nfiles(checkpoint_nfiles);
 
-	// write the cell-centred MultiFab data to, e.g., chk00010/Level_0/
+	// write the cell-centred MultiFab data to, e.g., chk0000010/Level_0/
 	for (int lev = 0; lev <= finest_level; ++lev) {
 		amrex::VisMF::Write(state_new_cc_[lev], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "Cell"));
 		amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 	}
 
-	// write the face-centred MultiFab data to, e.g., chk00010/Level_0/
+	// write the face-centred MultiFab data to, e.g., chk0000010/Level_0/
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			for (int lev = 0; lev <= finest_level; ++lev) {


### PR DESCRIPTION
### Description
Switch to using 7 digits for numbering checkpoint and plotfile outputs by default.

Since we regularly run simulations with millions of timesteps, this will avoid changes in the number of digits in output filenames in most cases.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
