### PR TITLE
Modularize particle accretion

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -55,13 +55,14 @@ class PhysicsParticleDescriptorBase
 
 	int massAtBirthIndex_{-1};     // Index for particle mass at birth (-1 if not used)
 	bool forceFinestLevel_{false}; // Whether particles are forced to live in the finest level
+	int mdotIndex_{-1};	       // Index for accretion rate (-1 if not used)
 
       public:
 	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, int death_time_idx, bool allows_creation, bool allows_destruction = false,
-				      int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1)
+				      int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1, int mdot_idx = -1)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), deathTimeIndex_(death_time_idx), allowsCreation_(allows_creation),
 	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx), allowsAccretion_(allows_accretion),
-	      massAtBirthIndex_(mass_at_birth_idx)
+	      massAtBirthIndex_(mass_at_birth_idx), mdotIndex_(mdot_idx)
 	{
 	}
 
@@ -84,10 +85,9 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getAllowsAccretion() const -> bool { return allowsAccretion_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getMassAtBirthIndex() const -> int { return massAtBirthIndex_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getForceFinestLevel() const -> bool { return forceFinestLevel_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto getMdotIndex() const -> int { return mdotIndex_; }
 
 	// setter methods for particle properties
-	AMREX_FORCE_INLINE void setEvolutionStageIndex(int evolution_stage_idx) { evolutionStageIndex_ = evolution_stage_idx; }
-	AMREX_FORCE_INLINE void setAllowsAccretion(bool allows_accretion) { allowsAccretion_ = allows_accretion; }
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
 
 	// New method to get particle positions and data
@@ -175,7 +175,7 @@ class PhysicsParticleDescriptorBase
 	}
 
 	// Update particle properties (e.g., luminosity) based on current state
-	virtual void updateParticleProperties(amrex::Real current_time) { /* Default empty implementation */ }
+	virtual void updateParticleProperties(amrex::Real current_time, Real dt) { /* Default empty implementation */ }
 #endif // AMREX_SPACEDIM == 3
 };
 
@@ -194,9 +194,10 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, int death_time_idx, bool allows_creation,
-				  bool allows_destruction = false, int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1)
+				  bool allows_destruction = false, int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1,
+				  int mdot_idx = -1)
 	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, death_time_idx, allows_creation, allows_destruction, evolution_stage_idx,
-					    allows_accretion, mass_at_birth_idx),
+					    allows_accretion, mass_at_birth_idx, mdot_idx),
 	      container_(container)
 	{
 	}
@@ -664,9 +665,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	}
 
 	// Delegate particle property update to the traits class
-	void updateParticleProperties(amrex::Real current_time) override
+	void updateParticleProperties(amrex::Real current_time, amrex::Real dt) override
 	{
-		ParticlePropertyUpdateTraits<particleType>::template updateParticleProperties<problem_t, ContainerType>(this->container_, current_time);
+		ParticlePropertyUpdateTraits<particleType>::template updateParticleProperties<problem_t, ContainerType>(this->container_, current_time, dt);
 	}
 
 	// Implementation of supernova energy and momentum deposition from particles to grid
@@ -711,7 +712,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				const amrex::Geometry &geom, int lev, amrex::Real time, amrex::Real dt) override
 	{
 		SinkAccretionUtils::applyAccretion<ContainerType, problem_t>(this->container_, state, state_accretion_rate, state_fc, geom, lev, time, dt,
-									     this->getMassIndex());
+									     this->getMassIndex(), this->getMdotIndex());
 	}
 
 	void createParticlesFromState(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, int lev, amrex::Real current_time, amrex::Real dt,
@@ -805,7 +806,7 @@ template <typename problem_t> class PhysicsParticleRegister
 
 		// Create the appropriate descriptor based on the particle type
 		// The parameters for the descriptor are: mass_idx, lum_idx, birth_time_idx, death_time_idx, allows_creation, allows_destruction,
-		// evolution_stage_idx, allows_accretion
+		// evolution_stage_idx, allows_accretion, mass_at_birth_idx, mdot_idx
 		if constexpr (particleType == ParticleType::Rad) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Rad>>(
 			    container, -1, RadParticleLumIdx, RadParticleBirthTimeIdx, RadParticleDeathTimeIdx, false, false);
@@ -824,7 +825,7 @@ template <typename problem_t> class PhysicsParticleRegister
 			    StochasticStellarPopParticleMassAtBirthIdx);
 		} else if constexpr (particleType == ParticleType::Sink) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Sink>>(
-			    container, SinkParticleMassIdx, -1, -1, -1, true, false, -1, true);
+			    container, SinkParticleMassIdx, -1, -1, -1, true, false, -1, true, -1, SinkParticleMdotIdx);
 		} else if constexpr (particleType == ParticleType::Test) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    container, TestParticleMassIdx, TestParticleLumIdx, TestParticleBirthTimeIdx, TestParticleDeathTimeIdx, true, true,
