### PR TITLE
add helper functions for SFR diagnostics

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -1,6 +1,7 @@
 #ifndef PHYSICS_PARTICLES_HPP_
 #define PHYSICS_PARTICLES_HPP_
 
+#include <algorithm>
 #include <array>
 #include <cstdint>
 #include <map>
@@ -1061,6 +1062,75 @@ template <typename problem_t> class PhysicsParticleRegister
 				sfh_data_[type].emplace_back(nstep, time, total_mass);
 			}
 		}
+	}
+
+	[[nodiscard]] auto computeTotalStellarMass() const -> amrex::Real
+	{
+		amrex::Real total_mass = 0.0;
+		for (const auto &entry : particleRegistry_) {
+			const auto &descriptor = entry.second;
+			if (descriptor->getAllowsCreation()) {
+				total_mass += descriptor->computeStellarMass();
+			}
+		}
+		return total_mass;
+	}
+
+	auto computeSfrAveragedOverTime(amrex::Real current_time, amrex::Real time_window) const -> amrex::Real
+	{
+		if (sfh_data_.empty()) {
+			return 0.0;
+		}
+
+		auto compute_mass_at_time = [](auto const &history, amrex::Real time) -> amrex::Real {
+			if (history.empty()) {
+				return 0.0;
+			}
+			const auto &front = history.front();
+			const auto &back = history.back();
+			const amrex::Real t_front = std::get<1>(front);
+			const amrex::Real t_back = std::get<1>(back);
+
+			if (time <= t_front) {
+				return std::get<2>(front);
+			}
+			if (time >= t_back) {
+				return std::get<2>(back);
+			}
+
+			auto upper = std::upper_bound(history.begin(), history.end(), time,
+						      [](amrex::Real value, auto const &entry) { return value < std::get<1>(entry); });
+			auto lower = std::prev(upper);
+			const amrex::Real t0 = std::get<1>(*lower);
+			const amrex::Real t1 = std::get<1>(*upper);
+			const amrex::Real m0 = std::get<2>(*lower);
+			const amrex::Real m1 = std::get<2>(*upper);
+			const amrex::Real frac = (time - t0) / (t1 - t0);
+			return m0 + frac * (m1 - m0);
+		};
+
+		amrex::Real total_sfr = 0.0;
+		for (const auto &entry : sfh_data_) {
+			const auto &history = entry.second;
+			if (history.empty()) {
+				continue;
+			}
+			const amrex::Real t_back = std::get<1>(history.back());
+			const amrex::Real t_front = std::get<1>(history.front());
+			const amrex::Real time_now = std::min(current_time, t_back);
+			const amrex::Real time_start_requested = time_now - time_window;
+			const amrex::Real time_start = std::max(time_start_requested, t_front);
+
+			if (time_now <= time_start) {
+				continue;
+			}
+
+			const amrex::Real mass_now = compute_mass_at_time(history, time_now);
+			const amrex::Real mass_start = compute_mass_at_time(history, time_start);
+			total_sfr += (mass_now - mass_start) / (time_now - time_start);
+		}
+
+		return total_sfr;
 	}
 
 	// Write SFH data from memory to metadata

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -256,8 +256,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Compute total stellar mass at birth
 	[[nodiscard]] auto computeStellarMassAtBirth() const -> amrex::Real override
 	{
-		if (this->getMassAtBirthIndex() < 0) {
-			return computeStellarMass();
+		if (container_ == nullptr || this->getMassAtBirthIndex() < 0) {
+			return 0.0; // if it doesn't exist, return zero
 		}
 
 		amrex::Real total_mass = 0.0;
@@ -285,8 +285,8 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	[[nodiscard]] auto computeStellarMassAtBirthBornByTime(amrex::Real time) const -> amrex::Real override
 	{
 		const int birth_time_idx = this->getBirthTimeIndex();
-		const int mass_idx = (this->getMassAtBirthIndex() >= 0) ? this->getMassAtBirthIndex() : this->getMassIndex();
-		if (container_ == nullptr || birth_time_idx < 0 || mass_idx < 0) {
+		const int birth_mass_idx = this->getMassAtBirthIndex();
+		if (container_ == nullptr || birth_time_idx < 0 || birth_mass_idx < 0) {
 			return 0.0;
 		}
 
@@ -303,7 +303,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				    if (time < birth_time) {
 					    return 0.0;
 				    }
-				    return p_type.m_aos[i].rdata(mass_idx);
+				    return p_type.m_aos[i].rdata(birth_mass_idx);
 			    },
 			    reduce_ops);
 			total_mass += amrex::get<0>(result_tuple);

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -124,6 +124,7 @@ class PhysicsParticleDescriptorBase
 	// Compute total stellar mass
 	[[nodiscard]] virtual auto computeStellarMass() const -> amrex::Real = 0;
 	[[nodiscard]] virtual auto computeStellarMassAtBirth() const -> amrex::Real = 0;
+	[[nodiscard]] virtual auto computeStellarMassAtBirthBornByTime(amrex::Real time) const -> amrex::Real = 0;
 
 #if AMREX_SPACEDIM == 3
 	virtual void depositMass(const amrex::Vector<amrex::MultiFab *> &rhs, int finest_lev, amrex::Real Gconst) = 0;
@@ -277,6 +278,37 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				total_mass += amrex::get<0>(result_tuple);
 			}
 		}
