### PR TITLE
Add meaningful particle component names to I/O headers

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -506,52 +506,16 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		}
 	}
 
-	// Get real component names for this particle type
+	// Get real component names for this particle type using unified template function
 	[[nodiscard]] static auto getRealCompNames() -> amrex::Vector<std::string>
 	{
-		if constexpr (particleType_ == ParticleType::Rad) {
-			return getRadParticleRealCompNames<problem_t>();
-		}
-#if AMREX_SPACEDIM == 3
-		else if constexpr (particleType_ == ParticleType::CIC) {
-			return getCICParticleRealCompNames();
-		} else if constexpr (particleType_ == ParticleType::CICRad) {
-			return getCICRadParticleRealCompNames<problem_t>();
-		} else if constexpr (particleType_ == ParticleType::StochasticStellarPop) {
-			return getStochasticStellarPopParticleRealCompNames<problem_t>();
-		} else if constexpr (particleType_ == ParticleType::Sink) {
-			return getSinkParticleRealCompNames();
-		} else if constexpr (particleType_ == ParticleType::Test) {
-			return getTestParticleRealCompNames<problem_t>();
-		}
-#endif
-		else {
-			return {};
-		}
+		return getParticleRealCompNames<particleType_, problem_t>();
 	}
 
-	// Get int component names for this particle type
+	// Get int component names for this particle type using unified template function
 	[[nodiscard]] static auto getIntCompNames() -> amrex::Vector<std::string>
 	{
-		if constexpr (particleType_ == ParticleType::Rad) {
-			return getRadParticleIntCompNames<problem_t>();
-		}
-#if AMREX_SPACEDIM == 3
-		else if constexpr (particleType_ == ParticleType::CIC) {
-			return getCICParticleIntCompNames();
-		} else if constexpr (particleType_ == ParticleType::CICRad) {
-			return getCICRadParticleIntCompNames();
-		} else if constexpr (particleType_ == ParticleType::StochasticStellarPop) {
-			return getStochasticStellarPopParticleIntCompNames();
-		} else if constexpr (particleType_ == ParticleType::Sink) {
-			return getSinkParticleIntCompNames();
-		} else if constexpr (particleType_ == ParticleType::Test) {
-			return getTestParticleIntCompNames();
-		}
-#endif
-		else {
-			return {};
-		}
+		return getParticleIntCompNames<particleType_, problem_t>();
 	}
 
 	// Implementation of particle data output to plot file

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -507,16 +507,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 
 	// Get real component names for this particle type using unified template function
-	[[nodiscard]] static auto getRealCompNames() -> amrex::Vector<std::string>
-	{
-		return getParticleRealCompNames<particleType_, problem_t>();
-	}
+	[[nodiscard]] static auto getRealCompNames() -> amrex::Vector<std::string> { return getParticleRealCompNames<particleType_, problem_t>(); }
 
 	// Get int component names for this particle type using unified template function
-	[[nodiscard]] static auto getIntCompNames() -> amrex::Vector<std::string>
-	{
-		return getParticleIntCompNames<particleType_, problem_t>();
-	}
+	[[nodiscard]] static auto getIntCompNames() -> amrex::Vector<std::string> { return getParticleIntCompNames<particleType_, problem_t>(); }
 
 	// Implementation of particle data output to plot file
 	void writePlotFile(const std::string &plotfilename, const std::string &name) override

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -506,11 +506,61 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		}
 	}
 
+	// Get real component names for this particle type
+	[[nodiscard]] static auto getRealCompNames() -> amrex::Vector<std::string>
+	{
+		if constexpr (particleType_ == ParticleType::Rad) {
+			return getRadParticleRealCompNames<problem_t>();
+		}
+#if AMREX_SPACEDIM == 3
+		else if constexpr (particleType_ == ParticleType::CIC) {
+			return getCICParticleRealCompNames();
+		} else if constexpr (particleType_ == ParticleType::CICRad) {
+			return getCICRadParticleRealCompNames<problem_t>();
+		} else if constexpr (particleType_ == ParticleType::StochasticStellarPop) {
+			return getStochasticStellarPopParticleRealCompNames<problem_t>();
+		} else if constexpr (particleType_ == ParticleType::Sink) {
+			return getSinkParticleRealCompNames();
+		} else if constexpr (particleType_ == ParticleType::Test) {
+			return getTestParticleRealCompNames<problem_t>();
+		}
+#endif
+		else {
+			return {};
+		}
+	}
+
+	// Get int component names for this particle type
+	[[nodiscard]] static auto getIntCompNames() -> amrex::Vector<std::string>
+	{
+		if constexpr (particleType_ == ParticleType::Rad) {
+			return getRadParticleIntCompNames<problem_t>();
+		}
+#if AMREX_SPACEDIM == 3
+		else if constexpr (particleType_ == ParticleType::CIC) {
+			return getCICParticleIntCompNames();
+		} else if constexpr (particleType_ == ParticleType::CICRad) {
+			return getCICRadParticleIntCompNames();
+		} else if constexpr (particleType_ == ParticleType::StochasticStellarPop) {
+			return getStochasticStellarPopParticleIntCompNames();
+		} else if constexpr (particleType_ == ParticleType::Sink) {
+			return getSinkParticleIntCompNames();
+		} else if constexpr (particleType_ == ParticleType::Test) {
+			return getTestParticleIntCompNames();
+		}
+#endif
+		else {
+			return {};
+		}
+	}
+
 	// Implementation of particle data output to plot file
 	void writePlotFile(const std::string &plotfilename, const std::string &name) override
 	{
 		if (container_ != nullptr) {
-			container_->WritePlotFile(plotfilename, name);
+			const amrex::Vector<std::string> real_comp_names = getRealCompNames();
+			const amrex::Vector<std::string> int_comp_names = getIntCompNames();
+			container_->WritePlotFile(plotfilename, name, real_comp_names, int_comp_names);
 		}
 	}
 
