### PR TITLE
Compute projections with explicit max_grid_size

### DIFF
--- a/src/io/DiagProjectionPlot.H
+++ b/src/io/DiagProjectionPlot.H
@@ -65,7 +65,7 @@ template <typename problem_t> void DiagProjectionPlot::processDiag(int a_nstep, 
 		for (const auto &field : m_fieldNames) {
 			const int comp = getFieldIndex(field, *m_diagVars);
 			proj[field] = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(*m_diagMF, sim->finestLevel(), *m_geoms, *m_refRatio,
-												     max_grid_size, dir, comp);
+											      max_grid_size, dir, comp);
 		}
 
 		// Skip if no projection data

--- a/src/io/DiagProjectionPlot.H
+++ b/src/io/DiagProjectionPlot.H
@@ -52,6 +52,10 @@ template <typename problem_t> void DiagProjectionPlot::processDiag(int a_nstep, 
 
 	// Get the simulation pointer
 	auto *sim = getSim<problem_t>();
+	amrex::Vector<amrex::IntVect> max_grid_size(sim->finestLevel() + 1);
+	for (int lev = 0; lev <= sim->finestLevel(); ++lev) {
+		max_grid_size[lev] = sim->maxGridSize(lev);
+	}
 
 	// Loop through all requested projection directions
 	for (auto const &dir : m_projectionDirs) {
@@ -60,7 +64,8 @@ template <typename problem_t> void DiagProjectionPlot::processDiag(int a_nstep, 
 		proj.reserve(m_fieldNames.size());
 		for (const auto &field : m_fieldNames) {
 			const int comp = getFieldIndex(field, *m_diagVars);
-			proj[field] = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(*m_diagMF, sim->finestLevel(), *m_geoms, *m_refRatio, dir, comp);
+			proj[field] = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(*m_diagMF, sim->finestLevel(), *m_geoms, *m_refRatio,
+												     max_grid_size, dir, comp);
 		}
 
 		// Skip if no projection data

--- a/src/io/projection.hpp
+++ b/src/io/projection.hpp
@@ -69,7 +69,8 @@ void write_2D_header(std::ostream &os, const amrex::FArrayBox &f, int nvar);
 
 inline auto ComputePlaneProjectionFromMultiFab(const amrex::Vector<const amrex::MultiFab *> &mfs, const int finest_level,
 					       amrex::Vector<amrex::Geometry> const &geom, amrex::Vector<amrex::IntVect> const &ref_ratio,
-					       const amrex::Direction dir, const int comp) -> amrex::Vector<amrex::MultiFab>
+					       amrex::Vector<amrex::IntVect> const &max_grid_size, const amrex::Direction dir,
+					       const int comp) -> amrex::Vector<amrex::MultiFab>
 {
 	// compute plane-parallel projection of a single MultiFab component along the given axis.
 	const BL_PROFILE("quokka::DiagProjection::computePlaneProjectionFromMultiFab()");
@@ -84,6 +85,7 @@ inline auto ComputePlaneProjectionFromMultiFab(const amrex::Vector<const amrex::
 	}
 
 	for (int lev = 0; lev <= finest_level; ++lev) {
+		AMREX_ALWAYS_ASSERT(static_cast<int>(max_grid_size.size()) > lev);
 		amrex::iMultiFab mask;
 		if (lev == finest_level) {
 			mask.define(mfs[lev]->boxArray(), mfs[lev]->DistributionMap(), 1, amrex::IntVect(0));
@@ -95,14 +97,17 @@ inline auto ComputePlaneProjectionFromMultiFab(const amrex::Vector<const amrex::
 		auto const &mf_arr = mfs[lev]->const_arrays();
 		auto const &mask_arr = mask.const_arrays();
 		auto const &dx = geom[lev].CellSizeArray();
+		amrex::IntVect plane_max_grid_size = max_grid_size[lev];
+		plane_max_grid_size[static_cast<int>(dir)] = 1;
 
-		auto plane_pair = amrex::ReduceToPlaneMF2Patchy<amrex::ReduceOpSum>(static_cast<int>(dir), geom[lev].Domain(), *mfs[lev],
-										    [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) -> amrex::Real {
-											    if (mask_arr[box_no](i, j, k) == 0) {
-												    return 0.0;
-											    }
-											    return dx[static_cast<int>(dir)] * mf_arr[box_no](i, j, k, comp);
-										    });
+		auto plane_pair = amrex::ReduceToPlaneMF2Patchy<amrex::ReduceOpSum>(
+		    static_cast<int>(dir), geom[lev].Domain(), *mfs[lev], plane_max_grid_size,
+		    [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) -> amrex::Real {
+			    if (mask_arr[box_no](i, j, k) == 0) {
+				    return 0.0;
+			    }
+			    return dx[static_cast<int>(dir)] * mf_arr[box_no](i, j, k, comp);
+		    });
 		auto &plane_global = plane_pair.second;
 		const auto &plane_ba = plane_global.boxArray();
 		amrex::BoxList bl2d(plane_ba.ixType());

--- a/src/io/projection.hpp
+++ b/src/io/projection.hpp
@@ -69,8 +69,8 @@ void write_2D_header(std::ostream &os, const amrex::FArrayBox &f, int nvar);
 
 inline auto ComputePlaneProjectionFromMultiFab(const amrex::Vector<const amrex::MultiFab *> &mfs, const int finest_level,
 					       amrex::Vector<amrex::Geometry> const &geom, amrex::Vector<amrex::IntVect> const &ref_ratio,
-					       amrex::Vector<amrex::IntVect> const &max_grid_size, const amrex::Direction dir,
-					       const int comp) -> amrex::Vector<amrex::MultiFab>
+					       amrex::Vector<amrex::IntVect> const &max_grid_size, const amrex::Direction dir, const int comp)
+    -> amrex::Vector<amrex::MultiFab>
 {
 	// compute plane-parallel projection of a single MultiFab component along the given axis.
 	const BL_PROFILE("quokka::DiagProjection::computePlaneProjectionFromMultiFab()");
@@ -100,14 +100,13 @@ inline auto ComputePlaneProjectionFromMultiFab(const amrex::Vector<const amrex::
 		amrex::IntVect plane_max_grid_size = max_grid_size[lev];
 		plane_max_grid_size[static_cast<int>(dir)] = 1;
 
-		auto plane_pair = amrex::ReduceToPlaneMF2Patchy<amrex::ReduceOpSum>(
-		    static_cast<int>(dir), geom[lev].Domain(), *mfs[lev], plane_max_grid_size,
-		    [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) -> amrex::Real {
-			    if (mask_arr[box_no](i, j, k) == 0) {
-				    return 0.0;
-			    }
-			    return dx[static_cast<int>(dir)] * mf_arr[box_no](i, j, k, comp);
-		    });
+		auto plane_pair = amrex::ReduceToPlaneMF2Patchy<amrex::ReduceOpSum>(static_cast<int>(dir), geom[lev].Domain(), *mfs[lev], plane_max_grid_size,
+										    [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) -> amrex::Real {
+											    if (mask_arr[box_no](i, j, k) == 0) {
+												    return 0.0;
+											    }
+											    return dx[static_cast<int>(dir)] * mf_arr[box_no](i, j, k, comp);
+										    });
 		auto &plane_global = plane_pair.second;
 		const auto &plane_ba = plane_global.boxArray();
 		amrex::BoxList bl2d(plane_ba.ixType());

--- a/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
+++ b/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
@@ -133,13 +133,17 @@ namespace
 auto checkGasDensityProjection(const QuokkaSimulation<ParticleProblem> &sim) -> int
 {
 	const amrex::Vector<const amrex::MultiFab *> state_mfs = amrex::GetVecOfConstPtrs(sim.state_new_cc_);
+	amrex::Vector<amrex::IntVect> max_grid_size(sim.finestLevel() + 1);
+	for (int lev = 0; lev <= sim.finestLevel(); ++lev) {
+		max_grid_size[lev] = sim.maxGridSize(lev);
+	}
 
 	constexpr std::array dirs = {amrex::Direction::x, amrex::Direction::y, amrex::Direction::z};
 	const amrex::Box &domain = sim.Geom(0).Domain();
 
 	for (const auto dir : dirs) {
-		const auto projections = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(state_mfs, sim.finestLevel(), sim.Geom(), sim.refRatio(), dir,
-												 RadSystem<ParticleProblem>::gasDensity_index);
+		const auto projections = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(state_mfs, sim.finestLevel(), sim.Geom(), sim.refRatio(),
+												 max_grid_size, dir, RadSystem<ParticleProblem>::gasDensity_index);
 		const amrex::MultiFab &projection = projections.front();
 		const amrex::Real projection_min = projection.min(0);
 		const amrex::Real projection_max = projection.max(0);

--- a/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
+++ b/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
@@ -142,8 +142,8 @@ auto checkGasDensityProjection(const QuokkaSimulation<ParticleProblem> &sim) -> 
 	const amrex::Box &domain = sim.Geom(0).Domain();
 
 	for (const auto dir : dirs) {
-		const auto projections = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(state_mfs, sim.finestLevel(), sim.Geom(), sim.refRatio(),
-												 max_grid_size, dir, RadSystem<ParticleProblem>::gasDensity_index);
+		const auto projections = quokka::diagnostics::ComputePlaneProjectionFromMultiFab(
+		    state_mfs, sim.finestLevel(), sim.Geom(), sim.refRatio(), max_grid_size, dir, RadSystem<ParticleProblem>::gasDensity_index);
 		const amrex::MultiFab &projection = projections.front();
 		const amrex::Real projection_min = projection.min(0);
 		const amrex::Real projection_max = projection.max(0);


### PR DESCRIPTION
### Description
This computes projections with an explicit `max_grid_size` parameter. This allows for slightly more efficient (both memory and communication) projection computations.

This also updates the AMReX submodule (required to support this parameter).

### Related issues
AMReX PR: https://github.com/AMReX-Codes/amrex/pull/5258

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
