### PR TITLE
Use `stop_time` instead of `max_timesteps` in all regression tests 

### DIFF
--- a/inputs/RandomBlastAMR_regression.in
+++ b/inputs/RandomBlastAMR_regression.in
@@ -30,12 +30,12 @@ cfl = 0.2
 hydro.reconstruction_order = 3
 derived_vars = temperature
 
-plotfile_interval = 1000
+plotfile_interval = 10000
 checkpoint_interval = -1
-max_timesteps = 1000
+max_timesteps = 10000
 
-dt_initial = 3.154e10       # 1000 yr
-stop_time = 3.154e13       # 1e6 yr
+dt_shrink = 0.01
+stop_time = 7.32505344665246e11
 
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1

--- a/inputs/RandomBlastAMR_regression.in
+++ b/inputs/RandomBlastAMR_regression.in
@@ -26,13 +26,14 @@ problem.part_fn = "./particles_stochastic_n100.txt"
 do_reflux = 1
 do_subcycle = 0
 
-cfl = 0.2
+cfl = 0.3
 hydro.reconstruction_order = 3
+hydro.artificial_viscosity_coefficient = 0.1
 derived_vars = temperature
 
 plotfile_interval = 10000
 checkpoint_interval = -1
-max_timesteps = 10000
+max_timesteps = 10000 # set a maximum number of timesteps to avoid infinite loops
 
 dt_shrink = 0.01
 stop_time = 7.32505344665246e11

--- a/inputs/RandomBlastAMR_regression.in
+++ b/inputs/RandomBlastAMR_regression.in
@@ -33,7 +33,7 @@ derived_vars = temperature
 
 plotfile_interval = 10000
 checkpoint_interval = -1
-max_timesteps = 10000 # set a maximum number of timesteps to avoid infinite loops
+max_timesteps = 10000 # set to avoid running the simulation indefinitely
 
 dt_shrink = 0.01
 stop_time = 7.32505344665246e11

--- a/inputs/ShockCloud_64.in
+++ b/inputs/ShockCloud_64.in
@@ -16,7 +16,7 @@ amr.v               = 1     # verbosity in Amr
 amr.n_cell          = 256 64 64
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 16  	# grid size must be divisible by this
-amr.max_grid_size   = 64
+amr.max_grid_size   = 256
 
 # *****************************************************************
 # Quokka options

--- a/inputs/ShockCloud_64_regression.in
+++ b/inputs/ShockCloud_64_regression.in
@@ -16,7 +16,7 @@ amr.v               = 1     # verbosity in Amr
 amr.n_cell          = 256 64 64
 amr.max_level       = 0     # number of levels = max_level + 1
 amr.blocking_factor = 32  	# grid size must be divisible by this
-amr.max_grid_size   = 128
+amr.max_grid_size   = 256
 
 # *****************************************************************
 # Quokka options

--- a/inputs/Turbulence_regression.in
+++ b/inputs/Turbulence_regression.in
@@ -19,8 +19,8 @@ amr.blocking_factor = 32 # grid size must be divisible by this
 amr.max_grid_size   = 64 # at least 128 for GPUs
 
 stop_time = 15
-plottime_interval = 15
-max_timesteps = 20000
+plotfile_interval = 100000
+max_timesteps = 100000
 
 do_reflux = 0
 do_subcycle = 0

--- a/inputs/blast_unigrid_128_AMR_regression.in
+++ b/inputs/blast_unigrid_128_AMR_regression.in
@@ -26,5 +26,6 @@ do_tracers = 1      # turn on tracer particles
 
 hydro.artificial_viscosity_coefficient = 0.1
 
-plotfile_interval  = 20000
-max_timesteps = 100
+plotfile_interval  = 100000
+stop_time = 0.0009781580821
+

--- a/inputs/blast_unigrid_128_regression.in
+++ b/inputs/blast_unigrid_128_regression.in
@@ -26,4 +26,6 @@ do_tracers = 1      # turn on tracer particles
 
 hydro.artificial_viscosity_coefficient = 0.1
 
-plotfile_interval  = 20000
+plotfile_interval  = 100000
+stop_time = 1.0
+


### PR DESCRIPTION
### Description
Use `stop_time` instead of `max_timesteps` in all regression tests so that when we update the physics of our code, we can compare the relative change at a fixed time before and after the change. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
