### PR TITLE
Set a safe default number of iterations for AMR grid generation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,10 +49,10 @@ auto main(int argc, char **argv) -> int
 		/// iterate the grid generation at least max(4, amr.max_level) times.
 		/// [see https://github.com/AMReX-Codes/amrex/pull/4903 for details]
 		amrex::ParmParse pp_amr("amr");
-		if (!pp_amr.contains("amr.max_grid_iterations")) {
+		if (!pp_amr.contains("max_grid_iterations")) {
 			int amr_max_level = -1;
 			pp_amr.query("max_level", amr_max_level);
-			pp_amr.add("amr.max_grid_iterations", std::max(4, amr_max_level));
+			pp_amr.add("max_grid_iterations", std::max(4, amr_max_level));
 		}
 
 		/// override geometry.is_periodic based on quokka.bc

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,17 @@ auto main(int argc, char **argv) -> int
 			pp.add("use_gpu_aware_mpi", 1);
 		}
 
+		/// set number of grid generation iterations
+		/// when refining small regions on deeply nested AMR, it's necessary to
+		/// iterate the grid generation at least max(4, amr.max_level) times.
+		/// [see https://github.com/AMReX-Codes/amrex/pull/4903 for details]
+		amrex::ParmParse pp_amr("amr");
+		if (!pp_amr.contains("amr.max_grid_iterations")) {
+			int amr_max_level = -1;
+			pp_amr.query("max_level", amr_max_level);
+			pp_amr.add("amr.max_grid_iterations", std::max(4, amr_max_level));
+		}
+
 		/// override geometry.is_periodic based on quokka.bc
 		amrex::Vector<std::string> bc_str;
 		amrex::ParmParse const pp_quokka("quokka");


### PR DESCRIPTION
### Description
Sets a safe default for the number of iterations to perform when tagging and re-gridding AMR levels.
This is an example of why this is required: https://github.com/BenWibking/amrex-gridgen-test

### Related issues
See https://github.com/AMReX-Codes/amrex/pull/4903.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
