### PR TITLE
Ensure particle params are read on restart

### DIFF
--- a/inputs/ParticleSF_restart_cap.in
+++ b/inputs/ParticleSF_restart_cap.in
@@ -1,0 +1,58 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -3.949667304e+19 -3.949667304e+19 -3.949667304e+19
+geometry.prob_hi     =  3.949667304e+19 3.949667304e+19 3.949667304e+19
+quokka.bc = periodic periodic periodic
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 32 32 32
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 16    # grid size must be divisible by this
+amr.max_grid_size   = 16    # at least 128 for GPUs
+amr.n_error_buf     = 2     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 0.7   # default
+
+do_reflux = 1
+do_subcycle = 0
+do_tracers = 0      # turn on tracer particles
+
+hydro.artificial_viscosity_coefficient = 0.1
+
+particles.SN_scheme = SN_thermal_or_thermal_momentum
+particles.verbose = 0
+particles.eps_ff = 0.5
+particles.low_mass_composite_max_mass = 2.0e35
+# Maximum velocity limit for stellar particles (cm/s), default: 1.0e8 (1000 km/s)
+particles.stellar_velocity_limit = 1.0e8
+
+problem.n0 = 1.0e5
+problem.Tamb = 1.0e1
+
+max_timesteps = 10
+initial_dt = 3.15576e12
+plotfile_prefix = plt_sf_cap
+checkpoint_prefix = chk_sf_cap
+plotfile_interval = 10
+checkpoint_interval = 10
+
+# *****************************************************************
+# Cooling parameters
+# *****************************************************************
+cooling.enabled = 1
+cooling.cooling_table_type = resampled
+cooling.hdf5_data_file = "../extern/cooling/CloudyData_UVB=HM2012_resampled_no_PE.h5"
+use_sfh_based_pe_heating = true
+sfh_to_pe_heating_table = "../extern/cooling/photoelectric_heating_from_sfh.csv"
+#sfh_interval = 3
+sfh_time_interval = 4e10 		# years
+sf_area_kpc2 = 1.0 					# kpc^2
+
+problem.validate_initial_imf_stats = false

--- a/inputs/ParticleSF_restart_cap2.in
+++ b/inputs/ParticleSF_restart_cap2.in
@@ -1,0 +1,60 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo     =  -3.949667304e+19 -3.949667304e+19 -3.949667304e+19
+geometry.prob_hi     =  3.949667304e+19 3.949667304e+19 3.949667304e+19
+quokka.bc = periodic periodic periodic
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v              = 1       # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell          = 32 32 32
+amr.max_level       = 0     # number of levels = max_level + 1
+amr.blocking_factor = 16    # grid size must be divisible by this
+amr.max_grid_size   = 16    # at least 128 for GPUs
+amr.n_error_buf     = 2     # minimum 3 cell buffer around tagged cells
+amr.grid_eff        = 0.7   # default
+
+do_reflux = 1
+do_subcycle = 0
+do_tracers = 0      # turn on tracer particles
+
+hydro.artificial_viscosity_coefficient = 0.1
+
+particles.SN_scheme = SN_thermal_or_thermal_momentum
+particles.verbose = 0
+particles.eps_ff = 0.5
+# Maximum velocity limit for stellar particles (cm/s), default: 1.0e8 (1000 km/s)
+particles.stellar_velocity_limit = 1.0e8
+
+problem.n0 = 1.0e5
+problem.Tamb = 1.0e1
+
+restartfile = chk_sf_cap0000010
+plotfile_prefix = plt_sf_cap
+checkpoint_prefix = chk_sf_cap
+particles.low_mass_composite_max_mass = 2.0e35
+problem.verify_low_mass_cap_on_restart = true
+max_timesteps = 20
+initial_dt = 3.15576e12
+plotfile_interval = 10
+checkpoint_interval = -1
+
+# *****************************************************************
+# Cooling parameters
+# *****************************************************************
+cooling.enabled = 1
+cooling.cooling_table_type = resampled
+cooling.hdf5_data_file = "../extern/cooling/CloudyData_UVB=HM2012_resampled_no_PE.h5"
+use_sfh_based_pe_heating = true
+const_sfr_Msun_per_year_per_kpc2 = 3.0e-2
+sfh_to_pe_heating_table = "../extern/cooling/photoelectric_heating_from_sfh.csv"
+#sfh_interval = 3
+sfh_time_interval = 4e10
+
+problem.validate_initial_imf_stats = false

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -253,7 +253,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void defineComponentNames();
 	void defineDefaultPlotfileVariables();
 	void readParmParse();
