### PR TITLE
Fix a bug in artificial viscosity 

### DIFF
--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1412,6 +1412,11 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 
 		quokka::valarray<double, nHydroScalars_> F = F_canonical;
 
+		// permute momentum components according to flux direction DIR
+		F[velN_index] = F_canonical[x1Momentum_index];
+		F[velV_index] = F_canonical[x2Momentum_index];
+		F[velW_index] = F_canonical[x3Momentum_index];
+
 		// add artificial viscosity
 		// following Colella & Woodward (1984), eq. (4.2)
 		const double div_v = AMREX_D_TERM(du, +0.5 * (dvl + dvr), +0.5 * (dwl + dwr));
@@ -1437,11 +1442,6 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		}
 
 		F = F + viscosity * (U_L - U_R);
-
-		// permute momentum components according to flux direction DIR
-		F[velN_index] = F_canonical[x1Momentum_index];
-		F[velV_index] = F_canonical[x2Momentum_index];
-		F[velW_index] = F_canonical[x3Momentum_index];
 
 		// set energy fluxes to zero if EOS is isothermal
 		if constexpr (HydroSystem<problem_t>::is_eos_isothermal()) {


### PR DESCRIPTION
### Description
In the current implementation of artificial viscosity, the viscosity term is only added to energy and density but not momentum. This PR fixed the bug by updating the momentum as well.

This makes the Mach 50 Turbulent box (with `hydro.artificial_viscosity_coefficient = 0.1`) run a lot longer: previously it runs to `t=0.016` and fail with `max_retries exceeded`. With this PR, it runs to at least `t=0.024` (have not tested running longer). 

Thanks to @mxchen39 for pointing out this bug.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
