### PR TITLE
Add angular momentum tracking to sink particles

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -56,13 +56,15 @@ class PhysicsParticleDescriptorBase
 	int massAtBirthIndex_{-1};     // Index for particle mass at birth (-1 if not used)
 	bool forceFinestLevel_{false}; // Whether particles are forced to live in the finest level
 	int mdotIndex_{-1};	       // Index for accretion rate (-1 if not used)
+	int angMomIndex_{-1};	       // Index for angular momentum x-component (-1 if not used; Ly=+1, Lz=+2)
 
       public:
 	PhysicsParticleDescriptorBase(int mass_idx, int lum_idx, int birth_time_idx, int death_time_idx, bool allows_creation, bool allows_destruction = false,
-				      int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1, int mdot_idx = -1)
+				      int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1, int mdot_idx = -1,
+				      int ang_mom_idx = -1)
 	    : massIndex_(mass_idx), lumIndex_(lum_idx), birthTimeIndex_(birth_time_idx), deathTimeIndex_(death_time_idx), allowsCreation_(allows_creation),
 	      allowsDestruction_(allows_destruction), evolutionStageIndex_(evolution_stage_idx), allowsAccretion_(allows_accretion),
-	      massAtBirthIndex_(mass_at_birth_idx), mdotIndex_(mdot_idx)
+	      massAtBirthIndex_(mass_at_birth_idx), mdotIndex_(mdot_idx), angMomIndex_(ang_mom_idx)
 	{
 	}
 
@@ -86,6 +88,7 @@ class PhysicsParticleDescriptorBase
 	[[nodiscard]] AMREX_FORCE_INLINE auto getMassAtBirthIndex() const -> int { return massAtBirthIndex_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getForceFinestLevel() const -> bool { return forceFinestLevel_; }
 	[[nodiscard]] AMREX_FORCE_INLINE auto getMdotIndex() const -> int { return mdotIndex_; }
+	[[nodiscard]] AMREX_FORCE_INLINE auto getAngMomIndex() const -> int { return angMomIndex_; }
 
 	// setter methods for particle properties
 	AMREX_FORCE_INLINE void setForceFinestLevel(bool force) { forceFinestLevel_ = force; }
@@ -193,9 +196,9 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 	// Constructor initializing descriptor with container and particle properties
 	PhysicsParticleDescriptor(ContainerType *container, int mass_idx, int lum_idx, int birth_time_idx, int death_time_idx, bool allows_creation,
 				  bool allows_destruction = false, int evolution_stage_idx = -1, bool allows_accretion = false, int mass_at_birth_idx = -1,
-				  int mdot_idx = -1)
+				  int mdot_idx = -1, int ang_mom_idx = -1)
 	    : PhysicsParticleDescriptorBase(mass_idx, lum_idx, birth_time_idx, death_time_idx, allows_creation, allows_destruction, evolution_stage_idx,
-					    allows_accretion, mass_at_birth_idx, mdot_idx),
+					    allows_accretion, mass_at_birth_idx, mdot_idx, ang_mom_idx),
 	      container_(container)
 	{
 	}
