### PR TITLE
Add scalar in the IC of DiskGalaxy

### DIFF
--- a/inputs/DiskGalaxy.in
+++ b/inputs/DiskGalaxy.in
@@ -66,3 +66,7 @@ quokka.update_initial_b_energy = true
 
 agora_galaxy.halo_temperature = 1.0e6       # K
 agora_galaxy.halo_number_density = 1.0e-4   # cm^-3
+
+# metal scalar
+particles.scalar_yield_per_SN = 1.99e33 # 1 Msun, given a density of 6e-29 when spreaded in a sphere of radius 64 pc
+disk_galaxy.initial_scalar_density = 1.67e-35 # 1e-11 mH/cm^3

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -178,7 +178,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	double T_disk = NAN;		     // K
 	double disk_perturb_amplitude = NAN; // amplitude of harmonic mode perturbation
 	double disk_perturb_Rmax_kpc = NAN;  // max radius (in kpc) for harmonic mode perturbations
-	double initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
+	double initial_scalar_density = NAN; // scalar density at cgs units (cm^-3)
 	pp.query("disk_gas_mass_Msun", disk_gas_mass_Msun);
 	pp.query("disk_Rscale_kpc", disk_Rscale_kpc);
 	pp.query("disk_zscale_kpc", disk_zscale_kpc);
@@ -192,6 +192,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	AMREX_ALWAYS_ASSERT(!std::isnan(T_disk));
 	AMREX_ALWAYS_ASSERT(!std::isnan(disk_perturb_amplitude));
 	AMREX_ALWAYS_ASSERT(!std::isnan(disk_perturb_Rmax_kpc));
+	AMREX_ALWAYS_ASSERT(!std::isnan(initial_scalar_density));
 
 	const double disk_gas_mass = disk_gas_mass_Msun * C::M_solar;
 	const double R_d = disk_Rscale_kpc * (1.0e3 * C::parsec);
@@ -233,6 +234,15 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	// particles.scalar_yield_per_SN must be set as well, and it should be greater than (initial_scalar_density * (128 pc)^3),
+	// so that the SN ejected metal density in SN remnant is greater than the background density.
+	amrex::ParmParse const pp_particles("particles");
+	double scalar_yield_per_SN = NAN;
+	pp_particles.query("scalar_yield_per_SN", scalar_yield_per_SN);
+	AMREX_ALWAYS_ASSERT(!std::isnan(scalar_yield_per_SN));
+	const Real SNR_volume = std::pow(128.0 * C::parsec, 3);
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(scalar_yield_per_SN > initial_scalar_density * SNR_volume, "particles.scalar_yield_per_SN must be greater than (initial_scalar_density * (128 pc)^3)");
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// Cartesian coordinates

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -242,7 +242,8 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	pp_particles.query("scalar_yield_per_SN", scalar_yield_per_SN);
 	AMREX_ALWAYS_ASSERT(!std::isnan(scalar_yield_per_SN));
 	const Real SNR_volume = std::pow(128.0 * C::parsec, 3);
-	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(scalar_yield_per_SN > initial_scalar_density * SNR_volume, "particles.scalar_yield_per_SN must be greater than (initial_scalar_density * (128 pc)^3)");
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(scalar_yield_per_SN > initial_scalar_density * SNR_volume,
+					 "particles.scalar_yield_per_SN must be greater than (initial_scalar_density * (128 pc)^3)");
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// Cartesian coordinates

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -62,7 +62,7 @@ template <> struct Physics_Traits<DiskGalaxy> {
 	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
 	static constexpr int nGroups = 1;			     // number of radiation groups
 };
 
@@ -71,6 +71,8 @@ template <> struct Particle_Traits<DiskGalaxy> {
 };
 
 template <> struct SimulationData<DiskGalaxy> {
+	amrex::Real initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
+
 	amrex::Real r_inner{};
 	amrex::Real r_outer{};
 	amrex::Real vcirc_outer{};
@@ -231,6 +233,8 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	const amrex::Real initial_scalar_density = userData_.initial_scalar_density;
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// Cartesian coordinates
@@ -422,6 +426,11 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 		state_cc(i, j, k, HydroSystem<DiskGalaxy>::x3Momentum_index) = momz_disk_halo;
 		state_cc(i, j, k, HydroSystem<DiskGalaxy>::energy_index) = Etot_disk_halo;
 		state_cc(i, j, k, HydroSystem<DiskGalaxy>::internalEnergy_index) = Eint_disk_halo;
+
+		// Initialize passive scalar field
+		if constexpr (Physics_Traits<DiskGalaxy>::numPassiveScalars > 0) {
+			state_cc(i, j, k, HydroSystem<DiskGalaxy>::scalar0_index) = initial_scalar_density;
+		}
 	});
 }
 
