### PR TITLE
Pin Canary version to 25.10.07

### DIFF
--- a/.github/workflows/cmake-arm64-debug.yml
+++ b/.github/workflows/cmake-arm64-debug.yml
@@ -58,7 +58,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Initialize ccache
       run: |

--- a/.github/workflows/cmake-arm64-hwasan.yml
+++ b/.github/workflows/cmake-arm64-hwasan.yml
@@ -61,7 +61,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Initialize ccache
       run: |

--- a/.github/workflows/cmake-arm64-release.yml
+++ b/.github/workflows/cmake-arm64-release.yml
@@ -58,7 +58,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Initialize ccache
       run: |

--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -65,7 +65,7 @@ jobs:
       run: python3 -m pip install --user numpy matplotlib
 
     - name: Install Canary
-      run: python3 -m pip install --user canary-wm
+      run: python3 -m pip install --user canary-wm==25.10.7
 
     - name: Set Up Cache
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         python3 -m venv ${{runner.temp}}/canary-venv
         ${{runner.temp}}/canary-venv/bin/python -m pip install --upgrade pip
-        ${{runner.temp}}/canary-venv/bin/pip install canary-wm
+        ${{runner.temp}}/canary-venv/bin/pip install canary-wm==25.10.7
         echo "${{runner.temp}}/canary-venv/bin" >> "$GITHUB_PATH"
 
     - name: Initialize ccache

--- a/.github/workflows/hydro-wave-convergence.yml
+++ b/.github/workflows/hydro-wave-convergence.yml
@@ -40,7 +40,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install gcc-13 g++-13 python3-dev python3-numpy python3-matplotlib python3-pip libopenmpi-dev libhdf5-mpi-dev
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Configure CMake
       shell: bash

--- a/.github/workflows/mhd-asan.yml
+++ b/.github/workflows/mhd-asan.yml
@@ -58,7 +58,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Initialize ccache
       run: |

--- a/.github/workflows/mhd.yml
+++ b/.github/workflows/mhd.yml
@@ -58,7 +58,7 @@ jobs:
              ccache-${{ github.workflow }}-${{ github.job }}-git-
 
     - name: Install Canary
-      run: python3 -m pip install canary-wm
+      run: python3 -m pip install canary-wm==25.10.7
 
     - name: Initialize ccache
       run: |


### PR DESCRIPTION
### Description
This pins all Canary installs (used to run the test suite on GitHub actions) to version 25.10.07. This prevents a major breakage with the version released a few days ago that causes all CI actions to fail.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