@@ -705,7 +708,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 				const amrex::Geometry &geom, int lev, amrex::Real time, amrex::Real dt) override
 	{
 		SinkAccretionUtils::applyAccretion<ContainerType, problem_t>(this->container_, state, state_accretion_rate, state_fc, geom, lev, time, dt,
-									     this->getMassIndex(), this->getMdotIndex());
+									     this->getMassIndex(), this->getMdotIndex(), this->getAngMomIndex());
 	}
 
 	void createParticlesFromState(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, int lev, amrex::Real current_time, amrex::Real dt,
@@ -815,7 +818,7 @@ template <typename problem_t> class PhysicsParticleRegister
 			    StochasticStellarPopParticleMassAtBirthIdx);
 		} else if constexpr (particleType == ParticleType::Sink) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Sink>>(
-			    container, SinkParticleMassIdx, -1, -1, -1, true, false, -1, true, -1, SinkParticleMdotIdx);
+			    container, SinkParticleMassIdx, -1, -1, -1, true, false, -1, true, -1, SinkParticleMdotIdx, SinkParticleLxIdx);
 		} else if constexpr (particleType == ParticleType::Test) {
 			descriptor = std::make_unique<PhysicsParticleDescriptor<ContainerType, problem_t, ParticleType::Test>>(
 			    container, TestParticleMassIdx, TestParticleLumIdx, TestParticleBirthTimeIdx, TestParticleDeathTimeIdx, true, true,

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -575,8 +575,7 @@ void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::Mul
 	ComputeScaleDown<problem_t>(state, state_accretion_rate, scale_down, geom, state_fc);
 
 	// Step 3: Update particle mass, momentum, accretion rate, and angular momentum
-	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index,
-								ang_mom_index);
+	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index, ang_mom_index);
 
 	// Step 4: Update the hydro state. We do this at last because the original state is needed for updating particles in step 3.
 	UpdateHydroState<problem_t>(state, state_accretion_rate);

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -183,9 +183,9 @@ void ComputeAccretionRateInBox(const typename ContainerType::ParIterType &pti, c
 		for (int ii = ix - stencil_size; ii <= ix + stencil_size; ++ii) {
 			for (int jj = iy - stencil_size; jj <= iy + stencil_size; ++jj) {
 				for (int kk = iz - stencil_size; kk <= iz + stencil_size; ++kk) {
-					const double x = p.pos(0) - plo[0] - (ii + static_cast<amrex::Real>(0.5)) * dx[0];
-					const double y = p.pos(1) - plo[1] - (jj + static_cast<amrex::Real>(0.5)) * dx[1];
-					const double z = p.pos(2) - plo[2] - (kk + static_cast<amrex::Real>(0.5)) * dx[2];
+					const double x = plo[0] + (ii + static_cast<amrex::Real>(0.5)) * dx[0] - p.pos(0);
+					const double y = plo[1] + (jj + static_cast<amrex::Real>(0.5)) * dx[1] - p.pos(1);
+					const double z = plo[2] + (kk + static_cast<amrex::Real>(0.5)) * dx[2] - p.pos(2);
 					const double r_sqr = x * x + y * y + z * z;
 					double r_acc_sqr = stencil_size * stencil_size * dx_max * dx_max;
 					if (use_uniform_kernel) {
@@ -209,9 +209,9 @@ void ComputeAccretionRateInBox(const typename ContainerType::ParIterType &pti, c
 		for (int ii = ix - stencil_size; ii <= ix + stencil_size; ++ii) {
 			for (int jj = iy - stencil_size; jj <= iy + stencil_size; ++jj) {
 				for (int kk = iz - stencil_size; kk <= iz + stencil_size; ++kk) {
-					const double x = p.pos(0) - plo[0] - (ii + static_cast<amrex::Real>(0.5)) * dx[0];
-					const double y = p.pos(1) - plo[1] - (jj + static_cast<amrex::Real>(0.5)) * dx[1];
-					const double z = p.pos(2) - plo[2] - (kk + static_cast<amrex::Real>(0.5)) * dx[2];
+					const double x = plo[0] + (ii + static_cast<amrex::Real>(0.5)) * dx[0] - p.pos(0);
+					const double y = plo[1] + (jj + static_cast<amrex::Real>(0.5)) * dx[1] - p.pos(1);
+					const double z = plo[2] + (kk + static_cast<amrex::Real>(0.5)) * dx[2] - p.pos(2);
 					const double r_sqr = x * x + y * y + z * z;
 					double r_acc_sqr = stencil_size * stencil_size * dx_max * dx_max;
 					if (use_uniform_kernel) {
@@ -357,9 +357,9 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 		for (int ii = ix - stencil_size; ii <= ix + stencil_size; ++ii) {
 			for (int jj = iy - stencil_size; jj <= iy + stencil_size; ++jj) {
 				for (int kk = iz - stencil_size; kk <= iz + stencil_size; ++kk) {
-					const double x = p.pos(0) - plo[0] - (ii + static_cast<amrex::Real>(0.5)) * dx[0];
-					const double y = p.pos(1) - plo[1] - (jj + static_cast<amrex::Real>(0.5)) * dx[1];
-					const double z = p.pos(2) - plo[2] - (kk + static_cast<amrex::Real>(0.5)) * dx[2];
+					const double x = plo[0] + (ii + static_cast<amrex::Real>(0.5)) * dx[0] - p.pos(0);
+					const double y = plo[1] + (jj + static_cast<amrex::Real>(0.5)) * dx[1] - p.pos(1);
+					const double z = plo[2] + (kk + static_cast<amrex::Real>(0.5)) * dx[2] - p.pos(2);
 					const double r_sqr = x * x + y * y + z * z;
 					double r_acc_sqr = stencil_size * stencil_size * dx_max * dx_max;
 					if (use_uniform_kernel) {
@@ -395,10 +395,10 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 		for (int ii = ix - stencil_size; ii <= ix + stencil_size; ++ii) {
 			for (int jj = iy - stencil_size; jj <= iy + stencil_size; ++jj) {
 				for (int kk = iz - stencil_size; kk <= iz + stencil_size; ++kk) {
-					// x,y,z = (particle_pos - cell_center), so cell-relative-to-particle = (-x,-y,-z)
-					const double x = p.pos(0) - plo[0] - (ii + static_cast<amrex::Real>(0.5)) * dx[0];
-					const double y = p.pos(1) - plo[1] - (jj + static_cast<amrex::Real>(0.5)) * dx[1];
-					const double z = p.pos(2) - plo[2] - (kk + static_cast<amrex::Real>(0.5)) * dx[2];
+					// x,y,z = r_cell = cell_center - par_pos (vector from particle to cell center)
+					const double x = plo[0] + (ii + static_cast<amrex::Real>(0.5)) * dx[0] - p.pos(0);
+					const double y = plo[1] + (jj + static_cast<amrex::Real>(0.5)) * dx[1] - p.pos(1);
+					const double z = plo[2] + (kk + static_cast<amrex::Real>(0.5)) * dx[2] - p.pos(2);
 					const double r_sqr = x * x + y * y + z * z;
 					double r_acc_sqr = stencil_size * stencil_size * dx_max * dx_max;
 					if (use_uniform_kernel) {
@@ -431,11 +431,11 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					accreted_momentum_x += accreted_mass_cell * vx_lab;
 					accreted_momentum_y += accreted_mass_cell * vy_lab;
 					accreted_momentum_z += accreted_mass_cell * vz_lab;
-					// Angular momentum: L += dm * (r_cell × v_rel), where r_cell = cell_center - par_pos = (-x, -y, -z)
+					// Angular momentum: L += dm * (r_cell × v_rel), where r_cell = (x, y, z) = cell_center - par_pos
 					// and v_rel = v_gas - v_par (relative velocity, Galilean invariant by construction).
-					// L_x = dm * ((-y)*vz_rel - (-z)*vy_rel) = dm * (z*vy_rel - y*vz_rel)
-					// L_y = dm * ((-z)*vx_rel - (-x)*vz_rel) = dm * (x*vz_rel - z*vx_rel)
-					// L_z = dm * ((-x)*vy_rel - (-y)*vx_rel) = dm * (y*vx_rel - x*vy_rel)
+					// L_x = dm * (y*vz_rel - z*vy_rel)
+					// L_y = dm * (z*vx_rel - x*vz_rel)
+					// L_z = dm * (x*vy_rel - y*vx_rel)
 					//
 					// NOTE: Galilean invariance of L is only approximate (~2% at typical boost/dt).
 					// The residual error arises because p.pos() here is the *post-drift* position:
@@ -444,13 +444,13 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					// relative to the unboosted frame, breaking exact Galilean invariance of L.
 					// A potential solution is to use the pre-drift (rewound) particle position when
 					// computing r_cell for angular momentum, e.g.:
-					//   const double x_rewind = (p.pos(0) - pvx * dt) - plo[0] - (ii + 0.5) * dx[0];
+					//   const double x_rewind = plo[0] + (ii + 0.5) * dx[0] - (p.pos(0) - pvx * dt);
 					// This might restore Galilean invariance for all particles. However, this breaks
 					// the order of operations of the current scheme, so it is not necessarily the
 					// right thing to do.
-					accreted_ang_mom_x += accreted_mass_cell * (z * vy_rel - y * vz_rel);
-					accreted_ang_mom_y += accreted_mass_cell * (x * vz_rel - z * vx_rel);
-					accreted_ang_mom_z += accreted_mass_cell * (y * vx_rel - x * vy_rel);
+					accreted_ang_mom_x += accreted_mass_cell * (y * vz_rel - z * vy_rel);
+					accreted_ang_mom_y += accreted_mass_cell * (z * vx_rel - x * vz_rel);
+					accreted_ang_mom_z += accreted_mass_cell * (x * vy_rel - y * vx_rel);
 					//-----------------------------------------------------------------------------------------------------
 				}
 			}

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -379,6 +379,11 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 			}
 		}
 
+		// get particle velocity
+		const double pvx = p.rdata(mass_index + 1);
+		const double pvy = p.rdata(mass_index + 2);
+		const double pvz = p.rdata(mass_index + 3);
+
 		// compute the accretion rate at each cell; use atomic operations
 		double accreted_mass = 0.0;
 		double accreted_momentum_x = 0.0;
@@ -416,9 +421,9 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					// M_dot_cell is negative, so we multiply it by -1 to get the accreted mass
 					const double accreted_mass_cell = -M_dot_cell * dt * scale_down_factor;
 					const double rho = local_state(ii, jj, kk, HydroSystem<problem_t>::density_index);
-					const double vx = local_state(ii, jj, kk, HydroSystem<problem_t>::x1Momentum_index) / rho;
-					const double vy = local_state(ii, jj, kk, HydroSystem<problem_t>::x2Momentum_index) / rho;
-					const double vz = local_state(ii, jj, kk, HydroSystem<problem_t>::x3Momentum_index) / rho;
+					const double vx = local_state(ii, jj, kk, HydroSystem<problem_t>::x1Momentum_index) / rho - pvx;
+					const double vy = local_state(ii, jj, kk, HydroSystem<problem_t>::x2Momentum_index) / rho - pvy;
+					const double vz = local_state(ii, jj, kk, HydroSystem<problem_t>::x3Momentum_index) / rho - pvz;
 					accreted_mass += accreted_mass_cell;
 					accreted_momentum_x += accreted_mass_cell * vx;
 					accreted_momentum_y += accreted_mass_cell * vy;

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -428,10 +428,23 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					accreted_momentum_x += accreted_mass_cell * vx;
 					accreted_momentum_y += accreted_mass_cell * vy;
 					accreted_momentum_z += accreted_mass_cell * vz;
-					// Angular momentum: L += dm * (r_cell × v_cell), where r_cell = cell_center - par_pos = (-x, -y, -z)
+					// Angular momentum: L += dm * (r_cell × v_rel), where r_cell = cell_center - par_pos = (-x, -y, -z)
+					// and v_rel = v_gas - v_par (relative velocity, Galilean invariant by construction).
 					// L_x = dm * ((-y)*vz - (-z)*vy) = dm * (z*vy - y*vz)
 					// L_y = dm * ((-z)*vx - (-x)*vz) = dm * (x*vz - z*vx)
 					// L_z = dm * ((-x)*vy - (-y)*vx) = dm * (y*vx - x*vy)
+					//
+					// NOTE: Galilean invariance of L is only approximate (~2% at typical boost/dt).
+					// The residual error arises because p.pos() here is the *post-drift* position:
+					// the particle mover has already advanced the particle by v_par*dt before this
+					// accretion step is called. In a boosted frame, this shifts r_cell by -v_par*dt
+					// relative to the unboosted frame, breaking exact Galilean invariance of L.
+					// A potential solution is to use the pre-drift (rewound) particle position when
+					// computing r_cell for angular momentum, e.g.:
+					//   const double x_rewind = (p.pos(0) - pvx * dt) - plo[0] - (ii + 0.5) * dx[0];
+					// This might restore Galilean invariance for all particles. However, this breaks
+					// the order of operations of the current scheme, so it is not necessarily the
+					// right thing to do.
 					accreted_ang_mom_x += accreted_mass_cell * (z * vy - y * vz);
 					accreted_ang_mom_y += accreted_mass_cell * (x * vz - z * vx);
 					accreted_ang_mom_z += accreted_mass_cell * (y * vx - x * vy);

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -448,9 +448,11 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					// This might restore Galilean invariance for all particles. However, this breaks
 					// the order of operations of the current scheme, so it is not necessarily the
 					// right thing to do.
-					accreted_ang_mom_x += accreted_mass_cell * (y * vz_rel - z * vy_rel);
-					accreted_ang_mom_y += accreted_mass_cell * (z * vx_rel - x * vz_rel);
-					accreted_ang_mom_z += accreted_mass_cell * (x * vy_rel - y * vx_rel);
+					if (ang_mom_index >= 0) {
+						accreted_ang_mom_x += accreted_mass_cell * (y * vz_rel - z * vy_rel);
+						accreted_ang_mom_y += accreted_mass_cell * (z * vx_rel - x * vz_rel);
+						accreted_ang_mom_z += accreted_mass_cell * (x * vy_rel - y * vx_rel);
+					}
 					//-----------------------------------------------------------------------------------------------------
 				}
 			}

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -328,7 +328,7 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					const amrex::Array4<const amrex::Real> &local_scale_down, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &plo,
 					const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx,
 					std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> fab_fc, int mass_index, amrex::Real /*time*/,
-					amrex::Real dt, amrex::Real /*vol*/, int mdot_index = -1)
+					amrex::Real dt, amrex::Real /*vol*/, int mdot_index = -1, int ang_mom_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::UpdateParticleMassAndMomentumInBox()");
 	// Get the particle array of structs
@@ -384,9 +384,13 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 		double accreted_momentum_x = 0.0;
 		double accreted_momentum_y = 0.0;
 		double accreted_momentum_z = 0.0;
+		double accreted_ang_mom_x = 0.0;
+		double accreted_ang_mom_y = 0.0;
+		double accreted_ang_mom_z = 0.0;
 		for (int ii = ix - stencil_size; ii <= ix + stencil_size; ++ii) {
 			for (int jj = iy - stencil_size; jj <= iy + stencil_size; ++jj) {
 				for (int kk = iz - stencil_size; kk <= iz + stencil_size; ++kk) {
+					// x,y,z = (particle_pos - cell_center), so cell-relative-to-particle = (-x,-y,-z)
 					const double x = p.pos(0) - plo[0] - (ii + static_cast<amrex::Real>(0.5)) * dx[0];
 					const double y = p.pos(1) - plo[1] - (jj + static_cast<amrex::Real>(0.5)) * dx[1];
 					const double z = p.pos(2) - plo[2] - (kk + static_cast<amrex::Real>(0.5)) * dx[2];
@@ -419,6 +423,13 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					accreted_momentum_x += accreted_mass_cell * vx;
 					accreted_momentum_y += accreted_mass_cell * vy;
 					accreted_momentum_z += accreted_mass_cell * vz;
+					// Angular momentum: L += dm * (r_cell × v_cell), where r_cell = cell_center - par_pos = (-x, -y, -z)
+					// L_x = dm * ((-y)*vz - (-z)*vy) = dm * (z*vy - y*vz)
+					// L_y = dm * ((-z)*vx - (-x)*vz) = dm * (x*vz - z*vx)
+					// L_z = dm * ((-x)*vy - (-y)*vx) = dm * (y*vx - x*vy)
+					accreted_ang_mom_x += accreted_mass_cell * (z * vy - y * vz);
+					accreted_ang_mom_y += accreted_mass_cell * (x * vz - z * vx);
+					accreted_ang_mom_z += accreted_mass_cell * (y * vx - x * vy);
 					//-----------------------------------------------------------------------------------------------------
 				}
 			}
@@ -433,13 +444,18 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 		if (mdot_index >= 0) {
 			p.rdata(mdot_index) = accreted_mass / dt;
 		}
+		if (ang_mom_index >= 0) {
+			p.rdata(ang_mom_index) += accreted_ang_mom_x;
+			p.rdata(ang_mom_index + 1) += accreted_ang_mom_y;
+			p.rdata(ang_mom_index + 2) += accreted_ang_mom_z;
+		}
 	});
 }
 
 template <typename ContainerType, typename problem_t>
 void UpdateParticleMassAndMomentum(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &scale_down,
 				   std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc, int lev, int mass_index, amrex::Real time, amrex::Real dt,
-				   int mdot_index = -1)
+				   int mdot_index = -1, int ang_mom_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::UpdateParticleMassAndMomentum()");
 	for (typename ContainerType::ParIterType pti(*container, lev); pti.isValid(); ++pti) {
@@ -463,7 +479,7 @@ void UpdateParticleMassAndMomentum(ContainerType *container, amrex::MultiFab &st
 
 		// Process particles in this box
 		UpdateParticleMassAndMomentumInBox<ContainerType, problem_t>(pti, local_state, local_scale_down, plo, dx, local_fab_fc, mass_index, time, dt,
-									     vol, mdot_index);
+									     vol, mdot_index, ang_mom_index);
 	}
 }
 
@@ -527,7 +543,7 @@ void computeAccretion(ContainerType *container, amrex::MultiFab &state, amrex::M
 template <typename ContainerType, typename problem_t>
 void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::MultiFab &state_accretion_rate,
 		    std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc, const amrex::Geometry &geom, int lev, amrex::Real time, amrex::Real dt,
-		    int mass_index, int mdot_index = -1)
+		    int mass_index, int mdot_index = -1, int ang_mom_index = -1)
 {
 	const BL_PROFILE("SinkAccretionUtils::applyAccretion()");
 	// Step 2: Compute the scale_down factor. We scale down the accretion rate to prevent accretion rates from exceeding 100%
@@ -537,8 +553,9 @@ void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::Mul
 	// Update accretion_rate and compute scale_down
 	ComputeScaleDown<problem_t>(state, state_accretion_rate, scale_down, geom, state_fc);
 
-	// Step 3: Update particle mass, momentum, and accretion rate
-	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index);
+	// Step 3: Update particle mass, momentum, accretion rate, and angular momentum
+	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index,
+								ang_mom_index);
 
 	// Step 4: Update the hydro state. We do this at last because the original state is needed for updating particles in step 3.
 	UpdateHydroState<problem_t>(state, state_accretion_rate);

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -421,18 +421,21 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					// M_dot_cell is negative, so we multiply it by -1 to get the accreted mass
 					const double accreted_mass_cell = -M_dot_cell * dt * scale_down_factor;
 					const double rho = local_state(ii, jj, kk, HydroSystem<problem_t>::density_index);
-					const double vx = local_state(ii, jj, kk, HydroSystem<problem_t>::x1Momentum_index) / rho - pvx;
-					const double vy = local_state(ii, jj, kk, HydroSystem<problem_t>::x2Momentum_index) / rho - pvy;
-					const double vz = local_state(ii, jj, kk, HydroSystem<problem_t>::x3Momentum_index) / rho - pvz;
+					const double vx_lab = local_state(ii, jj, kk, HydroSystem<problem_t>::x1Momentum_index) / rho;
+					const double vy_lab = local_state(ii, jj, kk, HydroSystem<problem_t>::x2Momentum_index) / rho;
+					const double vz_lab = local_state(ii, jj, kk, HydroSystem<problem_t>::x3Momentum_index) / rho;
+					const double vx_rel = vx_lab - pvx;
+					const double vy_rel = vy_lab - pvy;
+					const double vz_rel = vz_lab - pvz;
 					accreted_mass += accreted_mass_cell;
-					accreted_momentum_x += accreted_mass_cell * vx;
-					accreted_momentum_y += accreted_mass_cell * vy;
-					accreted_momentum_z += accreted_mass_cell * vz;
+					accreted_momentum_x += accreted_mass_cell * vx_lab;
+					accreted_momentum_y += accreted_mass_cell * vy_lab;
+					accreted_momentum_z += accreted_mass_cell * vz_lab;
 					// Angular momentum: L += dm * (r_cell × v_rel), where r_cell = cell_center - par_pos = (-x, -y, -z)
 					// and v_rel = v_gas - v_par (relative velocity, Galilean invariant by construction).
-					// L_x = dm * ((-y)*vz - (-z)*vy) = dm * (z*vy - y*vz)
-					// L_y = dm * ((-z)*vx - (-x)*vz) = dm * (x*vz - z*vx)
-					// L_z = dm * ((-x)*vy - (-y)*vx) = dm * (y*vx - x*vy)
+					// L_x = dm * ((-y)*vz_rel - (-z)*vy_rel) = dm * (z*vy_rel - y*vz_rel)
+					// L_y = dm * ((-z)*vx_rel - (-x)*vz_rel) = dm * (x*vz_rel - z*vx_rel)
+					// L_z = dm * ((-x)*vy_rel - (-y)*vx_rel) = dm * (y*vx_rel - x*vy_rel)
 					//
 					// NOTE: Galilean invariance of L is only approximate (~2% at typical boost/dt).
 					// The residual error arises because p.pos() here is the *post-drift* position:
@@ -445,9 +448,9 @@ void UpdateParticleMassAndMomentumInBox(const typename ContainerType::ParIterTyp
 					// This might restore Galilean invariance for all particles. However, this breaks
 					// the order of operations of the current scheme, so it is not necessarily the
 					// right thing to do.
-					accreted_ang_mom_x += accreted_mass_cell * (z * vy - y * vz);
-					accreted_ang_mom_y += accreted_mass_cell * (x * vz - z * vx);
-					accreted_ang_mom_z += accreted_mass_cell * (y * vx - x * vy);
+					accreted_ang_mom_x += accreted_mass_cell * (z * vy_rel - y * vz_rel);
+					accreted_ang_mom_y += accreted_mass_cell * (x * vz_rel - z * vx_rel);
+					accreted_ang_mom_z += accreted_mass_cell * (y * vx_rel - x * vy_rel);
 					//-----------------------------------------------------------------------------------------------------
 				}
 			}

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -316,7 +316,10 @@ AMREX_ENUM(SinkParticleRealIdx, // NOLINT
 	   vx,			// Velocity in x direction
 	   vy,			// Velocity in y direction
 	   vz,			// Velocity in z direction
-	   mdot			// Current mass accretion rate
+	   mdot,		// Current mass accretion rate
+	   Lx,			// Angular momentum in x direction
+	   Ly,			// Angular momentum in y direction
+	   Lz			// Angular momentum in z direction
 );
 
 // Backward compatibility aliases for existing code
@@ -325,9 +328,12 @@ constexpr int SinkParticleVxIdx = static_cast<int>(SinkParticleRealIdx::vx);
 constexpr int SinkParticleVyIdx = static_cast<int>(SinkParticleRealIdx::vy);
 constexpr int SinkParticleVzIdx = static_cast<int>(SinkParticleRealIdx::vz);
 constexpr int SinkParticleMdotIdx = static_cast<int>(SinkParticleRealIdx::mdot);
+constexpr int SinkParticleLxIdx = static_cast<int>(SinkParticleRealIdx::Lx);
+constexpr int SinkParticleLyIdx = static_cast<int>(SinkParticleRealIdx::Ly);
+constexpr int SinkParticleLzIdx = static_cast<int>(SinkParticleRealIdx::Lz);
 
 // Number of real components for Sink_particles
-constexpr int SinkParticleRealComps = 5; // mass, vx, vy, vz, mdot
+constexpr int SinkParticleRealComps = 8; // mass, vx, vy, vz, mdot, Lx, Ly, Lz
 
 // Type definitions for Sink_particles container and iterator
 using SinkParticleContainer = amrex::AmrParticleContainer<SinkParticleRealComps>;
@@ -447,7 +453,15 @@ inline auto get_units_data() -> const auto &
 	       {"death_density", {1, -3, 0, 0}},
 	       {"mass_at_birth", {1, 0, 0, 0}},
 	       {"luminosity", {-1, 2, -3, 0}}}}},
-	    {ParticleType::Sink, {{{"mass", {1, 0, 0, 0}}, {"vx", {0, 1, -1, 0}}, {"vy", {0, 1, -1, 0}}, {"vz", {0, 1, -1, 0}}, {"mdot", {1, 0, -1, 0}}}}},
+	    {ParticleType::Sink,
+	     {{{"mass", {1, 0, 0, 0}},
+	       {"vx", {0, 1, -1, 0}},
+	       {"vy", {0, 1, -1, 0}},
+	       {"vz", {0, 1, -1, 0}},
+	       {"mdot", {1, 0, -1, 0}},
+	       {"Lx", {1, 2, -1, 0}},
+	       {"Ly", {1, 2, -1, 0}},
+	       {"Lz", {1, 2, -1, 0}}}}},
 	    {ParticleType::Test,
 	     {{{"mass", {1, 0, 0, 0}},
 	       {"vx", {0, 1, -1, 0}},

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -241,6 +241,14 @@ auto problem_main() -> int
 		amrex::Print() << "Total mass change = " << gas_mass_change + particle_mass_change << "\n";
 		amrex::Print() << "Relative error in change of mass = " << rel_mass_error << "\n";
 
+		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
+		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
+		for (int pi = 0; pi < static_cast<int>(real_data_ste1.size()); ++pi) {
+			const auto &p = real_data_ste1[pi];
+			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
+						      p[Lx_offset + 2]);
+		}
+
 		// compute relative error in the change of total mass
 		const double rel_error_total_mass = std::abs(total_total_mass_step1 - total_total_mass_init) / total_total_mass_init;
 		amrex::Print() << "Relative error in change of total mass = " << rel_error_total_mass << "\n";
@@ -355,6 +363,8 @@ auto problem_main() -> int
 	sim2.maxTimesteps_ = 1;
 	sim2.evolve();
 
+	const auto &real_data_phase2 = sim2.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
+
 	// Extract density profile from boosted simulation
 	auto [position2, values2] = fextract(sim2.state_new_cc_[0], sim2.Geom(0), 0, 0.0, true);
 
@@ -362,6 +372,14 @@ auto problem_main() -> int
 	// If the physics is Galilean invariant, the boosted simulation should match its analytical
 	// solution with the same accuracy as the base simulation matches its analytical solution
 	if (amrex::ParallelDescriptor::IOProcessor()) {
+		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
+		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
+		for (int pi = 0; pi < static_cast<int>(real_data_phase2.size()); ++pi) {
+			const auto &p = real_data_phase2[pi];
+			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
+									p[Lx_offset + 2]);
+		}
+
 		// Compute analytical solution for boosted case based on its actual evolution time
 		const Real drho2 = rho_dot_exact * sim2.tNew_[0];
 

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -12,6 +12,7 @@
 #include "util/fextract.hpp"
 #include <format>
 #include <numeric>
+#include <utility>
 
 #include "QuokkaSimulation.hpp"
 #include "fundamental_constants.H"
@@ -248,7 +249,7 @@ auto problem_main() -> int
 
 		// Print and store angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
 		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
-		for (int pi = 0; pi < static_cast<int>(real_data_ste1.size()); ++pi) {
+		for (int pi = 0; std::cmp_less(pi, real_data_ste1.size()); ++pi) {
 			const auto &p = real_data_ste1[pi];
 			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
 						      p[Lx_offset + 2]);
@@ -519,7 +520,7 @@ auto problem_main() -> int
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
 		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
-		for (int pi = 0; pi < static_cast<int>(real_data_phase3.size()); ++pi) {
+		for (int pi = 0; std::cmp_less(pi, real_data_phase3.size()); ++pi) {
 			const auto &p = real_data_phase3[pi];
 			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
 						      p[Lx_offset + 2]);

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -392,8 +392,7 @@ auto problem_main() -> int
 		std::vector<int> idx1(npar);
 		std::iota(idx1.begin(), idx1.end(), 0);
 		std::sort(idx1.begin(), idx1.end(), [&](int a, int b) {
-			return std::tie(pos_phase1[a][0], pos_phase1[a][1], pos_phase1[a][2]) <
-			       std::tie(pos_phase1[b][0], pos_phase1[b][1], pos_phase1[b][2]);
+			return std::tie(pos_phase1[a][0], pos_phase1[a][1], pos_phase1[a][2]) < std::tie(pos_phase1[b][0], pos_phase1[b][1], pos_phase1[b][2]);
 		});
 
 		std::vector<int> idx2(npar);
@@ -415,8 +414,7 @@ auto problem_main() -> int
 			const double Ly1 = ang_mom_phase1[idx1[pi]][1];
 			const double Lz1 = ang_mom_phase1[idx1[pi]][2];
 			const double L1_norm = std::sqrt(Lx1 * Lx1 + Ly1 * Ly1 + Lz1 * Lz1);
-			const double dL_norm =
-			    std::sqrt((Lx2 - Lx1) * (Lx2 - Lx1) + (Ly2 - Ly1) * (Ly2 - Ly1) + (Lz2 - Lz1) * (Lz2 - Lz1));
+			const double dL_norm = std::sqrt((Lx2 - Lx1) * (Lx2 - Lx1) + (Ly2 - Ly1) * (Ly2 - Ly1) + (Lz2 - Lz1) * (Lz2 - Lz1));
 			const double ang_mom_rel_error = (L1_norm > 0.0) ? dL_norm / L1_norm : dL_norm;
 			amrex::Print() << std::format("Particle {} angular momentum relative error (Phase1 vs Phase2): {:.4e}\n", pi, ang_mom_rel_error);
 			if (!(ang_mom_rel_error < ang_mom_rel_error_tol)) {

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -471,7 +471,17 @@ auto problem_main() -> int
 	}
 	const double total_total_mass_phase3_final = total_mass_phase3_final + total_particle_mass_phase3_final;
 
+	const auto &real_data_phase3 = sim2.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
+
 	if (amrex::ParallelDescriptor::IOProcessor()) {
+		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
+		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
+		for (int pi = 0; pi < static_cast<int>(real_data_phase3.size()); ++pi) {
+			const auto &p = real_data_phase3[pi];
+			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
+						      p[Lx_offset + 2]);
+		}
+
 		amrex::Print() << "\nPhase 3 mass conservation check:\n";
 		amrex::Print() << "Initial total mass = " << total_total_mass_phase3_init << "\n";
 		amrex::Print() << "Final total mass = " << total_total_mass_phase3_final << "\n";

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -11,6 +11,7 @@
 #include "math/interpolate.hpp"
 #include "util/fextract.hpp"
 #include <format>
+#include <numeric>
 
 #include "QuokkaSimulation.hpp"
 #include "fundamental_constants.H"
@@ -223,6 +224,10 @@ auto problem_main() -> int
 
 	const auto &real_data_ste1 = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::Sink)->getParticleDataAtLevel(0).first;
 
+	// Store Phase 1 particle positions and angular momentum for later Galilean invariance comparison
+	std::vector<std::array<double, 3>> ang_mom_phase1;
+	std::vector<std::array<double, 3>> pos_phase1;
+
 	if (amrex::ParallelDescriptor::IOProcessor()) {
 		// compute total particle mass and error
 		double total_particle_mass_step1 = 0.0;
@@ -241,12 +246,14 @@ auto problem_main() -> int
 		amrex::Print() << "Total mass change = " << gas_mass_change + particle_mass_change << "\n";
 		amrex::Print() << "Relative error in change of mass = " << rel_mass_error << "\n";
 
-		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
+		// Print and store angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
 		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
 		for (int pi = 0; pi < static_cast<int>(real_data_ste1.size()); ++pi) {
 			const auto &p = real_data_ste1[pi];
 			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
 						      p[Lx_offset + 2]);
+			ang_mom_phase1.push_back({p[Lx_offset], p[Lx_offset + 1], p[Lx_offset + 2]});
+			pos_phase1.push_back({p[0], p[1], p[2]});
 		}
 
 		// compute relative error in the change of total mass
@@ -372,12 +379,60 @@ auto problem_main() -> int
 	// If the physics is Galilean invariant, the boosted simulation should match its analytical
 	// solution with the same accuracy as the base simulation matches its analytical solution
 	if (amrex::ParallelDescriptor::IOProcessor()) {
-		// Print angular momentum for each particle (data layout: x,y,z, mass,vx,vy,vz,mdot,Lx,Ly,Lz)
+		// Compare angular momentum vs Phase 1 for Galilean invariance validation.
+		// Angular momentum is computed in the particle's rest frame (using relative velocity), so
+		// the accreted L must be identical regardless of the boost.
+		// Sort both Phase 1 and Phase 2 particles by position before comparing to ensure
+		// consistent ordering, since particle redistribution may change the array order.
 		constexpr int Lx_offset = AMREX_SPACEDIM + quokka::SinkParticleLxIdx;
-		for (int pi = 0; pi < static_cast<int>(real_data_phase2.size()); ++pi) {
-			const auto &p = real_data_phase2[pi];
-			amrex::Print() << std::format("Particle {} angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, p[Lx_offset], p[Lx_offset + 1],
-									p[Lx_offset + 2]);
+		const double ang_mom_rel_error_tol = 0.03; // 3% tolerance
+
+		// Build sorted index arrays for Phase 1 and Phase 2 by (x, y, z)
+		const int npar = static_cast<int>(ang_mom_phase1.size());
+		std::vector<int> idx1(npar);
+		std::iota(idx1.begin(), idx1.end(), 0);
+		std::sort(idx1.begin(), idx1.end(), [&](int a, int b) {
+			if (pos_phase1[a][0] != pos_phase1[b][0]) {
+				return pos_phase1[a][0] < pos_phase1[b][0];
+			}
+			if (pos_phase1[a][1] != pos_phase1[b][1]) {
+				return pos_phase1[a][1] < pos_phase1[b][1];
+			}
+			return pos_phase1[a][2] < pos_phase1[b][2];
+		});
+
+		std::vector<int> idx2(npar);
+		std::iota(idx2.begin(), idx2.end(), 0);
+		std::sort(idx2.begin(), idx2.end(), [&](int a, int b) {
+			if (real_data_phase2[a][0] != real_data_phase2[b][0]) {
+				return real_data_phase2[a][0] < real_data_phase2[b][0];
+			}
+			if (real_data_phase2[a][1] != real_data_phase2[b][1]) {
+				return real_data_phase2[a][1] < real_data_phase2[b][1];
+			}
+			return real_data_phase2[a][2] < real_data_phase2[b][2];
+		});
+
+		amrex::Print() << "\nAngular momentum Galilean invariance check:\n";
+		for (int pi = 0; pi < npar; ++pi) {
+			const auto &p2 = real_data_phase2[idx2[pi]];
+			const double Lx2 = p2[Lx_offset];
+			const double Ly2 = p2[Lx_offset + 1];
+			const double Lz2 = p2[Lx_offset + 2];
+			amrex::Print() << std::format("Particle {} (Phase2) angular momentum: Lx={:.4e} Ly={:.4e} Lz={:.4e}\n", pi, Lx2, Ly2, Lz2);
+
+			const double Lx1 = ang_mom_phase1[idx1[pi]][0];
+			const double Ly1 = ang_mom_phase1[idx1[pi]][1];
+			const double Lz1 = ang_mom_phase1[idx1[pi]][2];
+			const double L1_norm = std::sqrt(Lx1 * Lx1 + Ly1 * Ly1 + Lz1 * Lz1);
+			const double dL_norm =
+			    std::sqrt((Lx2 - Lx1) * (Lx2 - Lx1) + (Ly2 - Ly1) * (Ly2 - Ly1) + (Lz2 - Lz1) * (Lz2 - Lz1));
+			const double ang_mom_rel_error = (L1_norm > 0.0) ? dL_norm / L1_norm : dL_norm;
+			amrex::Print() << std::format("Particle {} angular momentum relative error (Phase1 vs Phase2): {:.4e}\n", pi, ang_mom_rel_error);
+			if (!(ang_mom_rel_error < ang_mom_rel_error_tol)) {
+				status = 1;
+				amrex::Print() << std::format("Test failed: angular momentum not Galilean invariant for particle {}\n", pi);
+			}
 		}
 
 		// Compute analytical solution for boosted case based on its actual evolution time

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -392,25 +392,15 @@ auto problem_main() -> int
 		std::vector<int> idx1(npar);
 		std::iota(idx1.begin(), idx1.end(), 0);
 		std::sort(idx1.begin(), idx1.end(), [&](int a, int b) {
-			if (pos_phase1[a][0] != pos_phase1[b][0]) {
-				return pos_phase1[a][0] < pos_phase1[b][0];
-			}
-			if (pos_phase1[a][1] != pos_phase1[b][1]) {
-				return pos_phase1[a][1] < pos_phase1[b][1];
-			}
-			return pos_phase1[a][2] < pos_phase1[b][2];
+			return std::tie(pos_phase1[a][0], pos_phase1[a][1], pos_phase1[a][2]) <
+			       std::tie(pos_phase1[b][0], pos_phase1[b][1], pos_phase1[b][2]);
 		});
 
 		std::vector<int> idx2(npar);
 		std::iota(idx2.begin(), idx2.end(), 0);
 		std::sort(idx2.begin(), idx2.end(), [&](int a, int b) {
-			if (real_data_phase2[a][0] != real_data_phase2[b][0]) {
-				return real_data_phase2[a][0] < real_data_phase2[b][0];
-			}
-			if (real_data_phase2[a][1] != real_data_phase2[b][1]) {
-				return real_data_phase2[a][1] < real_data_phase2[b][1];
-			}
-			return real_data_phase2[a][2] < real_data_phase2[b][2];
+			return std::tie(real_data_phase2[a][0], real_data_phase2[a][1], real_data_phase2[a][2]) <
+			       std::tie(real_data_phase2[b][0], real_data_phase2[b][1], real_data_phase2[b][2]);
 		});
 
 		amrex::Print() << "\nAngular momentum Galilean invariance check:\n";


### PR DESCRIPTION
### Description

- Add angular momentum components (`Lx`, `Ly`, `Lz`) to sink particle real data, bringing the total from 5 to 8 real components (`mass`, `vx`, `vy`, `vz`, `mdot`, `Lx`, `Ly`, `Lz`).
- During accretion, accumulate angular momentum from each gas cell: `ΔL = Δm × (r_cell × v_rel)`, where `r_cell` is the cell center position relative to the sink particle and `v_rel = v_gas - v_particle` (relative velocity for Galilean invariance).
- Wire `angMomIndex_` through `PhysicsParticleDescriptorBase` and `PhysicsParticleDescriptor` so any future particle type can opt in to angular momentum tracking.
- Validated with the `ParticleSink` test problem, which passes all 3 phases (density accuracy, Galilean invariance, and mass conservation), and prints per-particle angular momentum after evolution.

### Files Changed

- `src/particles/particle_types.hpp`: Added `Lx`, `Ly`, `Lz` to `SinkParticleRealIdx`; updated `SinkParticleRealComps` and units data.
- `src/particles/particle_accretion.hpp`: Added angular momentum accumulation in `UpdateParticleMassAndMomentumInBox`; threaded `ang_mom_index` through `UpdateParticleMassAndMomentum` and `applyAccretion`.
- `src/particles/PhysicsParticles.hpp`: Added `angMomIndex_` field and getter to the descriptor base class; updated constructors; passed `SinkParticleLxIdx` for sink particles.
- `src/problems/ParticleSink/testParticleSink.cpp`: Added Galilean invariance check for angular momentum (Phase 1 vs Phase 2, 3% tolerance, sorted by particle position); prints per-particle angular momentum after evolution.


### Related issues

None.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

