### PR TITLE
Set the number of ghost cells based on methods used

### DIFF
--- a/docs/markdown/hydro_integrator.md
+++ b/docs/markdown/hydro_integrator.md
@@ -16,6 +16,41 @@ The hydro integrator advances the conservative gas (and optionally MHD) variable
 - Directional flux functions call the appropriate Riemann solver: `HLLC` for pure hydro, `HLLD` plus constrained transport (`SolveInductionEqn`) for MHD. The solver also returns face-centered velocities and the fastest MHD wave speeds used by the EMF update.
 - Before the second-order update, a first-order (donor-cell) set of fluxes is computed through `computeFOHydroFluxes`. These rely on the diffusive `LLF` solvers so that first-order flux correction has the most stable possible fallback without discarding the high-order solution everywhere.
 
+## Ghost-cell requirements
+The hydro update uses ghosted Riemann outputs with width `nghost_Riemann`. The
+minimum safe value depends on two independent constraints:
+
+- Tracer particles require `nghost_Riemann >= 2` because the time-averaged
+  face velocity used by `AdvectWithUmac` is stored with two ghost faces.
+- MHD may require additional Riemann ghosts for the EMF reconstruction and EMF
+  averaging stencils.
+
+For the persistent state, the current code uses:
+
+- All hydro and MHD paths: `nghost_cc_ = nghost_Riemann + 4`
+- `nghost_fc_ = nghost_cc_`
+
+The full case table is:
+
+| Physics path | Tracers | EMF compute | EMF averaging | `nghost_Riemann` | `nghost_cc_` | `nghost_fc_` |
+|---|---:|---|---|---:|---:|---:|
+| Hydro-only | off | n/a | n/a | 0 | 4 | 4 |
+| Hydro-only | on | n/a | n/a | 2 | 6 | 6 |
+| MHD | off | `FelkerStone2017` | `BalsaraSpicer2004` | 0 | 4 | 4 |
+| MHD | on | `FelkerStone2017` | `BalsaraSpicer2004` | 2 | 6 | 6 |
+| MHD | off | `FelkerStone2017` | `LondrilloDelZanna2004` | 1 | 5 | 5 |
+| MHD | on | `FelkerStone2017` | `LondrilloDelZanna2004` | 2 | 6 | 6 |
+| MHD | off | `FelkerStone2017` | `Balsara2025` | 2 | 6 | 6 |
+| MHD | on | `FelkerStone2017` | `Balsara2025` | 2 | 6 | 6 |
+| MHD | off | `Balsara2025` | `BalsaraSpicer2004` | 0 | 4 | 4 |
+| MHD | on | `Balsara2025` | `BalsaraSpicer2004` | 2 | 6 | 6 |
+| MHD | off | `Balsara2025` | `LondrilloDelZanna2004` | 1 | 5 | 5 |
+| MHD | on | `Balsara2025` | `LondrilloDelZanna2004` | 2 | 6 | 6 |
+| MHD | off | `Balsara2025` | `Balsara2025` | 2 | 6 | 6 |
+| MHD | on | `Balsara2025` | `Balsara2025` | 2 | 6 | 6 |
+| MHD | off | `Quokka2026` | any | 3 | 7 | 7 |
+| MHD | on | `Quokka2026` | any | 3 | 7 | 7 |
+
 ## First-order fallback and stability guards
 Throughout each timestep the solver decorates the update with physics-aware stability checks:
 - `HydroSystem<problem_t>::AddInternalEnergyPdV` and `PredictStep` compute the stage RHS and provisional states. `redoFlag` flips only when the provisional density in a cell becomes non-positive, so flagged cells have their fluxes replaced with the pre-computed first-order counterparts via `replaceFluxes`/`replaceEMFs`. The full timestep in those cells is therefore carried out at first order in both space and time.

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -244,6 +244,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 
 	void initialize()
 	{
+		AMRSimulation<problem_t>::initialize();
+
 		static_assert(!(Physics_Traits<problem_t>::is_mhd_enabled && Physics_Traits<problem_t>::is_radiation_enabled),
 			      "MHD + Radiation is not supported yet.");
 #if (AMREX_SPACEDIM != 3)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2097,7 +2097,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	}
 
 	const amrex::Real stage1Weight = (integratorOrder_ == 2) ? 0.5 : 1.0;
-	const int nghost_Riemann = (Physics_Traits<problem_t>::is_mhd_enabled && emfComputingScheme_ == EMFComputeScheme::Quokka2026) ? 3 : 2;
+	const int nghost_Riemann =
+	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emfComputingScheme_, emfAveragingScheme_, do_tracers != 0);
 
 	auto ba_cc = grids[lev];
 	auto dm = dmap[lev];
