### PR TITLE
Add physics module compatibility matrix

### DIFF
--- a/docs/markdown/components.md
+++ b/docs/markdown/components.md
@@ -50,13 +50,13 @@ This matrix covers hydro, MHD, radiation, cooling, chemistry, particles, and the
 
 | Module | Hydro | MHD | Radiation | Cooling | Chemistry | Particles | Dust |
 | ------ |:-----:|:---:|:---------:|:-------:|:---------:|:---------:|:----:|
-| Hydro | | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| MHD | | | ❌ | ✅ | ⚠️ | ✅ | ⚠️ |
-| Radiation | | | | ⚠️ | | ✅ | |
-| Cooling | | | | | ⚠️ | ✅ | |
-| Chemistry | | | | | | | |
-| Particles | | | | | | | |
-| Dust | | | | | | | |
+| Hydro | - | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MHD | - | - | ❌ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Radiation | - | - | - | ⚠️ | | ✅ | |
+| Cooling | - | - | - | - | ⚠️ | ✅ | |
+| Chemistry | - | - | - | - | - | | |
+| Particles | - | - | - | - | - | - | |
+| Dust | - | - | - | - | - | - | - |
 
 Notes:
 

--- a/docs/markdown/components.md
+++ b/docs/markdown/components.md
@@ -35,6 +35,44 @@ Defined in `src/physics_info.hpp`. User-specialized per problem to enable/disabl
 | `nGroups`                                                                       | Number of radiation photon groups                                                   |
 | `nDustGroups`                                                                   | Number of dust groups                                                               |
 
+## Physics module compatibility matrix
+
+The table below summarizes the current compatibility status for the built-in physics modules documented in Quokka.
+
+- `✅` means the combination is supported and exercised by at least one in-tree problem or test case.
+- `❌` means the combination is explicitly unsupported.
+- `⚠️` means the combination appears intended to work, but no in-tree test problem currently exercises it.
+- A blank cell means the compatibility is currently unknown.
+
+Here, `Dust` refers to the dedicated dust dynamics module enabled with `Physics_Traits<problem_t>::is_dust_enabled`. It is distinct from the thermal dust coupling used in several radiation test problems.
+
+This matrix covers hydro, MHD, radiation, cooling, chemistry, particles, and the dedicated dust module. It does not include self-gravity.
+
+| Module | Hydro | MHD | Radiation | Cooling | Chemistry | Particles | Dust |
+| ------ | ----- | --- | --------- | ------- | --------- | --------- | ---- |
+| Hydro |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MHD | ✅ |  | ❌ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Radiation | ✅ | ❌ |  | ⚠️ |  | ✅ |  |
+| Cooling | ✅ | ✅ | ⚠️ |  | ⚠️ | ✅ |  |
+| Chemistry | ✅ | ⚠️ |  | ⚠️ |  |  |  |
+| Particles | ✅ | ✅ | ✅ | ✅ |  |  |  |
+| Dust | ✅ | ⚠️ |  |  |  |  |  |
+
+Notes:
+
+- `Hydro + MHD` is tested by the MHD problem suite, including `AlfvenWave*`, `BrioWuShockTube`, `MHDBlast`, `MHDQuirk`, and `OrszagTang`.
+- `Hydro + radiation` is tested by the radiation-hydrodynamics problems such as `RadhydroPulse*`, `RadhydroShock*`, `RadhydroShell`, `RadTube`, and `RadhydroBB`.
+- `Hydro + cooling` is tested by `ResampledCoolingTest`, `ShockCloud`, `RandomBlast`, and `SN`.
+- `Hydro + chemistry` is tested by `PrimordialChem` and `PopIII`.
+- `MHD + radiation` is explicitly disabled in `src/QuokkaSimulation.hpp` with `static_assert(!(is_mhd_enabled && is_radiation_enabled), "MHD + Radiation is not supported yet.")`.
+- `MHD + cooling` is exercised by the `SN` problem with `is_mhd_enabled = true` and `cooling.enabled = 1`.
+- `Hydro + particles` is exercised by problems such as `BinaryOrbitCIC`, `ParticleSink*`, `ParticleSF`, `ParticleRadiation`, `RandomBlast`, and `SN`.
+- `MHD + particles` is exercised by `DiskGalaxy`, `ParticleAccretion`, `ParticleCreation`, `ParticleSink`, and `ParticleSinkFormation`.
+- `Radiation + particles` is exercised by `ParticleRadiation` and `GravRadParticle3D`.
+- `Cooling + particles` is exercised by `ParticleSF`, `TallBoxSf`, `RandomBlast`, and `DiskGalaxy` through their input files.
+- `Hydro + dust` is exercised by the dust dynamics problems `DustAdvection*`, `DustDamping*`, `DustSoundwave`, and `DustyShock`.
+- `MHD + dust` is marked untested: the drag implementation contains MHD-aware code paths, but there is no in-tree problem that enables both `is_mhd_enabled` and `is_dust_enabled`.
+
 
 ## Cell-centred state vector layout
 
@@ -183,4 +221,3 @@ Cell-centred layout (16 components total):
   [14] x2RadFlux (group 1)
   [15] x3RadFlux (group 1)
 ```
-

--- a/docs/markdown/components.md
+++ b/docs/markdown/components.md
@@ -49,14 +49,14 @@ Here, `Dust` refers to the dedicated dust dynamics module enabled with `Physics_
 This matrix covers hydro, MHD, radiation, cooling, chemistry, particles, and the dedicated dust module. It does not include self-gravity.
 
 | Module | Hydro | MHD | Radiation | Cooling | Chemistry | Particles | Dust |
-| ------ | ----- | --- | --------- | ------- | --------- | --------- | ---- |
-| Hydro |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| MHD | ✅ |  | ❌ | ✅ | ⚠️ | ✅ | ⚠️ |
-| Radiation | ✅ | ❌ |  | ⚠️ |  | ✅ |  |
-| Cooling | ✅ | ✅ | ⚠️ |  | ⚠️ | ✅ |  |
-| Chemistry | ✅ | ⚠️ |  | ⚠️ |  |  |  |
-| Particles | ✅ | ✅ | ✅ | ✅ |  |  |  |
-| Dust | ✅ | ⚠️ |  |  |  |  |  |
+| ------ |:-----:|:---:|:---------:|:-------:|:---------:|:---------:|:----:|
+| Hydro | | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MHD | | | ❌ | ✅ | ⚠️ | ✅ | ⚠️ |
+| Radiation | | | | ⚠️ | | ✅ | |
+| Cooling | | | | | ⚠️ | ✅ | |
+| Chemistry | | | | | | | |
+| Particles | | | | | | | |
+| Dust | | | | | | | |
 
 Notes:
 


### PR DESCRIPTION
### Description
Adds a compatibility matrix to the documentation describing which physics modules are compatible (and tested) with each other.

This only considers 2-way compatibility for the moment, not 3-way or higher-N-way compatibility.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
