### PR TITLE
use cumulative SN count for DiskGalaxy history file

### DIFF
--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -743,7 +743,7 @@ template <> auto QuokkaSimulation<DiskGalaxy>::ComputeStatistics() -> std::map<s
 
 	const amrex::Real stellar_mass_at_birth = particleRegister_.computeTotalStellarMassAtBirth();
 	stats["stellar_mass_at_birth"] = stellar_mass_at_birth / C::M_solar;
-	stats["sn_count"] = sn_count_;
+	stats["sn_count_cumulative"] = sn_count_cumulative_;
 
 	return stats;
 }


### PR DESCRIPTION
### Description
Outputs the cumulative SN count in history.txt output for DiskGalaxy, instead of the SN count for that step only.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
