### PR TITLE
Guard against FPE in convergence rate estimate

### DIFF
--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,7 +260,7 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		const double epsilon = delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ); // normalized amplitude
+		double epsilon = delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ); // normalized amplitude (undefined if sinθ=0; overridden below)
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 
@@ -278,6 +278,7 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 				amrex::Warning(
 				    "Warning: angle between k and B0 is 0 or 180 deg. Fast wave reduces to pure sound wave with no magnetic perturbation.");
 			}
+			epsilon = delta_b_magn / b0_magn; // density/pressure perturbation amplitude (sinθ=0 case)
 			v1_mrf = -delta_b_magn / b0_magn * cf * cos_phase; // velocity along k̂ (parallel component)
 			v2_mrf = 0.0;					   // perpendicular velocity suppressed
 			delta_B2 = 0.0;					   // no transverse magnetic perturbation

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,8 +260,9 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = (std::abs(sinθ) < tiny) ? (delta_b_magn / b0_magn)
-							     : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
+		double epsilon = (std::abs(sinθ) < tiny)
+				     ? (delta_b_magn / b0_magn)
+				     : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,7 +260,8 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ); // normalized amplitude (undefined if sinθ=0; overridden below)
+		double epsilon = (std::abs(sinθ) < tiny) ? (delta_b_magn / b0_magn)
+							     : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 
@@ -278,7 +279,6 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 				amrex::Warning(
 				    "Warning: angle between k and B0 is 0 or 180 deg. Fast wave reduces to pure sound wave with no magnetic perturbation.");
 			}
-			epsilon = delta_b_magn / b0_magn; // density/pressure perturbation amplitude (sinθ=0 case)
 			v1_mrf = -delta_b_magn / b0_magn * cf * cos_phase; // velocity along k̂ (parallel component)
 			v2_mrf = 0.0;					   // perpendicular velocity suppressed
 			delta_B2 = 0.0;					   // no transverse magnetic perturbation

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,7 +260,8 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ); // normalized amplitude (undefined if sinθ=0; overridden below)
+		double epsilon = delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) /
+				 (cf * cf * sinθ); // normalized amplitude (undefined if sinθ=0; overridden below)
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 
@@ -278,7 +279,7 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 				amrex::Warning(
 				    "Warning: angle between k and B0 is 0 or 180 deg. Fast wave reduces to pure sound wave with no magnetic perturbation.");
 			}
