### PR TITLE
Print simulation end time

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1563,6 +1563,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		}
 	}
 
+	// Print final simulation time
+	if (suppress_output == 0) {
+		amrex::Print() << "\nSimulation ended at t = " << cur_time << " (" << (cur_time / stopTime_) * 100. << "%)\n";
+	}
+
 	if (step == 0) {
 		amrex::Print() << "No cell updates performed!\n";
 #ifdef AMREX_USE_ASCENT

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1565,7 +1565,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 	// Print final simulation time
 	if (suppress_output == 0) {
-		amrex::Print() << "\nSimulation ended at t = " << cur_time << " (" << (cur_time / stopTime_) * 100. << "%)\n";
+		if (stopTime_ > 0.0) {
+			amrex::Print() << "\nSimulation ended at t = " << cur_time << " (" << (cur_time / stopTime_) * 100. << "%)\n";
+		} else {
+			amrex::Print() << "\nSimulation ended at t = " << cur_time << "\n";
+		}
 	}
 
 	if (step == 0) {


### PR DESCRIPTION
### Description
Added a print message to display the exact time when a simulation ends. Previously, only the time at the beginning of the last step was shown. Now, after the main time loop completes, the code prints:

```
Simulation ended at t = XXX (XXX%)
```

This provides clarity on the final simulation time, especially useful when verifying that simulations reach their specified `stop_time`.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