@@ -518,7 +568,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	void writeCheckpoint(const std::string &checkpointname, const std::string &name, bool include_header) override
 	{
 		if (container_ != nullptr) {
-			container_->Checkpoint(checkpointname, name, include_header);
+			const amrex::Vector<std::string> real_comp_names = getRealCompNames();
+			const amrex::Vector<std::string> int_comp_names = getIntCompNames();
+			container_->Checkpoint(checkpointname, name, include_header, real_comp_names, int_comp_names);
 		}
 	}
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -88,12 +88,16 @@ AMREX_ENUM(SNScheme,				   // NOLINT
 
 //-------------------- Radiation particles --------------------
 
-// Indices for radiation particles (Rad_particles), birth time + death time + radiation groups
-enum RadParticleDataIdx {
-	RadParticleBirthTimeIdx = 0, // Time when particle becomes active
-	RadParticleDeathTimeIdx,     // Time when particle becomes inactive
-	RadParticleLumIdx	     // Base index for luminosity components
-};
+// Indices for radiation particles (Rad_particles) using AMREX_ENUM for automatic string conversion
+AMREX_ENUM(RadParticleRealIdx, // NOLINT
+	   birth_time,	       // Time when particle becomes active
+	   death_time	       // Time when particle becomes inactive (luminosity components follow dynamically)
+);
+
+// Backward compatibility aliases for existing code
+constexpr int RadParticleBirthTimeIdx = static_cast<int>(RadParticleRealIdx::birth_time);
+constexpr int RadParticleDeathTimeIdx = static_cast<int>(RadParticleRealIdx::death_time);
+constexpr int RadParticleLumIdx = RadParticleDeathTimeIdx + 1; // Base index for luminosity components
 
 // Number of real components for Rad_particles, birth time + death time + radiation groups
 template <typename problem_t>
@@ -113,13 +117,19 @@ template <typename problem_t> using RadParticleIterator = amrex::ParIter<RadPart
 
 //-------------------- Gravitating particles --------------------
 
-// Indices for gravitating particles (CIC_particles), mass + 3 velocity components
-enum CICParticleDataIdx {
-	CICParticleMassIdx = 0, // Mass of the particle
-	CICParticleVxIdx,	// Velocity in x direction
-	CICParticleVyIdx,	// Velocity in y direction
-	CICParticleVzIdx	// Velocity in z direction
-};
+// Indices for gravitating particles (CIC_particles) using AMREX_ENUM for automatic string conversion
+AMREX_ENUM(CICParticleRealIdx, // NOLINT
+	   mass,	       // Mass of the particle
+	   vx,		       // Velocity in x direction
+	   vy,		       // Velocity in y direction
+	   vz		       // Velocity in z direction
+);
+
+// Backward compatibility aliases for existing code
+constexpr int CICParticleMassIdx = static_cast<int>(CICParticleRealIdx::mass);
+constexpr int CICParticleVxIdx = static_cast<int>(CICParticleRealIdx::vx);
+constexpr int CICParticleVyIdx = static_cast<int>(CICParticleRealIdx::vy);
+constexpr int CICParticleVzIdx = static_cast<int>(CICParticleRealIdx::vz);
 
 // Number of real components for CIC_particles, mass + 3 velocity components
 constexpr int CICParticleRealComps = 4;
@@ -130,16 +140,24 @@ using CICParticleIterator = amrex::ParIter<CICParticleRealComps>;
 
 //-------------------- Gravitating radiation particles --------------------
 
-// Indices for gravitating radiation particles (CICRad_particles), mass + 3 velocity components + birth time + death time + radiation groups
-enum CICRadParticleDataIdx {
-	CICRadParticleMassIdx = 0,  // Mass of the particle
-	CICRadParticleVxIdx,	    // Velocity in x direction
-	CICRadParticleVyIdx,	    // Velocity in y direction
-	CICRadParticleVzIdx,	    // Velocity in z direction
-	CICRadParticleBirthTimeIdx, // Time when particle becomes active
-	CICRadParticleDeathTimeIdx, // Time when particle becomes inactive
-	CICRadParticleLumIdx	    // Base index for luminosity components
-};
+// Indices for gravitating radiation particles (CICRad_particles) using AMREX_ENUM for automatic string conversion
+AMREX_ENUM(CICRadParticleRealIdx, // NOLINT
+	   mass,		  // Mass of the particle
+	   vx,			  // Velocity in x direction
+	   vy,			  // Velocity in y direction
+	   vz,			  // Velocity in z direction
+	   birth_time,		  // Time when particle becomes active
+	   death_time		  // Time when particle becomes inactive (luminosity components follow dynamically)
+);
+
+// Backward compatibility aliases for existing code
+constexpr int CICRadParticleMassIdx = static_cast<int>(CICRadParticleRealIdx::mass);
+constexpr int CICRadParticleVxIdx = static_cast<int>(CICRadParticleRealIdx::vx);
+constexpr int CICRadParticleVyIdx = static_cast<int>(CICRadParticleRealIdx::vy);
+constexpr int CICRadParticleVzIdx = static_cast<int>(CICRadParticleRealIdx::vz);
+constexpr int CICRadParticleBirthTimeIdx = static_cast<int>(CICRadParticleRealIdx::birth_time);
+constexpr int CICRadParticleDeathTimeIdx = static_cast<int>(CICRadParticleRealIdx::death_time);
+constexpr int CICRadParticleLumIdx = CICRadParticleDeathTimeIdx + 1; // Base index for luminosity components
 
 // Number of real components for CICRad_particles, mass + 3 velocity components + birth time + death time + radiation groups
 template <typename problem_t>
@@ -168,19 +186,32 @@ enum class StellarEvolutionStage { LowMassStar, SNProgenitor, SNRemnant, LowMass
 
 //-------------------- Stellar population particles --------------------
 
-// Indices for StochasticStellarPop_particles
-enum StochasticStellarPopParticleDataIdx {
-	StochasticStellarPopParticleMassIdx = 0,    // Mass of the particle
-	StochasticStellarPopParticleVxIdx,	    // Velocity in x direction
-	StochasticStellarPopParticleVyIdx,	    // Velocity in y direction
-	StochasticStellarPopParticleVzIdx,	    // Velocity in z direction
-	StochasticStellarPopParticleBirthTimeIdx,   // Time when particle becomes active
-	StochasticStellarPopParticleDeathTimeIdx,   // Time when particle becomes inactive
-	StochasticStellarPopParticleMassAtBirthIdx, // Particle mass at birth
-	StochasticStellarPopParticleLumIdx	    // Base index for luminosity components
-};
+// Indices for StochasticStellarPop_particles using AMREX_ENUM for automatic string conversion
+AMREX_ENUM(StochasticStellarPopParticleRealIdx, // NOLINT
+	   mass,				// Mass of the particle
+	   vx,					// Velocity in x direction
+	   vy,					// Velocity in y direction
+	   vz,					// Velocity in z direction
+	   birth_time,				// Time when particle becomes active
+	   death_time,				// Time when particle becomes inactive
+	   mass_at_birth			// Particle mass at birth (luminosity components follow dynamically)
+);
 
-constexpr int StochasticStellarPopParticleStageIdx = 0; // Evolution stage of the particle, index in the integer components
+// Integer component indices using AMREX_ENUM
+AMREX_ENUM(StochasticStellarPopParticleIntIdx, // NOLINT
+	   evolution_stage		       // Evolution stage of the particle
+);
+
+// Backward compatibility aliases for existing code
+constexpr int StochasticStellarPopParticleMassIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::mass);
+constexpr int StochasticStellarPopParticleVxIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::vx);
+constexpr int StochasticStellarPopParticleVyIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::vy);
+constexpr int StochasticStellarPopParticleVzIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::vz);
+constexpr int StochasticStellarPopParticleBirthTimeIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::birth_time);
+constexpr int StochasticStellarPopParticleDeathTimeIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::death_time);
+constexpr int StochasticStellarPopParticleMassAtBirthIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::mass_at_birth);
+constexpr int StochasticStellarPopParticleLumIdx = StochasticStellarPopParticleMassAtBirthIdx + 1; // Base index for luminosity components
+constexpr int StochasticStellarPopParticleStageIdx = static_cast<int>(StochasticStellarPopParticleIntIdx::evolution_stage);
 
 // Number of real components for StochasticStellarPop_particles, mass + 3 velocity components + luminosity
 template <typename problem_t>