-			epsilon = delta_b_magn / b0_magn; // density/pressure perturbation amplitude (sinθ=0 case)
+			epsilon = delta_b_magn / b0_magn;		   // density/pressure perturbation amplitude (sinθ=0 case)
 			v1_mrf = -delta_b_magn / b0_magn * cf * cos_phase; // velocity along k̂ (parallel component)
 			v2_mrf = 0.0;					   // perpendicular velocity suppressed
 			delta_B2 = 0.0;					   // no transverse magnetic perturbation

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,7 +260,9 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		const double epsilon = (std::abs(sinθ) < tiny) ? (delta_b_magn / b0_magn) : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
+		const double epsilon = (std::abs(sinθ) < tiny)
+					   ? (delta_b_magn / b0_magn)
+					   : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -260,9 +260,7 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cf * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = (std::abs(sinθ) < tiny)
-				     ? (delta_b_magn / b0_magn)
-				     : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
+		const double epsilon = (std::abs(sinθ) < tiny) ? (delta_b_magn / b0_magn) : (delta_b_magn / b0_magn * (cf * cf - vA * vA * cosθ * cosθ) / (cf * cf * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -261,8 +261,8 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cs * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = (std::abs(sinθ) < tiny) ? 0.0
-							     : (delta_b_magn / b0_magn * (cs * cs - vA * vA * cosθ * cosθ) / (cs * cs * sinθ)); // normalized amplitude
+		double epsilon =
+		    (std::abs(sinθ) < tiny) ? 0.0 : (delta_b_magn / b0_magn * (cs * cs - vA * vA * cosθ * cosθ) / (cs * cs * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -261,7 +261,8 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double omega = cs * k_magn;
 		const double phase = omega * time - k_magn * x_vec_mrf_C[0];
 		const double cos_phase = std::cos(phase);
-		double epsilon = delta_b_magn / b0_magn * (cs * cs - vA * vA * cosθ * cosθ) / (cs * cs * sinθ); // normalized amplitude
+		double epsilon = (std::abs(sinθ) < tiny) ? 0.0
+							     : (delta_b_magn / b0_magn * (cs * cs - vA * vA * cosθ * cosθ) / (cs * cs * sinθ)); // normalized amplitude
 		const double B0_1 = b0_magn * cosθ;
 		const double B0_2 = b0_magn * sinθ;
 

--- a/src/util/richardson.hpp
+++ b/src/util/richardson.hpp
@@ -109,6 +109,10 @@ template <typename Callable> auto run(const Parameters &params, Callable &&runTe
 	if (resolutions.size() >= 2) {
 		if (!std::isfinite(errors[0]) || !std::isfinite(errors.back()) || errors.back() <= 0.0 || errors[0] <= 0.0) {
 			amrex::Print() << "\nOverall convergence rate: N/A (non-positive or non-finite errors)\n";
+			amrex::Print() << "Problematic values:\n";
+			for (int i = 0; i < resolutions.size(); ++i) {
+				amrex::Print() << std::format("  nx={:4d}  error={:.6e}\n", resolutions[i], errors[i]);
+			}
 		} else {
 			double const overall_log_error_ratio = std::log(errors[0] / errors.back());
 			double const overall_log_dx_ratio = std::log(dx_values[0] / dx_values.back());

--- a/src/util/richardson.hpp
+++ b/src/util/richardson.hpp
@@ -90,6 +90,11 @@ template <typename Callable> auto run(const Parameters &params, Callable &&runTe
 	bool convergence_passed = true;
 
 	for (int i = 1; i < resolutions.size(); ++i) {
+		if (!std::isfinite(errors[i - 1]) || !std::isfinite(errors[i]) || errors[i] <= 0.0 || errors[i - 1] <= 0.0) {
+			amrex::Print() << std::format("{:4d} -> {:4d}\t{:>13}\t{:13.1f}\n", resolutions[i - 1], resolutions[i], "N/A", params.expected_rate);
+			convergence_passed = false;
+			continue;
+		}
 		double const log_error_ratio = std::log(errors[i - 1] / errors[i]);
 		double const log_dx_ratio = std::log(dx_values[i - 1] / dx_values[i]);
 		double const observed_rate = log_error_ratio / log_dx_ratio;
@@ -102,15 +107,19 @@ template <typename Callable> auto run(const Parameters &params, Callable &&runTe
 	}
 
 	if (resolutions.size() >= 2) {
-		double const overall_log_error_ratio = std::log(errors[0] / errors.back());
-		double const overall_log_dx_ratio = std::log(dx_values[0] / dx_values.back());
-		double const overall_rate = overall_log_error_ratio / overall_log_dx_ratio;
+		if (!std::isfinite(errors[0]) || !std::isfinite(errors.back()) || errors.back() <= 0.0 || errors[0] <= 0.0) {
+			amrex::Print() << "\nOverall convergence rate: N/A (non-positive or non-finite errors)\n";
+		} else {
+			double const overall_log_error_ratio = std::log(errors[0] / errors.back());
+			double const overall_log_dx_ratio = std::log(dx_values[0] / dx_values.back());
+			double const overall_rate = overall_log_error_ratio / overall_log_dx_ratio;
 
-		amrex::Print() << std::format("\nOverall convergence rate: {:.2f}\n", overall_rate);
-		amrex::Print() << std::format("Expected rate: {:.1f}\n", params.expected_rate);
+			amrex::Print() << std::format("\nOverall convergence rate: {:.2f}\n", overall_rate);
+			amrex::Print() << std::format("Expected rate: {:.1f}\n", params.expected_rate);
 
-		if (overall_rate + params.tolerance < params.expected_rate) {
-			convergence_passed = false;
+			if (overall_rate + params.tolerance < params.expected_rate) {
+				convergence_passed = false;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description
This PR fixes a bug that leads to the "Erroneous arithmetic operation" (SIGFPE) crash in the MHD convergence tests when run with canary. Two root causes are fixed here: (1) `src/util/richardson.hpp` computed `std::log(errors[i-1] / errors[i])` without guarding against zero, negative, or non-finite error norms -- a zero error norm causes an FE_DIVBYZERO trap; guards using `std::isfinite` and positivity checks are now applied before all log ratio computations, with "N/A" printed and the test marked failed in degenerate cases. (2) `src/problems/FastWaveConvergence/testFastWaveConvergence.cpp` unconditionally computed `epsilon` via division by `sinθ`, which is undefined when sinθ = 0; `epsilon` is now reassigned to a safe value inside the existing `sinθ < tiny` branch.

### Related issues
#1721

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
