### PR TITLE
Add .claude to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ Backtrace.*
 !/tests/matplotlibrc
 # !/tests/ascent_actions.yaml
 
+# agent files
+/.claude
+/.agent
+/.agents
+
 # LaTeX files
 *.aux
 *.dbl


### PR DESCRIPTION
### Description
Add common agent/skills folder to .gitignore: `.claude` and `.agent`