@@ -2622,11 +2623,12 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 	const auto ba = grids[lev];
 	const auto dm = dmap[lev];
 
-	// default is 2. we need +1 ghost to get fc-vels in the ghost-zones (for piecewise-constant reconstruction)
-	// for MHD we need to accommodate the higher order reconstruction we need to do in computeEMF
+	// Reconstruct one extra face layer beyond the requested ghosted Riemann outputs
+	// so the outermost ghost face has left/right interface states.
 	const int reconstructGhost = nghost_Riemann + 1;
 
-	// // we need two additional ghost cells in order to compute two ghost face velocities
+	// Shock flattening coefficients are computed one cell farther out than the
+	// reconstructed interfaces and use a +/-2 pressure stencil.
 	const int flatteningGhost = reconstructGhost + 1;
 
 	// allocate temporary MultiFabs
@@ -2831,8 +2833,8 @@ auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &co
 	const auto ba = grids[lev];
 	const auto dm = dmap[lev];
 
-	// same as above: default is 2. we need +1 ghost to get fc-vels in the ghost-zones (for piecewise-constant reconstruction)
-	// for MHD we need to accommodate the higher order reconstruction we need to do in computeEMF
+	// Reconstruct one extra face layer beyond the requested ghosted Riemann outputs
+	// so the outermost ghost face has left/right interface states.
 	const int reconstructRange = nghost_Riemann + 1;
 
 	// allocate temporary MultiFabs

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -34,6 +34,29 @@ AMREX_ENUM(EMFAvgScheme, BalsaraSpicer2004, LondrilloDelZanna2004, Balsara2025);
 // Londrillo + Del Zanna (2004)
 // Balsara (2025): Higher-order averaging
 
+AMREX_FORCE_INLINE constexpr auto MinimumHydroRiemannGhost(bool is_mhd_enabled, EMFComputeScheme emf_compute_scheme, EMFAvgScheme emf_avg_scheme,
+							   bool require_tracer_ghosts = false) -> int
+{
+	int nghost = require_tracer_ghosts ? 2 : 0;
+	if (is_mhd_enabled) {
+		if (emf_compute_scheme == EMFComputeScheme::Quokka2026) {
+			nghost = std::max(nghost, 3);
+		} else {
+			switch (emf_avg_scheme) {
+				case EMFAvgScheme::BalsaraSpicer2004:
+					break;
+				case EMFAvgScheme::LondrilloDelZanna2004:
+					nghost = std::max(nghost, 1);
+					break;
+				case EMFAvgScheme::Balsara2025:
+					nghost = std::max(nghost, 2);
+					break;
+			}
+		}
+	}
+	return nghost;
+}
+
 /// Class for a MHD system of conservation laws
 template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_t>
 {

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -9,6 +9,7 @@
 /// \brief Implements classes and functions to organise the overall setup,
 /// timestepping, solving, and I/O of a simulation for linear advection.
 
+#include <algorithm>
 #include <array>
 #include <fstream>
 
@@ -40,6 +41,7 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	using AMRSimulation<problem_t>::dt_;
 	using AMRSimulation<problem_t>::BCs_cc_;
 	using AMRSimulation<problem_t>::nghost_cc_;
+	using AMRSimulation<problem_t>::nghost_fc_;
 	using AMRSimulation<problem_t>::cycleCount_;
 	using AMRSimulation<problem_t>::istep;
 	using AMRSimulation<problem_t>::areInitialConditionsDefined_;
@@ -68,8 +70,23 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	using AMRSimulation<problem_t>::luminosityTables_;
 #endif // AMREX_SPACEDIM == 3
 
-	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { componentNames_cc_.push_back({"density"}); }
-	explicit AdvectionSimulation() : AMRSimulation<problem_t>() { componentNames_cc_.push_back({"density"}); }
+	explicit AdvectionSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : AMRSimulation<problem_t>(BCs_cc) { initialize(); }
+	explicit AdvectionSimulation() : AMRSimulation<problem_t>() { initialize(); }
+
+	void initialize()
+	{
+		AMRSimulation<problem_t>::initialize();
+		componentNames_cc_.push_back({"density"});
+	}
+
+	void setCustomGhostCells() override
+	{
+		// PPM_EP reconstructs a 3-cell ghost range with a 5-point stencil.
+		constexpr int reconstruct_ghost = 3;
+		constexpr int required_cell_ghost = reconstruct_ghost + 2;
+		nghost_cc_ = std::max(nghost_cc_, required_cell_ghost);
+		nghost_fc_ = std::max(nghost_fc_, nghost_cc_);
+	}
 
 	void computeMaxSignalLocal(int level) override;
 	void printCellProperties(int lev, amrex::IntVect const &index) override;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -870,8 +870,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 		mhd_pp.query("emf_compute_scheme", emf_compute_scheme);
 		mhd_pp.query("emf_averaging_scheme", emf_avg_scheme);
 	}