@@ -249,13 +280,19 @@ template <typename problem_t> using TestParticleIterator = amrex::ParIter<TestPa
 
 //-------------------- Sink particles --------------------
 
-// Indices for Sink_particles
-enum SinkParticleDataIdx {
-	SinkParticleMassIdx = 0, // Mass of the particle
-	SinkParticleVxIdx,	 // Velocity in x direction
-	SinkParticleVyIdx,	 // Velocity in y direction
-	SinkParticleVzIdx,	 // Velocity in z direction
-};
+// Indices for Sink_particles using AMREX_ENUM for automatic string conversion
+AMREX_ENUM(SinkParticleRealIdx, // NOLINT
+	   mass,		// Mass of the particle
+	   vx,			// Velocity in x direction
+	   vy,			// Velocity in y direction
+	   vz			// Velocity in z direction
+);
+
+// Backward compatibility aliases for existing code
+constexpr int SinkParticleMassIdx = static_cast<int>(SinkParticleRealIdx::mass);
+constexpr int SinkParticleVxIdx = static_cast<int>(SinkParticleRealIdx::vx);
+constexpr int SinkParticleVyIdx = static_cast<int>(SinkParticleRealIdx::vy);
+constexpr int SinkParticleVzIdx = static_cast<int>(SinkParticleRealIdx::vz);
 
 // Number of real components for Sink_particles
 constexpr int SinkParticleRealComps = 4; // mass, vx, vy, vz
@@ -268,12 +305,14 @@ using SinkParticleIterator = amrex::ParIter<SinkParticleRealComps>;
 
 //-------------------- Component Names for I/O --------------------
 
-// Helper function to generate component names for radiation particles
+// Helper function to generate component names for radiation particles using AMREX_ENUM
 template <typename problem_t> auto getRadParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	amrex::Vector<std::string> names;
-	names.push_back("birth_time");
-	names.push_back("death_time");
+	// Get names from AMREX_ENUM (birth_time, death_time)
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<RadParticleRealIdx>();
+	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
+
+	// Add luminosity components dynamically
 	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
 	for (int i = 0; i < nGroups; ++i) {
 		names.push_back("luminosity_" + std::to_string(i));
@@ -288,10 +327,11 @@ template <typename problem_t> auto getRadParticleIntCompNames() -> amrex::Vector
 
 #if AMREX_SPACEDIM == 3
 
-// Helper function to generate component names for CIC particles
+// Helper function to generate component names for CIC particles using AMREX_ENUM
 inline auto getCICParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	return {"mass", "vx", "vy", "vz"};
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICParticleRealIdx>();
+	return {enum_names.begin(), enum_names.end()};
 }
 
 inline auto getCICParticleIntCompNames() -> amrex::Vector<std::string>
@@ -299,16 +339,14 @@ inline auto getCICParticleIntCompNames() -> amrex::Vector<std::string>
 	return {}; // No integer components
 }
 
-// Helper function to generate component names for CICRad particles
+// Helper function to generate component names for CICRad particles using AMREX_ENUM
 template <typename problem_t> auto getCICRadParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	amrex::Vector<std::string> names;
-	names.push_back("mass");
-	names.push_back("vx");
-	names.push_back("vy");
-	names.push_back("vz");
-	names.push_back("birth_time");
-	names.push_back("death_time");
+	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time)
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICRadParticleRealIdx>();
+	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
+
+	// Add luminosity components dynamically
 	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
 	for (int i = 0; i < nGroups; ++i) {
 		names.push_back("luminosity_" + std::to_string(i));
@@ -321,17 +359,14 @@ inline auto getCICRadParticleIntCompNames() -> amrex::Vector<std::string>
 	return {}; // No integer components
 }
 
-// Helper function to generate component names for StochasticStellarPop particles
+// Helper function to generate component names for StochasticStellarPop particles using AMREX_ENUM
 template <typename problem_t> auto getStochasticStellarPopParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	amrex::Vector<std::string> names;
