### PR TITLE
[codex] document quokka smoke workflow

### DIFF
--- a/docs/markdown/contributing.md
+++ b/docs/markdown/contributing.md
@@ -86,6 +86,8 @@ quokka clean [--root <path>]
 
 `build`, `run`, and `buildrun` print final summary lines (`<name> SUCCESS|FAIL|SKIPPED`) to make tail-based status checks easy.
 
+`quokka run --filter <regex>` delegates directly to `ctest -R`, so it expects the matching executables to have already been built via `quokka build` or `quokka buildrun`.
+
 ### Typical workflow
 
 ```bash
@@ -123,6 +125,23 @@ quokka list
 # 11. Clean up test output
 quokka clean
 ```
+
+### Smoke-test workflow
+
+If you only need a quick local smoke test of the build/run/test flow, the following sequence keeps the dependency surface small and works well on systems without the optional Python plotting stack:
+
+```bash
+# Configure a fresh 1D build without Python plotting support
+quokka config -d 1d --delete -DQUOKKA_PYTHON=OFF
+
+# Build and run a fast 1D problem
+quokka buildrun -d 1d HydroWave -j 4
+
+# Re-run the same problem through the CTest path
+quokka run -d 1d --filter '^HydroWave$' -j 2
+```
+
+If you leave `QUOKKA_PYTHON` enabled, some problem runs may require optional Python imaging packages in addition to `matplotlib`.
 
 ## Git workflow
 


### PR DESCRIPTION
## Summary
Document a small `quokka` smoke-test workflow that exercises configure, build, direct run, and ctest-driven run paths.

## What changed
- note that `quokka run --filter <regex>` delegates to `ctest -R` and expects executables to already be built
- add a tested 1D smoke-test recipe using `HydroWave`
- call out `-DQUOKKA_PYTHON=OFF` as a practical option when optional Python plotting/image packages are not installed

## Why
While testing the wrapper, the direct `HydroWave` run failed in a default configuration because Python plotting support was enabled and the local environment lacked `PIL`. The smoke-test recipe documents a lower-friction path for validating the wrapper itself.

## Validation
- `scripts/bash/quokka config -d 1d`
- `scripts/bash/quokka build -d 1d HydroWave -j 4`
- `scripts/bash/quokka run -d 1d HydroWave` (failed in the default config due to missing `PIL` with `QUOKKA_PYTHON=ON`)
- `scripts/bash/quokka config -d 1d --delete -DQUOKKA_PYTHON=OFF`
- `scripts/bash/quokka buildrun -d 1d HydroWave -j 4`
- `scripts/bash/quokka run -d 1d --filter ^HydroWave -j 2`
