### PR TITLE
make git push robust and solves the regression hanging issue

### DIFF
--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -48,7 +48,26 @@ jobs:
       condition: succeededOrFailed()
       artifact: regressionHTMLOutput
       displayName: 'Upload results to Azure Pipelines'
-    - script: cd /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web && git add . && git commit -m 'updated results' && git push
+    - script: |
+        set -x
+        cd /priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests/web
+        export GIT_TERMINAL_PROMPT=0
+        echo "Checking for changes in regression results..."
+        git status
+        git add .
+        if git diff --staged --quiet; then
+          echo "No changes to commit, skipping push..."
+          exit 0
+        fi
+        echo "Committing changes..."
+        git -c user.name="ChongChong He" -c user.email="chongchonghe99@gmail.com" \
+            commit --no-verify -m "updated results [skip ci]"
+        echo "Pushing to GitHub Pages..."
+        git -c core.askPass= push origin HEAD 2>&1 || {
+          echo "Push failed with exit code $?, but continuing..."
+          exit 0
+        }
+        echo "Successfully pushed regression results"
       condition: succeededOrFailed()
       displayName: 'Upload results to GitHub Pages'
     - template: templates/ccache-stats.yml

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -38,7 +38,7 @@ jobs:
 
     - template: templates/ccache-prepare.yml
 
-    - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
+    - script: echo "Skipping regression testing for debugging"
       displayName: 'Run regression testing'
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -38,7 +38,7 @@ jobs:
 
     - template: templates/ccache-prepare.yml
 
-    - script: echo "Skipping regression testing for debugging"
+    - script: ./extern/regression_testing/regtest.py --clean_testdir regression/quokka-tests.ini
       displayName: 'Run regression testing'
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache

--- a/.ci/azure-pipelines-regression.yml
+++ b/.ci/azure-pipelines-regression.yml
@@ -60,7 +60,7 @@ jobs:
           exit 0
         fi
         echo "Committing changes..."
-        git -c user.name="ChongChong He" -c user.email="chongchonghe99@gmail.com" \
+        git -c user.name="Quokka CI Bot" -c user.email="quokka-ci-bot@quokka.dev" \
             commit --no-verify -m "updated results [skip ci]"
         echo "Pushing to GitHub Pages..."
         git -c core.askPass= push origin HEAD 2>&1 || {


### PR DESCRIPTION
### Description
Solves the 'publish to github' hanging issue. 

The origin of the issue is that, whenever 'git' tries to ask the user for input, like to set `--user` and `--email`, or adding an address to known_host, it will wait for the user to confirm, and this causes the workflow to hang indefinitely. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
