### PR TITLE
Add documentation for sink particles

### DIFF
--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -88,7 +88,7 @@ r_{\text{acc}} / 2 & r_{\text{BH}} > r_{\text{acc}} / 2.
 \end{cases}
 $$
 
-The accretion rate deposited in each cell is $\dot{M} \, w_i / \sum_i w_i$. Optionally, a uniform kernel ($w = 1$ for all cells in the $(7 \Delta x)^3$ stencil) can be used for testing by setting `particles.sink_particle_use_uniform_kernel = 1`.
+The accretion rate deposited in each cell is $-\dot{M} \, w_i / \sum_i w_i$ (negative means accreting). Optionally, a uniform kernel ($w = 1$ for all cells in the $(7 \Delta x)^3$ stencil) can be used for testing by setting `particles.sink_particle_use_uniform_kernel = 1`.
 
 ### Accretion limiters
 

--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -43,7 +43,7 @@ The particle inherits the gas velocity of the parent cell. The cell density is t
 
 ### Practical considerations
 
-- The local maximum check uses a strict inequality ($\rho_{\text{cell}} > \rho_{\text{neighbor}}$), so ties do not prevent formation. In practice, exact density ties only occur in artificial initial conditions.
+- The local maximum check uses a non-strict inequality ($\rho_{\text{cell}} \ge \rho_{\text{neighbor}}$), so ties do not prevent formation. In practice, exact density ties only occur in artificial initial conditions.
 - Sink formation is applied after sink accretion in each timestep, so newly formed particles do not overlap with existing accretion zones.
 
 ## Sink Particle Accretion

--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -43,7 +43,7 @@ The particle inherits the gas velocity of the parent cell. The cell density is t
 
 ### Practical considerations
 
-- The local maximum check uses a strict inequality ($\rho_{\text{neighbor}} > \rho_{\text{cell}}$), so ties do not prevent formation. In practice, exact density ties only occur in artificial initial conditions.
+- The local maximum check uses a strict inequality ($\rho_{\text{cell}} > \rho_{\text{neighbor}}$), so ties do not prevent formation. In practice, exact density ties only occur in artificial initial conditions.
 - Sink formation is applied after sink accretion in each timestep, so newly formed particles do not overlap with existing accretion zones.
 
 ## Sink Particle Accretion
@@ -60,7 +60,7 @@ $$
 r_{\text{BH}} = \frac{G M}{v_\infty^2 + c_{f,\infty}^2},
 $$
 
-where $M$ is the particle mass, $v_\infty$ is the gas velocity relative to the particle (mass-weighted mean over the accretion zone), and $c_{f,\infty}$ is the fast magnetosonic speed (mass-weighted mean over the accretion zone). For MHD, $c_f^2 = c_s^2 (1 + 2/\beta)$; for non-MHD, $c_f = c_s$.
+where $M$ is the particle mass, $v_\infty$ is the gas velocity relative to the particle (mass-weighted mean over the accretion zone), and $c_{f,\infty}$ is the fast magnetosonic speed. We take the upper bound of the fast speed (when the wave propagates perpendicular to the magnetic field): $c_f^2 = c_s^2 + v_A^2 = c_s^2 (1 + 2/\beta)$. For non-MHD, this reduces to $c_f = c_s$.
 
 The accretion rate is
 
@@ -168,7 +168,7 @@ The star formation module adds star particles through a stochastic prescription 
 
 Eligible cells are first identified through a Jeans-length check before any stochastic sampling occurs.
 
-- Compute the Jeans density $\rho_J = J^2 \pi c_{\text{eff}}^2 / (G \Delta x^2)$, where $J = 0.25$ is the Jeans number and $c_{\text{eff}} = c_s \sqrt{1 + 0.74 / \beta}$ is the effective sound speed, accounting for thermal pressure and magnetic pressure with $\beta = P_{\text{thermal}} / P_{\text{magnetic}}$.
+- Compute the Jeans density $\rho_J = J^2 \pi c_{\text{eff}}^2 / (G \Delta x^2)$, where $J = 0.25$ is the Jeans number and $c_{\text{eff}} = c_s \sqrt{1 + 0.74 / \beta}$ is the effective sound speed, accounting for thermal pressure and magnetic pressure with $\beta = P_{\text{thermal}} / P_{\text{magnetic}}$ (Mouschovias & Spitzer, 1976, ApJ, 210, 326; see also Myers et al, 2013, ApJ, 766, 97).
 - Mark the cell as eligible when $\rho > \rho_J$.
 - Only eligible cells continue to the sampling steps below.
 

--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -1,23 +1,5 @@
 # Particles, star formation and feedback
 