-	names.push_back("mass");
-	names.push_back("vx");
-	names.push_back("vy");
-	names.push_back("vz");
-	names.push_back("birth_time");
-	names.push_back("death_time");
-	names.push_back("mass_at_birth");
+	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time, mass_at_birth)
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleRealIdx>();
+	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
+
+	// Add luminosity components dynamically
 	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
 	for (int i = 0; i < nGroups; ++i) {
 		names.push_back("luminosity_" + std::to_string(i));
@@ -339,15 +374,18 @@ template <typename problem_t> auto getStochasticStellarPopParticleRealCompNames(
 	return names;
 }
 
+// Helper function to generate integer component names for StochasticStellarPop particles using AMREX_ENUM
 inline auto getStochasticStellarPopParticleIntCompNames() -> amrex::Vector<std::string>
 {
-	return {"evolution_stage"};
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleIntIdx>();
+	return {enum_names.begin(), enum_names.end()};
 }
 
-// Helper function to generate component names for Sink particles
+// Helper function to generate component names for Sink particles using AMREX_ENUM
 inline auto getSinkParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	return {"mass", "vx", "vy", "vz"};
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<SinkParticleRealIdx>();
+	return {enum_names.begin(), enum_names.end()};
 }
 
 inline auto getSinkParticleIntCompNames() -> amrex::Vector<std::string>

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -309,22 +309,33 @@ using SinkParticleIterator = amrex::ParIter<SinkParticleRealComps>;
 
 //-------------------- Component Names for I/O --------------------
 
