### PR TITLE
fix LinearAlfvenWave-GPU regression test

### DIFF
--- a/inputs/alfven_wave_linear_regression.in
+++ b/inputs/alfven_wave_linear_regression.in
@@ -37,6 +37,7 @@ hydro.use_dual_energy = 0
 
 mhd.emf_compute_scheme = Quokka2026
 mhd.emf_averaging_scheme = LondrilloDelZanna2004
+mhd.update_initial_b_energy = false
 
 
 setup.num_modes_x = 1


### PR DESCRIPTION
### Description
Fixes the LinearAlfvenWave-GPU regression test (currently failing: https://quokka-astro.github.io/regression-testing-results/2026-01-12/LinearAlfvenWave-GPU.html)

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
