### PR TITLE
add optional cap on composite star particle masses

### DIFF
--- a/inputs/ParticleSF.in
+++ b/inputs/ParticleSF.in
@@ -37,8 +37,8 @@ problem.Tamb = 1.0e1
 
 max_timesteps = 10
 initial_dt = 3.15576e12
-plotfile_interval = 5
-checkpoint_interval = 5
+plotfile_interval = 10
+checkpoint_interval = 10
 
 # *****************************************************************
 # Cooling parameters

--- a/inputs/ParticleSF2.in
+++ b/inputs/ParticleSF2.in
@@ -38,8 +38,8 @@ problem.Tamb = 1.0e1
 restartfile = chk0000010
 max_timesteps = 20
 initial_dt = 3.15576e12
-plotfile_interval = 5
-checkpoint_interval = 5
+plotfile_interval = 10
+checkpoint_interval = -1
 
 # *****************************************************************
 # Cooling parameters

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -508,9 +508,6 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 						++num_low;
 					}
 				}
-				if (num_low > num_particles) {
-					num_low = num_particles;
-				}
 				const int num_high = num_particles - num_low;
 				const amrex::Real mass_low_each = mass_low_mass_star / static_cast<amrex::Real>(num_low);
 				const bool split_low_mass_composite = (num_low > 1);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -551,7 +551,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 						p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::LowMassComposite);
 						// Set particle mass
 						p.rdata(mass_idx) = mass_low_each;
-						// Set particle postion and velocity
+						// Set particle position and velocity
 						if (split_low_mass_composite) {
 							// Randomize velocity within the cell only when split
 							const amrex::Real rx = amrex::Random(engine);
@@ -696,7 +696,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= factor;
 					state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= factor;
 
-					// Update internal energy to relect mass change
+					// Update internal energy to reflect mass change
 					state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
 
 					// Update total energy

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -585,7 +585,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 							double const cos_theta_random = 2. * amrex::Random(engine) - 1.;
 							double const sin_theta_random = std::sqrt(1. - cos_theta_random * cos_theta_random);
 							// Sample phi from a uniform distribution between 0 and 2*pi
-							double const phi_random = (1. - amrex::Random(engine)) * 2. * std::numbers::pi;
+							double const phi_random = amrex::Random(engine) * 2. * std::numbers::pi;
 
 							double const vx_random = v_mag * sin_theta_random * std::cos(phi_random);
 							double const vy_random = v_mag * sin_theta_random * std::sin(phi_random);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -399,6 +399,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		amrex::Real param1 = particle_param1;
 		amrex::Real param2 = particle_param2;
 		amrex::Real eps_ff_ = eps_ff;
+		amrex::Real low_mass_composite_max_mass_ = low_mass_composite_max_mass;
 
 		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
 
@@ -426,8 +427,17 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			    random_draw < prob_star_formation) { // Create a particle only if LambdaJ < J*dx and prob_star_formation> random draw
 				const amrex::Real particle_mass = cell_density * cell_volume * eps_star;
 				const amrex::Real m_high_tot = particle_mass * fstar_high;
+				const amrex::Real mass_low_mass_star = particle_mass * (1.0 - fstar_high);
 				amrex::Real const num_high_mass_stars_exp = m_high_tot / m_star_high_avg;
-				num_star = static_cast<int>(1 + (amrex::RandomPoisson(num_high_mass_stars_exp, engine)));
+				const int num_high = static_cast<int>(amrex::RandomPoisson(num_high_mass_stars_exp, engine));
+				int num_low = 1;
+				if ((low_mass_composite_max_mass_ > 0.0) && (mass_low_mass_star > low_mass_composite_max_mass_)) {
+					num_low = static_cast<int>(mass_low_mass_star / low_mass_composite_max_mass_);
+					if (mass_low_mass_star > static_cast<amrex::Real>(num_low) * low_mass_composite_max_mass_) {
+						++num_low;
+					}
+				}
+				num_star = num_low + num_high;
 			}
 			return num_star;
 		}
@@ -448,6 +458,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		amrex::Real param2 = particle_param2;
 		amrex::Real eps_ff_ = eps_ff;
 		amrex::Real stellar_velocity_limit_ = stellar_velocity_limit;
+		amrex::Real low_mass_composite_max_mass_ = low_mass_composite_max_mass;
 
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int death_time_index, int processor_id, amrex::Long particle_id_start,
@@ -483,7 +494,20 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				double total_momy = 0.0;
 				double total_momz = 0.0;
 
-				// p_idx = 0 represents the low mass star and p_idx = 1, 2..  represent the high mass stars
+				int num_low = 1;
+				if ((low_mass_composite_max_mass_ > 0.0) && (mass_low_mass_star > low_mass_composite_max_mass_)) {
+					num_low = static_cast<int>(mass_low_mass_star / low_mass_composite_max_mass_);
+					if (mass_low_mass_star > static_cast<amrex::Real>(num_low) * low_mass_composite_max_mass_) {
+						++num_low;
+					}
+				}
+				if (num_low > num_particles) {
+					num_low = num_particles;
+				}
+				const int num_high = num_particles - num_low;
+				const amrex::Real mass_low_each = mass_low_mass_star / static_cast<amrex::Real>(num_low);
+
+				// p_idx = 0..(num_low-1) represent the low mass composites, p_idx = num_low.. represent the high mass stars
 
 				for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
 					auto &p = particles[p_idx]; // NOLINT
