### PR TITLE
Fix passive scalar handling in diode boundary conditions

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2651,6 +2651,11 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setDiodeBCLo(
 			    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::energy_index);
 			consVar(i, j, k, HydroSystem<problem_t>::internalEnergy_index) =
 			    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::internalEnergy_index);
+			// copy passive scalars
+			for (int n = 0; n < HydroSystem<problem_t>::nscalars_; ++n) {
+				consVar(i, j, k, HydroSystem<problem_t>::scalar0_index + n) =
+				    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::scalar0_index + n);
+			}
 		} else {
 			// Inflow: use reflection from mirror cell with flipped normal momentum
 			// Mirror cell: reflect around lower boundary face
@@ -2692,6 +2697,11 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setDiodeBCLo(
 			consVar(i, j, k, HydroSystem<problem_t>::x3Momentum_index) = (dir == 2) ? mom_normal : x3Mom;
 			consVar(i, j, k, HydroSystem<problem_t>::energy_index) = etot;
 			consVar(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = eint;
+			// copy passive scalars from mirror cell
+			for (int n = 0; n < HydroSystem<problem_t>::nscalars_; ++n) {
+				consVar(i, j, k, HydroSystem<problem_t>::scalar0_index + n) =
+				    consVar(i_mirror, j_mirror, k_mirror, HydroSystem<problem_t>::scalar0_index + n);
+			}
 		}
 	}
 }
@@ -2762,6 +2772,11 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setDiodeBCHi(
 			    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::energy_index);
 			consVar(i, j, k, HydroSystem<problem_t>::internalEnergy_index) =
 			    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::internalEnergy_index);
+			// copy passive scalars
+			for (int n = 0; n < HydroSystem<problem_t>::nscalars_; ++n) {
+				consVar(i, j, k, HydroSystem<problem_t>::scalar0_index + n) =
+				    consVar(i_interior, j_interior, k_interior, HydroSystem<problem_t>::scalar0_index + n);
+			}
 		} else {
 			// Inflow: use reflection from mirror cell with flipped normal momentum
 			// Mirror cell: reflect around upper boundary face
@@ -2803,6 +2818,11 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<problem_t>::setDiodeBCHi(
 			consVar(i, j, k, HydroSystem<problem_t>::x3Momentum_index) = (dir == 2) ? mom_normal : x3Mom;
 			consVar(i, j, k, HydroSystem<problem_t>::energy_index) = etot;
 			consVar(i, j, k, HydroSystem<problem_t>::internalEnergy_index) = eint;
+			// copy passive scalars from mirror cell
+			for (int n = 0; n < HydroSystem<problem_t>::nscalars_; ++n) {
+				consVar(i, j, k, HydroSystem<problem_t>::scalar0_index + n) =
+				    consVar(i_mirror, j_mirror, k_mirror, HydroSystem<problem_t>::scalar0_index + n);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description
**Problem**
The `setDiodeBCLo` and `setDiodeBCHi` functions in `src/simulation.hpp` only copied core hydro fields (density, momentum, energy, internal energy) when filling ghost cells. Passive scalars were not being copied, leading to incorrect behavior for simulations using passive scalars with diode boundary conditions.

**Solution**
Added loops to copy all passive scalars in both the outflow (first-order extrapolation) and inflow (reflection) paths:
- Outflow: Copy passive scalars from the nearest interior cell
- Inflow: Copy passive scalars from the mirror cell

### Related issues
closes #1681 and https://github.com/quokka-astro/quokka/issues/1682.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