-	const int nghost_Riemann =
-	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emf_compute_scheme, emf_avg_scheme, do_tracers != 0);
+	const int nghost_Riemann = MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emf_compute_scheme, emf_avg_scheme, do_tracers != 0);
 	nghost_cc_ = nghost_Riemann + 4;
 	nghost_fc_ = nghost_cc_;
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -549,11 +549,15 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
 
 	// Persistent cell-/face-centered state ghost cells.
-	// `readParameters()` updates these before any AMR nesting checks:
-	// - 6 ghosts cover the standard MHD hydro path:
-	//   3 reconstructed ghost interfaces + 1 extra flattening-coefficient layer
-	//   + the +/-2 pressure stencil used to build those coefficients.
-	// - Quokka2026 needs one extra layer because it requests ghosted face-centered Riemann data.
+	// `readParameters()` updates these before any AMR nesting checks.
+	// The hydro path needs `nghost_cc_ = nghost_Riemann + 4`:
+	// - 1 extra reconstructed interface layer beyond the ghosted Riemann outputs
+	// - 1 extra flattening-coefficient layer
+	// - the +/-2 pressure stencil used to build those coefficients
+	// The face-centered ghost count tracks the cell-centered ghost count. This
+	// is required for MHD because converting B_face -> B_cell at the outermost
+	// cell ghost uses the adjacent high-side face, and it also keeps generic
+	// plot/diagnostic code paths from truncating the available cell ghosts.
 	int nghost_cc_ = 6;
 	int nghost_fc_ = 6;
 
@@ -857,21 +861,19 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// ParmParse reads inputs from the *.inputs file
 	const amrex::ParmParse pp;
+	pp.query("do_tracers", do_tracers);
 
+	EMFComputeScheme emf_compute_scheme = EMFComputeScheme::FelkerStone2017;
+	EMFAvgScheme emf_avg_scheme = EMFAvgScheme::LondrilloDelZanna2004;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		EMFComputeScheme emf_compute_scheme = EMFComputeScheme::FelkerStone2017;
 		amrex::ParmParse const mhd_pp("mhd");
 		mhd_pp.query("emf_compute_scheme", emf_compute_scheme);
-
-		// The face-centered state must track the cell-centered ghost count because
-		// converting B_face -> B_cell at the outermost cell ghost uses the adjacent
-		// high-side face.
-		nghost_cc_ = (emf_compute_scheme == EMFComputeScheme::Quokka2026) ? 7 : 6;
-		nghost_fc_ = nghost_cc_;
-	} else {
-		nghost_cc_ = 6;
-		nghost_fc_ = 6;
+		mhd_pp.query("emf_averaging_scheme", emf_avg_scheme);
 	}
+	const int nghost_Riemann =
+	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emf_compute_scheme, emf_avg_scheme, do_tracers != 0);
+	nghost_cc_ = nghost_Riemann + 4;
+	nghost_fc_ = nghost_cc_;
 
 	// Default == true
 	pp.query("show_performance_hints", showPerformanceHints_);
@@ -958,9 +960,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	// Default Poisson solver tolerances
 	pp.query("poisson_reltol", reltolPoisson_);
 	pp.query("poisson_abstol", abstolPoisson_);
-
-	// Default do_tracers = 0 (turns on/off tracer particles)
-	pp.query("do_tracers", do_tracers);
 
 	// Default suppress_output = 0
 	pp.query("suppress_output", suppress_output);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -244,14 +244,13 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	mutable YAML::Node simulationMetadata_;
 
 	// constructor
-	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) { initialize(); }
+	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc, amrex::Vector<amrex::BCRec> &BCs_fc) : BCs_cc_(BCs_cc), BCs_fc_(BCs_fc) {}
 
-	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) { initialize(); }
+	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) {}
 
 	explicit AMRSimulation()
 	{
 		readBCs();
-		initialize();
 	}
 
 	auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> & /*BCs_cc*/) -> amrex::Vector<amrex::BCRec>
