### PR TITLE
Prevent avatargpu job between 3:30 and 7 am

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -67,8 +67,8 @@ jobs:
 
     - script: |
         # Keep the job idle during the restricted window [03:30, 07:00).
-        blocked_start_minutes=$((12 * 60 + 30))
-        blocked_end_minutes=$((14 * 60))
+        blocked_start_minutes=$((3 * 60 + 30))
+        blocked_end_minutes=$((7 * 60))
         check_interval=600
 
         while true; do

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
         # Keep the job idle during the restricted window [03:30, 07:00).
         blocked_start_minutes=$((3 * 60 + 30))
         blocked_end_minutes=$((7 * 60))
-        check_interval=600
+        time_check_interval=600
 
         while true; do
           hour=$(date +%H)
@@ -77,7 +77,7 @@ jobs:
           now_minutes=$((10#$hour * 60 + 10#$minute))
 
           if [ "$now_minutes" -lt "$blocked_start_minutes" ] || [ "$now_minutes" -ge "$blocked_end_minutes" ]; then
-            echo "Current time $(date '+%F %T') is outside restricted window. Proceeding."
+            echo "Current time $(date '+%F %T') is outside restricted window."
             break
           fi
 
@@ -85,13 +85,47 @@ jobs:
           remaining_seconds=$((remaining_minutes * 60))
           echo "Current time $(date '+%F %T') is within restricted window (03:30-07:00). Remaining wait: ${remaining_minutes}m."
 
-          if [ "$remaining_seconds" -le "$check_interval" ]; then
+          if [ "$remaining_seconds" -le "$time_check_interval" ]; then
             sleep "$remaining_seconds"
           else
-            sleep "$check_interval"
+            sleep "$time_check_interval"
           fi
         done
-      displayName: 'Wait for allowed CI start window'
+
+        echo "Checking for conflicting jobs on the GPU..."
+        gpu_check_interval=60
+        waited=0
+        while true; do
+          # Primary: check for active CUDA processes via GPU driver (cross-container reliable)
+          gpu_procs=$(nvidia-smi --query-compute-apps=pid,name --format=csv,noheader 2>/dev/null || true)
+          # Secondary: check for cron regression test script (best-effort; requires shared PID namespace)
+          regtest_running=0
+          if pgrep -f "regtest.py" > /dev/null 2>&1; then
+            regtest_running=1
+          fi
+          if [ -z "$gpu_procs" ] && [ "$regtest_running" -eq 0 ]; then
+            if [ "$waited" -gt 0 ]; then
+              echo "GPU is free and no regression test detected, proceeding..."
+            else
+              echo "GPU is free, proceeding..."
+            fi
+            break
+          fi
+          reasons=""
+          if [ -n "$gpu_procs" ]; then
+            count=$(echo "$gpu_procs" | grep -c '[0-9]' || true)
+            names=$(echo "$gpu_procs" | awk -F',' '{print $2}' | tr '\n' ' ' | sed 's/ $//')
+            reasons="GPU has ${count} active CUDA process(es) [${names}]"
+          fi
+          if [ "$regtest_running" -eq 1 ]; then
+            [ -n "$reasons" ] && reasons="${reasons}; "
+            reasons="${reasons}regression test (regtest.py) is running"
+          fi
+          echo "Waiting: ${reasons}. Rechecking in ${gpu_check_interval}s (${waited}s elapsed)..."
+          sleep "$gpu_check_interval"
+          waited=$((waited + gpu_check_interval))
+        done
+      displayName: 'Wait for allowed time and free GPU'
 
     - task: CMake@1
       displayName: 'Configure CMake'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -69,7 +69,7 @@ jobs:
         # Keep the job idle during the restricted window [03:30, 07:00).
         blocked_start_minutes=$((3 * 60 + 30))
         blocked_end_minutes=$((7 * 60))
-        check_interval=60
+        check_interval=600
 
         while true; do
           hour=$(date +%H)

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -46,7 +46,7 @@ pr:
 jobs:
   - job: CUDA_Build_Test
     pool: avatar
-    timeoutInMinutes: 150
+    timeoutInMinutes: 330
     steps:
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"
@@ -66,40 +66,32 @@ jobs:
     - template: templates/ccache-prepare.yml
 
     - script: |
-        echo "Checking for conflicting jobs on the GPU..."
+        # Keep the job idle during the restricted window [03:30, 07:00).
+        blocked_start_minutes=$((3 * 60 + 30))
+        blocked_end_minutes=$((7 * 60))
         check_interval=60
-        waited=0
+
         while true; do
-          # Primary: check for active CUDA processes via GPU driver (cross-container reliable)
-          gpu_procs=$(nvidia-smi --query-compute-apps=pid,name --format=csv,noheader 2>/dev/null || true)
-          # Secondary: check for cron regression test script (best-effort; requires shared PID namespace)
-          regtest_running=0
-          if pgrep -f "regtest.py" > /dev/null 2>&1; then
-            regtest_running=1
-          fi
-          if [ -z "$gpu_procs" ] && [ "$regtest_running" -eq 0 ]; then
-            if [ "$waited" -gt 0 ]; then
-              echo "GPU is free and no regression test detected, proceeding..."
-            else
-              echo "GPU is free, proceeding..."
-            fi
+          hour=$(date +%H)
+          minute=$(date +%M)
+          now_minutes=$((10#$hour * 60 + 10#$minute))
+
+          if [ "$now_minutes" -lt "$blocked_start_minutes" ] || [ "$now_minutes" -ge "$blocked_end_minutes" ]; then
+            echo "Current time $(date '+%F %T') is outside restricted window. Proceeding."
             break
           fi
-          reasons=""
-          if [ -n "$gpu_procs" ]; then
-            count=$(echo "$gpu_procs" | grep -c '[0-9]' || true)
-            names=$(echo "$gpu_procs" | awk -F',' '{print $2}' | tr '\n' ' ' | sed 's/ $//')
-            reasons="GPU has ${count} active CUDA process(es) [${names}]"
+
+          remaining_minutes=$((blocked_end_minutes - now_minutes))
+          remaining_seconds=$((remaining_minutes * 60))
+          echo "Current time $(date '+%F %T') is within restricted window (03:30-07:00). Remaining wait: ${remaining_minutes}m."
+
+          if [ "$remaining_seconds" -le "$check_interval" ]; then
+            sleep "$remaining_seconds"
+          else
+            sleep "$check_interval"
           fi
-          if [ "$regtest_running" -eq 1 ]; then
-            [ -n "$reasons" ] && reasons="${reasons}; "
-            reasons="${reasons}regression test (regtest.py) is running"
-          fi
-          echo "Waiting: ${reasons}. Rechecking in ${check_interval}s (${waited}s elapsed)..."
-          sleep "$check_interval"
-          waited=$((waited + check_interval))
         done
-      displayName: 'Wait for GPU to be free'
+      displayName: 'Wait for allowed CI start window'
 
     - task: CMake@1
       displayName: 'Configure CMake'

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -46,7 +46,7 @@ pr:
 jobs:
   - job: CUDA_Build_Test
     pool: avatar
-    timeoutInMinutes: 330
+    timeoutInMinutes: 360
     steps:
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -67,8 +67,8 @@ jobs:
 
     - script: |
         # Keep the job idle during the restricted window [03:30, 07:00).
-        blocked_start_minutes=$((3 * 60 + 30))
-        blocked_end_minutes=$((7 * 60))
+        blocked_start_minutes=$((12 * 60 + 30))
+        blocked_end_minutes=$((14 * 60))
         check_interval=600
 
         while true; do


### PR DESCRIPTION
### Description
The regression test is expected to be running between 4:00 and 7:00, so the most reliable way to avoid conflicts is to disable CUDA GPU CI tests in this time window. The GPU usage check is kept as a further check when it's not in this time window. 

### Related issues
Regression testing crashes sometimes due to conflicts with CI tests. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