@@ -1076,11 +1077,11 @@ template <typename problem_t> class PhysicsParticleRegister
 	}
 
 	// Update particle properties for all registered particles
-	void updateParticleProperties(amrex::Real current_time)
+	void updateParticleProperties(amrex::Real current_time, amrex::Real dt)
 	{
 		const BL_PROFILE("PhysicsParticleRegister::updateParticleProperties()");
 		for (const auto &[type, descriptor] : particleRegistry_) {
-			descriptor->updateParticleProperties(current_time);
+			descriptor->updateParticleProperties(current_time, dt);
 		}
 	}
 #endif // AMREX_SPACEDIM == 3

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -330,7 +330,7 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					const amrex::Array4<const amrex::Real> &local_scale_down, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &plo,
 					const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx,
 					std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> fab_fc, int mass_index, amrex::Real /*time*/,
-					amrex::Real dt, amrex::Real /*vol*/)
+					amrex::Real dt, amrex::Real /*vol*/, int mdot_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::UpdateParticleMassAndMomentumInBox()");
 	// Get the particle array of structs
@@ -432,12 +432,16 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 		p.rdata(mass_index + 1) = (par_m * p.rdata(mass_index + 1) + accreted_momentum_x) / par_m_new;
 		p.rdata(mass_index + 2) = (par_m * p.rdata(mass_index + 2) + accreted_momentum_y) / par_m_new;
 		p.rdata(mass_index + 3) = (par_m * p.rdata(mass_index + 3) + accreted_momentum_z) / par_m_new;
+		if (mdot_index >= 0) {
+			p.rdata(mdot_index) = accreted_mass / dt;
+		}
 	});
 }
 
 template <typename ContainerType, typename problem_t>
 void UpdateParticleMassAndMomentum(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &scale_down,
-				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc, int lev, int mass_index, amrex::Real time, amrex::Real dt)
+				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc, int lev, int mass_index, amrex::Real time, amrex::Real dt,
+				   int mdot_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::UpdateParticleMassAndMomentum()");
 	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
@@ -461,7 +465,7 @@ void UpdateParticleMassAndMomentum(ContainerType *container, amrex::MultiFab &st
 
 		// Process particles in this box
 		UpdateParticleMassAndMomentumInBox<ContainerType, problem_t>(pti, local_state, local_scale_down, plo, dx, local_fab_fc, mass_index, time, dt,
-									     vol);
+									     vol, mdot_index);
 	}
 }
 
@@ -525,7 +529,7 @@ void computeAccretion(ContainerType *container, amrex::MultiFab &state, amrex::M
 template <typename ContainerType, typename problem_t>
 void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &state_accretion_rate,
 		    std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc, const amrex::Geometry &geom, int lev, amrex::Real time, amrex::Real dt,
-		    int mass_index)
+		    int mass_index, int mdot_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::applyAccretion()");
 	// Step 2: Compute the scale_down factor. We scale down the accretion rate to prevent accretion rates from exceeding 100%
@@ -535,8 +539,8 @@ void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::Mul
 	// Update accretion_rate and compute scale_down
 	ComputeScaleDown<problem_t>(state, state_accretion_rate, scale_down, geom, state_fc);
 
-	// Step 3: Update particle mass and momentum
-	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt);
+	// Step 3: Update particle mass, momentum, and accretion rate
+	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index);
 
 	// Step 4: Update the hydro state. We do this at last because the original state is needed for updating particles in step 3.
 	UpdateHydroState<problem_t>(state, state_accretion_rate);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -3,7 +3,6 @@
 
 #include "AMReX_BLProfiler.H"
 #include "AMReX_BLassert.H"