@@ -499,10 +523,20 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// This gets changed in the for loop below if this is a high mass star
 					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::LowMassComposite);
 
-					// Low Mass particle position at cell center
-					p.pos(0) = plo[0] + (i + 0.5) * dx[0];
-					p.pos(1) = plo[1] + (j + 0.5) * dx[1];
-					p.pos(2) = plo[2] + (k + 0.5) * dx[2];
+					if (p_idx < num_low) {
+						// Randomize LowMassComposite position within the cell
+						const amrex::Real rx = amrex::Random(engine);
+						const amrex::Real ry = amrex::Random(engine);
+						const amrex::Real rz = amrex::Random(engine);
+						p.pos(0) = plo[0] + (i + rx) * dx[0];
+						p.pos(1) = plo[1] + (j + ry) * dx[1];
+						p.pos(2) = plo[2] + (k + rz) * dx[2];
+					} else {
+						// High mass stars at cell center
+						p.pos(0) = plo[0] + (i + 0.5) * dx[0];
+						p.pos(1) = plo[1] + (j + 0.5) * dx[1];
+						p.pos(2) = plo[2] + (k + 0.5) * dx[2];
+					}
 
 					p.rdata(StochasticStellarPopParticleBirthPosXIdx) = p.pos(0);
 					p.rdata(StochasticStellarPopParticleBirthPosYIdx) = p.pos(1);
@@ -513,13 +547,13 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					p.rdata(StochasticStellarPopParticleDeathDensityIdx) = unset_position;
 
 					// Low Mass particle mass and velocity
-					p.rdata(mass_idx) = mass_low_mass_star;
+					p.rdata(mass_idx) = (p_idx < num_low) ? mass_low_each : 0.0;
 					p.rdata(mass_idx + 1) = vx;
 					p.rdata(mass_idx + 2) = vy;
 					p.rdata(mass_idx + 3) = vz;
 
 					p.rdata(death_time_index) = std::numeric_limits<amrex::Real>::max();
-					if (p_idx > 0) {
+					if (p_idx >= num_low) {
 						// This is the loop that sets the velocity of the high mass stars
 						double const km_per_s = 1.e5; // convert km/s to cm/s
 						double const v_min = 3.0;     // Minimum velocity from the distribution
@@ -571,12 +605,16 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					}
 				}
 
-				if (num_particles > 1) { // Update momentum of the low mass star if there is(are) high mass star(s) in the cell
-					const int p_idx = 0;
-					auto &plow = particles[p_idx]; // NOLINT
-					plow.rdata(mass_idx + 1) = -total_momx / plow.rdata(mass_idx);
-					plow.rdata(mass_idx + 2) = -total_momy / plow.rdata(mass_idx);
-					plow.rdata(mass_idx + 3) = -total_momz / plow.rdata(mass_idx);
+				if (num_high > 0) { // Update momentum of the low mass stars if there is(are) high mass star(s) in the cell
+					const amrex::Real vx_low = -total_momx / mass_low_mass_star;
+					const amrex::Real vy_low = -total_momy / mass_low_mass_star;
+					const amrex::Real vz_low = -total_momz / mass_low_mass_star;
+					for (int p_idx = 0; p_idx < num_low; ++p_idx) {
+						auto &plow = particles[p_idx]; // NOLINT
+						plow.rdata(mass_idx + 1) = vx_low;
+						plow.rdata(mass_idx + 2) = vy_low;
+						plow.rdata(mass_idx + 3) = vz_low;
+					}
 				}
 
 				const double factor = (1. - particle_mass / cell_mass);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -513,6 +513,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				}
 				const int num_high = num_particles - num_low;
 				const amrex::Real mass_low_each = mass_low_mass_star / static_cast<amrex::Real>(num_low);
+				const bool split_low_mass_composite = (num_low > 1);
 
 				// p_idx = 0..(num_low-1) represent the low mass composites, p_idx = num_low.. represent the high mass stars
 
@@ -530,8 +531,8 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// This gets changed in the for loop below if this is a high mass star
 					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::LowMassComposite);
 
-					if (p_idx < num_low) {
-						// Randomize LowMassComposite position within the cell
+					if ((p_idx < num_low) && split_low_mass_composite) {
+						// Randomize LowMassComposite position within the cell only when split.
 						const amrex::Real rx = amrex::Random(engine);
 						const amrex::Real ry = amrex::Random(engine);
 						const amrex::Real rz = amrex::Random(engine);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -542,7 +542,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 
 					// Everything is now set EXCEPT for mass, velocity, evolutionary stage, and mass at birth.
 					// (For SN progenitors, the death time will be overridden based on the interpolated lifetime.)
-					// (Mass at birth is set at the end of this loop. It MUST be set for all star particles, 
+					// (Mass at birth is set at the end of this loop. It MUST be set for all star particles,
 					// 	because it is used to calculate the star formation rate in outputs.)
 
 					// This is a LowMassComposite star particle
@@ -632,55 +632,55 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					}
 				}
 
