### PR TITLE
Set trigger: none in the CI tests

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -20,12 +20,19 @@ pr:
     - CMakeLists.txt
     - .ci/azure-pipelines-amdgpu.yml
     - extern/cooling/*.h5
+    - extern/amrex
     - extern/amrex/**
+    - extern/Microphysics
     - extern/Microphysics/**
+    - extern/fmt
     - extern/fmt/**
+    - extern/yaml-cpp
     - extern/yaml-cpp/**
+    - extern/openPMD-api
     - extern/openPMD-api/**
+    - extern/AMReX-Hydro
     - extern/AMReX-Hydro/**
+    - extern/turbulence
     - extern/turbulence/**
     exclude:
     - docs/**

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -3,31 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-  branches:
-    include:
-    - development
-  paths:
-    include:
-    - src/**
-    - tests/**
-    - inputs/**
-    - CMakeLists.txt
-    - .ci/azure-pipelines-amdgpu.yml
-    - extern/cooling/*.h5
-    - extern/amrex/**
-    - extern/Microphysics/**
-    - extern/fmt/**
-    - extern/yaml-cpp/**
-    - extern/openPMD-api/**
-    - extern/AMReX-Hydro/**
-    exclude:
-    - docs/**
-    - paper/**
-    - scripts/**
-    - '*.md'
-    - '*.rst'
-    - '*.txt'
+# Disable automatic CI trigger on push/merge to development branch.
+# Pipeline can still be triggered manually via `/azp run` or on PR validation.
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,30 +3,9 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-trigger:
-  branches:
-    include:
-    - development
-  paths:
-    include:
-    - src/**
-    - inputs/**
-    - CMakeLists.txt
-    - .ci/azure-pipelines.yml
-    - extern/cooling/*.h5
-    - extern/amrex/**
-    - extern/Microphysics/**
-    - extern/fmt/**
-    - extern/yaml-cpp/**
-    - extern/openPMD-api/**
-    - extern/AMReX-Hydro/**
-    exclude:
-    - docs/**
-    - paper/**
-    - scripts/**
-    - '*.md'
-    - '*.rst'
-    - '*.txt'
+# Disable automatic CI trigger on push/merge to development branch.
+# Pipeline can still be triggered manually via `/azp run` or on PR validation.
+trigger: none
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -20,12 +20,19 @@ pr:
     - CMakeLists.txt
     - .ci/azure-pipelines.yml
     - extern/cooling/*.h5
+    - extern/amrex
     - extern/amrex/**
+    - extern/Microphysics
     - extern/Microphysics/**
+    - extern/fmt
     - extern/fmt/**
+    - extern/yaml-cpp
     - extern/yaml-cpp/**
+    - extern/openPMD-api
     - extern/openPMD-api/**
+    - extern/AMReX-Hydro
     - extern/AMReX-Hydro/**
+    - extern/turbulence
     - extern/turbulence/**
     exclude:
     - docs/**


### PR DESCRIPTION
### Description
This way, the GPU CI tests will only be tiggered via a manual '/azp run' in a PR targeted at any branch. Commits into development branch won't trigger CI tests.

Also added the submodules to the include list so that a pointer change (the commit SHA reference) at submodules like extern/amrex itself will trigger CI test. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