-#include "gcem.hpp"
 #include "hydro/EOS.hpp"
 #include "hydro/hydro_system.hpp"
 #include "particle_types.hpp"
@@ -196,6 +195,136 @@ template <ParticleType particleType> struct ParticleCreationTraits {
 
 #if AMREX_SPACEDIM == 3
 
+// Helper namespace for Jeans-instability-based (sink-like) particle creation.
+// These helpers are shared between Sink and Star particle creation specializations.
+namespace SinkCreationHelpers
+{
+static constexpr int stencil_size = ParticleUtils::stencil_size;
+
+/// \brief Checks if a cell meets the Jeans instability + local density maximum criterion.
+/// \return 1 if a sink-like particle should be created at (i,j,k), 0 otherwise.
+template <typename problem_t>
+AMREX_GPU_DEVICE inline auto checkSinkCreation(amrex::Array4<const amrex::Real> const &state_arr, amrex::Array4<const amrex::Real> const &accretion_rate_arr,
+					       int i, int j, int k, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					       std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc) -> int
+{
+	const double dx_max = std::max({dx[0], dx[1], dx[2]});
+
+	// Determine sound speed.
+	const Real cs = HydroSystem<problem_t>::ComputeIsothermalSoundSpeed(state_arr, i, j, k, fab_fc);
+	// Compute plasma beta for MHD-aware Jeans density (returns inf for non-MHD)
+	const double plasma_beta = HydroSystem<problem_t>::ComputePlasmaBeta(state_arr, i, j, k, fab_fc);
+
+	// Jeans density with MHD correction:
+	//   rho_J = J^2 * pi * cs_eff^2 / (G * dx^2)
+	//   cs_eff^2 = cs^2 * (1 + 0.74/beta)
+	// (For non-MHD, beta=inf, so cs_eff^2 = cs^2)
+	const auto rho_J = ParticleUtils::computeJeansDensity(cs, dx_max, plasma_beta);
+	const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
+	const double accretion_rate_cell = accretion_rate_arr(i, j, k);
+
+	// Only form a particle if:
+	// 1. Cell density is above Jeans density
+	// 2. Cell accretion rate (a non-positive number) is zero
+	// 3. Cell density is the local maximum density
+	if (cell_density > rho_J && accretion_rate_cell >= 0.0) {
+		bool is_local_maximum = true;
+		for (int di = -3; di <= 3 && is_local_maximum; ++di) {
+			for (int dj = -3; dj <= 3 && is_local_maximum; ++dj) {
+				for (int dk = -3; dk <= 3 && is_local_maximum; ++dk) {
+					// Skip the center cell
+					if (di == 0 && dj == 0 && dk == 0) {
+						continue;
+					}
+					// Only check cells within spherical radius of 3
+					// A small epsilon is added to the right hand side to ensure both (i - stencil_size) and (i +
+					// stencil_size) are included
+					if (di * di + dj * dj + dk * dk <= static_cast<Real>(stencil_size * stencil_size) + 1.0e-10) {
+						const Real rho_ijk = state_arr(i + di, j + dj, k + dk, HydroSystem<problem_t>::density_index);
+						if (rho_ijk > cell_density) {
+							is_local_maximum = false;
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		if (is_local_maximum) {
+			return 1;
+		}
+	}
+	return 0;
+}
+
+/// \brief Initializes sink-like particle properties and updates the cell state.
+///
+/// Sets particle position (cell center), ID, CPU, mass (at mass_idx), and velocity
+/// (at mass_idx+1, mass_idx+2, mass_idx+3). Also reduces cell density to the Jeans
+/// threshold and scales momentum/energy accordingly to conserve mass and momentum.
+template <typename problem_t, typename PType, typename StateArray>
+AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int num_particles, StateArray const &state_arr, int i, int j, int k,
+							 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+							 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
+							 std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, int mass_idx, int cpu_id,
+							 amrex::Long pid_start, amrex::Long base_offset)
+{
+	const double dx_max = std::max({dx[0], dx[1], dx[2]});
+
+	// Determine sound speed.
+	// ComputeIsothermalSoundSpeed internally handles the special case where gamma equals 1.0.
+	const Real cs = HydroSystem<problem_t>::ComputeIsothermalSoundSpeed(state_arr, i, j, k, fab_fc);
+	// Compute plasma beta for MHD-aware Jeans density (returns inf for non-MHD)
+	const double plasma_beta = HydroSystem<problem_t>::ComputePlasmaBeta(state_arr, i, j, k, fab_fc);
+
+	// Jeans density with MHD correction:
+	//   rho_J = J^2 * pi * cs_eff^2 / (G * dx^2)
+	//   cs_eff^2 = cs^2 * (1 + 0.74/beta)
+	// (For non-MHD, beta=inf, so cs_eff^2 = cs^2)
+	const auto rho_J = ParticleUtils::computeJeansDensity(cs, dx_max, plasma_beta);
+
+	// Calculate common values for all particles
+	const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
+	const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+	const amrex::Real particle_mass = (cell_density - rho_J) * cell_volume;
+
+	const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
+	const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
+	const amrex::Real vz = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
+
+	for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
+		auto &p = particles[p_idx]; // NOLINT
+
+		// Set particle position at cell center
+		p.pos(0) = plo[0] + (i + 0.5) * dx[0];
+		p.pos(1) = plo[1] + (j + 0.5) * dx[1];
+		p.pos(2) = plo[2] + (k + 0.5) * dx[2];
+
+		// Set particle ID and CPU
+		p.id() = pid_start + base_offset + p_idx;
+		p.cpu() = cpu_id;
+
+		// Initialize particle mass and velocity
+		p.rdata(mass_idx) = particle_mass / num_particles;
+		// add a check to avoid compiler warnings about array-bounds
+		if (mass_idx + 3 < PType::NReal) {
+			p.rdata(mass_idx + 1) = vx;
+			p.rdata(mass_idx + 2) = vy;
+			p.rdata(mass_idx + 3) = vz;
+		}
+	}
+
+	// update cell density to be the threshold density
+	const amrex::Real scale_factor = rho_J / cell_density;
+	state_arr(i, j, k, HydroSystem<problem_t>::density_index) = rho_J;
+	state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= scale_factor;
+	state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= scale_factor;
+	state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
+	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
+	state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
+}
+} // namespace SinkCreationHelpers
+
 // Specialization for Sink particles
 template <> struct ParticleCreationTraits<ParticleType::Sink> {
 
@@ -204,12 +333,6 @@ template <> struct ParticleCreationTraits<ParticleType::Sink> {
 		amrex::Real current_time;
 		amrex::Real dt;
 
-		static constexpr int stencil_size = ParticleUtils::stencil_size;
-
-		static constexpr Real Gconst = C::Gconst;
-		static constexpr Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-		static constexpr Real mu = quokka::EOS_Traits<problem_t>::mean_molecular_weight;
-
 		AMREX_GPU_HOST_DEVICE ParticleChecker(amrex::Real current_time, amrex::Real dt) : current_time(current_time), dt(dt) {}
 
 		AMREX_GPU_DEVICE auto operator()(amrex::Array4<const amrex::Real> const &state_arr, amrex::Array4<const amrex::Real> const &accretion_rate_arr,
@@ -217,53 +340,8 @@ template <> struct ParticleCreationTraits<ParticleType::Sink> {
 						 std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc,
 						 amrex::RandomEngine const & /*engine*/) const -> int
 		{
-			const double dx_max = std::max({dx[0], dx[1], dx[2]});
-
-			// Determine sound speed.
-			const Real cs = HydroSystem<problem_t>::ComputeIsothermalSoundSpeed(state_arr, i, j, k, fab_fc);
-			// Compute plasma beta for MHD-aware Jeans density (returns inf for non-MHD)
-			const double plasma_beta = HydroSystem<problem_t>::ComputePlasmaBeta(state_arr, i, j, k, fab_fc);
-
-			// Jeans density with MHD correction:
-			//   rho_J = J^2 * pi * cs_eff^2 / (G * dx^2)
-			//   cs_eff^2 = cs^2 * (1 + 0.74/beta)
-			// (For non-MHD, beta=inf, so cs_eff^2 = cs^2)
-			const auto rho_J = ParticleUtils::computeJeansDensity(cs, dx_max, plasma_beta);
-			const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
-			const double accretion_rate_cell = accretion_rate_arr(i, j, k);
-
-			// Only form a star if
-			// 1. Cell density is above Jeans density
-			// 2. Cell accretion rate (a non-positive number) is zero
-			// 3. Cell density is the local maximum density
-			if (cell_density > rho_J && accretion_rate_cell >= 0.0) {
-				bool is_local_maximum = true;
-				for (int di = -3; di <= 3 && is_local_maximum; ++di) {
-					for (int dj = -3; dj <= 3 && is_local_maximum; ++dj) {
-						for (int dk = -3; dk <= 3 && is_local_maximum; ++dk) {
-							// Skip the center cell
-							if (di == 0 && dj == 0 && dk == 0) {
-								continue;
-							}
-							// Only check cells within spherical radius of 3
-							// A small epsilon is added to the right hand side to ensure both (i - stencil_size) and (i +
-							// stencil_size) are included
-							if (di * di + dj * dj + dk * dk <= static_cast<Real>(stencil_size * stencil_size) + 1.0e-10) {
-								const Real rho_ijk = state_arr(i + di, j + dj, k + dk, HydroSystem<problem_t>::density_index);
-								if (rho_ijk > cell_density) {
-									is_local_maximum = false;
-									break;
-								}
-							}
-						}
-					}
-				}
-
-				if (is_local_maximum) {
-					return 1;
-				}
-			}
-			return 0;
+			amrex::ignore_unused(current_time, dt);
+			return SinkCreationHelpers::checkSinkCreation<problem_t>(state_arr, accretion_rate_arr, i, j, k, dx, fab_fc);
 		}
 	};
 
@@ -278,10 +356,6 @@ template <> struct ParticleCreationTraits<ParticleType::Sink> {
 		amrex::Long pid_start;
 		amrex::Real current_time;
 		amrex::Real dt;
-
-		static constexpr Real Gconst = C::Gconst;
-		static constexpr Real gamma = quokka::EOS_Traits<problem_t>::gamma;
-		static constexpr Real mu = quokka::EOS_Traits<problem_t>::mean_molecular_weight;
 
 		AMREX_GPU_HOST_DEVICE
 		ParticleCreator(int mass_index, int birth_time_index, int death_time_index, int processor_id, amrex::Long particle_id_start,
@@ -299,60 +373,8 @@ template <> struct ParticleCreationTraits<ParticleType::Sink> {
 			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, amrex::Long base_offset,
 			   amrex::RandomEngine const & /*engine*/) const
 		{
-			const double dx_max = std::max({dx[0], dx[1], dx[2]});
-
-			// Determine sound speed.
-			// ComputeIsothermalSoundSpeed internally handles the special case where gamma equals 1.0.
-			const Real cs = HydroSystem<problem_t>::ComputeIsothermalSoundSpeed(state_arr, i, j, k, fab_fc);
-			// Compute plasma beta for MHD-aware Jeans density (returns inf for non-MHD)
-			const double plasma_beta = HydroSystem<problem_t>::ComputePlasmaBeta(state_arr, i, j, k, fab_fc);
-
-			// Jeans density with MHD correction:
-			//   rho_J = J^2 * pi * cs_eff^2 / (G * dx^2)
-			//   cs_eff^2 = cs^2 * (1 + 0.74/beta)
-			// (For non-MHD, beta=inf, so cs_eff^2 = cs^2)
-			const auto rho_J = ParticleUtils::computeJeansDensity(cs, dx_max, plasma_beta);
-
-			// Calculate common values for all particles
-			const amrex::Real cell_density = state_arr(i, j, k, HydroSystem<problem_t>::density_index);
-			const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-			const amrex::Real particle_mass = (cell_density - rho_J) * cell_volume;
-
-			const amrex::Real vx = state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) / cell_density;
-			const amrex::Real vy = state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) / cell_density;
-			const amrex::Real vz = state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) / cell_density;
-
-			for (int p_idx = 0; p_idx < num_particles; ++p_idx) {
-				auto &p = particles[p_idx]; // NOLINT
-
-				// Set particle position at cell center
-				p.pos(0) = plo[0] + (i + 0.5) * dx[0];
-				p.pos(1) = plo[1] + (j + 0.5) * dx[1];
-				p.pos(2) = plo[2] + (k + 0.5) * dx[2];
-
-				// Set particle ID and CPU
-				p.id() = pid_start + base_offset + p_idx;
-				p.cpu() = cpu_id;
-
-				// Initialize particle properties
-				p.rdata(mass_idx) = particle_mass / num_particles;
-				// add a check to avoid compiler warnings about array-bounds
-				if (mass_idx + 3 < ParticleType::NReal) {
-					p.rdata(mass_idx + 1) = vx;
-					p.rdata(mass_idx + 2) = vy;
-					p.rdata(mass_idx + 3) = vz;
-				}
-			}
-
-			// update cell density to be the threshold density
-			//	const amrex::Real scale_factor = n_thresh / cell_density;
-			const amrex::Real scale_factor = rho_J / cell_density;
-			state_arr(i, j, k, HydroSystem<problem_t>::density_index) = rho_J;
-			state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= scale_factor;
-			state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= scale_factor;
-			state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
-			state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
-			state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
+			SinkCreationHelpers::initializeSinkLikeParticles<problem_t>(particles, num_particles, state_arr, i, j, k, dx, plo, fab_fc, mass_idx,
+										    cpu_id, pid_start, base_offset);
 		}
 	};
 
@@ -550,8 +572,9 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 							const amrex::Real rx = amrex::Random(engine);
 							const amrex::Real ry = amrex::Random(engine);
 							const amrex::Real rz = amrex::Random(engine);
-							// Set velocity dispersion to the cell-scale escape speed of the LowMassComposite cluster:
-							// v_esc = sqrt(2 G M_cluster / dx), where M_cluster is the total low-mass composite mass in this cell.
+							// Set velocity dispersion to the cell-scale escape speed of the LowMassComposite
+							// cluster: v_esc = sqrt(2 G M_cluster / dx), where M_cluster is the total low-mass
+							// composite mass in this cell.
 							const amrex::Real dx_cell = std::min({dx[0], dx[1], dx[2]});
 							const amrex::Real m_cluster = mass_low_mass_star;
 							const amrex::Real v_esc = std::sqrt(2.0 * C::Gconst * m_cluster / dx_cell);

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -317,7 +317,8 @@ AMREX_ENUM(SinkParticleRealIdx, // NOLINT
 	   mass,		// Mass of the particle
 	   vx,			// Velocity in x direction
 	   vy,			// Velocity in y direction
-	   vz			// Velocity in z direction
+	   vz,			// Velocity in z direction
+	   mdot			// Current mass accretion rate
 );
 
 // Backward compatibility aliases for existing code
@@ -325,9 +326,10 @@ constexpr int SinkParticleMassIdx = static_cast<int>(SinkParticleRealIdx::mass);
 constexpr int SinkParticleVxIdx = static_cast<int>(SinkParticleRealIdx::vx);
 constexpr int SinkParticleVyIdx = static_cast<int>(SinkParticleRealIdx::vy);
 constexpr int SinkParticleVzIdx = static_cast<int>(SinkParticleRealIdx::vz);
+constexpr int SinkParticleMdotIdx = static_cast<int>(SinkParticleRealIdx::mdot);
 
 // Number of real components for Sink_particles
-constexpr int SinkParticleRealComps = 4; // mass, vx, vy, vz
+constexpr int SinkParticleRealComps = 5; // mass, vx, vy, vz, mdot
 
 // Type definitions for Sink_particles container and iterator
 using SinkParticleContainer = amrex::AmrParticleContainer<SinkParticleRealComps>;
@@ -391,6 +393,7 @@ template <ParticleType particleType, typename problem_t> auto getParticleRealCom
 	}
 #endif
 	else {
+		amrex::Abort("Unknown particle type");
 		return {};
 	}
 }
@@ -416,6 +419,8 @@ template <ParticleType particleType, typename problem_t> auto getParticleIntComp
 	} else if constexpr (particleType == ParticleType::Test) {
 		const std::vector<std::string> enum_names = amrex::getEnumNameStrings<TestParticleIntIdx>();
 		names = {enum_names.begin(), enum_names.end()};
+	} else {
+		amrex::Abort("Unknown particle type");
 	}
 #endif
 	return names;
@@ -453,7 +458,7 @@ inline auto get_units_data() -> const auto &
 	       {"death_density", {1, -3, 0, 0}},
 	       {"mass_at_birth", {1, 0, 0, 0}},
 	       {"luminosity", {-1, 2, -3, 0}}}}},
