### PR TITLE
Fix typos and update GitHub links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
 # QUOKKA
 *Quadrilateral, Umbra-producing, Orthogonal, Kangaroo-conserving Kode for Astrophysics!*
 
-**For detailed instructions on installing the code, please refer to the [Quokka Documentation](https://quokka-astro.github.io/quokka/index.html). You can start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support, or open an [Issue](https://github.com/BenWibking/quokka/issues) for any bug reports.**
+**For detailed instructions on installing the code, please refer to the [Quokka Documentation](https://quokka-astro.github.io/quokka/index.html). You can start a [Discussion](https://github.com/quokka-astro/quokka/discussions) for technical support, or open an [Issue](https://github.com/quokka-astro/quokka/issues) for any bug reports.**
 
 Quokka is a two-moment radiation hydrodynamics code that uses the piecewise-parabolic method, with AMR and subcycling in time. Runs on CPUs (MPI+vectorized) or NVIDIA GPUs (MPI+CUDA) with a single-source codebase. Written in C++20. (100% Fortran-free.)
 
 ![Quokka capabilities showcase graphic](extern/quokka_graphic.png)
 
-This is a [a Kelvin-Helmholz instability simulated with Quokka](https://vimeo.com/714653592) on a 512x512 uniform grid:
+This is a [Kelvin-Helmholtz instability simulated with Quokka](https://vimeo.com/714653592) on a 512x512 uniform grid:
 
 ![Animated GIF of KH Instability](https://videoapi-muybridge.vimeocdn.com/animated-thumbnails/image/1f468be6-6d7b-4d53-a02c-4dd8f3ad5154.gif?ClientID=vimeo-core-prod&Date=1653705774&Signature=9bea89d5c9657180391a9538a10fd4f8f7099025)
 
@@ -33,7 +33,7 @@ This is a [a Kelvin-Helmholz instability simulated with Quokka](https://vimeo.co
 * ADIOS2 2.9+ with GPU-aware support (optional, for writing terabyte-sized or larger outputs)
 
 ## Problems?
-If you run into problems, please start a [Discussion](https://github.com/BenWibking/quokka/discussions) for technical support. If you discover a bug, please let us know by opening an [Issue](https://github.com/BenWibking/quokka/issues). You can also join our [Zulip community](https://quokka-astro.zulipchat.com/join/3sahu2rgvkengbkzwkpndc5h/).
+If you run into problems, please start a [Discussion](https://github.com/quokka-astro/quokka/discussions) for technical support. If you discover a bug, please let us know by opening an [Issue](https://github.com/quokka-astro/quokka/issues). You can also join our [Zulip community](https://quokka-astro.zulipchat.com/join/3sahu2rgvkengbkzwkpndc5h/).
 
 ## Acknowledgements
 We thank Kandra Labs, Inc. (“Zulip”) for providing hosted [Zulip](https://zulip.com/) chat for our open-source community.


### PR DESCRIPTION
### Description
This PR makes the following improvements to the README.md:
- Fixed typo: Changed "Kelvin-Helmholz" to "Kelvin-Helmholtz" 
- Updated GitHub repository references to use the correct organization "quokka-astro" instead of "BenWibking" for Discussion and Issue links

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.