### PR TITLE
truncate star formation at high densities / low Jeans number

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -368,7 +368,12 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 	// Specialized nested ParticleChecker for StochasticStellarPop particles
 
 	static constexpr amrex::Real eps_star = 0.5; // fraction of gas mass that goes into star particles
-	static constexpr amrex::Real J = 0.5;	     // Jeans parameter
+	static constexpr amrex::Real J = 0.5;	     // Jeans number (Truelove et al. 1997)
+	// Truncating the collapse at sufficiently low Jeans number is needed to prevent
+	// runaway collapse to very high densities. This is absolutely critical to include because half
+	// of the cell mass will turn into stars and produce composite star particle masses
+	// that are so large they cause heating due to dynamical friction in the galaxy.
+	static constexpr amrex::Real J_truncate = 0.01 * J; // Jeans number for guaranteed star formation
 
 	// Constants for the Chabrier IMF
 	// These are the parameters used in extern/ChabrierIMGCalculation.nb
@@ -408,7 +413,9 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			const amrex::Real cs = HydroSystem<problem_t>::ComputeSoundSpeed(state_arr, i, j, k, fab_fc);
 			const amrex::Real LambdaJ = cs / std::sqrt(C::Gconst * cell_density);
 			const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * cell_density));
-			const amrex::Real prob_star_formation = (eps_ff_ / eps_star) * (dt / t_ff);
+			const amrex::Real nominal_prob_star_formation = (eps_ff_ / eps_star) * (dt / t_ff);
+			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)
+			const amrex::Real actual_prob_star_formation = (LambdaJ < (J_truncate * dx[0])) ? 1.0 : nominal_prob_star_formation;
 			const amrex::Real random_draw = amrex::Random(engine);
 			int num_star = 0;
 
@@ -417,7 +424,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			// Checkout docs/star_formation for more details
 
 			if ((LambdaJ < J * dx[0]) &&
-			    random_draw < prob_star_formation) { // Create a particle only if LambdaJ < J*dx and prob_star_formation> random draw
+			    random_draw < actual_prob_star_formation) { // Create a particle only if LambdaJ < J*dx and actual_prob_star_formation > random draw
 				const amrex::Real particle_mass = cell_density * cell_volume * eps_star;
 				const amrex::Real m_high_tot = particle_mass * fstar_high;
 				amrex::Real const num_high_mass_stars_exp = m_high_tot / m_star_high_avg;


### PR DESCRIPTION
### Description
This forces the probability of forming stars to 1 at sufficiently high densities (more precisely, sufficiently low Jeans number).

Since half of the cell mass is converted into stars when the trial succeeds, this fail-safe step is required to avoid pathologically large LowMassComposite star particles.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