-					// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
-					if (num_high >= 1) {
-						// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)
-						amrex::Real real_particle_total_mass = 0.;
-						for (int pp = 0; pp < num_particles; ++pp) {
-							real_particle_total_mass += particles[pp].rdata(mass_idx);
-						}
-
-						// Option 1 (preferred): Ensure COM velocity of all stars equals cell velocity (vx, vy, vz).
-						// This may violate momentum conservation because real_particle_total_mass != particle_mass
-						// due to stochastic sampling of high-mass star masses from the IMF.
-						// However, since mass conservation is already violated in a single cell due to stochasticity,
-						// it's more important to preserve correct velocities in a rotating disk.
-						const amrex::Real target_low_momx = real_particle_total_mass * vx - total_high_momx;
-						const amrex::Real target_low_momy = real_particle_total_mass * vy - total_high_momy;
-						const amrex::Real target_low_momz = real_particle_total_mass * vz - total_high_momz;
-
-						amrex::Real low_momx = 0.0;
-						amrex::Real low_momy = 0.0;
-						amrex::Real low_momz = 0.0;
-						for (int pp = 0; pp < num_low; ++pp) {
-							auto &plow = particles[pp]; // NOLINT
-							low_momx += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVxIdx);
-							low_momy += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVyIdx);
-							low_momz += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVzIdx);
-						}
-
-						const amrex::Real delta_vx = (target_low_momx - low_momx) / mass_low_mass_star;
-						const amrex::Real delta_vy = (target_low_momy - low_momy) / mass_low_mass_star;
-						const amrex::Real delta_vz = (target_low_momz - low_momz) / mass_low_mass_star;
-
-						for (int pp = 0; pp < num_low; ++pp) {
-							auto &plow = particles[pp]; // NOLINT
-							plow.rdata(StochasticStellarPopParticleVxIdx) += delta_vx;
-							plow.rdata(StochasticStellarPopParticleVyIdx) += delta_vy;
-							plow.rdata(StochasticStellarPopParticleVzIdx) += delta_vz;
-						}
-
-						// Option 2 (alternative): Guarantee momentum conservation.
-						// This uses particle_mass (the mass removed from the cell) instead of real_particle_total_mass.
-						// While this conserves momentum exactly, it results in incorrect COM velocity because
-						// real_particle_total_mass != particle_mass due to stochastic sampling.
-						// const amrex::Real target_low_momx2 = particle_mass * vx - total_momx;
-						// const amrex::Real target_low_momy2 = particle_mass * vy - total_momy;
-						// const amrex::Real target_low_momz2 = particle_mass * vz - total_momz;
-						// const amrex::Real delta_vx2 = (target_low_momx2 - low_momx) / mass_low_mass_star;
-						// const amrex::Real delta_vy2 = (target_low_momy2 - low_momy) / mass_low_mass_star;
-						// const amrex::Real delta_vz2 = (target_low_momz2 - low_momz) / mass_low_mass_star;
+				// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
+				if (num_high >= 1) {
+					// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)
+					amrex::Real real_particle_total_mass = 0.;
+					for (int pp = 0; pp < num_particles; ++pp) {
+						real_particle_total_mass += particles[pp].rdata(mass_idx);
 					}
+
+					// Option 1 (preferred): Ensure COM velocity of all stars equals cell velocity (vx, vy, vz).
+					// This may violate momentum conservation because real_particle_total_mass != particle_mass
+					// due to stochastic sampling of high-mass star masses from the IMF.
+					// However, since mass conservation is already violated in a single cell due to stochasticity,
+					// it's more important to preserve correct velocities in a rotating disk.
+					const amrex::Real target_low_momx = real_particle_total_mass * vx - total_high_momx;
+					const amrex::Real target_low_momy = real_particle_total_mass * vy - total_high_momy;
+					const amrex::Real target_low_momz = real_particle_total_mass * vz - total_high_momz;
+
+					amrex::Real low_momx = 0.0;
+					amrex::Real low_momy = 0.0;
+					amrex::Real low_momz = 0.0;
+					for (int pp = 0; pp < num_low; ++pp) {
+						auto &plow = particles[pp]; // NOLINT
+						low_momx += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVxIdx);
+						low_momy += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVyIdx);
+						low_momz += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVzIdx);
+					}
+
+					const amrex::Real delta_vx = (target_low_momx - low_momx) / mass_low_mass_star;
+					const amrex::Real delta_vy = (target_low_momy - low_momy) / mass_low_mass_star;
+					const amrex::Real delta_vz = (target_low_momz - low_momz) / mass_low_mass_star;
+
+					for (int pp = 0; pp < num_low; ++pp) {
+						auto &plow = particles[pp]; // NOLINT
+						plow.rdata(StochasticStellarPopParticleVxIdx) += delta_vx;
+						plow.rdata(StochasticStellarPopParticleVyIdx) += delta_vy;
+						plow.rdata(StochasticStellarPopParticleVzIdx) += delta_vz;
+					}
+
+					// Option 2 (alternative): Guarantee momentum conservation.
+					// This uses particle_mass (the mass removed from the cell) instead of real_particle_total_mass.
+					// While this conserves momentum exactly, it results in incorrect COM velocity because
+					// real_particle_total_mass != particle_mass due to stochastic sampling.
+					// const amrex::Real target_low_momx2 = particle_mass * vx - total_momx;
+					// const amrex::Real target_low_momy2 = particle_mass * vy - total_momy;
+					// const amrex::Real target_low_momz2 = particle_mass * vz - total_momz;
+					// const amrex::Real delta_vx2 = (target_low_momx2 - low_momx) / mass_low_mass_star;
+					// const amrex::Real delta_vy2 = (target_low_momy2 - low_momy) / mass_low_mass_star;
+					// const amrex::Real delta_vz2 = (target_low_momz2 - low_momz) / mass_low_mass_star;
+				}
 
 				// Update the hydro state to reflect the mass that was removed to create the star particle(s)
 				{

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <numbers>
 
 namespace quokka
 {
@@ -483,10 +484,8 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, amrex::Long base_offset,
 			   amrex::RandomEngine const &engine) const
 		{
-			amrex::ignore_unused(fab_fc);
-
 			if (mass_idx + 3 < ParticleType::NReal) {
-				const amrex::Real unset_position = std::numeric_limits<amrex::Real>::max();
+				constexpr amrex::Real unset_position = std::numeric_limits<amrex::Real>::max();
 				// Calculate common values for all particles
 				const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
 				const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
@@ -494,12 +493,9 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
 				const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
 				const amrex::Real vz = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
-				const int nscalars = Physics_Traits<problem_t>::numPassiveScalars;
+				constexpr int nscalars = Physics_Traits<problem_t>::numPassiveScalars;
 				const amrex::Real particle_mass = cell_density * cell_volume * eps_star;
 				const amrex::Real mass_low_mass_star = particle_mass * (1.0 - fstar_high);
-				double total_momx = 0.0;
-				double total_momy = 0.0;
-				double total_momz = 0.0;
 
 				int num_low = 1;
 				if ((low_mass_composite_max_mass_ > 0.0) && (mass_low_mass_star > low_mass_composite_max_mass_)) {
@@ -511,6 +507,10 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				const int num_high = num_particles - num_low;
 				const amrex::Real mass_low_each = mass_low_mass_star / static_cast<amrex::Real>(num_low);
 				const bool split_low_mass_composite = (num_low > 1);
+
+				double total_high_momx = 0.0;
+				double total_high_momy = 0.0;
+				double total_high_momz = 0.0;
 
 				// p_idx = 0..(num_low-1) represent the low mass composites, p_idx = num_low.. represent the high mass stars
 
@@ -524,140 +524,189 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// Set particle birth time
 					p.rdata(birth_time_index) = current_time;
 
-					// Set particle evolution stage to LowMassComposite if it is a low-mass stellar composite
-					// This gets changed in the for loop below if this is a high mass star
-					p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::LowMassComposite);
+					// Set particle position to cell center
+					// (Note: if multiple particles are formed, their velocities will be randomized.)
+					p.pos(0) = plo[0] + (i + 0.5) * dx[0];
+					p.pos(1) = plo[1] + (j + 0.5) * dx[1];
+					p.pos(2) = plo[2] + (k + 0.5) * dx[2];
 
-					if ((p_idx < num_low) && split_low_mass_composite) {
-						// Randomize LowMassComposite position within the cell only when split.
-						const amrex::Real rx = amrex::Random(engine);
-						const amrex::Real ry = amrex::Random(engine);
-						const amrex::Real rz = amrex::Random(engine);
-						p.pos(0) = plo[0] + (i + rx) * dx[0];
-						p.pos(1) = plo[1] + (j + ry) * dx[1];
-						p.pos(2) = plo[2] + (k + rz) * dx[2];
-					} else {
-						// High mass stars at cell center
-						p.pos(0) = plo[0] + (i + 0.5) * dx[0];
-						p.pos(1) = plo[1] + (j + 0.5) * dx[1];
-						p.pos(2) = plo[2] + (k + 0.5) * dx[2];
-					}
-
+					// Set birth and death metadata
 					p.rdata(StochasticStellarPopParticleBirthPosXIdx) = p.pos(0);
 					p.rdata(StochasticStellarPopParticleBirthPosYIdx) = p.pos(1);
 					p.rdata(StochasticStellarPopParticleBirthPosZIdx) = p.pos(2);
 					p.rdata(StochasticStellarPopParticleDeathPosXIdx) = unset_position;
 					p.rdata(StochasticStellarPopParticleDeathPosYIdx) = unset_position;
 					p.rdata(StochasticStellarPopParticleDeathPosZIdx) = unset_position;
+					p.rdata(StochasticStellarPopParticleDeathTimeIdx) = unset_position;
 					p.rdata(StochasticStellarPopParticleDeathDensityIdx) = unset_position;
 
-					// Low Mass particle mass and velocity
-					p.rdata(mass_idx) = (p_idx < num_low) ? mass_low_each : 0.0;
-					p.rdata(mass_idx + 1) = vx;
-					p.rdata(mass_idx + 2) = vy;
-					p.rdata(mass_idx + 3) = vz;
+					// Everything is now set EXCEPT for mass, velocity, evolutionary stage, and mass at birth.
+					// (For SN progenitors, the death time will be overridden based on the interpolated lifetime.)
+					// (Mass at birth is set at the end of this loop. It MUST be set for all star particles, 
+					// 	because it is used to calculate the star formation rate in outputs.)
 
-					p.rdata(death_time_index) = std::numeric_limits<amrex::Real>::max();
+					// This is a LowMassComposite star particle
+					if (p_idx < num_low) {
+						// Set particle evolution stage
+						p.idata(evolution_stage_index) = static_cast<int>(StellarEvolutionStage::LowMassComposite);
+						// Set particle mass
+						p.rdata(mass_idx) = mass_low_each;
+						// Set particle postion and velocity
+						if (split_low_mass_composite) {
+							// Randomize velocity within the cell only when split
+							const amrex::Real rx = amrex::Random(engine);
+							const amrex::Real ry = amrex::Random(engine);
+							const amrex::Real rz = amrex::Random(engine);
+							// randomize velocity with velocity dispersion ~0.5*cs
+							const amrex::Real cs = HydroSystem<problem_t>::ComputeSoundSpeed(state_arr, i, j, k, fab_fc);
+							constexpr amrex::Real vdisp_norm = 0.5 / std::numbers::sqrt3;
+							p.rdata(StochasticStellarPopParticleVxIdx) = vx + vdisp_norm * (rx - 0.5) * cs;
+							p.rdata(StochasticStellarPopParticleVyIdx) = vy + vdisp_norm * (ry - 0.5) * cs;
+							p.rdata(StochasticStellarPopParticleVzIdx) = vz + vdisp_norm * (rz - 0.5) * cs;
+						} else {
+							p.rdata(StochasticStellarPopParticleVxIdx) = vx;
+							p.rdata(StochasticStellarPopParticleVyIdx) = vy;
+							p.rdata(StochasticStellarPopParticleVzIdx) = vz;
+						}
+					}
+
+					// This is a HighMass star particle
 					if (p_idx >= num_low) {
-						// This is the loop that sets the velocity of the high mass stars
-						double const km_per_s = 1.e5; // convert km/s to cm/s
-						double const v_min = 3.0;     // Minimum velocity from the distribution
-						double const v_max = 385.0;   // Maximum velocity from the distribution
-						double const beta = 1.8;      // Slope of the velocity distribution
+						// Set particle velocity
+						{
+							double constexpr km_per_s = 1.e5; // convert km/s to cm/s
+							double constexpr v_min = 3.0;	  // Minimum velocity from the distribution
+							double constexpr v_max = 385.0;	  // Maximum velocity from the distribution
+							double constexpr beta = 1.8;	  // Slope of the velocity distribution
+							double constexpr vmin_pow = gcem::pow(v_min, 1. - beta);
+							double constexpr vmax_pow = gcem::pow(v_max, 1. - beta);
 
-						// Draw velocity from the power-law distribution
-						double const xx_random = amrex::Random(engine);
-						double v_mag =
-						    xx_random * (std::pow(v_max, 1. - beta) - std::pow(v_min, 1. - beta)) + std::pow(v_min, 1. - beta);
-						v_mag = std::pow(v_mag, 1. / (1. - beta)) * km_per_s; // Convert to km/s
+							// Draw velocity from the power-law distribution with inverse transform sampling
+							double v_mag = amrex::Random(engine) * (vmax_pow - vmin_pow) + vmin_pow;
+							v_mag = std::pow(v_mag, 1. / (1. - beta)) * km_per_s; // Convert to km/s
 
-						double const cos_theta_random =
-						    (2 * amrex::Random(engine) - 1.0); // Sample cos theta from a uniform distribution between -1 to 1.
-						double const phi_random =
-						    (1. - amrex::Random(engine)) * 2. * M_PI; // Sample phi from a uniform distribution between 0 and 2*pi
+							// Sample cos theta from a uniform distribution between -1 to 1
+							double const cos_theta_random = 2. * amrex::Random(engine) - 1.;
+							double const sin_theta_random = std::sqrt(1. - cos_theta_random * cos_theta_random);
+							// Sample phi from a uniform distribution between 0 and 2*pi
+							double const phi_random = (1. - amrex::Random(engine)) * 2. * std::numbers::pi;
 
-						double const vx_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::cos(phi_random);
-						double const vy_random = v_mag * std::sqrt(1. - cos_theta_random * cos_theta_random) * std::sin(phi_random);
-						double const vz_random = v_mag * cos_theta_random;
+							double const vx_random = v_mag * sin_theta_random * std::cos(phi_random);
+							double const vy_random = v_mag * sin_theta_random * std::sin(phi_random);
+							double const vz_random = v_mag * cos_theta_random;
 
-						p.rdata(mass_idx + 1) = vx + vx_random;
-						p.rdata(mass_idx + 2) = vy + vy_random;
-						p.rdata(mass_idx + 3) = vz + vz_random;
+							p.rdata(StochasticStellarPopParticleVxIdx) = vx + vx_random;
+							p.rdata(StochasticStellarPopParticleVyIdx) = vy + vy_random;
+							p.rdata(StochasticStellarPopParticleVzIdx) = vz + vz_random;
+						}
 
-						// Sample mass randomly from the IMF between m_star_high, which is the min mass and max mass in the Sukhbold
-						// table
-						double mass_of_star = NAN;
-						const double xx = amrex::Random(engine);
-						mass_of_star = xx * (std::pow(m_imf_max, 1.0 - alpha) - std::pow(m_star_high, 1.0 - alpha)) +
-							       std::pow(m_star_high, 1.0 - alpha);
-						mass_of_star = std::pow(mass_of_star, 1. / (1. - alpha));
-						p.rdata(mass_idx) = mass_of_star;
+						// Set particle mass
+						{
+							// Sample mass from the IMF between m_star_high and m_imf_max using inverse transform sampling
+							constexpr double mimf_max_pow = gcem::pow(m_imf_max, 1.0 - alpha);
+							constexpr double mstar_high_pow = gcem::pow(m_star_high, 1.0 - alpha);
+							double mass_of_star = amrex::Random(engine) * (mimf_max_pow - mstar_high_pow) + mstar_high_pow;
+							mass_of_star = std::pow(mass_of_star, 1. / (1. - alpha));
+							p.rdata(mass_idx) = mass_of_star;
 
-						total_momx += p.rdata(mass_idx + 1) * p.rdata(mass_idx);
-						total_momy += p.rdata(mass_idx + 2) * p.rdata(mass_idx);
-						total_momz += p.rdata(mass_idx + 3) * p.rdata(mass_idx);
+							total_high_momx += p.rdata(StochasticStellarPopParticleVxIdx) * p.rdata(mass_idx);
+							total_high_momy += p.rdata(StochasticStellarPopParticleVyIdx) * p.rdata(mass_idx);
+							total_high_momz += p.rdata(StochasticStellarPopParticleVzIdx) * p.rdata(mass_idx);
+						}
 
-						// Determine the evolutionary stage based on whether this star will explode as a supernova
+						// Set the evolutionary stage based on whether this star will explode as a supernova
 						// interpolate_whether_SN_explosion returns true if the star will undergo a supernova explosion
 						p.idata(evolution_stage_index) = interpolate_whether_SN_explosion(p.rdata(mass_idx))
 										     ? static_cast<int>(StellarEvolutionStage::SNProgenitor)
 										     : static_cast<int>(StellarEvolutionStage::HighMassNonExploding);
+
+						// Set the particle death time for all high mass stars (both SN progenitors and non-exploding)
 						p.rdata(death_time_index) = current_time + interpolate_death_time(p.rdata(mass_idx));
 					}
-					// Set mass_at_birth
+
+					// Set mass_at_birth for ALL star particles
+					// (NOTE: this must be set for BOTH LowMassComposite and HighMass star particles
+					// 	in order to properly track the star formation rate.)
 					if (mass_at_birth_idx >= 0) {
 						p.rdata(mass_at_birth_idx) = p.rdata(mass_idx);
 					}
 				}
 
-				if (num_particles > 1) { // Update momentum of the low mass star if there is(are) high mass star(s) in the cell
-					const int p_idx = 0;
-					auto &plow = particles[p_idx]; // NOLINT
+					// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
+					if (num_high >= 1) {
+						// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)
+						amrex::Real real_particle_total_mass = 0.;
+						for (int pp = 0; pp < num_particles; ++pp) {
+							real_particle_total_mass += particles[pp].rdata(mass_idx);
+						}
 
-					// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)
-					amrex::Real real_particle_total_mass = mass_low_mass_star;
-					for (int pp = 1; pp < num_particles; ++pp) {
-						real_particle_total_mass += particles[pp].rdata(mass_idx);
+						// Option 1 (preferred): Ensure COM velocity of all stars equals cell velocity (vx, vy, vz).
+						// This may violate momentum conservation because real_particle_total_mass != particle_mass
+						// due to stochastic sampling of high-mass star masses from the IMF.
+						// However, since mass conservation is already violated in a single cell due to stochasticity,
+						// it's more important to preserve correct velocities in a rotating disk.
+						const amrex::Real target_low_momx = real_particle_total_mass * vx - total_high_momx;
+						const amrex::Real target_low_momy = real_particle_total_mass * vy - total_high_momy;
+						const amrex::Real target_low_momz = real_particle_total_mass * vz - total_high_momz;
+
+						amrex::Real low_momx = 0.0;
+						amrex::Real low_momy = 0.0;
+						amrex::Real low_momz = 0.0;
+						for (int pp = 0; pp < num_low; ++pp) {
+							auto &plow = particles[pp]; // NOLINT
+							low_momx += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVxIdx);
+							low_momy += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVyIdx);
+							low_momz += plow.rdata(mass_idx) * plow.rdata(StochasticStellarPopParticleVzIdx);
+						}
+
+						const amrex::Real delta_vx = (target_low_momx - low_momx) / mass_low_mass_star;
+						const amrex::Real delta_vy = (target_low_momy - low_momy) / mass_low_mass_star;
+						const amrex::Real delta_vz = (target_low_momz - low_momz) / mass_low_mass_star;
+
+						for (int pp = 0; pp < num_low; ++pp) {
+							auto &plow = particles[pp]; // NOLINT
+							plow.rdata(StochasticStellarPopParticleVxIdx) += delta_vx;
+							plow.rdata(StochasticStellarPopParticleVyIdx) += delta_vy;
+							plow.rdata(StochasticStellarPopParticleVzIdx) += delta_vz;
+						}
+
+						// Option 2 (alternative): Guarantee momentum conservation.
+						// This uses particle_mass (the mass removed from the cell) instead of real_particle_total_mass.
+						// While this conserves momentum exactly, it results in incorrect COM velocity because
+						// real_particle_total_mass != particle_mass due to stochastic sampling.
+						// const amrex::Real target_low_momx2 = particle_mass * vx - total_momx;
+						// const amrex::Real target_low_momy2 = particle_mass * vy - total_momy;
+						// const amrex::Real target_low_momz2 = particle_mass * vz - total_momz;
+						// const amrex::Real delta_vx2 = (target_low_momx2 - low_momx) / mass_low_mass_star;
+						// const amrex::Real delta_vy2 = (target_low_momy2 - low_momy) / mass_low_mass_star;
+						// const amrex::Real delta_vz2 = (target_low_momz2 - low_momz) / mass_low_mass_star;
 					}
 
-					// Option 1 (preferred): Ensure COM velocity of all stars equals cell velocity (vx, vy, vz).
-					// This may violate momentum conservation because real_particle_total_mass != particle_mass
-					// due to stochastic sampling of high-mass star masses from the IMF.
-					// However, since mass conservation is already violated in a single cell due to stochasticity,
-					// it's more important to preserve correct velocities in a rotating disk.
-					plow.rdata(mass_idx + 1) = (real_particle_total_mass * vx - total_momx) / mass_low_mass_star;
-					plow.rdata(mass_idx + 2) = (real_particle_total_mass * vy - total_momy) / mass_low_mass_star;
-					plow.rdata(mass_idx + 3) = (real_particle_total_mass * vz - total_momz) / mass_low_mass_star;
+				// Update the hydro state to reflect the mass that was removed to create the star particle(s)
+				{
+					//  We use the *expectation value* of the mass of the created particles in this cell,
+					// 	NOT the actual mass of the stochastically created particles, to update the hydro state.)
+					const double factor = (1. - particle_mass / cell_mass);
 
-					// Option 2 (alternative): Guarantee momentum conservation.
-					// This uses particle_mass (the mass removed from the cell) instead of real_particle_total_mass.
-					// While this conserves momentum exactly, it results in incorrect COM velocity because
-					// real_particle_total_mass != particle_mass due to stochastic sampling.
-					// plow.rdata(mass_idx + 1) = (particle_mass * vx - total_momx) / mass_low_mass_star;
-					// plow.rdata(mass_idx + 2) = (particle_mass * vy - total_momy) / mass_low_mass_star;
-					// plow.rdata(mass_idx + 3) = (particle_mass * vz - total_momz) / mass_low_mass_star;
-				}
+					// Update the cell density to reflect mass conversion into stars
+					state_arr(i, j, k, HydroSystem<problem_t>::density_index) *= factor;
 
-				const double factor = (1. - particle_mass / cell_mass);
+					// Update the cell momentum to make sure velocities don't change
+					state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= factor;
+					state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= factor;
+					state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= factor;
 
-				// Update the cell density to reflect mass conversion into stars
-				state_arr(i, j, k, HydroSystem<problem_t>::density_index) *= factor;
+					// Update internal energy to relect mass change
+					state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
 
-				// Update the cell momentum to make sure velocities don't change
-				state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= factor;
-				state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= factor;
-				state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= factor;
+					// Update total energy
+					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
 
-				// Update internal energy to relect mass change
-				state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
-
-				// Update total energy
-				state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
-
-				// Update mass scalars including passive scalars
-				if (nscalars > 0) {
-					for (int nn = 0; nn < nscalars; ++nn) {
-						state_arr(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) *= factor;
+					// Update mass scalars including passive scalars
+					if (nscalars > 0) {
+						for (int nn = 0; nn < nscalars; ++nn) {
+							state_arr(i, j, k, HydroSystem<problem_t>::scalar0_index + nn) *= factor;
+						}
 					}
 				}
 			}

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -440,10 +440,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				const int num_high = static_cast<int>(amrex::RandomPoisson(num_high_mass_stars_exp, engine));
 				int num_low = 1;
 				if ((low_mass_composite_max_mass_ > 0.0) && (mass_low_mass_star > low_mass_composite_max_mass_)) {
-					num_low = static_cast<int>(mass_low_mass_star / low_mass_composite_max_mass_);
-					if (mass_low_mass_star > static_cast<amrex::Real>(num_low) * low_mass_composite_max_mass_) {
-						++num_low;
-					}
+					num_low = static_cast<int>(std::ceil(mass_low_mass_star / low_mass_composite_max_mass_));
 				}
 				num_star = num_low + num_high;
 			}
@@ -497,13 +494,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				const amrex::Real particle_mass = cell_density * cell_volume * eps_star;
 				const amrex::Real mass_low_mass_star = particle_mass * (1.0 - fstar_high);
 
-				int num_low = 1;
-				if ((low_mass_composite_max_mass_ > 0.0) && (mass_low_mass_star > low_mass_composite_max_mass_)) {
-					num_low = static_cast<int>(mass_low_mass_star / low_mass_composite_max_mass_);
-					if (mass_low_mass_star > static_cast<amrex::Real>(num_low) * low_mass_composite_max_mass_) {
-						++num_low;
-					}
-				}
+				const int num_low = static_cast<int>(std::ceil(mass_low_mass_star / low_mass_composite_max_mass_));
 				const int num_high = num_particles - num_low;
 				const amrex::Real mass_low_each = mass_low_mass_star / static_cast<amrex::Real>(num_low);
 				const bool split_low_mass_composite = (num_low > 1);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -623,7 +623,6 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					}
 				}
 