-// Helper function to expand the last component (e.g., "luminosity") into indexed names (luminosity_0, luminosity_1, ...)
-// All components except the last are added as-is; the last component is replicated with _0, _1, ... suffixes
-template <typename EnumType, typename problem_t> auto expandEnumNamesWithLuminosity() -> amrex::Vector<std::string>
+// Helper function to generate component names from an enum type
+// If expandLast is true, the last enum component is expanded with _0, _1, ... suffixes
+// to fill up to nComps total components
+template <typename EnumType, int nComps, bool expandLast> auto expandEnumNames() -> amrex::Vector<std::string>
 {
 	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<EnumType>();
+	const auto enum_size = static_cast<int>(enum_names.size());
 	amrex::Vector<std::string> names;
 
-	// Add all components except the last one (luminosity)
-	for (size_t i = 0; i < enum_names.size() - 1; ++i) {
+	if constexpr (nComps <= 0) {
+		return names;
+	}
+
+	if constexpr (!expandLast) {
+		// No expansion - use enum names directly
+		return {enum_names.begin(), enum_names.end()};
+	}
+
+	// Add all components except the last one
+	for (int i = 0; i < enum_size - 1; ++i) {
 		names.push_back(enum_names[i]);
 	}
 
-	// Expand the last component (luminosity) into luminosity_0, luminosity_1, ...
+	// Expand the last component into name_0, name_1, ...
 	const std::string &base_name = enum_names.back();
-	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-	for (int i = 0; i < nGroups; ++i) {
+	const int nExtra = nComps - enum_size + 1;
+	for (int i = 0; i < nExtra; ++i) {
 		names.push_back(base_name + "_" + std::to_string(i));
 	}
 
@@ -332,27 +343,23 @@ template <typename EnumType, typename problem_t> auto expandEnumNamesWithLuminos
 }
 
 // Unified template function to get real component names for any particle type
-// Uses AMREX_ENUM's getEnumNameStrings() and expands luminosity components where needed
+// Uses AMREX_ENUM's getEnumNameStrings() and expands the last component for particle types with luminosity
 template <ParticleType particleType, typename problem_t> auto getParticleRealCompNames() -> amrex::Vector<std::string>
 {
 	if constexpr (particleType == ParticleType::Rad) {
-		return expandEnumNamesWithLuminosity<RadParticleRealIdx, problem_t>();
+		return expandEnumNames<RadParticleRealIdx, RadParticleRealComps<problem_t>, true>();
 	}
 #if AMREX_SPACEDIM == 3
 	else if constexpr (particleType == ParticleType::CIC) {
-		// No luminosity - use enum names directly
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICParticleRealIdx>();
-		return {enum_names.begin(), enum_names.end()};
+		return expandEnumNames<CICParticleRealIdx, CICParticleRealComps, false>();
 	} else if constexpr (particleType == ParticleType::CICRad) {
-		return expandEnumNamesWithLuminosity<CICRadParticleRealIdx, problem_t>();
+		return expandEnumNames<CICRadParticleRealIdx, CICRadParticleRealComps<problem_t>, true>();
 	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
-		return expandEnumNamesWithLuminosity<StochasticStellarPopParticleRealIdx, problem_t>();
+		return expandEnumNames<StochasticStellarPopParticleRealIdx, StochasticStellarPopParticleRealComps<problem_t>, true>();
 	} else if constexpr (particleType == ParticleType::Sink) {
-		// No luminosity - use enum names directly
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<SinkParticleRealIdx>();
-		return {enum_names.begin(), enum_names.end()};
+		return expandEnumNames<SinkParticleRealIdx, SinkParticleRealComps, false>();
 	} else if constexpr (particleType == ParticleType::Test) {
-		return expandEnumNamesWithLuminosity<TestParticleRealIdx, problem_t>();
+		return expandEnumNames<TestParticleRealIdx, TestParticleRealComps<problem_t>, true>();
 	}
 #endif
 	else {

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -91,13 +91,14 @@ AMREX_ENUM(SNScheme,				   // NOLINT
 // Indices for radiation particles (Rad_particles) using AMREX_ENUM for automatic string conversion
 AMREX_ENUM(RadParticleRealIdx, // NOLINT
 	   birth_time,	       // Time when particle becomes active
-	   death_time	       // Time when particle becomes inactive (luminosity components follow dynamically)
+	   death_time,	       // Time when particle becomes inactive
+	   luminosity	       // Base luminosity component (expanded to luminosity_0, luminosity_1, ... in I/O)
 );
 
 // Backward compatibility aliases for existing code
 constexpr int RadParticleBirthTimeIdx = static_cast<int>(RadParticleRealIdx::birth_time);
 constexpr int RadParticleDeathTimeIdx = static_cast<int>(RadParticleRealIdx::death_time);
-constexpr int RadParticleLumIdx = RadParticleDeathTimeIdx + 1; // Base index for luminosity components
+constexpr int RadParticleLumIdx = static_cast<int>(RadParticleRealIdx::luminosity); // Base index for luminosity components
 
 // Number of real components for Rad_particles, birth time + death time + radiation groups
 template <typename problem_t>
@@ -147,7 +148,8 @@ AMREX_ENUM(CICRadParticleRealIdx, // NOLINT
 	   vy,			  // Velocity in y direction
 	   vz,			  // Velocity in z direction
 	   birth_time,		  // Time when particle becomes active
-	   death_time		  // Time when particle becomes inactive (luminosity components follow dynamically)
+	   death_time,		  // Time when particle becomes inactive
+	   luminosity		  // Base luminosity component (expanded to luminosity_0, luminosity_1, ... in I/O)
 );
 
 // Backward compatibility aliases for existing code
@@ -157,7 +159,7 @@ constexpr int CICRadParticleVyIdx = static_cast<int>(CICRadParticleRealIdx::vy);
 constexpr int CICRadParticleVzIdx = static_cast<int>(CICRadParticleRealIdx::vz);
 constexpr int CICRadParticleBirthTimeIdx = static_cast<int>(CICRadParticleRealIdx::birth_time);
 constexpr int CICRadParticleDeathTimeIdx = static_cast<int>(CICRadParticleRealIdx::death_time);
-constexpr int CICRadParticleLumIdx = CICRadParticleDeathTimeIdx + 1; // Base index for luminosity components
+constexpr int CICRadParticleLumIdx = static_cast<int>(CICRadParticleRealIdx::luminosity); // Base index for luminosity components
 
 // Number of real components for CICRad_particles, mass + 3 velocity components + birth time + death time + radiation groups
 template <typename problem_t>
@@ -194,7 +196,8 @@ AMREX_ENUM(StochasticStellarPopParticleRealIdx, // NOLINT
 	   vz,					// Velocity in z direction
 	   birth_time,				// Time when particle becomes active
 	   death_time,				// Time when particle becomes inactive
-	   mass_at_birth			// Particle mass at birth (luminosity components follow dynamically)
+	   mass_at_birth,			// Particle mass at birth
+	   luminosity				// Base luminosity component (expanded to luminosity_0, luminosity_1, ... in I/O)
 );
 
 // Integer component indices using AMREX_ENUM
@@ -210,7 +213,7 @@ constexpr int StochasticStellarPopParticleVzIdx = static_cast<int>(StochasticSte
 constexpr int StochasticStellarPopParticleBirthTimeIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::birth_time);
 constexpr int StochasticStellarPopParticleDeathTimeIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::death_time);
 constexpr int StochasticStellarPopParticleMassAtBirthIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::mass_at_birth);
-constexpr int StochasticStellarPopParticleLumIdx = StochasticStellarPopParticleMassAtBirthIdx + 1; // Base index for luminosity components
+constexpr int StochasticStellarPopParticleLumIdx = static_cast<int>(StochasticStellarPopParticleRealIdx::luminosity); // Base index for luminosity components
 constexpr int StochasticStellarPopParticleStageIdx = static_cast<int>(StochasticStellarPopParticleIntIdx::evolution_stage);
 
 // Number of real components for StochasticStellarPop_particles, mass + 3 velocity components + luminosity
@@ -243,7 +246,8 @@ AMREX_ENUM(TestParticleRealIdx, // NOLINT
 	   vy,			// Velocity in y direction
 	   vz,			// Velocity in z direction
 	   birth_time,		// Time when particle becomes active
-	   death_time		// Time when particle becomes inactive (luminosity components follow dynamically)
+	   death_time,		// Time when particle becomes inactive
+	   luminosity		// Base luminosity component (expanded to luminosity_0, luminosity_1, ... in I/O)
 );
 
 // Integer component indices using AMREX_ENUM
@@ -258,7 +262,7 @@ constexpr int TestParticleVyIdx = static_cast<int>(TestParticleRealIdx::vy);
 constexpr int TestParticleVzIdx = static_cast<int>(TestParticleRealIdx::vz);
 constexpr int TestParticleBirthTimeIdx = static_cast<int>(TestParticleRealIdx::birth_time);
 constexpr int TestParticleDeathTimeIdx = static_cast<int>(TestParticleRealIdx::death_time);
-constexpr int TestParticleLumIdx = TestParticleDeathTimeIdx + 1; // Base index for luminosity components (follows death_time)
+constexpr int TestParticleLumIdx = static_cast<int>(TestParticleRealIdx::luminosity); // Base index for luminosity components
 constexpr int TestParticleStageIdx = static_cast<int>(TestParticleIntIdx::evolution_stage);
 
 // Number of real components for Test_particles
@@ -305,55 +309,55 @@ using SinkParticleIterator = amrex::ParIter<SinkParticleRealComps>;
 
 //-------------------- Component Names for I/O --------------------
 
-// Unified template function to get real component names for any particle type
-// Uses AMREX_ENUM's getEnumNameStrings() and adds dynamic luminosity components where needed
-template <ParticleType particleType, typename problem_t> auto getParticleRealCompNames() -> amrex::Vector<std::string>
+// Helper function to expand the last component (e.g., "luminosity") into indexed names (luminosity_0, luminosity_1, ...)
+// All components except the last are added as-is; the last component is replicated with _0, _1, ... suffixes
+template <typename EnumType, typename problem_t> auto expandEnumNamesWithLuminosity() -> amrex::Vector<std::string>
 {
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<EnumType>();
 	amrex::Vector<std::string> names;
 
+	// Add all components except the last one (luminosity)
+	for (size_t i = 0; i < enum_names.size() - 1; ++i) {
+		names.push_back(enum_names[i]);
+	}
+
+	// Expand the last component (luminosity) into luminosity_0, luminosity_1, ...
+	const std::string &base_name = enum_names.back();
+	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+	for (int i = 0; i < nGroups; ++i) {
+		names.push_back(base_name + "_" + std::to_string(i));
+	}
+
+	return names;
+}
+
+// Unified template function to get real component names for any particle type
+// Uses AMREX_ENUM's getEnumNameStrings() and expands luminosity components where needed
+template <ParticleType particleType, typename problem_t> auto getParticleRealCompNames() -> amrex::Vector<std::string>
+{
 	if constexpr (particleType == ParticleType::Rad) {
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<RadParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
-		// Add luminosity components
-		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-		for (int i = 0; i < nGroups; ++i) {
-			names.push_back("luminosity_" + std::to_string(i));
-		}
+		return expandEnumNamesWithLuminosity<RadParticleRealIdx, problem_t>();
 	}
 #if AMREX_SPACEDIM == 3
 	else if constexpr (particleType == ParticleType::CIC) {
+		// No luminosity - use enum names directly
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
+		return {enum_names.begin(), enum_names.end()};
 	} else if constexpr (particleType == ParticleType::CICRad) {
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICRadParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
-		// Add luminosity components
-		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-		for (int i = 0; i < nGroups; ++i) {
-			names.push_back("luminosity_" + std::to_string(i));
-		}
+		return expandEnumNamesWithLuminosity<CICRadParticleRealIdx, problem_t>();
 	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
-		// Add luminosity components
-		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-		for (int i = 0; i < nGroups; ++i) {
-			names.push_back("luminosity_" + std::to_string(i));
-		}
+		return expandEnumNamesWithLuminosity<StochasticStellarPopParticleRealIdx, problem_t>();
 	} else if constexpr (particleType == ParticleType::Sink) {
+		// No luminosity - use enum names directly
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<SinkParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
+		return {enum_names.begin(), enum_names.end()};
 	} else if constexpr (particleType == ParticleType::Test) {
-		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleRealIdx>();
-		names = {enum_names.begin(), enum_names.end()};
-		// Add luminosity components
-		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-		for (int i = 0; i < nGroups; ++i) {
-			names.push_back("luminosity_" + std::to_string(i));
-		}
+		return expandEnumNamesWithLuminosity<TestParticleRealIdx, problem_t>();
 	}
 #endif
-	return names;
+	else {
+		return {};
+	}
 }
 
 // Unified template function to get integer component names for any particle type

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -2,6 +2,7 @@
 #define PARTICLE_TYPES_HPP_
 
 #include "AMReX_AmrParticles.H"
+#include "AMReX_Enum.H"
 #include "AMReX_ParIter.H"
 #include "physics_info.hpp"
 
@@ -203,18 +204,31 @@ using StochasticStellarPopParticleIterator = amrex::ParIter<StochasticStellarPop
 
 //-------------------- Test particles --------------------
 
-// Indices for test particles (Test_particles)
-enum TestParticleDataIdx {
-	TestParticleMassIdx = 0,  // Mass of the particle
-	TestParticleVxIdx,	  // Velocity in x direction
-	TestParticleVyIdx,	  // Velocity in y direction
-	TestParticleVzIdx,	  // Velocity in z direction
-	TestParticleBirthTimeIdx, // Time when particle becomes active
-	TestParticleDeathTimeIdx, // Time when particle becomes inactive
-	TestParticleLumIdx	  // Base index for luminosity components
-};
+// Indices for test particles (Test_particles) using AMREX_ENUM for automatic string conversion
+// The enum values are short names that will appear directly in the Header file
+AMREX_ENUM(TestParticleRealIdx, // NOLINT
+	   mass,		// Mass of the particle
+	   vx,			// Velocity in x direction
+	   vy,			// Velocity in y direction
+	   vz,			// Velocity in z direction
+	   birth_time,		// Time when particle becomes active
+	   death_time		// Time when particle becomes inactive (luminosity components follow dynamically)
+);
 
-constexpr int TestParticleStageIdx = 0; // Evolution stage of the particle, index in the integer components
+// Integer component indices using AMREX_ENUM
+AMREX_ENUM(TestParticleIntIdx, // NOLINT
+	   evolution_stage     // Evolution stage of the particle
+);
+
+// Backward compatibility aliases for existing code
+constexpr int TestParticleMassIdx = static_cast<int>(TestParticleRealIdx::mass);
+constexpr int TestParticleVxIdx = static_cast<int>(TestParticleRealIdx::vx);
+constexpr int TestParticleVyIdx = static_cast<int>(TestParticleRealIdx::vy);
+constexpr int TestParticleVzIdx = static_cast<int>(TestParticleRealIdx::vz);
+constexpr int TestParticleBirthTimeIdx = static_cast<int>(TestParticleRealIdx::birth_time);
+constexpr int TestParticleDeathTimeIdx = static_cast<int>(TestParticleRealIdx::death_time);
+constexpr int TestParticleLumIdx = TestParticleDeathTimeIdx + 1; // Base index for luminosity components (follows death_time)
+constexpr int TestParticleStageIdx = static_cast<int>(TestParticleIntIdx::evolution_stage);
 
 // Number of real components for Test_particles
 template <typename problem_t>
@@ -249,6 +263,119 @@ constexpr int SinkParticleRealComps = 4; // mass, vx, vy, vz
 // Type definitions for Sink_particles container and iterator
 using SinkParticleContainer = amrex::AmrParticleContainer<SinkParticleRealComps>;
 using SinkParticleIterator = amrex::ParIter<SinkParticleRealComps>;
+
+#endif // AMREX_SPACEDIM == 3
+
+//-------------------- Component Names for I/O --------------------
+
+// Helper function to generate component names for radiation particles
+template <typename problem_t> auto getRadParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	amrex::Vector<std::string> names;
+	names.push_back("birth_time");
+	names.push_back("death_time");
+	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+	for (int i = 0; i < nGroups; ++i) {
+		names.push_back("luminosity_" + std::to_string(i));
+	}
+	return names;
+}
+
+template <typename problem_t> auto getRadParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	return {}; // No integer components
+}
+
+#if AMREX_SPACEDIM == 3
+
+// Helper function to generate component names for CIC particles
+inline auto getCICParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	return {"mass", "vx", "vy", "vz"};
+}
+
+inline auto getCICParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	return {}; // No integer components
+}
+
+// Helper function to generate component names for CICRad particles
+template <typename problem_t> auto getCICRadParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	amrex::Vector<std::string> names;
+	names.push_back("mass");
+	names.push_back("vx");
+	names.push_back("vy");
+	names.push_back("vz");
+	names.push_back("birth_time");
+	names.push_back("death_time");
+	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+	for (int i = 0; i < nGroups; ++i) {
+		names.push_back("luminosity_" + std::to_string(i));
+	}
+	return names;
+}
+
+inline auto getCICRadParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	return {}; // No integer components
+}
+
+// Helper function to generate component names for StochasticStellarPop particles
+template <typename problem_t> auto getStochasticStellarPopParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	amrex::Vector<std::string> names;
+	names.push_back("mass");
+	names.push_back("vx");
+	names.push_back("vy");
+	names.push_back("vz");
+	names.push_back("birth_time");
+	names.push_back("death_time");
+	names.push_back("mass_at_birth");
+	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+	for (int i = 0; i < nGroups; ++i) {
+		names.push_back("luminosity_" + std::to_string(i));
+	}
+	return names;
+}
+
+inline auto getStochasticStellarPopParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	return {"evolution_stage"};
+}
+
+// Helper function to generate component names for Sink particles
+inline auto getSinkParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	return {"mass", "vx", "vy", "vz"};
+}
+
+inline auto getSinkParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	return {}; // No integer components
+}
+
+// Helper function to generate component names for Test particles using AMREX_ENUM
+template <typename problem_t> auto getTestParticleRealCompNames() -> amrex::Vector<std::string>
+{
+	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time)
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleRealIdx>();
+	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
+
+	// Add luminosity components dynamically
+	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+	for (int i = 0; i < nGroups; ++i) {
+		names.push_back("luminosity_" + std::to_string(i));
+	}
+	return names;
+}
+
+// Helper function to generate integer component names for Test particles using AMREX_ENUM
+inline auto getTestParticleIntCompNames() -> amrex::Vector<std::string>
+{
+	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();
+	return {enum_names.begin(), enum_names.end()};
+}
 
 #endif // AMREX_SPACEDIM == 3
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -305,117 +305,82 @@ using SinkParticleIterator = amrex::ParIter<SinkParticleRealComps>;
 
 //-------------------- Component Names for I/O --------------------
 