+		amrex::ParallelAllReduce::Sum(total_mass, amrex::ParallelContext::CommunicatorSub());
+		return total_mass;
+	}
+
+	[[nodiscard]] auto computeStellarMassAtBirthBornByTime(amrex::Real time) const -> amrex::Real override
+	{
+		const int birth_time_idx = this->getBirthTimeIndex();
+		const int mass_idx = (this->getMassAtBirthIndex() >= 0) ? this->getMassAtBirthIndex() : this->getMassIndex();
+		if (container_ == nullptr || birth_time_idx < 0 || mass_idx < 0) {
+			return 0.0;
+		}
+
+		amrex::Real total_mass = 0.0;
+		amrex::ReduceOps<amrex::ReduceOpSum> reduce_ops;
+		using ReduceDataType = amrex::ReduceData<amrex::Real>;
+		using PTDType = typename ContainerType::ParticleTileType::ConstParticleTileDataType;
+
+		for (int lev = 0; lev <= container_->finestLevel(); ++lev) {
+			auto result_tuple = amrex::ParticleReduce<ReduceDataType>(
+			    *container_, lev,
+			    [=] AMREX_GPU_DEVICE(const PTDType &p_type, const int i) noexcept -> amrex::Real {
+				    const amrex::Real birth_time = p_type.m_aos[i].rdata(birth_time_idx);
+				    if (time < birth_time) {
+					    return 0.0;
+				    }
+				    return p_type.m_aos[i].rdata(mass_idx);
+			    },
+			    reduce_ops);
+			total_mass += amrex::get<0>(result_tuple);
+		}
+
 		amrex::ParallelAllReduce::Sum(total_mass, amrex::ParallelContext::CommunicatorSub());
 		return total_mass;
 	}
@@ -1078,59 +1110,23 @@ template <typename problem_t> class PhysicsParticleRegister
 
 	[[nodiscard]] auto computeSfrAveragedOverTime(amrex::Real current_time, amrex::Real time_window) const -> amrex::Real
 	{
-		if (sfh_data_.empty()) {
+		if (time_window <= 0.0) {
 			return 0.0;
 		}
 
-		auto compute_mass_at_time = [](auto const &history, amrex::Real time) -> amrex::Real {
-			if (history.empty()) {
-				return 0.0;
-			}
-			const auto &front = history.front();
-			const auto &back = history.back();
-			const amrex::Real t_front = std::get<1>(front);
-			const amrex::Real t_back = std::get<1>(back);
-
-			if (time <= t_front) {
-				return std::get<2>(front);
-			}
-			if (time >= t_back) {
-				return std::get<2>(back);
-			}
-
-			auto upper = std::upper_bound(history.begin(), history.end(), time,
-						      [](amrex::Real value, auto const &entry) { return value < std::get<1>(entry); });
-			auto lower = std::prev(upper);
-			const amrex::Real t0 = std::get<1>(*lower);
-			const amrex::Real t1 = std::get<1>(*upper);
-			const amrex::Real m0 = std::get<2>(*lower);
-			const amrex::Real m1 = std::get<2>(*upper);
-			const amrex::Real frac = (time - t0) / (t1 - t0);
-			return m0 + frac * (m1 - m0);
-		};
-
-		amrex::Real total_sfr = 0.0;
-		for (const auto &entry : sfh_data_) {
-			const auto &history = entry.second;
-			if (history.empty()) {
-				continue;
-			}
-			const amrex::Real t_back = std::get<1>(history.back());
-			const amrex::Real t_front = std::get<1>(history.front());
-			const amrex::Real time_now = std::min(current_time, t_back);
-			const amrex::Real time_start_requested = time_now - time_window;
-			const amrex::Real time_start = std::max(time_start_requested, t_front);
-
-			if (time_now <= time_start) {
-				continue;
-			}
-
-			const amrex::Real mass_now = compute_mass_at_time(history, time_now);
-			const amrex::Real mass_start = compute_mass_at_time(history, time_start);
-			total_sfr += (mass_now - mass_start) / (time_now - time_start);
+		auto descriptor_it = particleRegistry_.find(ParticleType::StochasticStellarPop);
+		if (descriptor_it == particleRegistry_.end() || descriptor_it->second == nullptr) {
+			return 0.0;
 		}
 
-		return total_sfr;
+		const amrex::Real time_now = current_time;
+		const amrex::Real time_start = current_time - time_window;
+
+		const auto &descriptor = descriptor_it->second;
+		const amrex::Real mass_now = descriptor->computeStellarMassAtBirthBornByTime(time_now);
+		const amrex::Real mass_start = descriptor->computeStellarMassAtBirthBornByTime(time_start);
+
+		return (mass_now - mass_start) / time_window;
 	}
 
 	// Write SFH data from memory to metadata

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -1096,13 +1096,13 @@ template <typename problem_t> class PhysicsParticleRegister
 		}
 	}
 
-	[[nodiscard]] auto computeTotalStellarMass() const -> amrex::Real
+	[[nodiscard]] auto computeTotalStellarMassAtBirth() const -> amrex::Real
 	{
 		amrex::Real total_mass = 0.0;
 		for (const auto &entry : particleRegistry_) {
 			const auto &descriptor = entry.second;
 			if (descriptor->getAllowsCreation()) {
-				total_mass += descriptor->computeStellarMass();
+				total_mass += descriptor->computeStellarMassAtBirth();
 			}
 		}
 		return total_mass;

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -1076,7 +1076,7 @@ template <typename problem_t> class PhysicsParticleRegister
 		return total_mass;
 	}
 
-	auto computeSfrAveragedOverTime(amrex::Real current_time, amrex::Real time_window) const -> amrex::Real
+	[[nodiscard]] auto computeSfrAveragedOverTime(amrex::Real current_time, amrex::Real time_window) const -> amrex::Real
 	{
 		if (sfh_data_.empty()) {
 			return 0.0;


### PR DESCRIPTION
### Description
This adds helper functions to compute SFR history diagnostics.

This is useful to write SFR history with multiple sliding windows to the statistics output file `history.txt`.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