@@ -766,6 +775,10 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<DiskGalaxy> sim(BCs_cc, BCs_fc);
+
+	// read parameters
+	amrex::ParmParse const pp("disk_galaxy");
+	pp.query("initial_scalar_density", sim.userData_.initial_scalar_density);
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -71,8 +71,6 @@ template <> struct Particle_Traits<DiskGalaxy> {
 };
 
 template <> struct SimulationData<DiskGalaxy> {
-	amrex::Real initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
-
 	amrex::Real r_inner{};
 	amrex::Real r_outer{};
 	amrex::Real vcirc_outer{};
@@ -180,12 +178,14 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	double T_disk = NAN;		     // K
 	double disk_perturb_amplitude = NAN; // amplitude of harmonic mode perturbation
 	double disk_perturb_Rmax_kpc = NAN;  // max radius (in kpc) for harmonic mode perturbations
+	double initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
 	pp.query("disk_gas_mass_Msun", disk_gas_mass_Msun);
 	pp.query("disk_Rscale_kpc", disk_Rscale_kpc);
 	pp.query("disk_zscale_kpc", disk_zscale_kpc);
 	pp.query("disk_temperature", T_disk);
 	pp.query("disk_perturb_amplitude", disk_perturb_amplitude);
 	pp.query("disk_perturb_Rmax_kpc", disk_perturb_Rmax_kpc);
+	pp.query("initial_scalar_density", initial_scalar_density);
 	AMREX_ALWAYS_ASSERT(!std::isnan(disk_gas_mass_Msun));
 	AMREX_ALWAYS_ASSERT(!std::isnan(disk_Rscale_kpc));
 	AMREX_ALWAYS_ASSERT(!std::isnan(disk_zscale_kpc));
@@ -233,8 +233,6 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
-
-	const amrex::Real initial_scalar_density = userData_.initial_scalar_density;
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// Cartesian coordinates
@@ -427,9 +425,12 @@ template <> void QuokkaSimulation<DiskGalaxy>::setInitialConditionsOnGrid(quokka
 		state_cc(i, j, k, HydroSystem<DiskGalaxy>::energy_index) = Etot_disk_halo;
 		state_cc(i, j, k, HydroSystem<DiskGalaxy>::internalEnergy_index) = Eint_disk_halo;
 
+		// first capture on device
+		const auto initial_scalar_density_d = initial_scalar_density;
+
 		// Initialize passive scalar field
 		if constexpr (Physics_Traits<DiskGalaxy>::numPassiveScalars > 0) {
-			state_cc(i, j, k, HydroSystem<DiskGalaxy>::scalar0_index) = initial_scalar_density;
+			state_cc(i, j, k, HydroSystem<DiskGalaxy>::scalar0_index) = initial_scalar_density_d;
 		}
 	});
 }