-// Helper function to generate component names for radiation particles using AMREX_ENUM
-template <typename problem_t> auto getRadParticleRealCompNames() -> amrex::Vector<std::string>
+// Unified template function to get real component names for any particle type
+// Uses AMREX_ENUM's getEnumNameStrings() and adds dynamic luminosity components where needed
+template <ParticleType particleType, typename problem_t> auto getParticleRealCompNames() -> amrex::Vector<std::string>
 {
-	// Get names from AMREX_ENUM (birth_time, death_time)
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<RadParticleRealIdx>();
-	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
+	amrex::Vector<std::string> names;
 
-	// Add luminosity components dynamically
-	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-	for (int i = 0; i < nGroups; ++i) {
-		names.push_back("luminosity_" + std::to_string(i));
+	if constexpr (particleType == ParticleType::Rad) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<RadParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+		// Add luminosity components
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		for (int i = 0; i < nGroups; ++i) {
+			names.push_back("luminosity_" + std::to_string(i));
+		}
 	}
-	return names;
-}
-
-template <typename problem_t> auto getRadParticleIntCompNames() -> amrex::Vector<std::string>
-{
-	return {}; // No integer components
-}
-
 #if AMREX_SPACEDIM == 3
-
-// Helper function to generate component names for CIC particles using AMREX_ENUM
-inline auto getCICParticleRealCompNames() -> amrex::Vector<std::string>
-{
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICParticleRealIdx>();
-	return {enum_names.begin(), enum_names.end()};
-}
-
-inline auto getCICParticleIntCompNames() -> amrex::Vector<std::string>
-{
-	return {}; // No integer components
-}
-
-// Helper function to generate component names for CICRad particles using AMREX_ENUM
-template <typename problem_t> auto getCICRadParticleRealCompNames() -> amrex::Vector<std::string>
-{
-	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time)
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICRadParticleRealIdx>();
-	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
-
-	// Add luminosity components dynamically
-	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-	for (int i = 0; i < nGroups; ++i) {
-		names.push_back("luminosity_" + std::to_string(i));
+	else if constexpr (particleType == ParticleType::CIC) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+	} else if constexpr (particleType == ParticleType::CICRad) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<CICRadParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+		// Add luminosity components
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		for (int i = 0; i < nGroups; ++i) {
+			names.push_back("luminosity_" + std::to_string(i));
+		}
+	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+		// Add luminosity components
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		for (int i = 0; i < nGroups; ++i) {
+			names.push_back("luminosity_" + std::to_string(i));
+		}
+	} else if constexpr (particleType == ParticleType::Sink) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<SinkParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+	} else if constexpr (particleType == ParticleType::Test) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleRealIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+		// Add luminosity components
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		for (int i = 0; i < nGroups; ++i) {
+			names.push_back("luminosity_" + std::to_string(i));
+		}
 	}
