### PR TITLE
add separate dust density floor and dust density check

### DIFF
--- a/docs/markdown/parameters.md
+++ b/docs/markdown/parameters.md
@@ -122,7 +122,7 @@ These parameters are read in the `QuokkaSimulation<problem_t>::readParmParse()` 
 | dust.enable_iter_stoptime   | Boolean (0/1) | `0` (Disabled) | If set to 1, enables iterative dust stopping time calculation.                                                                 |
 | dust.omega                  | Float         | `1.0`          | Controls the level of frictional heating, with omega = 0 turning it off and omega = 1 depositing all dissipation into the gas. |
 | dust.print_iteration_counts | Boolean (0/1) | `0` (Disabled) | If set to 1, prints dust drag iteration counts for debugging.                                                                  |
-
+| dust.density_floor | Float | `0.0` | The minimum dust density value allowed in the simulation. Enforced through EnforceLimits.                                                           |
 ## Particles
 
 These parameters are read in the `particleParmParse()` function in `src/particles/particle_types.hpp` and `readParmParse()` in `src/simulation.hpp`.

--- a/inputs/DustAdvection.in
+++ b/inputs/DustAdvection.in
@@ -22,3 +22,5 @@ suppress_output = 0
 
 stop_time = 1
 max_timesteps = 5000
+
+dust.density_floor = 1e-6

--- a/inputs/DustAdvection3D.in
+++ b/inputs/DustAdvection3D.in
@@ -22,3 +22,5 @@ suppress_output = 0
 
 stop_time = 0.9
 max_timesteps = 5000
+
+dust.density_floor = 1e-6

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -136,6 +136,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	using AMRSimulation<problem_t>::Gconst_;
 
 	using AMRSimulation<problem_t>::densityFloor_;
+	using AMRSimulation<problem_t>::dustDensityFloor_;
 	using AMRSimulation<problem_t>::tempFloor_;
 
 	using AMRSimulation<problem_t>::max_level;
@@ -682,6 +683,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		dpp.query("omega", dust_omega_);
 		dpp.query("enable_iter_stoptime", enableIterDustStoptime_);
 		dpp.query("print_iteration_counts", print_dust_counter_);
+		dpp.query("density_floor", dustDensityFloor_);
 	}
 
 	// set radiation runtime parameters
@@ -1766,13 +1768,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::FixupState(int l
 									  amrex::Real base_density_floor) -> amrex::Real {
 			return density_floor_parser(x, y, z, base_density_floor);
 		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, state_new_cc_[lev], geom[lev], density_floor_func);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_new_cc_[lev], geom[lev], density_floor_func);
 	} else {
 		auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
 									     amrex::Real base_density_floor) -> amrex::Real {
 			return densityFloor(x, y, z, base_density_floor);
 		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, state_new_cc_[lev], geom[lev], density_floor_func);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_new_cc_[lev], geom[lev], density_floor_func);
 	}
 
 	// sync internal energy and total energy
@@ -2283,13 +2285,13 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 										  amrex::Real base_density_floor) -> amrex::Real {
 				return density_floor_parser(x, y, z, base_density_floor);
 			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
 		} else {
 			auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
 										     amrex::Real base_density_floor) -> amrex::Real {
 				return densityFloor(x, y, z, base_density_floor);
 			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
 		}
 
 		if (useDualEnergy_ == 1) {
@@ -2407,13 +2409,13 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 										  amrex::Real base_density_floor) -> amrex::Real {
 				return density_floor_parser(x, y, z, base_density_floor);
 			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
+			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
 		} else {
 			auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
 										     amrex::Real base_density_floor) -> amrex::Real {
 				return densityFloor(x, y, z, base_density_floor);
 			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
+			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
 		}
 
 		if (useDualEnergy_ == 1) {

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1070,14 +1070,12 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 		}
 
 		// Enforce dust density floor
+		amrex::Real const dust_floor = dustDensityFloor;
 		if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
 			for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
-				amrex::Real const dust_floor = dustDensityFloor;
-				for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
-					amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
-					if (dust_rho < dust_floor) {
-						state[bx](i, j, k, dustDensity_index + g * numDustVars_) = dust_floor;
-					}
+				amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
+				if (dust_rho < dust_floor) {
+					state[bx](i, j, k, dustDensity_index + g * numDustVars_) = dust_floor;
 				}
 			}
 		}

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -158,8 +158,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 	AMREX_GPU_DEVICE static auto GetGradFixedPotential(amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> posvec) -> amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>;
 
 	template <typename DensityFloorFunc>
-	static void EnforceLimits(amrex::Real densityFloor, amrex::Real tempFloor, amrex::MultiFab &state_mf, amrex::Geometry const &geom,
-				  DensityFloorFunc const &density_floor_func);
+	static void EnforceLimits(amrex::Real densityFloor, amrex::Real dustDensityFloor, amrex::Real tempFloor, amrex::MultiFab &state_mf,
+				  amrex::Geometry const &geom, DensityFloorFunc const &density_floor_func);
 
 	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
