### PR TITLE
Add a derived field for H2 density

### DIFF
--- a/inputs/DiskGalaxy.toml
+++ b/inputs/DiskGalaxy.toml
@@ -40,7 +40,7 @@ signal_speed_abort = 6e8
 
 checkpoint_interval = 100
 plotfile_interval = 10
-derived_vars = ["temperature", "gpot"]
+derived_vars = ["temperature", "gpot", "h2_mass"]
 
 # max_level = 7 implies a maximum resolution of dx =  73.2 pc (LOW res).
 # max_level = 8 implies a maximum resolution of dx =  36.6 pc (MED res).

--- a/src/cooling/ResampledCooling.hpp
+++ b/src/cooling/ResampledCooling.hpp
@@ -118,6 +118,86 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputePressureFromRhoEint(Real co
 	return P;
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeMeanMolecularWeightFromRhoPT(Real const rho, Real const P, Real const T) -> Real
+{
+	if ((rho <= 0.0) || (P <= 0.0) || (T <= 0.0)) {
+		return 0.0;
+	}
+	return (rho * C::k_B * T) / (P * C::m_p);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeElectronFractionFromRhoPT(Real const rho, Real const P, Real const T,
+									       resampledGpuConstTables const &tables) -> Real
+{
+	if ((rho <= 0.0) || (P <= 0.0) || (T <= 0.0) || (tables.cloudy_H_mass_fraction <= 0.0)) {
+		return 0.0;
+	}
+
+	const Real mu = ComputeMeanMolecularWeightFromRhoPT(rho, P, T);
+	if (mu <= 0.0) {
+		return 0.0;
+	}
+
+	// Match extern/cooling/grackle_tables.py: recover the free-electron abundance x_e = n_e / n_H
+	// from the photoionization-equilibrium mean molecular weight.
+	const Real X = tables.cloudy_H_mass_fraction;
+	const Real Z = 0.02;
+	const Real Y = 1.0 - X - Z;
+	const Real mean_metals_A = 16.0;
+	const Real electron_mass_over_hydrogen_mass = C::m_e / C::m_p;
+	const Real numerator = 1.0 - mu * (X + 0.25 * Y + (Z / mean_metals_A));
+	const Real denominator = X * (mu - electron_mass_over_hydrogen_mass);
+	if (denominator <= 0.0) {
+		return 0.0;
+	}
+
+	Real electron_fraction = numerator / denominator;
+	if (electron_fraction < 0.0) {
+		electron_fraction = 0.0;
+	}
+	return electron_fraction;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeHIIFractionApproxFromRhoPT(Real const rho, Real const P, Real const T,
+										resampledGpuConstTables const &tables) -> Real
+{
+	const Real electron_fraction = ComputeElectronFractionFromRhoPT(rho, P, T, tables);
+
+	// Match the approximate closure used in the resampling scripts:
+	// assume H and He share a common ionization progress chi, such that
+	// x_e = n_e / n_H ~= chi * (1 + 2 n_He / n_H), with xHII = chi.
+	const Real X = tables.cloudy_H_mass_fraction;
+	const Real Z = 0.02;
+	const Real Y = 1.0 - X - Z;
+	const Real nHe_over_nH = Y / (4.0 * X);
+	const Real electron_capacity_per_H = 1.0 + 2.0 * nHe_over_nH;
+	if (electron_capacity_per_H <= 0.0) {
+		return 0.0;
+	}
+
+	Real ionized_fraction = electron_fraction / electron_capacity_per_H;
+	if (ionized_fraction < 0.0) {
+		ionized_fraction = 0.0;
+	}
+	if (ionized_fraction > 1.0) {
+		ionized_fraction = 1.0;
+	}
+	return ionized_fraction;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeHIFractionApproxFromRhoPT(Real const rho, Real const P, Real const T,
+									       resampledGpuConstTables const &tables) -> Real
+{
+	Real neutral_fraction = 1.0 - ComputeHIIFractionApproxFromRhoPT(rho, P, T, tables);
+	if (neutral_fraction < 0.0) {
+		neutral_fraction = 0.0;
+	}
+	if (neutral_fraction > 1.0) {
+		neutral_fraction = 1.0;
+	}
+	return neutral_fraction;
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto ComputeEntropyFromRhoEint(Real const rho, Real const Eint, resampledGpuConstTables const &tables) -> Real
 {
 	// Convert Eint (energy density) to eint (specific energy) and then to fast log scale for interpolation

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -42,6 +42,8 @@ namespace
 {
 constexpr double keV_in_ergs = 1000.0 * C::ev2erg; // ergs == 1 keV
 constexpr double seconds_per_year = 3.15576e7;
+constexpr double h2_pressure_scale = 1.7e4; // K cm^-3
+constexpr double h2_pressure_alpha = 0.8;
 } // namespace
 
 struct DiskGalaxy {
@@ -607,6 +609,44 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				Real const Pgas = HydroSystem<DiskGalaxy>::ComputePressure(state, i, j, k, &cons_fc);
 				output(i, j, k, ncomp) = Pgas / C::k_B;
+			});
+		}
+	}
+
+	if (dname == "h2_mass") {
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "DiskGalaxy h2_mass requires resampled cooling tables.");
+		const int ncomp = ncomp_cc_in;
+		auto tables = resampledTables_.const_tables();
+		const auto dx = geom[lev].CellSizeArray();
+		const Real dvol = dx[0] * dx[1] * dx[2];
+		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
+			const amrex::Box &indexRange = iter.validbox();
+			auto const &output = mf.array(iter);
+			auto const &state = state_new_cc_[lev].const_array(iter);
+			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+				Real const rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
+				if (rho <= 0.0) {
+					output(i, j, k, ncomp) = 0.0;
+					return;
+				}
+				Real const x1Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index);
+				Real const x2Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x2Momentum_index);
+				Real const x3Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x3Momentum_index);
+				Real const Egas = state(i, j, k, HydroSystem<DiskGalaxy>::energy_index);
+				Real const Eint = RadSystem<DiskGalaxy>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas);
+				Real const Tgas = quokka::ResampledCooling::ComputeTgasFromEgas(rho, Eint, tables);
+				Real const Pgas = quokka::ResampledCooling::ComputePressureFromRhoEint(rho, Eint, tables);
+				Real const xHI = quokka::ResampledCooling::ComputeHIFractionApproxFromRhoPT(rho, Pgas, Tgas, tables);
+				Real const P_over_kB = Pgas / C::k_B;
+
+				Real h2_mass = 0.0;
+				if ((xHI > 0.0) && (P_over_kB > 0.0)) {
+					Real const neutral_h_mass = rho * dvol * tables.cloudy_H_mass_fraction * xHI;
+					Real const R_mol = std::pow((xHI * P_over_kB) / h2_pressure_scale, h2_pressure_alpha);
+					h2_mass = neutral_h_mass * (R_mol / (1.0 + R_mol));
+				}
+
+				output(i, j, k, ncomp) = h2_mass;
 			});
 		}
 	}


### PR DESCRIPTION
### Description
Adds a derived field for H2 density, based on the prescription of https://scixplorer.org/abs/2006ApJ...650..933B/abstract.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