+#endif
 	return names;
 }
 
-inline auto getCICRadParticleIntCompNames() -> amrex::Vector<std::string>
+// Unified template function to get integer component names for any particle type
+template <ParticleType particleType, typename problem_t> auto getParticleIntCompNames() -> amrex::Vector<std::string>
 {
-	return {}; // No integer components
-}
+	amrex::Vector<std::string> names;
 
-// Helper function to generate component names for StochasticStellarPop particles using AMREX_ENUM
-template <typename problem_t> auto getStochasticStellarPopParticleRealCompNames() -> amrex::Vector<std::string>
-{
-	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time, mass_at_birth)
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleRealIdx>();
-	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
-
-	// Add luminosity components dynamically
-	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-	for (int i = 0; i < nGroups; ++i) {
-		names.push_back("luminosity_" + std::to_string(i));
+	if constexpr (particleType == ParticleType::Rad) {
+		// No integer components
 	}
+#if AMREX_SPACEDIM == 3
+	else if constexpr (particleType == ParticleType::CIC) {
+		// No integer components
+	} else if constexpr (particleType == ParticleType::CICRad) {
+		// No integer components
+	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleIntIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+	} else if constexpr (particleType == ParticleType::Sink) {
+		// No integer components
+	} else if constexpr (particleType == ParticleType::Test) {
+		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();
+		names = {enum_names.begin(), enum_names.end()};
+	}
+#endif
 	return names;
 }
