### PR TITLE
Fix Frontier container build cache issue

### DIFF
--- a/.github/workflows/dockerfiles/ROCm-DiskGalaxy/Dockerfile
+++ b/.github/workflows/dockerfiles/ROCm-DiskGalaxy/Dockerfile
@@ -7,7 +7,6 @@ ARG MPICH_URL=https://www.mpich.org/static/downloads/4.1.2/mpich-4.1.2.tar.gz
 ARG AMREX_SPACEDIM=3
 ARG AMREX_MPI=ON
 ARG AMREX_AMD_ARCH=gfx90a
-ARG DOCKERFILES_DIR=.github/workflows/dockerfiles/ROCm-DiskGalaxy
 
 # Combine system updates, repo setup, and package installation
 RUN set -euo pipefail && \
@@ -42,34 +41,21 @@ ENV PATH="/opt/rocm/bin:${PATH}" \
     CC="amdclang" \
     CXX="amdclang++"
 
-COPY . /tmp/quokka-src
-WORKDIR /tmp/quokka-src
+COPY .github/workflows/dockerfiles/ROCm-DiskGalaxy/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch /tmp/mpich.patch
 
 # Combine MPICH download, patch, and build
 RUN set -euo pipefail && \
-    test -f CMakeLists.txt || { \
-      echo "ERROR: Quokka source not found in the Docker build context." >&2; \
-      echo "Build from the repo root, e.g.: docker build -f .github/workflows/dockerfiles/ROCm-DiskGalaxy/Dockerfile ." >&2; \
-      exit 1; \
-    } && \
-    if [ -f "/tmp/quokka-src/${DOCKERFILES_DIR}/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch" ]; then \
-        PATCH_PATH="/tmp/quokka-src/${DOCKERFILES_DIR}/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch"; \
-    elif [ -f "/tmp/quokka-src/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch" ]; then \
-        PATCH_PATH="/tmp/quokka-src/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch"; \
-    else \
-        echo "ERROR: MPICH patch not found." >&2; exit 1; \
-    fi && \
     mkdir -p /tmp/build-mpich && \
     cd /tmp/build-mpich && \
     wget -q "${MPICH_URL}" -O "mpich-${MPICH_VERSION}.tar.gz" && \
     tar xzf "mpich-${MPICH_VERSION}.tar.gz" && \
     cd "mpich-${MPICH_VERSION}" && \
-    patch -p1 < "$PATCH_PATH" && \
+    patch -p1 < /tmp/mpich.patch && \
     ./configure --with-device=ch4:ofi --disable-fortran --prefix="/opt/mpich/${MPICH_VERSION}" && \
     make -j"$(nproc)" && \
     make install && \
     cd .. && \
-    rm -rf mpich-4.1.2/ mpich-4.1.2.tar.gz /tmp/mpich-4.1.2-rocm-6.4-hip-pointer-attr.patch && \
+    rm -rf mpich-4.1.2/ mpich-4.1.2.tar.gz /tmp/mpich.patch && \
     cd / && \
     rm -rf /tmp/build-mpich
 
@@ -78,6 +64,9 @@ ENV MPICH_VERSION="${MPICH_VERSION}" \
     MPICH_DIR="/opt/mpich/${MPICH_VERSION}" \
     PATH="/opt/mpich/${MPICH_VERSION}/bin:${PATH}" \
     LD_LIBRARY_PATH="/opt/mpich/${MPICH_VERSION}/lib:${LD_LIBRARY_PATH}"
+
+COPY . /tmp/quokka-src
+WORKDIR /tmp/quokka-src
 
 # Build Quokka
 RUN set -euo pipefail && \

--- a/.github/workflows/rocm-diskgalaxy-container.yml
+++ b/.github/workflows/rocm-diskgalaxy-container.yml
@@ -63,8 +63,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-${{ env.IMAGE_TAG_SHA }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=rocm-diskgalaxy-container
+          cache-to: type=gha,mode=max,scope=rocm-diskgalaxy-container
 
       - name: Print DiskGalaxy image URL (development)
         if: ${{ github.event_name == 'push' }}
@@ -83,8 +83,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-pr-${{ github.event.pull_request.number }}
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:rocm-diskgalaxy-pr-${{ github.event.pull_request.number }}-${{ env.IMAGE_TAG_SHA }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=rocm-diskgalaxy-container
+          cache-to: type=gha,mode=max,scope=rocm-diskgalaxy-container
 
       - name: Print DiskGalaxy image URL (PR)
         if: ${{ env.IS_INTERNAL_PR == 'true' }}
@@ -101,5 +101,5 @@ jobs:
             AMREX_MPI=ON
           push: false
           tags: rocm-diskgalaxy-pr-${{ github.event.pull_request.number }}:${{ env.IMAGE_TAG_SHA }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=rocm-diskgalaxy-container
+          cache-to: type=gha,mode=max,scope=rocm-diskgalaxy-container

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -86,6 +86,11 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_OpenBC.H"
 #endif
 
+#ifdef AMREX_USE_ASCENT
+#include <AMReX_Conduit_Blueprint.H>
+#include <ascent.hpp>
+#endif
+
 // internal headers
 #include "fundamental_constants.H"
 #include "grid.hpp"

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -86,11 +86,6 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_OpenBC.H"
 #endif
 
-#ifdef AMREX_USE_ASCENT
-#include <AMReX_Conduit_Blueprint.H>
-#include <ascent.hpp>
-#endif
-
 // internal headers
 #include "fundamental_constants.H"
 #include "grid.hpp"


### PR DESCRIPTION
### Description
This modifies the Frontier ROCm container build so that MPICH is built before copying the current repo into the container. This is necessary to ensure that the MPICH build is cached and not re-compiled each time.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
