### PR TITLE
Print full container URL after build

### DIFF
--- a/.github/workflows/rocm-diskgalaxy-container.yml
+++ b/.github/workflows/rocm-diskgalaxy-container.yml
@@ -66,6 +66,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Print DiskGalaxy image URL (development)
+        if: ${{ github.event_name == 'push' }}
+        run: |
+          echo "Built image: docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-${{ env.IMAGE_TAG_SHA }}"
+
       - name: Build and push DiskGalaxy image (PR)
         if: ${{ env.IS_INTERNAL_PR == 'true' }}
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
@@ -80,6 +85,11 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-pr-${{ github.event.pull_request.number }}-${{ env.IMAGE_TAG_SHA }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Print DiskGalaxy image URL (PR)
+        if: ${{ env.IS_INTERNAL_PR == 'true' }}
+        run: |
+          echo "Built image: docker://${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-pr-${{ github.event.pull_request.number }}-${{ env.IMAGE_TAG_SHA }}"
 
       - name: Build DiskGalaxy image (PR, no publish)
         if: ${{ github.event_name == 'pull_request' && env.IS_INTERNAL_PR != 'true' }}


### PR DESCRIPTION
### Description
Prints the full URL that can be used to pull the container image after a successful CI build of the image.

This URL can be used directly with `apptainer pull <url>`.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