-
-// Helper function to generate integer component names for StochasticStellarPop particles using AMREX_ENUM
-inline auto getStochasticStellarPopParticleIntCompNames() -> amrex::Vector<std::string>
-{
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleIntIdx>();
-	return {enum_names.begin(), enum_names.end()};
-}
-
-// Helper function to generate component names for Sink particles using AMREX_ENUM
-inline auto getSinkParticleRealCompNames() -> amrex::Vector<std::string>
-{
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<SinkParticleRealIdx>();
-	return {enum_names.begin(), enum_names.end()};
-}
-
-inline auto getSinkParticleIntCompNames() -> amrex::Vector<std::string>
-{
-	return {}; // No integer components
-}
-
-// Helper function to generate component names for Test particles using AMREX_ENUM
-template <typename problem_t> auto getTestParticleRealCompNames() -> amrex::Vector<std::string>
-{
-	// Get names from AMREX_ENUM (mass, vx, vy, vz, birth_time, death_time)
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleRealIdx>();
-	amrex::Vector<std::string> names(enum_names.begin(), enum_names.end());
-
-	// Add luminosity components dynamically
-	constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
-	for (int i = 0; i < nGroups; ++i) {
-		names.push_back("luminosity_" + std::to_string(i));
-	}
-	return names;
-}
-
-// Helper function to generate integer component names for Test particles using AMREX_ENUM
-inline auto getTestParticleIntCompNames() -> amrex::Vector<std::string>
-{
-	const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();
-	return {enum_names.begin(), enum_names.end()};
-}
-
-#endif // AMREX_SPACEDIM == 3
 
 //-------------------- Units --------------------
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -373,18 +373,18 @@ template <ParticleType particleType, typename problem_t> auto getParticleIntComp
 	amrex::Vector<std::string> names;
 
 	if constexpr (particleType == ParticleType::Rad) { // NOLINT
-		// No integer components
+							   // No integer components
 	}
 #if AMREX_SPACEDIM == 3
-	else if constexpr (particleType == ParticleType::CIC) { // NOLINT
-		// No integer components
+	else if constexpr (particleType == ParticleType::CIC) {	     // NOLINT
+								     // No integer components
 	} else if constexpr (particleType == ParticleType::CICRad) { // NOLINT
-		// No integer components
+								     // No integer components
 	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleIntIdx>();
 		names = {enum_names.begin(), enum_names.end()};
 	} else if constexpr (particleType == ParticleType::Sink) { // NOLINT
-		// No integer components
+								   // No integer components
 	} else if constexpr (particleType == ParticleType::Test) {
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();
 		names = {enum_names.begin(), enum_names.end()};

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -372,18 +372,18 @@ template <ParticleType particleType, typename problem_t> auto getParticleIntComp
 {
 	amrex::Vector<std::string> names;
 
-	if constexpr (particleType == ParticleType::Rad) {
+	if constexpr (particleType == ParticleType::Rad) { // NOLINT
 		// No integer components
 	}
 #if AMREX_SPACEDIM == 3
-	else if constexpr (particleType == ParticleType::CIC) {
+	else if constexpr (particleType == ParticleType::CIC) { // NOLINT
 		// No integer components
-	} else if constexpr (particleType == ParticleType::CICRad) {
+	} else if constexpr (particleType == ParticleType::CICRad) { // NOLINT
 		// No integer components
 	} else if constexpr (particleType == ParticleType::StochasticStellarPop) {
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<StochasticStellarPopParticleIntIdx>();
 		names = {enum_names.begin(), enum_names.end()};
-	} else if constexpr (particleType == ParticleType::Sink) {
+	} else if constexpr (particleType == ParticleType::Sink) { // NOLINT
 		// No integer components
 	} else if constexpr (particleType == ParticleType::Test) {
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();


### PR DESCRIPTION
## Summary

Updated particle I/O to write meaningful component names (e.g., `mass`, `vx`, `luminosity_0`) instead of generic names (`real_comp0`, `real_comp1`) in plotfile and checkpoint Header files.

## Changes

- **`src/particles/particle_types.hpp`**:
  - Converted particle data index enums to `AMREX_ENUM` for automatic string conversion
  - Added `luminosity` explicitly to enums for radiating particle types
  - Created `expandEnumNames<EnumType, nComps, expandLast>()` helper to generate component names
  - Added unified `getParticleRealCompNames<ParticleType, problem_t>()` and `getParticleIntCompNames<ParticleType, problem_t>()` template functions
  - Maintained backward compatibility with `constexpr int` aliases for existing code

- **`src/particles/PhysicsParticles.hpp`**:
  - Updated `writePlotFile()` and `writeCheckpoint()` to pass component names to AMReX

## Particle types updated

| Particle Type        | Real Components                                                            | Int Components  |
|----------------------|----------------------------------------------------------------------------|-----------------|
| Rad                  | birth_time, death_time, luminosity_0, ...                                  | (none)          |
| CIC                  | mass, vx, vy, vz                                                           | (none)          |
| CICRad               | mass, vx, vy, vz, birth_time, death_time, luminosity_0, ...                | (none)          |
| StochasticStellarPop | mass, vx, vy, vz, birth_time, death_time, mass_at_birth, luminosity_0, ... | evolution_stage |
| Sink                 | mass, vx, vy, vz                                                           | (none)          |
| Test                 | mass, vx, vy, vz, birth_time, death_time, luminosity_0, ...                | evolution_stage |


### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
