### PR TITLE
Set CFL to 0.3

### DIFF
--- a/inputs/RandomBlastAMR_regression.in
+++ b/inputs/RandomBlastAMR_regression.in
@@ -26,7 +26,7 @@ problem.part_fn = "./particles_stochastic_n100.txt"
 do_reflux = 1
 do_subcycle = 0
 
-cfl = 0.2
+cfl = 0.3
 hydro.reconstruction_order = 3
 derived_vars = temperature
 

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -54,8 +54,8 @@ constexpr Real cloudy_H_mass_fraction = 1.0 / (1.0 + 0.1 * 3.971);
 template <> struct SimulationData<RandomBlast> {
 	std::vector<int> SN_counter_arr; // Track cumulative number of SNe at all time
 
-	Real n_amb = 0.1;	     // ambient density (cm^-3)
-	Real T_amb = 1.0e4;	     // ambient temperature (K)
+	Real n_amb = 0.1;   // ambient density (cm^-3)
+	Real T_amb = 1.0e4; // ambient temperature (K)
 	std::string part_fn = "../inputs/particles_stochastic_n100.txt";
 
 	std::vector<Real> boost_velocity{0.0, 0.0, 0.0}; // NOLINT

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -56,7 +56,6 @@ template <> struct SimulationData<RandomBlast> {
 
 	Real n_amb = 0.1;	     // ambient density (cm^-3)
 	Real T_amb = 1.0e4;	     // ambient temperature (K)
-	Real refine_threshold = 1.0; // gradient refinement threshold
 	std::string part_fn = "../inputs/particles_stochastic_n100.txt";
 
 	std::vector<Real> boost_velocity{0.0, 0.0, 0.0}; // NOLINT
@@ -175,7 +174,6 @@ auto problem_main() -> int
 	amrex::ParmParse const pp("problem");
 	pp.query("n_amb", sim.userData_.n_amb);
 	pp.query("T_amb", sim.userData_.T_amb);
-	pp.query("refine_threshold", sim.userData_.refine_threshold); // dimensionless
 	pp.query("part_fn", sim.userData_.part_fn);
 
 	if (pp.queryarr("boost_velocity", sim.userData_.boost_velocity) == 0) {


### PR DESCRIPTION
### Description
Somehow, after the recent update of the SN module, RandomBlast regression test failed with 'Hydro update exceeded max_retries on level 1'. Changing `CFL` from 0.2 to 0.3 somehow fixed the problem. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
 