@@ -288,6 +287,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	auto computeTimestepAtLevel(int lev) -> amrex::ValLocPair<amrex::Real, amrex::IntVect>;
 
 	void AverageFCToCC(amrex::MultiFab &mf_cc, const amrex::MultiFab &mf_fc, int idim, int dstcomp_start, int srccomp_start, int srccomp_total) const;
+	virtual void setCustomGhostCells() {}
 
 	virtual void computeMaxSignalLocal(int level) = 0;
 	virtual void printCellProperties(int lev, amrex::IntVect const &index) = 0;
@@ -873,6 +873,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 	const int nghost_Riemann = MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emf_compute_scheme, emf_avg_scheme, do_tracers != 0);
 	nghost_cc_ = nghost_Riemann + 4;
 	nghost_fc_ = nghost_cc_;
+	setCustomGhostCells();
 
 	// Default == true
 	pp.query("show_performance_hints", showPerformanceHints_);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -94,6 +94,7 @@ namespace filesystem = experimental::filesystem;
 // internal headers
 #include "fundamental_constants.H"
 #include "grid.hpp"
+#include "hydro/mhd_system.hpp"
 #include "io/DiagBase.H"
 #include "io/DiagFramePlane.H"
 #include "io/DiagPDF.H"
@@ -547,10 +548,14 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	// This is for fillpatch during timestepping, but not for regridding.
 	amrex::Vector<std::unique_ptr<amrex::FillPatcher<amrex::MultiFab>>> fillpatcher_;
 
-	// Nghost = number of ghost cells for each array
-	// For our new scheme MHD-scheme, we need 7 ghosts for MHD (4 base + 3 for EMF) or 6 otherwise
-	int nghost_cc_ = Physics_Traits<problem_t>::is_mhd_enabled ? 7 : 6;
-	int nghost_fc_ = nghost_cc_;
+	// Persistent cell-/face-centered state ghost cells.
+	// `readParameters()` updates these before any AMR nesting checks:
+	// - 6 ghosts cover the standard MHD hydro path:
+	//   3 reconstructed ghost interfaces + 1 extra flattening-coefficient layer
+	//   + the +/-2 pressure stencil used to build those coefficients.
+	// - Quokka2026 needs one extra layer because it requests ghosted face-centered Riemann data.
+	int nghost_cc_ = 6;
+	int nghost_fc_ = 6;
 
 	amrex::Vector<std::string> componentNames_cc_;
 	amrex::Vector<std::string> componentNames_fc_flat_;
@@ -852,6 +857,21 @@ template <typename problem_t> void AMRSimulation<problem_t>::readParameters()
 
 	// ParmParse reads inputs from the *.inputs file
 	const amrex::ParmParse pp;
+
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		EMFComputeScheme emf_compute_scheme = EMFComputeScheme::FelkerStone2017;
+		amrex::ParmParse const mhd_pp("mhd");
+		mhd_pp.query("emf_compute_scheme", emf_compute_scheme);
+
+		// The face-centered state must track the cell-centered ghost count because
+		// converting B_face -> B_cell at the outermost cell ghost uses the adjacent
+		// high-side face.
+		nghost_cc_ = (emf_compute_scheme == EMFComputeScheme::Quokka2026) ? 7 : 6;
+		nghost_fc_ = nghost_cc_;
+	} else {
+		nghost_cc_ = 6;
+		nghost_fc_ = 6;
+	}
 
 	// Default == true
 	pp.query("show_performance_hints", showPerformanceHints_);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -248,10 +248,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	explicit AMRSimulation(amrex::Vector<amrex::BCRec> &BCs_cc) : BCs_cc_(BCs_cc), BCs_fc_(builtin_BCs_fc(BCs_cc)) {}
 
-	explicit AMRSimulation()
-	{
-		readBCs();
-	}
+	explicit AMRSimulation() { readBCs(); }
 
 	auto builtin_BCs_fc(amrex::Vector<amrex::BCRec> & /*BCs_cc*/) -> amrex::Vector<amrex::BCRec>
 	{


### PR DESCRIPTION
### Description
Sets the number of ghost cells and faces (`nghost_cc_` and `nghost_fc_`) based on:
* whether MHD is enabled,
* whether tracer particles are enabled,
* what methods are used for computing the EMF update.

This allows the minimum safe number of ghosts to be used in each case, which minimizes the amount of communication that is done.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
