### PR TITLE
Fix bug in SN count

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -1054,8 +1054,10 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Write SFH data from memory to metadata
-	void writeSFHToMetadata(YAML::Node &metadata) const
+	void writeSFHToMetadata(YAML::Node &metadata, int sn_count_cumulative) const
 	{
+		metadata["sn_count_cumulative"] = sn_count_cumulative;
+
 		if (!HasFormationParticles()) {
 			return;
 		}
@@ -1077,8 +1079,12 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Read SFH data from metadata and return the last time
-	auto readSFH(const YAML::Node &metadata) -> Real
+	auto readSFH(const YAML::Node &metadata, int &sn_count_cumulative) -> Real
 	{
+		if (metadata["sn_count_cumulative"]) {
+			sn_count_cumulative = metadata["sn_count_cumulative"].as<int>();
+		}
+
 		if (!HasFormationParticles()) {
 			return 0.0;
 		}

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -49,7 +49,6 @@ constexpr Real cloudy_H_mass_fraction = 1.0 / (1.0 + 0.1 * 3.971);
 constexpr Real rho0 = nH0 * (m_H / cloudy_H_mass_fraction); // g cm^-3
 
 template <> struct SimulationData<RandomBlast> {
-	int SN_counter_cumulative = 0;	 // Track cumulative number of SNe at current time
 	std::vector<int> SN_counter_arr; // Track cumulative number of SNe at all time
 
 	Real refine_threshold = 1.0; // gradient refinement threshold
@@ -112,8 +111,7 @@ template <> void QuokkaSimulation<RandomBlast>::createInitialStochasticStellarPo
 template <> void QuokkaSimulation<RandomBlast>::computeAfterTimestep()
 {
 	// Count how many SN went off in this timestep
-	userData_.SN_counter_cumulative += sn_count_;
-	userData_.SN_counter_arr.push_back(userData_.SN_counter_cumulative);
+	userData_.SN_counter_arr.push_back(sn_count_cumulative_); // cumulative number of SNe at current time
 }
 
 template <> void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -212,7 +212,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int sfh_interval_ = -1;		       // interval for the star formation history
 	amrex::Real sfh_time_interval_ = -1.0; // time interval for the star formation history
 	amrex::Real last_sfh_time_ = 0.0;
-	int sn_count_ = 0; // number of SN explosions in a step (used for diagnostics)
+	int sn_count_ = 0;	      // number of SN explosions in a step (used for diagnostics)
+	int sn_count_cumulative_ = 0; // cumulative number of SN explosions (used for diagnostics)
 
 	amrex::Real densityFloor_ = 0.0; // default
 	amrex::Real tempFloor_ = 0.0;	 // default
@@ -1968,6 +1969,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 
 	// Deposit the SN particles into the MultiFab
 	const auto [num_sn_explosions, max_velocity] = particleRegister_.depositSN(state_new_cc_[lev], state_fc_ptr, lev, time, dt);
+	sn_count_ = num_sn_explosions;
+	sn_count_cumulative_ += num_sn_explosions;
 
 	// Print SN explosion count if verbose and non-zero
 	if (verbose && num_sn_explosions > 0) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3665,7 +3665,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WritePlotFile()
 	amrex::Print() << "Writing plotfile " << plotfilename << "\n";
 
 	// Update SFH data in metadata before writing
-	particleRegister_.writeSFHToMetadata(simulationMetadata_);
+	particleRegister_.writeSFHToMetadata(simulationMetadata_, sn_count_cumulative_);
 
 #ifdef QUOKKA_USE_OPENPMD
 	// TODO(bwibking): write particles using openPMD
@@ -3895,7 +3895,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	}
 
 	// Update SFH data in metadata before writing
-	particleRegister_.writeSFHToMetadata(simulationMetadata_);
+	particleRegister_.writeSFHToMetadata(simulationMetadata_, sn_count_cumulative_);
 
 	// write Metadata file
 	WriteMetadataFile(checkpointname + "/metadata.yaml");
@@ -4343,7 +4343,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	}
 
 	// Read SFH data from metadata
-	last_sfh_time_ = particleRegister_.readSFH(simulationMetadata_);
+	last_sfh_time_ = particleRegister_.readSFH(simulationMetadata_, sn_count_cumulative_);
 #endif // AMREX_SPACEDIM == 3
 
 	areInitialConditionsDefined_ = true;


### PR DESCRIPTION
### Description
There was a bug in my previous implementation of SN count: the global variable `sn_count_` was never updated and therefore always 0. This PR fixed this bug and also added a global parameter `sn_count_cumulative_` to record the cumulative number of SN events. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