-## StochasticStellarPop Particle Type
-
-StochasticStellarPop particles carry the following real-valued attributes:
-
-- **Mass**: Current particle mass ($M_{\star}$)
-- **Velocity**: Three-dimensional velocity vector $(v_x, v_y, v_z)$
-- **Birth time**: Simulation time when the particle formed
-- **Death time**: When the particle explodes as a supernova
-- **Mass at birth**: Initial mass before mass loss
-- **Luminosity**: Radiation luminosity (if radiation is enabled)
-
-Each particle also stores an integer **evolution stage** that tracks its lifecycle:
-
-- `SNProgenitor`: High-mass star ($M > 8 M_{\odot}$) that will explode as a supernova
-- `SNRemnant`: Compact remnant left after supernova explosion
-- `LowMassStar`: Low-mass star that will not explode (not used in the current star formation implementation)
-- `LowMassComposite`: Composite particle representing a population of low-mass stars
-
 ## Sink Particle Type
 
 Sink particles carry the following real-valued attributes:
@@ -153,6 +135,24 @@ The `ParticleSink` test validates Bondi-Hoyle accretion and Galilean invariance.
 1. **Base simulation**: Runs with zero boost velocity and validates the density profile against an analytical solution.
 2. **Boosted simulation**: Runs with a boost velocity of $10^8$ cm/s and verifies that the density profile matches the analytical solution, demonstrating Galilean invariance.
 3. **Multi-timestep evolution**: Continues the boosted simulation for additional timesteps and validates total mass conservation to machine precision.
+
+## StochasticStellarPop Particle Type
+
+StochasticStellarPop particles carry the following real-valued attributes:
+
+- **Mass**: Current particle mass ($M_{\star}$)
+- **Velocity**: Three-dimensional velocity vector $(v_x, v_y, v_z)$
+- **Birth time**: Simulation time when the particle formed
+- **Death time**: When the particle explodes as a supernova
+- **Mass at birth**: Initial mass before mass loss
+- **Luminosity**: Radiation luminosity (if radiation is enabled)
+
+Each particle also stores an integer **evolution stage** that tracks its lifecycle:
+
+- `SNProgenitor`: High-mass star ($M > 8 M_{\odot}$) that will explode as a supernova
+- `SNRemnant`: Compact remnant left after supernova explosion
+- `LowMassStar`: Low-mass star that will not explode (not used in the current star formation implementation)
+- `LowMassComposite`: Composite particle representing a population of low-mass stars
 
 ## Star Formation
 

--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -18,6 +18,142 @@ Each particle also stores an integer **evolution stage** that tracks its lifecyc
 - `LowMassStar`: Low-mass star that will not explode (not used in the current star formation implementation)
 - `LowMassComposite`: Composite particle representing a population of low-mass stars
 