@@ -775,10 +776,6 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<DiskGalaxy> sim(BCs_cc, BCs_fc);
-
-	// read parameters
-	amrex::ParmParse const pp("disk_galaxy");
-	pp.query("initial_scalar_density", sim.userData_.initial_scalar_density);
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -38,7 +38,7 @@ template <> struct SimulationData<TheProblem> {
 	Real dv_rms_generated{};
 	Real turbulent_amplitude = 1500.0; // cm/s,  0.05 * cs at 10K (~0.3 km/s)
 	int turbulent_size = 128;
-	Real initial_scalar_per_cell  = 0.0; // the actual density is initial_scalar_per_cell / cell_volume 
+	Real initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
 
 	Real refine_parameter = 1.0; // placeholder for refinement control
 	std::string stars_file;	     // default: no stars
@@ -241,11 +241,7 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	// Create GPU const tables for initial conditions if available
 	const auto &ic_table = userData_.ic_table.const_tables();
 
-	amrex::Real initial_scalar_density = 0.0;
-	if constexpr (Physics_Traits<TheProblem>::numPassiveScalars > 0) {
-		const amrex::Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-		initial_scalar_density = userData_.initial_scalar_per_cell / cell_vol;
-	}
+	const amrex::Real initial_scalar_density = userData_.initial_scalar_density;
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const z = prob_lo[2] + ((k + static_cast<amrex::Real>(0.5)) * dx[2]);
@@ -284,6 +280,7 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 		state_cc(i, j, k, HydroSystem<TheProblem>::internalEnergy_index) = P / (gamma - 1.);
 		state_cc(i, j, k, HydroSystem<TheProblem>::energy_index) = P / (gamma - 1.) + 0.5 * rho * (vx * vx + vy * vy + vz * vz);
 
+		// first capture on device
 		const auto initial_scalar_density_d = initial_scalar_density;
 
 		// Initialize passive scalar field
@@ -433,7 +430,7 @@ auto problem_main() -> int
 	pp.query("IC_file", sim.userData_.IC_file);
 	pp.query("rho01", sim.userData_.rho01);
 	pp.query("sigma1", sim.userData_.sigma1);
-	pp.query("initial_scalar_per_cell", sim.userData_.initial_scalar_per_cell);
+	pp.query("initial_scalar_density", sim.userData_.initial_scalar_density);
 
 	// preCalculate must be explicitly called here to ensure
 	// ic_table is initialized even when restarting from checkpoint

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -38,6 +38,7 @@ template <> struct SimulationData<TheProblem> {
 	Real dv_rms_generated{};
 	Real turbulent_amplitude = 1500.0; // cm/s,  0.05 * cs at 10K (~0.3 km/s)
 	int turbulent_size = 128;
+	Real initial_scalar_per_cell  = 0.0; // the actual density is initial_scalar_per_cell / cell_volume 
 
 	Real refine_parameter = 1.0; // placeholder for refinement control
 	std::string stars_file;	     // default: no stars
@@ -171,6 +172,9 @@ template <> void QuokkaSimulation<TheProblem>::preCalculateInitialConditions()
 		amrex::Print() << "turbulent amplitude = " << userData_.turbulent_amplitude << " cm/s\n";
 
 		userData_.turbulent_size = turbData.dvx.end[0] - turbData.dvx.begin[0];
+		const int nturb_y = turbData.dvx.end[1] - turbData.dvx.begin[1];
+		const int nturb_z = turbData.dvx.end[2] - turbData.dvx.begin[2];
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(userData_.turbulent_size == nturb_y && nturb_y == nturb_z, "Turbulence data must be a cube");
 		amrex::Print() << "turbulence data size is: " << userData_.turbulent_size << "^3\n";
 
 		// copy to GPU
@@ -219,11 +223,14 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	amrex::Array<int, 3> turb_lo = userData_.dvx.lo();
 	amrex::Array<int, 3> turb_hi = userData_.dvx.hi();
 
-	// get simulation box x-dimension as reference
+	// get simulation box dimensions
 	const int nx = indexRange.length(0);
+	const int ny = indexRange.length(1);
+	const int nz = indexRange.length(2);
 	const int nturb = turb_hi[0] - turb_lo[0] + 1;
 
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nx <= nturb, "nx must be less than or equal to turbulent_size (128)");
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ny >= nx && nz >= nx, "ny and nz must be greater than or equal to nx");
 
 	// Capture galaxy parameters from userData_ for GPU kernel
 	const Real sigma1_ic = userData_.sigma1;
@@ -237,7 +244,7 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	amrex::Real initial_scalar_density = 0.0;
 	if constexpr (Physics_Traits<TheProblem>::numPassiveScalars > 0) {
 		const amrex::Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-		initial_scalar_density = 1.0e-6 * quokka::scalar_yield_per_SN / cell_vol;
+		initial_scalar_density = userData_.initial_scalar_per_cell / cell_vol;
 	}
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
@@ -426,6 +433,7 @@ auto problem_main() -> int
 	pp.query("IC_file", sim.userData_.IC_file);
 	pp.query("rho01", sim.userData_.rho01);
 	pp.query("sigma1", sim.userData_.sigma1);
