### PR TITLE
call FixupState before particle operations

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1951,6 +1951,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::particleMeshInterac
 	// Assume all SN progenitors are at the finest level
 	const int lev = finest_level;
 
+	// Enforce floors and limits on hydro state to ensure we have valid hydro states
+	FixupState(lev);
+
 	// Fill ghost zones before computing accretion rate. This is necessary because the computation of accretion rate uses 3 ghost cells, but the
 	// boundaries are not filled at this point.
 	// TODO(cch): fill the hydro variables but not radiation variables, since radiation variables are used in accretion


### PR DESCRIPTION
### Description
Call `FixupState(lev)` before any particle creation or feedback operations. This ensures that hydro state is valid and within bounds.

This appears to be needed to ensure LowMassComposite star particles aren't unnecessarily created in cells below the temperature floor.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