@@ -998,8 +998,8 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 // floors and ceilings which can be set in the param file
 template <typename problem_t>
 template <typename DensityFloorFunc>
-void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex::Real const tempFloor, amrex::MultiFab &state_mf, amrex::Geometry const &geom,
-					   DensityFloorFunc const &density_floor_func)
+void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex::Real const dustDensityFloor, amrex::Real const tempFloor,
+					   amrex::MultiFab &state_mf, amrex::Geometry const &geom, DensityFloorFunc const &density_floor_func)
 {
 	auto state = state_mf.arrays();
 	auto const prob_lo = geom.ProbLoArray();
@@ -1058,6 +1058,16 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 				for (int idx = 0; idx < nmscalars_; ++idx) {
 					// renormalize
 					state[bx](i, j, k, scalar0_index + idx) /= sp_sum;
+				}
+			}
+		}
+
+		// Enforce dust density floor
+		if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
+			for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
+				amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
+				if (dust_rho < dustDensityFloor) {
+					state[bx](i, j, k, dustDensity_index + g * numDustVars_) = dustDensityFloor;
 				}
 			}
 		}

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -726,7 +726,14 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(am
 {
 	// check if cons(i, j, k) is a valid state
 	const amrex::Real rho = cons(i, j, k, density_index);
-	bool const isDensityPositive = (rho > 0.);
+	bool isDensityPositive = (rho > 0.);
+
+	if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
+		for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
+			const amrex::Real dust_rho = cons(i, j, k, dustDensity_index + g * numDustVars_);
+			isDensityPositive = isDensityPositive && (dust_rho >= 0.);
+		}
+	}
 
 	bool isMassScalarPositive = true;
 	if constexpr (nmscalars_ > 0) {

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1072,9 +1072,12 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 		// Enforce dust density floor
 		if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
 			for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
-				amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
-				if (dust_rho < dustDensityFloor) {
-					state[bx](i, j, k, dustDensity_index + g * numDustVars_) = dustDensityFloor;
+				amrex::Real const dust_floor = dustDensityFloor;
+				for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
+					amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
+					if (dust_rho < dust_floor) {
+						state[bx](i, j, k, dustDensity_index + g * numDustVars_) = dust_floor;
+					}
 				}
 			}
 		}

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -731,7 +731,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE auto HydroSystem<problem_t>::isStateValid(am
 	if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
 		for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
 			const amrex::Real dust_rho = cons(i, j, k, dustDensity_index + g * numDustVars_);
-			isDensityPositive = isDensityPositive && (dust_rho >= 0.);
+			isDensityPositive = isDensityPositive && (dust_rho > 0.);
 		}
 	}
 

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1062,16 +1062,6 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 			}
 		}
 
-		// Enforce dust density floor
-		if constexpr (Physics_Traits<problem_t>::is_dust_enabled) {
-			for (int g = 0; g < Physics_Traits<problem_t>::nDustGroups; ++g) {
-				amrex::Real dust_rho = state[bx](i, j, k, dustDensity_index + g * numDustVars_);
-				if (dust_rho < localDensityFloor) {
-					state[bx](i, j, k, dustDensity_index + g * numDustVars_) = localDensityFloor;
-				}
-			}
-		}
-
 		// Enforce temperature floor
 		if ((rho_new > std::numeric_limits<amrex::Real>::min()) && !HydroSystem<problem_t>::is_eos_isothermal()) {
 			amrex::Real const vx1 = state[bx](i, j, k, x1Momentum_index) / rho_new;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -232,8 +232,9 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	int sn_count_ = 0;	      // number of SN explosions in a step (used for diagnostics)
 	int sn_count_cumulative_ = 0; // cumulative number of SN explosions (used for diagnostics)
 
-	amrex::Real densityFloor_ = 0.0; // default
-	amrex::Real tempFloor_ = 0.0;	 // default
+	amrex::Real densityFloor_ = 0.0;     // default
+	amrex::Real dustDensityFloor_ = 0.0; // default
+	amrex::Real tempFloor_ = 0.0;	     // default
 	bool useDensityFloorParser_ = false;
 	std::string densityFloorExpr_;
 	std::optional<amrex::Parser> densityFloorParser_;


### PR DESCRIPTION
### Description
Currently, dust in QUOKKA uses the same density floor as the gas. This PR introduces a separate density floor for dust, controlled by the runtime parameter `dust.density_floor`, with a default value of 0.0.

This PR also adds dust density checks to `HydroSystem<problem_t>::isStateValid`. If a negative dust density is detected, it will trigger FOFC.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