+	pp.query("initial_scalar_per_cell", sim.userData_.initial_scalar_per_cell);
 
 	// preCalculate must be explicitly called here to ensure
 	// ic_table is initialized even when restarting from checkpoint

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -38,7 +38,6 @@ template <> struct SimulationData<TheProblem> {
 	Real dv_rms_generated{};
 	Real turbulent_amplitude = 1500.0; // cm/s,  0.05 * cs at 10K (~0.3 km/s)
 	int turbulent_size = 128;
-	Real initial_scalar_density = 0.0; // scalar density at cgs units (cm^-3)
 
 	Real refine_parameter = 1.0; // placeholder for refinement control
 	std::string stars_file;	     // default: no stars
@@ -172,9 +171,6 @@ template <> void QuokkaSimulation<TheProblem>::preCalculateInitialConditions()
 		amrex::Print() << "turbulent amplitude = " << userData_.turbulent_amplitude << " cm/s\n";
 
 		userData_.turbulent_size = turbData.dvx.end[0] - turbData.dvx.begin[0];
-		const int nturb_y = turbData.dvx.end[1] - turbData.dvx.begin[1];
-		const int nturb_z = turbData.dvx.end[2] - turbData.dvx.begin[2];
-		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(userData_.turbulent_size == nturb_y && nturb_y == nturb_z, "Turbulence data must be a cube");
 		amrex::Print() << "turbulence data size is: " << userData_.turbulent_size << "^3\n";
 
 		// copy to GPU
@@ -223,14 +219,11 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	amrex::Array<int, 3> turb_lo = userData_.dvx.lo();
 	amrex::Array<int, 3> turb_hi = userData_.dvx.hi();
 
-	// get simulation box dimensions
+	// get simulation box x-dimension as reference
 	const int nx = indexRange.length(0);
-	const int ny = indexRange.length(1);
-	const int nz = indexRange.length(2);
 	const int nturb = turb_hi[0] - turb_lo[0] + 1;
 
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(nx <= nturb, "nx must be less than or equal to turbulent_size (128)");
-	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(ny >= nx && nz >= nx, "ny and nz must be greater than or equal to nx");
 
 	// Capture galaxy parameters from userData_ for GPU kernel
 	const Real sigma1_ic = userData_.sigma1;
@@ -241,7 +234,11 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	// Create GPU const tables for initial conditions if available
 	const auto &ic_table = userData_.ic_table.const_tables();
 
-	const amrex::Real initial_scalar_density = userData_.initial_scalar_density;
+	amrex::Real initial_scalar_density = 0.0;
+	if constexpr (Physics_Traits<TheProblem>::numPassiveScalars > 0) {
+		const amrex::Real cell_vol = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+		initial_scalar_density = 1.0e-6 * quokka::scalar_yield_per_SN / cell_vol;
+	}
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const z = prob_lo[2] + ((k + static_cast<amrex::Real>(0.5)) * dx[2]);
@@ -280,7 +277,6 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 		state_cc(i, j, k, HydroSystem<TheProblem>::internalEnergy_index) = P / (gamma - 1.);
 		state_cc(i, j, k, HydroSystem<TheProblem>::energy_index) = P / (gamma - 1.) + 0.5 * rho * (vx * vx + vy * vy + vz * vz);
 
-		// first capture on device
 		const auto initial_scalar_density_d = initial_scalar_density;
 
 		// Initialize passive scalar field
@@ -430,7 +426,6 @@ auto problem_main() -> int
 	pp.query("IC_file", sim.userData_.IC_file);
 	pp.query("rho01", sim.userData_.rho01);
 	pp.query("sigma1", sim.userData_.sigma1);
-	pp.query("initial_scalar_density", sim.userData_.initial_scalar_density);
 
 	// preCalculate must be explicitly called here to ensure
 	// ic_table is initialized even when restarting from checkpoint


### PR DESCRIPTION
### Description
Add passive scalar support to the DiskGalaxy problem, enabling tracking of metals during galaxy simulations with supernova feedback. 

## Usage

Set the initial scalar density and SN metal yield in the input file. Note that the absolute values of these two variables are not important; what matters is their relative value.
```
# metal scalar
particles.scalar_yield_per_SN = 1.99e33 # 1 Msun, given a density of 6e-29 when spreaded in a sphere of radius 64 pc
disk_galaxy.initial_scalar_density = 1.67e-35 # 1e-11 mH/cm^3
```

### Related issues
Extends passive scalar support from PR #1658 to the DiskGalaxy problem.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
