### PR TITLE
Fix regression git issue

### DIFF
--- a/scripts/bash/run-regression-exe.sh
+++ b/scripts/bash/run-regression-exe.sh
@@ -61,23 +61,98 @@ fi
 
 TARGET=/priv/avatar/cche/azp-agent-in-docker-cuda/azp-agent-avatargpu/regression-tests
 
+#######################################
+# Parse webTopDir from the regression ini file.
+# Prints the path to stdout; prints warnings to stderr.
+# Returns 1 if the path cannot be determined.
+#######################################
+parse_web_dir() {
+    local ini_file="$1"
+    if [ ! -f "$ini_file" ]; then
+        echo "WARNING: Ini file not found: $ini_file" >&2
+        return 1
+    fi
+    local web_dir
+    web_dir=$(grep -E "^webTopDir[[:space:]]*=" "$ini_file" \
+        | sed -E 's/^webTopDir[[:space:]]*=[[:space:]]*//' \
+        | tr -d '\r')
+    if [ -z "$web_dir" ]; then
+        echo "WARNING: Could not parse webTopDir from $ini_file" >&2
+        return 1
+    fi
+    echo "$web_dir"
+}
+
+#######################################
+# Push committed results to the remote.
+# Runs on the HOST so that SSH credentials are always available and
+# results are pushed even when the container timed out or was killed.
+# Arguments:
+#   $1 - path to the web/git directory
+#######################################
+push_results() {
+    local web_dir="$1"
+
+    echo "=========================================="
+    echo "Pushing results to GitHub Pages (host)"
+    echo "=========================================="
+
+    if [ ! -d "$web_dir/.git" ]; then
+        echo "WARNING: $web_dir is not a git repository, skipping push"
+        return 0
+    fi
+
+    cd "$web_dir" || { echo "WARNING: Cannot access $web_dir, skipping push"; return 0; }
+
+    set +e
+    git push origin HEAD 2>&1
+    local push_exit=$?
+    set -e
+
+    if [ $push_exit -ne 0 ]; then
+        echo ""
+        echo "WARNING: Push failed with exit code $push_exit"
+        echo "         Results are committed locally but not yet on the remote."
+    else
+        echo ""
+        echo "✓ Successfully pushed results to GitHub Pages"
+    fi
+    echo ""
+}
+
+# Resolve web directory from ini file once, before launching the container.
+INI_FILE="${TARGET}/quokka/regression/quokka-tests.ini"
+WEB_DIR=$(parse_web_dir "$INI_FILE") || WEB_DIR=""
+
 # Check GPU occupancy on the host before launching the container.
 # This avoids false alarms from GPU memory allocated by Singularity's --nv init.
 wait_for_gpu
 
-# 4 hours timeout
+# 4 hours timeout.  Capture the exit code instead of exiting immediately so
+# that we can always attempt to push committed results afterwards.
+set +e
 timeout 14400 singularity exec --nv \
     --bind $TARGET:$TARGET \
     --pwd $TARGET \
     $sif \
     bash quokka2/scripts/bash/run-regression-tests.sh --ini-file ${TARGET}/quokka/regression/quokka-tests.ini \
     --ccache-dir ${TARGET}/ccache --source-dir ${TARGET}/quokka \
-    --skip-gpu-wait \
-    || {
-        rc=$?
-        if [ $rc -eq 124 ]; then
-            echo "ERROR: singularity exec timed out after 4 hours."
-        fi
-        exit $rc
-    }
+    --skip-gpu-wait
+container_rc=$?
+set -e
+
+if [ $container_rc -eq 124 ]; then
+    echo "ERROR: singularity exec timed out after 4 hours."
+fi
+
+# Push whatever was committed inside the container (log, status.json, html).
+# This runs on the host where SSH credentials are available and is reached
+# even when the container timed out, was OOM-killed, or exited with an error.
+if [ -n "$WEB_DIR" ]; then
+    push_results "$WEB_DIR"
+else
+    echo "WARNING: WEB_DIR unknown, skipping git push"
+fi
+
+exit $container_rc
 