-				
 				// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
 				if (num_high >= 1 || split_low_mass_composite) {
 					// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -624,7 +624,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 				}
 
 				// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
-				if (num_high >= 1) {
+				if (num_high >= 1 || split_low_mass_composite) {
 					// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)
 					amrex::Real real_particle_total_mass = 0.;
 					for (int pp = 0; pp < num_particles; ++pp) {

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -623,6 +623,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					}
 				}
 
+				
 				// Update momentum of the low mass composite star particles if there is(are) high mass star(s)
 				if (num_high >= 1 || split_low_mass_composite) {
 					// Calculate the actual total mass of all particles (high-mass stars sampled from IMF + low-mass composite)

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -478,7 +478,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		AMREX_GPU_DEVICE void
 		operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, StateArray const & /*accretion_rate_arr*/, int i, int j,
 			   int k, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, amrex::Long base_offset,
+			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const * /*fab_fc*/, amrex::Long base_offset,
 			   amrex::RandomEngine const &engine) const
 		{
 			if (mass_idx + 3 < ParticleType::NReal) {
@@ -548,12 +548,17 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 							const amrex::Real rx = amrex::Random(engine);
 							const amrex::Real ry = amrex::Random(engine);
 							const amrex::Real rz = amrex::Random(engine);
-							// randomize velocity with velocity dispersion ~0.5*cs
-							const amrex::Real cs = HydroSystem<problem_t>::ComputeSoundSpeed(state_arr, i, j, k, fab_fc);
-							constexpr amrex::Real vdisp_norm = 0.5 / std::numbers::sqrt3;
-							p.rdata(StochasticStellarPopParticleVxIdx) = vx + vdisp_norm * (rx - 0.5) * cs;
-							p.rdata(StochasticStellarPopParticleVyIdx) = vy + vdisp_norm * (ry - 0.5) * cs;
-							p.rdata(StochasticStellarPopParticleVzIdx) = vz + vdisp_norm * (rz - 0.5) * cs;
+							// Set velocity dispersion to the cell-scale escape speed of the LowMassComposite cluster:
+							// v_esc = sqrt(2 G M_cluster / dx), where M_cluster is the total low-mass composite mass in this cell.
+							const amrex::Real dx_cell = std::min({dx[0], dx[1], dx[2]});
+							const amrex::Real m_cluster = mass_low_mass_star;
+							const amrex::Real v_esc = std::sqrt(2.0 * C::Gconst * m_cluster / dx_cell);
+							// For U ~ Uniform[0,1], std(U - 0.5) = sqrt(1/12).
+							// Choose component std = v_esc / sqrt(3), so 3D RMS dispersion is v_esc.
+							const amrex::Real vdisp_norm = 2.0 * v_esc;
+							p.rdata(StochasticStellarPopParticleVxIdx) = vx + vdisp_norm * (rx - 0.5);
+							p.rdata(StochasticStellarPopParticleVyIdx) = vy + vdisp_norm * (ry - 0.5);
+							p.rdata(StochasticStellarPopParticleVzIdx) = vz + vdisp_norm * (rz - 0.5);
 						} else {
 							p.rdata(StochasticStellarPopParticleVxIdx) = vx;
 							p.rdata(StochasticStellarPopParticleVyIdx) = vy;

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -490,8 +490,8 @@ inline bool disable_particle_drift = false; // NOLINT
 // Maximum velocity limit for stellar particles in cm/s (default: 1000 km/s)
 inline amrex::Real stellar_velocity_limit = 1.0e8; // NOLINT
 
-// Maximum mass for LowMassComposite particles. If <= 0, no splitting is performed.
-inline amrex::Real low_mass_composite_max_mass = -1.0; // NOLINT
+// Maximum mass for LowMassComposite particles. Default is set to max(), so no splitting is performed.
+inline amrex::Real low_mass_composite_max_mass = std::numeric_limits<amrex::Real>::max(); // NOLINT
 
 inline int reproducibility_roundoff_redundancy = 20; // NOLINT; remove 20 bits from the significand
 

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -490,6 +490,9 @@ inline bool disable_particle_drift = false; // NOLINT
 // Maximum velocity limit for stellar particles in cm/s (default: 1000 km/s)
 inline amrex::Real stellar_velocity_limit = 1.0e8; // NOLINT
 
+// Maximum mass for LowMassComposite particles. If <= 0, no splitting is performed.
+inline amrex::Real low_mass_composite_max_mass = -1.0; // NOLINT
+
 inline int reproducibility_roundoff_redundancy = 20; // NOLINT; remove 20 bits from the significand
 
 // Function to parse particle parameters from input file
@@ -522,6 +525,9 @@ inline void particleParmParse()
 
 	// Stellar velocity limit parameter
 	pp.query("stellar_velocity_limit", stellar_velocity_limit);
+
+	// Low-mass composite particle mass cap (split into multiple particles if exceeded)
+	pp.query("low_mass_composite_max_mass", low_mass_composite_max_mass);
 
 	// Roundoff factor for particles
 	pp.query("reproducibility_roundoff_redundancy", reproducibility_roundoff_redundancy);


### PR DESCRIPTION
### Description
This adds an optional cap on the composite star particle masses. If the composite star particle would have a mass exceeding the cap, then it splits the composite star particle into multiple particles of equal mass with randomized velocities (dispersion set to 0.5*cs). In all other respects, the star formation algorithm is unchanged.

The cap is set in the ParmParse input with
```
particles.low_mass_composite_max_mass = 1.99e33 * 1e3   # mass in code units
```

This is needed to avoid dynamical friction effects due to large point masses. 

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
