### PR TITLE
Add git worktree support to `run-cuda-container.sh`

### DIFF
--- a/scripts/bash/run-cuda-container.sh
+++ b/scripts/bash/run-cuda-container.sh
@@ -55,7 +55,7 @@ TARGETS=""
 
 # Detect repository root
 # Use git to find the worktree root (works for both regular repos and git worktrees)
-REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)"
+REPO_ROOT="$(git -c core.hooksPath=/dev/null rev-parse --show-toplevel 2>/dev/null)"
 
 if [[ -z "$REPO_ROOT" ]]; then
 	echo "Error: Could not find Quokka repository root (.git directory)"

--- a/scripts/bash/run-cuda-container.sh
+++ b/scripts/bash/run-cuda-container.sh
@@ -54,16 +54,8 @@ RUN_TESTS=false
 TARGETS=""
 
 # Detect repository root
-# Try to find .git directory by walking up from current directory
-REPO_ROOT=""
-CURRENT_DIR="$(pwd)"
-while [[ "$CURRENT_DIR" != "/" ]]; do
-	if [[ -d "$CURRENT_DIR/.git" ]]; then
-		REPO_ROOT="$CURRENT_DIR"
-		break
-	fi
-	CURRENT_DIR="$(dirname "$CURRENT_DIR")"
-done
+# Use git to find the worktree root (works for both regular repos and git worktrees)
+REPO_ROOT="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)"
 
 if [[ -z "$REPO_ROOT" ]]; then
 	echo "Error: Could not find Quokka repository root (.git directory)"
@@ -100,8 +92,9 @@ else
 	IMAGE_NAME="ghcr.io/quokka-astro/quokka-linux-amd64-cuda:development"
 fi
 
-# Set container name
-CONTAINER_NAME="quokka-${ARCH}-cuda-container"
+# Set container name (include worktree name so each worktree gets its own container with the correct mount)
+WORKTREE_NAME="$(basename "$REPO_ROOT")"
+CONTAINER_NAME="quokka-${ARCH}-cuda-${WORKTREE_NAME}"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do

--- a/scripts/bash/run-cuda-container.sh
+++ b/scripts/bash/run-cuda-container.sh
@@ -93,7 +93,7 @@ else
 fi
 
 # Set container name (include worktree name so each worktree gets its own container with the correct mount)
-WORKTREE_NAME="$(basename "$REPO_ROOT")"
+WORKTREE_NAME="$(basename "$REPO_ROOT" | tr -cs 'a-zA-Z0-9_.-' '_')"
 CONTAINER_NAME="quokka-${ARCH}-cuda-${WORKTREE_NAME}"
 
 # Parse command line arguments


### PR DESCRIPTION
### Description

`scripts/bash/run-cuda-container.sh` now works correctly when run from git worktrees with different basenames (e.g. `quokka`, `quokka2`).

Two changes were made:

- **Worktree-aware root detection**: Replace the manual `.git` directory walk with `git rev-parse --show-toplevel`, which correctly identifies the root of the current worktree.
- **Per-worktree containers**: Container names now include `basename "$REPO_ROOT"` (e.g. `quokka-amd64-cuda-quokka2`), so each worktree gets its own container with the correct volume mount. Multiple worktrees can build independently without interfering with each other.


### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