--- a/scripts/bash/run-regression-exe.sh
+++ b/scripts/bash/run-regression-exe.sh
@@ -97,6 +97,22 @@ push_results() {
     echo "Pushing results to GitHub Pages (host)"
     echo "=========================================="
 
+    # Validate that web_dir is within the expected base directory.
+    # The path is parsed from quokka-tests.ini which is part of the source tree;
+    # an attacker-controlled PR could point it at a directory containing a
+    # malicious .git/hooks/ or .git/config on the shared volume.
+    local expected_base
+    expected_base="$(realpath "$TARGET")"
+    local resolved_dir
+    resolved_dir="$(realpath "$web_dir" 2>/dev/null)" || {
+        echo "WARNING: Cannot resolve $web_dir, skipping push"
+        return 0
+    }
+    if [[ "$resolved_dir" != "$expected_base"* ]]; then
+        echo "WARNING: web_dir '$resolved_dir' is outside expected base '$expected_base', skipping push"
+        return 0
+    fi
+
     if [ ! -d "$web_dir/.git" ]; then
         echo "WARNING: $web_dir is not a git repository, skipping push"
         return 0
@@ -105,7 +121,12 @@ push_results() {
     cd "$web_dir" || { echo "WARNING: Cannot access $web_dir, skipping push"; return 0; }
 
     set +e
-    git -c core.hooksPath=/dev/null -c core.sshCommand=ssh push origin HEAD 2>&1
+    # Disable hooks and override sshCommand to prevent execution of anything
+    # written into .git/ by the container (e.g. a malicious pre-push hook or
+    # core.sshCommand in .git/config planted via a PR that changes webTopDir).
+    git -c core.hooksPath=/dev/null \
+        -c core.sshCommand=ssh \
+        push origin HEAD 2>&1
     local push_exit=$?
     set -e
 

--- a/scripts/bash/run-regression-exe.sh
+++ b/scripts/bash/run-regression-exe.sh
@@ -105,7 +105,7 @@ push_results() {
     cd "$web_dir" || { echo "WARNING: Cannot access $web_dir, skipping push"; return 0; }
 
     set +e
-    git push origin HEAD 2>&1
+    git -c core.hooksPath=/dev/null -c core.sshCommand=ssh push origin HEAD 2>&1
     local push_exit=$?
     set -e
 

--- a/scripts/bash/run-regression-tests.sh
+++ b/scripts/bash/run-regression-tests.sh
@@ -357,7 +357,11 @@ EOF
 }
 
 #######################################
-# Publish results to GitHub Pages
+# Commit results to local git repo.
+# The actual 'git push' is performed by the host-side script
+# (run-regression-exe.sh) AFTER the container exits, so that:
+#   - host SSH credentials are used, and
+#   - results are pushed even if the container timed out or was killed.
 # Arguments:
 #   $1 - status string
 #######################################
@@ -365,7 +369,7 @@ publish_results() {
 	local status=$1
 
 	echo "=========================================="
-	echo "Publishing results to GitHub Pages"
+	echo "Committing results to local git repo"
 	echo "=========================================="
 
 	# Change to web directory
@@ -377,7 +381,7 @@ publish_results() {
 	# Check if this is a git repository
 	if [ ! -d .git ]; then
 		echo "ERROR: $WEB_DIR is not a git repository"
-		echo "       Cannot publish results without git repository"
+		echo "       Cannot commit results without git repository"
 		return 1
 	fi
 
@@ -392,7 +396,7 @@ publish_results() {
 
 	# Check if there are changes to commit
 	if git diff --staged --quiet; then
-		echo "No changes to commit, skipping push"
+		echo "No changes to commit"
 		return 0
 	fi
 
@@ -411,23 +415,8 @@ publish_results() {
 		-c user.email="quokka-ci-bot@quokka.dev" \
 		commit --no-verify -m "$commit_msg"
 
-	# Push to remote (origin HEAD = current branch)
 	echo ""
-	echo "Pushing to remote..."
-	set +e
-	git push origin HEAD 2>&1
-	local push_exit=$?
-	set -e
-
-	if [ $push_exit -ne 0 ]; then
-		echo ""
-		echo "WARNING: Push failed with exit code $push_exit"
-		echo "         Continuing anyway (results are committed locally)"
-		return 0
-	fi
-
-	echo ""
-	echo "✓ Successfully published results to GitHub Pages"
+	echo "✓ Results committed locally (git push will be performed by host)"
 	return 0
 }
 

--- a/scripts/bash/run-regression-tests.sh
+++ b/scripts/bash/run-regression-tests.sh
@@ -195,6 +195,10 @@ run_regression_tests() {
 	echo "Running regression tests"
 	echo "=========================================="
 
+  # uncomment to dry-run
+  #echo Dry run
+  #return 0
+
 	local exit_code=0
 	local log_file="$WEB_DIR/regression-run.log"
 
@@ -208,11 +212,13 @@ run_regression_tests() {
 
 	# Run regtest.py, capturing both stdout and stderr to log file
 	# Don't exit on failure - we want to always publish results
+	# Note: do NOT restore set -e here; the script header uses set -uo pipefail
+	# (not set -e), so calling set -e would globally enable it and cause the
+	# non-zero return below to abort the script before publish_results runs.
 	set +e
 	./extern/regression_testing/regtest.py --clean_testdir "$INI_FILE" \
 		> "$log_file" 2>&1
 	exit_code=$?
-	set -e
 
 	echo ""
 	echo "Regression tests completed with exit code: $exit_code"


### PR DESCRIPTION
### Description

Changes:
- move `push_results` to outside of container
- removed a `set -e` so that `publish_results` will run even if the regression test failed. 

### Related issues
This should fix the regression test results push issue.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
