### PR TITLE
[CRITICAL] Fix death time bug in SF

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -552,7 +552,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 
 						p.idata(evolution_stage_index) =
 						    interpolate_fate(p.rdata(mass_idx)) == 1 ? static_cast<int>(StellarEvolutionStage::SNProgenitor) : 0;
-						p.rdata(birth_time_index + 1) = interpolate_death_time(p.rdata(mass_idx));
+						p.rdata(birth_time_index + 1) = current_time + interpolate_death_time(p.rdata(mass_idx));
 					}
 					// Set mass_at_birth
 					if (mass_at_birth_idx >= 0) {


### PR DESCRIPTION
### Description
The death time of a star should be `interpolate_death_time(p.rdata(mass_idx)) + current_time`, but it was falsely set to `interpolate_death_time(p.rdata(mass_idx))`, since the component should store the 'death_time' of the particle, as its name suggests, not it's lifespan. This means, in our previous simulations, a SNProgenitor immediately explode as SN in the step after formation.

### Related issues
This explains why in the DiskGalaxy sim we don't see any SNProgenitor in a snapshot. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
