### PR TITLE
increase some plotfile_interval  from 10 to 100

### DIFF
--- a/inputs/AlfvenWaveLinear.in
+++ b/inputs/AlfvenWaveLinear.in
@@ -23,7 +23,7 @@ amr.blocking_factor_z = 8
 do_reflux = 0
 do_subcycle = 0
 
-plotfile_interval = 10
+plotfile_interval = 1000
 plotfile_prefix = alfven_wave_linear_plt
 checkpoint_interval = -1
 cfl = 0.3

--- a/inputs/FastWave.in
+++ b/inputs/FastWave.in
@@ -26,7 +26,7 @@ amr.blocking_factor_z = 8
 do_reflux = 0
 do_subcycle = 0
 
-plotfile_interval = 100
+plotfile_interval = -1
 checkpoint_interval = -1
 cfl = 0.3
 stop_time = 0.7071068

--- a/inputs/MHDBalsaraVortex.in
+++ b/inputs/MHDBalsaraVortex.in
@@ -23,7 +23,7 @@ amr.blocking_factor_z = 8
 do_reflux = 0
 do_subcycle = 0
 
-plotfile_interval = 10
+plotfile_interval = -1
 plotfile_prefix = balsara_vortex_plt
 checkpoint_interval = -1
 cfl = 0.3

--- a/inputs/MHDBlast.in
+++ b/inputs/MHDBlast.in
@@ -24,7 +24,7 @@ do_reflux = 1
 do_subcycle = 1
 do_tracers = 1      # turn on tracer particles
 
-plotfile_interval = 500
+plotfile_interval = 1000
 derived_vars = magnetic_divergence
 stop_time = 0.05
 

--- a/inputs/NscbcVortex.in
+++ b/inputs/NscbcVortex.in
@@ -28,7 +28,7 @@ max_timesteps = 2000
 stop_time = 1.0e-4
 
 checkpoint_interval = -1
-plotfile_interval = 20
+plotfile_interval = 500
 ascent_interval = -1
 
 hydro.rk_integrator_order = 2

--- a/inputs/alfven_wave_linear_regression.in
+++ b/inputs/alfven_wave_linear_regression.in
@@ -23,7 +23,7 @@ amr.blocking_factor_z = 64
 do_reflux = 0
 do_subcycle = 0
 
-plotfile_interval = 10
+plotfile_interval = 10000
 plotfile_prefix = alfven_wave_linear_plt
 checkpoint_interval = -1
 cfl = 0.3


### PR DESCRIPTION
### Description
Reduce output cadence of some tests.

Some MHD tests are using plotfile_interval=10 and max_timesteps = 10000. This causes the CI and regression tests to create a huge amount of files on disk.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