-	    {ParticleType::Sink, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}}}},
+	    {ParticleType::Sink, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"mdot", {1, 0, -1, 0}}}}},
 	    {ParticleType::Test,
 	     {{{"mass", {1, 0, 0, 0}},
 	       {"vx", {0, 1, -1, 0}},

--- a/src/particles/particle_update.hpp
+++ b/src/particles/particle_update.hpp
@@ -12,11 +12,59 @@
 namespace quokka
 {
 
-// Traits class for specializing particle property update behavior
-template <ParticleType particleType> struct ParticlePropertyUpdateTraits {
+// Forward declaration required so ParticlePropertyUpdateBase can call the (potentially specialized)
+// updateProperties without needing the full definition at the point of its own definition.
+template <ParticleType particleType> struct ParticlePropertyUpdateTraits;
+
+// Base class that holds the single shared container-level loop.
+// Calls ParticlePropertyUpdateTraits<particleType>::updateProperties per particle, which resolves
+// to whichever specialization (or the default no-op) is appropriate for particleType.
+// Specializations that require luminosity tables should override updateParticleProperties to
+// load the tables before calling applyUpdate.
+template <ParticleType particleType> struct ParticlePropertyUpdateBase {
+	template <typename problem_t, typename ContainerType>
+	static void updateParticleProperties(ContainerType *container, amrex::Real current_time, amrex::Real dt) noexcept
+	{
+		const BL_PROFILE("ParticlePropertyUpdateTraits::updateParticleProperties()");
+		if (container == nullptr) {
+			return;
+		}
+
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		// Default: pass empty tables (unused by per-particle functions that don't need them)
+		LuminosityGpuConstTables<nGroups> const gpu_tables{};
+		applyUpdate<problem_t, ContainerType>(container, current_time, dt, gpu_tables);
+	}
+
+      public:
+	template <typename problem_t, typename ContainerType>
+	static void applyUpdate(ContainerType *container, amrex::Real current_time, amrex::Real dt,
+				LuminosityGpuConstTables<Physics_Traits<problem_t>::nGroups> const &gpu_tables) noexcept
+	{
+		constexpr int nGroups = Physics_Traits<problem_t>::nGroups;
+		// Apply the updater to all particles across all levels
+		for (int lev = 0; lev <= container->finestLevel(); ++lev) {
+			for (typename ContainerType::ParIterType pIter(*container, lev); pIter.isValid(); ++pIter) {
+				auto &particles = pIter.GetArrayOfStructs();
+				auto *pData = particles().data();
+				const amrex::Long np = pIter.numParticles();
+
+				amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int64_t idx) {
+					auto &p = pData[idx]; // NOLINT
+					ParticlePropertyUpdateTraits<particleType>::template updateProperties<problem_t, typename ContainerType::ParticleType,
+													      nGroups>(p, current_time, dt, gpu_tables);
+				});
+			}
+		}
+	}
+};
+
+// Traits class for specializing the per-particle update. Inherits updateParticleProperties from the base.
+// Specializations only need to override updateProperties.
+template <ParticleType particleType> struct ParticlePropertyUpdateTraits : ParticlePropertyUpdateBase<particleType> {
 	// Default per-particle implementation - does nothing
 	template <typename problem_t, typename ParticleType, int Nout>
-	AMREX_GPU_DEVICE AMREX_FORCE_INLINE static void updateProperties(ParticleType & /*p*/, amrex::Real /*current_time*/,
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE static void updateProperties(ParticleType & /*p*/, amrex::Real /*current_time*/, amrex::Real /*dt*/,
 									 LuminosityGpuConstTables<Nout> const & /*gpu_tables*/) noexcept
 	{
 		// Default implementation does nothing
@@ -24,28 +72,19 @@ template <ParticleType particleType> struct ParticlePropertyUpdateTraits {
 
 	// Default container-level update - does nothing
 	template <typename problem_t, typename ContainerType>
-	static void updateParticleProperties(ContainerType * /*container*/, amrex::Real /*current_time*/) noexcept
+	static void updateParticleProperties(ContainerType * /*container*/, amrex::Real /*current_time*/, amrex::Real /*dt*/) noexcept
 	{
 		// Default implementation does nothing
 	}
 };
 
-// Specialization for StochasticStellarPop particles with stellar evolution
-// This uses table interpolation and can be overridden in the problem generator
-// Currently, the default is updateLuminosity. In the future, we can add more properties to update
-template <> struct ParticlePropertyUpdateTraits<ParticleType::StochasticStellarPop> {
-	template <typename problem_t, typename ParticleType, int Nout>
-	AMREX_GPU_DEVICE AMREX_FORCE_INLINE static void updateProperties(ParticleType &p, amrex::Real current_time,
-									 LuminosityGpuConstTables<Nout> const &gpu_tables) noexcept
+// Specialization for StochasticStellarPop particles: updates luminosity via table interpolation.
+// Overrides updateParticleProperties to gate the update on luminosity tables being initialized.
+template <> struct ParticlePropertyUpdateTraits<ParticleType::StochasticStellarPop> : ParticlePropertyUpdateBase<ParticleType::StochasticStellarPop> {
+	template <typename problem_t, typename ContainerType>
+	static void updateParticleProperties(ContainerType *container, amrex::Real current_time, amrex::Real dt) noexcept
 	{
-		// Update luminosity using the LuminosityUpdate class
-		LuminosityUpdate::updateLuminosity<problem_t>(p, current_time, gpu_tables);
-	}
-
-	// Container-level update for StochasticStellarPop particles
-	template <typename problem_t, typename ContainerType> static void updateParticleProperties(ContainerType *container, amrex::Real current_time)
-	{
-		const BL_PROFILE("ParticlePropertyUpdateTraits<StochasticStellarPop>::updateParticleProperties()");
+		const BL_PROFILE("ParticlePropertyUpdateTraits::updateParticleProperties()");
 		if (container == nullptr) {
 			return;
 		}
@@ -55,24 +94,16 @@ template <> struct ParticlePropertyUpdateTraits<ParticleType::StochasticStellarP
 
 		// Only proceed if tables are initialized
 		if (host_tables_ptr != nullptr && host_tables_ptr->is_initialized()) {
-			// Create GPU const tables by value to pass to device
 			auto const gpu_tables = host_tables_ptr->const_tables();
-
-			// Apply the updater to all particles across all levels
-			for (int lev = 0; lev <= container->finestLevel(); ++lev) {
-				for (typename ContainerType::ParIterType pIter(*container, lev); pIter.isValid(); ++pIter) {
-					auto &particles = pIter.GetArrayOfStructs();
-					auto *pData = particles().data();
-					const amrex::Long np = pIter.numParticles();
-
-					amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE(int64_t idx) {
-						auto &p = pData[idx]; // NOLINT
-						ParticlePropertyUpdateTraits<ParticleType::StochasticStellarPop>::template updateProperties<
-						    problem_t, typename ContainerType::ParticleType, nGroups>(p, current_time, gpu_tables);
-					});
-				}
-			}
+			applyUpdate<problem_t, ContainerType>(container, current_time, dt, gpu_tables);
 		}
+	}
+
+	template <typename problem_t, typename ParticleType, int Nout>
+	AMREX_GPU_DEVICE AMREX_FORCE_INLINE static void updateProperties(ParticleType &p, amrex::Real current_time, amrex::Real /*dt*/,
+									 LuminosityGpuConstTables<Nout> const &gpu_tables) noexcept
+	{
+		LuminosityUpdate::updateLuminosity<problem_t>(p, current_time, gpu_tables);
 	}
 };
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1434,7 +1434,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 
 			// Stellar evolution and SN deposition; only apply to star particles
 			// Update particle properties (e.g., luminosity) before particle-mesh interaction
-			particleRegister_.updateParticleProperties(cur_time);
+			particleRegister_.updateParticleProperties(cur_time, dt_[0]);
 
 			// TODO(cch): Need to take care of AMR subcycling
 			particleMeshInteraction(cur_time, dt_[0]);


### PR DESCRIPTION
### Description
Refactored sink particle creation and accretion to use helper functions so that more particle types use the same accretion routine. 

This is to prepare for the upcoming Star Particle module. 

Also add accretion rate `mdot` to sink particle components. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
