### PR TITLE
Make nghost counts compile-time constants in AMRSimulation

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -549,8 +549,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// Nghost = number of ghost cells for each array
 	// For our new scheme MHD-scheme, we need 7 ghosts for MHD (4 base + 3 for EMF) or 6 otherwise
-	static constexpr int nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6;
-	static constexpr int nghost_fc_ = nghost_cc_;
+	const int nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6;
+	const int nghost_fc_ = nghost_cc_;
 
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -549,8 +549,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// Nghost = number of ghost cells for each array
 	// For our new scheme MHD-scheme, we need 7 ghosts for MHD (4 base + 3 for EMF) or 6 otherwise
-	int nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6;
-	int nghost_fc_ = nghost_cc_;
+	static constexpr int nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6;
+	static constexpr int nghost_fc_ = nghost_cc_;
 
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;


### PR DESCRIPTION
### Motivation
- Make the number of ghost cells a compile-time constant so it can be used in constant expressions and to avoid runtime initialization issues for template-based physics traits.

### Description
- Change `nghost_cc_` and `nghost_fc_` from non-const `int` members to `static constexpr int` members with `nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6` and `nghost_fc_ = nghost_cc_`.

### Testing
- Project build (CI) and the existing unit/integration test suite were run and succeeded without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c11859b850832796bb4dbce6e62572)