### PR TITLE
[URGENT] update hard-coded path /data/mash to /priv/avatar

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -44,11 +44,11 @@ jobs:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
         CCACHE_NOHASHDIR: 1
-    - publish: /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
+    - publish: /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
       condition: succeededOrFailed()
       artifact: regressionHTMLOutput
       displayName: 'Upload results to Azure Pipelines'
-    - script: cd /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
+    - script: cd /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'
     - template: templates/ccache-stats.yml

--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -1,6 +1,6 @@
 [main]
-testTopDir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
-webTopDir  = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
+testTopDir = /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
+webTopDir  = /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
 
 sourceTree = C_Src
 useCmake = 1
@@ -53,11 +53,11 @@ MPIcommand = mpirun -n @nprocs@ @command@
 MPIhost =
 
 [AMReX]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
+dir = /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/amrex
 branch = development
 
 [source]
-dir = /data/mash/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka
+dir = /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/quokka
 branch = development
 
 # individual problems follow


### PR DESCRIPTION
### Description
update hard-coded path /data/mash to /priv/avatar since now the CUDA CI is hosted on /priv/avatar

### Related issues
Regression tests are still running on /data/mash and takes a long time to upload the results. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