+## Sink Particle Type
+
+Sink particles carry the following real-valued attributes:
+
+- **Mass**: Current particle mass ($M$)
+- **Velocity**: Three-dimensional velocity vector $(v_x, v_y, v_z)$
+
+Unlike StochasticStellarPop particles, sink particles have no evolution stage or birth/death metadata. They represent unresolved gravitationally-collapsed objects that accrete mass from the surrounding gas.
+
+## Sink Particle Formation
+
+### Overview
+
+The sink formation module creates sink particles from gas cells that violate the Jeans criterion (Truelove et al. 1997). The algorithm is operator-split from the hydrodynamics and runs once per hydro timestep at the finest AMR level.
+
+### Formation criteria
+
+A sink particle is created in a cell if **all** of the following conditions are met:
+
+1. **Jeans instability**: The cell density exceeds the local Jeans density,
+
+$$
+\rho > \rho_J = J^2 \frac{\pi c_{\text{eff}}^2}{G \Delta x^2},
+$$
+
+where $J = 0.25$ is the Jeans number and $c_{\text{eff}} = c_s \sqrt{1 + 0.74 / \beta}$ is the effective sound speed accounting for magnetic pressure support ($\beta = P_{\text{thermal}} / P_{\text{magnetic}}$). For non-MHD simulations, $\beta \to \infty$ and $c_{\text{eff}} = c_s$.
+
+2. **Not in an existing accretion zone**: The cell is not already being accreted by an existing sink particle (i.e., the accretion rate in the cell is zero).
+
+3. **Local density maximum**: The cell has the highest density among all cells within a sphere of radius $3 \Delta x$. This prevents multiple sink particles from forming in close proximity.
+
+### Mass and momentum assignment
+
+When a sink particle forms, it receives the excess mass above the Jeans density:
+
+$$
+m_{\text{particle}} = (\rho - \rho_J) \, \Delta x^3
+$$
+
+The particle inherits the gas velocity of the parent cell. The cell density is then set to $\rho_J$, and all conserved quantities (momentum, energy, internal energy) are scaled by the factor $\rho_J / \rho$.
+
+### Practical considerations
+
+- The local maximum check uses a strict inequality ($\rho_{\text{neighbor}} > \rho_{\text{cell}}$), so ties do not prevent formation. In practice, exact density ties only occur in artificial initial conditions.
+- Sink formation is applied after sink accretion in each timestep, so newly formed particles do not overlap with existing accretion zones.
+
+## Sink Particle Accretion
+
+### Overview
+
+Sink particle accretion follows the Bondi-Hoyle-Lyttleton prescription of Krumholz et al. (2004). Gas is removed from cells surrounding each sink particle and added to the particle's mass, with the accretion rate set by the local gas properties and the particle mass.
+
+### Accretion rate
+
+The Bondi-Hoyle radius is
+
+$$
+r_{\text{BH}} = \frac{G M}{v_\infty^2 + c_{f,\infty}^2},
+$$
+
+where $M$ is the particle mass, $v_\infty$ is the gas velocity relative to the particle (mass-weighted mean over the accretion zone), and $c_{f,\infty}$ is the fast magnetosonic speed (mass-weighted mean over the accretion zone). For MHD, $c_f^2 = c_s^2 (1 + 2/\beta)$; for non-MHD, $c_f = c_s$.
+
+The accretion rate is
+
+$$
+\dot{M} = 4 \pi \rho_\infty r_{\text{BH}}^2 \sqrt{v_\infty^2 + \lambda^2 c_{f,\infty}^2},
+$$
+
+where $\rho_\infty$ is the mean gas density in the accretion zone and $\lambda = e^{3/2}/4$.
+
+### Accretion kernel
+
+The accretion zone is a sphere of radius $r_{\text{acc}} = 3 \Delta x$ centered on the particle. Within this zone, each cell receives a Gaussian weight:
+
+$$
+w = \exp\left(-r^2 / r_K^2\right),
+$$
+
+where $r$ is the distance from the particle to the cell centre. The kernel radius $r_K$ is resolution-adaptive:
+
+$$
+r_K = \begin{cases}
+\Delta x / 4 & r_{\text{BH}} < \Delta x / 4, \\
+r_{\text{BH}} & \Delta x / 4 \leq r_{\text{BH}} \leq r_{\text{acc}} / 2, \\
+r_{\text{acc}} / 2 & r_{\text{BH}} > r_{\text{acc}} / 2.
+\end{cases}
+$$
+
+The accretion rate deposited in each cell is $\dot{M} \, w_i / \sum_i w_i$. Optionally, a uniform kernel ($w = 1$ for all cells in the $(7 \Delta x)^3$ stencil) can be used for testing by setting `particles.sink_particle_use_uniform_kernel = 1`.
+
+### Accretion limiters
+
+Two corrections are applied to the per-cell accretion rate, in the following order:
+
+1. **Mass removal cap**: No more than 25% of a cell's mass may be removed in a single timestep (Krumholz et al. 2004). This prevents artificial sound waves from being launched by rapid density changes.
+
+2. **Jeans density floor**: If the post-accretion cell density would still exceed the Jeans density $\rho_J$, the accretion rate is increased so that the final density equals $\rho_J$. This is safe because such cells are at the centre of highly supersonic convergence and are causally disconnected from their surroundings.
+
+### Momentum accretion
+
+When gas is accreted, the particle gains both mass and momentum. The new particle velocity is computed from momentum conservation:
+
+$$
+\vec{v}_{\text{new}} = \frac{m_{\text{old}} \vec{v}_{\text{old}} + \Delta m \, \vec{v}_{\text{gas}}}{m_{\text{old}} + \Delta m},
+$$
+
+where $\Delta m$ is the total accreted mass and $\vec{v}_{\text{gas}}$ is the mass-weighted gas velocity over the accreted cells. The gas state is then updated by scaling all conserved quantities by $(1 + \dot{M}_{\text{cell}} \Delta t / (\rho V))$, which preserves the gas velocity field.
+
+### Galilean invariance
+
+The accretion rate is computed using gas velocities in the particle frame ($\vec{v}_\infty = \vec{v}_{\text{gas}} - \vec{v}_{\text{particle}}$), ensuring Galilean invariance.
+
+### Runtime Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `particles.sink_particle_use_uniform_kernel` | Boolean | `0` | Use uniform accretion kernel (for testing) |
+
+### Examples
+
+#### ParticleSinkFormation Test
+
+The `ParticleSinkFormation` test validates combined sink particle formation and accretion. The test checks:
+
+1. Exactly one star forms in the first timestep.
+2. Mass is conserved to machine precision during sink formation.
+3. Mass is conserved to machine precision during sink accretion.
+
+#### ParticleSink Test
+
+The `ParticleSink` test validates Bondi-Hoyle accretion and Galilean invariance. It runs in three phases:
+
+1. **Base simulation**: Runs with zero boost velocity and validates the density profile against an analytical solution.
+2. **Boosted simulation**: Runs with a boost velocity of $10^8$ cm/s and verifies that the density profile matches the analytical solution, demonstrating Galilean invariance.
+3. **Multi-timestep evolution**: Continues the boosted simulation for additional timesteps and validates total mass conservation to machine precision.
+
 ## Star Formation
 
 ### Overview


### PR DESCRIPTION
### Description
Sink formation and accretion is missing from the documentation. This PR adds it. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