-	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
+	void rereadRuntimeParameters() override; // Re-read parameters to ensure runtime values override compile-time settings
 
 	void checkHydroStates(amrex::MultiFab &mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> &mf_fc, char const *file, int line);
 	void CheckHydroStates(amrex::MultiFab &mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> &mf_fc,

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -253,7 +253,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void defineComponentNames();
 	void defineDefaultPlotfileVariables();
 	void readParmParse();
-	void rereadRuntimeParameters() override; // Re-read parameters to ensure runtime values override compile-time settings
+	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
 
 	void checkHydroStates(amrex::MultiFab &mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> &mf_fc, char const *file, int line);
 	void CheckHydroStates(amrex::MultiFab &mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> &mf_fc,
@@ -707,8 +707,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimePar
 	// Re-read QuokkaSimulation-specific parameters
 	readParmParse();
 
-	// Re-read particle parameters
-	quokka::particleParmParse();
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -706,7 +706,6 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimePar
 
 	// Re-read QuokkaSimulation-specific parameters
 	readParmParse();
-
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -707,6 +707,8 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimePar
 	// Re-read QuokkaSimulation-specific parameters
 	readParmParse();
 
+	// Re-read particle parameters
+	quokka::particleParmParse();
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/problems/ParticleSF/CMakeLists.txt
+++ b/src/problems/ParticleSF/CMakeLists.txt
@@ -8,7 +8,11 @@ if(AMReX_SPACEDIM EQUAL 3)
 
   add_test(NAME ${JOB_NAME} COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
   add_test(NAME ${JOB_NAME}2 COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}2.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  add_test(NAME ${JOB_NAME}_restart_cap COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}_restart_cap.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  add_test(NAME ${JOB_NAME}_restart_cap2 COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}_restart_cap2.in ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
 
 	set_tests_properties(${JOB_NAME} PROPERTIES COST 100)
 	set_tests_properties(${JOB_NAME}2 PROPERTIES DEPENDS "${JOB_NAME}" COST 99)
+	set_tests_properties(${JOB_NAME}_restart_cap PROPERTIES COST 99)
+	set_tests_properties(${JOB_NAME}_restart_cap2 PROPERTIES DEPENDS "${JOB_NAME}_restart_cap" COST 98)
 endif()

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -280,8 +280,8 @@ auto problem_main() -> int
 		int num_cap_violations = 0;
 		int restart_validation_status = 0;
 
-		if (amrex::ParallelDescriptor::IOProcessor()) {
-			for (int i = 0; i < static_cast<int>(real_data_restart.size()); ++i) {
+			if (amrex::ParallelDescriptor::IOProcessor()) {
+				for (std::size_t i = 0; i < real_data_restart.size(); ++i) {
 				const bool is_low_mass_composite = (idata_restart[i][0] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
 				if (is_low_mass_composite) {
 					num_low_mass_particles++;

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -24,6 +24,7 @@ constexpr Real gamma_ = 5. / 3.;
 constexpr Real year = 3.15576e+07; // in seconds
 static Real n0 = 1.0e4;		   // NOLINT
 static Real Tamb = 10.0;	   // NOLINT
+static bool validate_initial_imf_stats = true; // NOLINT
 
 template <> struct Particle_Traits<ParticleSFProblem> {
 	// static constexpr ParticleSwitch particle_switch = ParticleSwitch::None;
@@ -93,7 +94,9 @@ template <> void QuokkaSimulation<ParticleSFProblem>::refineGrid(int lev, amrex:
 template <> void QuokkaSimulation<ParticleSFProblem>::computeAfterTimestep()
 {
 	const int step = istep[0];
-	if (step == 1) {
+	const bool use_default_low_mass_cap =
+	    (quokka::low_mass_composite_max_mass >= 0.99 * std::numeric_limits<amrex::Real>::max());
+	if (step == 1 && validate_initial_imf_stats && use_default_low_mass_cap) {
 		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 		const amrex::Real cell_volume = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 
@@ -242,6 +245,9 @@ auto problem_main() -> int
 	amrex::ParmParse const ppp("problem");
 	ppp.query("Tamb", Tamb);
 	ppp.query("n0", n0);
+	ppp.query("validate_initial_imf_stats", validate_initial_imf_stats);
+	bool verify_low_mass_cap_on_restart = false;
+	ppp.query("verify_low_mass_cap_on_restart", verify_low_mass_cap_on_restart);
 
 	sim.setInitialConditions();
 
@@ -259,6 +265,45 @@ auto problem_main() -> int
 	amrex::ParmParse const p3;
 	p3.query("restartfile", restartfile);
 	if (!restartfile.empty()) {
+		if (!verify_low_mass_cap_on_restart) {
+			return 0; // success
+		}
+
+		amrex::Real low_mass_cap = std::numeric_limits<amrex::Real>::max();
+		amrex::ParmParse const p_particles("particles");
+		p_particles.query("low_mass_composite_max_mass", low_mass_cap);
+
+		const auto [real_data_restart, idata_restart] =
+		    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::StochasticStellarPop)->getParticleDataAtLevel(0);
+		const amrex::Real mass_tol = 1.0e-12 * std::max(low_mass_cap, static_cast<amrex::Real>(1.0));
+
+		int num_low_mass_particles = 0;
+		int num_cap_violations = 0;
+		int restart_validation_status = 0;
+
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			for (int i = 0; i < static_cast<int>(real_data_restart.size()); ++i) {
+				const bool is_low_mass_composite =
+				    (idata_restart[i][0] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
+				if (is_low_mass_composite) {
+					num_low_mass_particles++;
+					if (real_data_restart[i][quokka::StochasticStellarPopParticleMassIdx] > (low_mass_cap + mass_tol)) {
+						num_cap_violations++;
+					}
+				}
+			}
+
+			amrex::Print() << "Restart low-mass cap validation: LowMassComposite particles = " << num_low_mass_particles
+				       << ", cap violations = " << num_cap_violations << ", cap = " << low_mass_cap / C::M_solar << " Msun\n";
+			if (num_low_mass_particles == 0 || num_cap_violations != 0) {
+				restart_validation_status = 1;
+			}
+		}
+
+		amrex::ParallelDescriptor::Bcast(&restart_validation_status, 1, amrex::ParallelDescriptor::IOProcessorNumber());
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+		    restart_validation_status == 0,
+		    "Restart low-mass cap validation failed: either no LowMassComposite particles were found or at least one exceeded the mass cap.");
 		return 0; // success
 	}
 

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -21,9 +21,9 @@ struct ParticleSFProblem {
 
 constexpr Real mu = 1.0 * C::m_p;
 constexpr Real gamma_ = 5. / 3.;
-constexpr Real year = 3.15576e+07; // in seconds
-static Real n0 = 1.0e4;		   // NOLINT
-static Real Tamb = 10.0;	   // NOLINT
+constexpr Real year = 3.15576e+07;	       // in seconds
+static Real n0 = 1.0e4;			       // NOLINT
+static Real Tamb = 10.0;		       // NOLINT
 static bool validate_initial_imf_stats = true; // NOLINT
 
 template <> struct Particle_Traits<ParticleSFProblem> {
@@ -94,8 +94,7 @@ template <> void QuokkaSimulation<ParticleSFProblem>::refineGrid(int lev, amrex:
 template <> void QuokkaSimulation<ParticleSFProblem>::computeAfterTimestep()
 {
 	const int step = istep[0];
-	const bool use_default_low_mass_cap =
-	    (quokka::low_mass_composite_max_mass >= 0.99 * std::numeric_limits<amrex::Real>::max());
+	const bool use_default_low_mass_cap = (quokka::low_mass_composite_max_mass >= 0.99 * std::numeric_limits<amrex::Real>::max());
 	if (step == 1 && validate_initial_imf_stats && use_default_low_mass_cap) {
 		amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 		const amrex::Real cell_volume = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
@@ -283,8 +282,7 @@ auto problem_main() -> int
 
 		if (amrex::ParallelDescriptor::IOProcessor()) {
 			for (int i = 0; i < static_cast<int>(real_data_restart.size()); ++i) {
-				const bool is_low_mass_composite =
-				    (idata_restart[i][0] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
+				const bool is_low_mass_composite = (idata_restart[i][0] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
 				if (is_low_mass_composite) {
 					num_low_mass_particles++;
 					if (real_data_restart[i][quokka::StochasticStellarPopParticleMassIdx] > (low_mass_cap + mass_tol)) {

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -257,9 +257,7 @@ auto problem_main() -> int
 
 	sim.evolve();
 
-	// If restarting from checkfile, return success. The initial gas mass is unknown, so there is nothing to compare with.
-	// We validate restarting from checkfile.
-
+	// We validate restarting from a checkpoint below when verify_low_mass_cap_on_restart is true.
 	std::string restartfile;
 	amrex::ParmParse const p3;
 	p3.query("restartfile", restartfile);
@@ -282,7 +280,7 @@ auto problem_main() -> int
 
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				for (std::size_t i = 0; i < real_data_restart.size(); ++i) {
-				const bool is_low_mass_composite = (idata_restart[i][0] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
+				const bool is_low_mass_composite = (idata_restart[i][quokka::StochasticStellarPopParticleStageIdx] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
 				if (is_low_mass_composite) {
 					num_low_mass_particles++;
 					if (real_data_restart[i][quokka::StochasticStellarPopParticleMassIdx] > (low_mass_cap + mass_tol)) {
@@ -305,7 +303,7 @@ auto problem_main() -> int
 		return 0; // success
 	}
 
-	// If not from checkpoint, validate mass sonservation (roughly)
+	// If not restarting from a checkpoint, validate mass sonservation (roughly)
 
 	const auto [real_data_final2, idata_final2] =
 	    sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::StochasticStellarPop)->getParticleDataAtLevel(0);

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -278,9 +278,10 @@ auto problem_main() -> int
 		int num_cap_violations = 0;
 		int restart_validation_status = 0;
 
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				for (std::size_t i = 0; i < real_data_restart.size(); ++i) {
-				const bool is_low_mass_composite = (idata_restart[i][quokka::StochasticStellarPopParticleStageIdx] == static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			for (std::size_t i = 0; i < real_data_restart.size(); ++i) {
+				const bool is_low_mass_composite = (idata_restart[i][quokka::StochasticStellarPopParticleStageIdx] ==
+								    static_cast<int>(quokka::StellarEvolutionStage::LowMassComposite));
 				if (is_low_mass_composite) {
 					num_low_mass_particles++;
 					if (real_data_restart[i][quokka::StochasticStellarPopParticleMassIdx] > (low_mass_cap + mass_tol)) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -261,7 +261,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void initialize();
 	void PerformanceHints();
 	void readParameters();
-	virtual void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
+	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
 	void setInitialConditions();
 	void setInitialConditionsAtLevel_cc(int level, amrex::Real time);
 	void setInitialConditionsAtLevel_fc(int level, amrex::Real time);
@@ -635,8 +635,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int do_tracers = 0;
 
       protected:
-	void InitParticles();	 // create tracer particles
-	void InitPhyParticles(); // create PhysicsParticles
+	void InitParticles(); // create tracer particles
+	void InitPhyParticles(amrex::Vector<amrex::BoxArray> const *header_box_arrays = nullptr); // create PhysicsParticles or load from checkpoint
 	std::unique_ptr<amrex::AmrTracerParticleContainer> TracerPC;
 	std::unique_ptr<quokka::RadParticleContainer<problem_t>> RadParticles;
 #if AMREX_SPACEDIM == 3
@@ -3369,7 +3369,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitParticles()
 	}
 }
 
-template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
+template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles(amrex::Vector<amrex::BoxArray> const *header_box_arrays)
 {
 	const BL_PROFILE("AMRSimulation::InitPhyParticles()");
 	// Verify that particle_switch is of the correct type
@@ -3378,90 +3378,116 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles()
 	// Read particle parameters from input file
 	quokka::particleParmParse();
 
+	const bool is_restart = (header_box_arrays != nullptr);
+
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
-		AMREX_ASSERT(RadParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::Rad>(RadParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(RadParticles == nullptr);
 
-		// Create particle container
-		RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
-		RadParticles->SetVerbose(0);
+			// Create particle container
+			RadParticles = std::make_unique<quokka::RadParticleContainer<problem_t>>(this);
+			RadParticles->SetVerbose(0);
 
-		// Register with particle register - Rad particles do not allow creation
-		particleRegister_.template registerParticleType<quokka::ParticleType::Rad>(RadParticles.get());
+			// Register with particle register - Rad particles do not allow creation
+			particleRegister_.template registerParticleType<quokka::ParticleType::Rad>(RadParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialRadParticles();
+			// Initialize particles through user-defined function
+			createInitialRadParticles();
+		}
 	}
 
 #if AMREX_SPACEDIM == 3
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CIC) {
-		AMREX_ASSERT(CICParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::CIC>(CICParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(CICParticles == nullptr);
 
-		// Create particle container
-		CICParticles = std::make_unique<quokka::CICParticleContainer>(this);
-		CICParticles->SetVerbose(0);
+			// Create particle container
+			CICParticles = std::make_unique<quokka::CICParticleContainer>(this);
+			CICParticles->SetVerbose(0);
 
-		// Register with particle register - CIC particles allow creation
-		particleRegister_.template registerParticleType<quokka::ParticleType::CIC>(CICParticles.get());
+			// Register with particle register - CIC particles allow creation
+			particleRegister_.template registerParticleType<quokka::ParticleType::CIC>(CICParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialCICParticles();
+			// Initialize particles through user-defined function
+			createInitialCICParticles();
+		}
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CICRad) {
-		AMREX_ASSERT(CICRadParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::CICRad>(CICRadParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(CICRadParticles == nullptr);
 
-		// Create particle container
-		CICRadParticles = std::make_unique<quokka::CICRadParticleContainer<problem_t>>(this);
-		CICRadParticles->SetVerbose(0);
+			// Create particle container
+			CICRadParticles = std::make_unique<quokka::CICRadParticleContainer<problem_t>>(this);
+			CICRadParticles->SetVerbose(0);
 
-		// Register with particle register - CICRad particles do not allow creation
-		particleRegister_.template registerParticleType<quokka::ParticleType::CICRad>(CICRadParticles.get());
+			// Register with particle register - CICRad particles do not allow creation
+			particleRegister_.template registerParticleType<quokka::ParticleType::CICRad>(CICRadParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialCICRadParticles();
+			// Initialize particles through user-defined function
+			createInitialCICRadParticles();
+		}
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
-		AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
 
-		static_assert(Physics_Traits<problem_t>::unit_system == UnitSystem::CGS, "UnitSystem must be CGS for StochasticStellarPop particles");
+			static_assert(Physics_Traits<problem_t>::unit_system == UnitSystem::CGS, "UnitSystem must be CGS for StochasticStellarPop particles");
 
-		// Create particle container
-		StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
-		StochasticStellarPopParticles->SetVerbose(0);
+			// Create particle container
+			StochasticStellarPopParticles = std::make_unique<quokka::StochasticStellarPopParticleContainer<problem_t>>(this);
+			StochasticStellarPopParticles->SetVerbose(0);
 
-		// Register with particle register - StochasticStellarPop particles allow creation
-		particleRegister_.template registerParticleType<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles.get());
+			// Register with particle register - StochasticStellarPop particles allow creation
+			particleRegister_.template registerParticleType<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialStochasticStellarPopParticles();
+			// Initialize particles through user-defined function
+			createInitialStochasticStellarPopParticles();
+		}
 	}
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Sink) {
-		AMREX_ASSERT(SinkParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::Sink>(SinkParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(SinkParticles == nullptr);
 
-		// Create particle container
-		SinkParticles = std::make_unique<quokka::SinkParticleContainer>(this);
-		SinkParticles->SetVerbose(0);
+			// Create particle container
+			SinkParticles = std::make_unique<quokka::SinkParticleContainer>(this);
+			SinkParticles->SetVerbose(0);
 
-		// Register with particle register - Sink particles allow creation
-		particleRegister_.template registerParticleType<quokka::ParticleType::Sink>(SinkParticles.get());
+			// Register with particle register - Sink particles allow creation
+			particleRegister_.template registerParticleType<quokka::ParticleType::Sink>(SinkParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialSinkParticles();
+			// Initialize particles through user-defined function
+			createInitialSinkParticles();
+		}
 	}
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
-		AMREX_ASSERT(TestParticles == nullptr);
+		if (is_restart) {
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::Test>(TestParticles, *header_box_arrays);
+		} else {
+			AMREX_ASSERT(TestParticles == nullptr);
 
-		// Create particle container
-		TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
-		TestParticles->SetVerbose(0);
+			// Create particle container
+			TestParticles = std::make_unique<quokka::TestParticleContainer<problem_t>>(this);
+			TestParticles->SetVerbose(0);
 
-		// Register with particle register - Test particles have all features enabled
-		particleRegister_.template registerParticleType<quokka::ParticleType::Test>(TestParticles.get());
+			// Register with particle register - Test particles have all features enabled
+			particleRegister_.template registerParticleType<quokka::ParticleType::Test>(TestParticles.get());
 
-		// Initialize particles through user-defined function
-		createInitialTestParticles();
+			// Initialize particles through user-defined function
+			createInitialTestParticles();
+		}
 	}
 #endif // AMREX_SPACEDIM == 3
 
@@ -4647,33 +4673,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		restartParticleContainerWithRefinement(TracerPC, restart_chkfile, "tracer_particles", header_box_arrays);
 	}
 
-	// 6. Initialize and register particle containers from checkpoint file
-
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Rad) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::Rad>(RadParticles, header_box_arrays);
-	}
+	// 6. Initialize and register physics particle containers from checkpoint file.
+	// This also parses particles.* parameters in restart runs.
+	InitPhyParticles(&header_box_arrays);
 
 #if AMREX_SPACEDIM == 3
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CIC) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::CIC>(CICParticles, header_box_arrays);
-	}
-
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::CICRad) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::CICRad>(CICRadParticles, header_box_arrays);
-	}
-
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles, header_box_arrays);
-	}
-
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Sink) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::Sink>(SinkParticles, header_box_arrays);
-	}
-
-	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::Test) {
-		initializeParticleContainerFromCheckpoint<quokka::ParticleType::Test>(TestParticles, header_box_arrays);
-	}
-
 	// Read SFH data from metadata
 	last_sfh_time_ = particleRegister_.readSFH(simulationMetadata_, sn_count_cumulative_);
 #endif // AMREX_SPACEDIM == 3

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -635,7 +635,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int do_tracers = 0;
 
       protected:
-	void InitParticles(); // create tracer particles
+	void InitParticles();									  // create tracer particles
 	void InitPhyParticles(amrex::Vector<amrex::BoxArray> const *header_box_arrays = nullptr); // create PhysicsParticles or load from checkpoint
 	std::unique_ptr<amrex::AmrTracerParticleContainer> TracerPC;
 	std::unique_ptr<quokka::RadParticleContainer<problem_t>> RadParticles;
@@ -3437,7 +3437,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles(am
 
 	if constexpr (Particle_Traits<problem_t>::particle_switch & ParticleSwitch::StochasticStellarPop) {
 		if (is_restart) {
-			initializeParticleContainerFromCheckpoint<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles, *header_box_arrays);
+			initializeParticleContainerFromCheckpoint<quokka::ParticleType::StochasticStellarPop>(StochasticStellarPopParticles,
+													      *header_box_arrays);
 		} else {
 			AMREX_ASSERT(StochasticStellarPopParticles == nullptr);
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -261,7 +261,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	void initialize();
 	void PerformanceHints();
 	void readParameters();
-	void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
+	virtual void rereadRuntimeParameters(); // Re-read parameters to ensure runtime values override compile-time settings
 	void setInitialConditions();
 	void setInitialConditionsAtLevel_cc(int level, amrex::Real time);
 	void setInitialConditionsAtLevel_fc(int level, amrex::Real time);


### PR DESCRIPTION
### Description
Ensure that particle parameters in the ParmParse input are re-read on restart. Otherwise, their default values are used, which may be inconsistent with the pre-restart simulation. A test is added to the test suite to verify this.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
