### PR TITLE
[WIP] Rewrite hydro integrator to use generic RK class

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2174,186 +2174,184 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 
-		if (do_tracers != 0 && final_success) {
+		if (do_tracers != 0 && final_success)
+		{
 			auto const &accum = integrator.getAccumulators();
 			TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
 		}
 
-			return final_success;
-		};
+		return final_success;
+	};
 
-		if (integratorOrder_ == 1) {
-			return run_integrator(std::type_identity<quokka::ForwardEulerScheme>{});
-		}
-
-		return run_integrator(std::type_identity<quokka::SSPRK2Scheme>{});
+	if (integratorOrder_ == 1) {
+		return run_integrator(std::type_identity<quokka::ForwardEulerScheme>{});
 	}
 
-	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState, PostInterpState);
+	return run_integrator(std::type_identity<quokka::SSPRK2Scheme>{});
+}
+
+// update ghost zones [old timestep]
+fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState, PostInterpState);
+if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		fillBoundaryConditions(state_old_fc_tmp[idim], state_old_fc_tmp[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
+				       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone, FillPatchType::fillpatch_function);
+	}
+}
+
+// LOW LEVEL DEBUGGING: output state_old_cc_tmp (with ghost cells)
+if (lowLevelDebuggingOutput_ == 1) {
+	// write AMReX plotfile
+	amrex::ParallelDescriptor::Barrier();
+	WriteSingleLevelPlotfile(CustomPlotFileName("debug_stage1_filled_state_old", istep[lev] + 1), state_old_cc_tmp, componentNames_cc_, geom[lev], time,
+				 istep[lev] + 1);
+	amrex::ParallelDescriptor::Barrier();
+}
+
+// check state validity
+AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
+AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
+
+auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] =
+    HydroRKPolicy<problem_t>::computeFOHydroFluxes(*this, state_old_cc_tmp, state_old_fc_tmp, nvars_, nghost_Riemann, lev);
+
+std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
+if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+		ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
+	}
+	MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, emfReconstructionOrder_,
+					 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+}
+
+auto const &stateOld_cc = state_old_cc_tmp;
+auto &stateNew_cc = state_new_cc_[lev];
+
+auto const &stateOld_fc = state_old_fc_tmp;
+auto &stateNew_fc = state_new_fc_[lev];
+
+auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = HydroRKPolicy<problem_t>::computeHydroFluxes(*this, stateOld_cc, stateOld_fc, nvars_, nghost_Riemann, lev);
+
+std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components;
+if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+		ec_emf_components[idim].define(ba_ec, dm, 1, 0);
+	}
+	MHDSystem<problem_t>::ComputeEMF(ec_emf_components, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds, emfReconstructionOrder_,
+					 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+}
+
+amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
+amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
+redoFlag.setVal(quokka::redoFlag::none);
+
+HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
+HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
+HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
+
+if (lowLevelDebuggingOutput_ == 1) {
+	std::string plotfile_name = CustomPlotFileName("debug_stage1_rhs_fluxes", istep[lev] + 1);
+	WriteSingleLevelPlotfileSimplified("debug_stage1_rhs_fluxes", rhs, componentNames_cc_, lev, 1);
+
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
+		}
+		std::string fullprefix =
+		    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("Flux_") + quokka::face_dir_str[idim]);
+		amrex::VisMF::Write(fluxArrays[idim], fullprefix);
+	}
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
+		}
+		std::string fullprefix =
+		    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("FaceVel_") + quokka::face_dir_str[idim]);
+		amrex::VisMF::Write(faceVel[idim], fullprefix);
+	}
+}
+
+amrex::Gpu::streamSynchronizeAll();
+
+amrex::Long const ncells_bad = redoFlag.sum(0);
+if (ncells_bad > 0) {
+	if (Verbose()) {
+		amrex::Print() << "[FOFC] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
+		const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
+		printCoordinates(lev, cell_idx);
+		amrex::print_state(stateNew_cc, cell_idx);
+	}
+
+	redoFlag.FillBoundary(geom[lev].periodicity());
+
+	HydroRKPolicy<problem_t>::replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
+	HydroRKPolicy<problem_t>::replaceFluxes(faceVel, FOfaceVel, redoFlag);
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			fillBoundaryConditions(state_old_fc_tmp[idim], state_old_fc_tmp[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
-					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
-					       FillPatchType::fillpatch_function);
-		}
+		HydroRKPolicy<problem_t>::replaceEMFs(ec_emf_components, ec_emf_components_fo, redoFlag);
 	}
-
-	// LOW LEVEL DEBUGGING: output state_old_cc_tmp (with ghost cells)
-	if (lowLevelDebuggingOutput_ == 1) {
-		// write AMReX plotfile
-		amrex::ParallelDescriptor::Barrier();
-		WriteSingleLevelPlotfile(CustomPlotFileName("debug_stage1_filled_state_old", istep[lev] + 1), state_old_cc_tmp, componentNames_cc_, geom[lev],
-					 time, istep[lev] + 1);
-		amrex::ParallelDescriptor::Barrier();
-	}
-
-	// check state validity
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
-
-	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] =
-	    HydroRKPolicy<problem_t>::computeFOHydroFluxes(*this, state_old_cc_tmp, state_old_fc_tmp, nvars_, nghost_Riemann, lev);
-
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
-		}
-		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
-	}
-
-	auto const &stateOld_cc = state_old_cc_tmp;
-	auto &stateNew_cc = state_new_cc_[lev];
-
-	auto const &stateOld_fc = state_old_fc_tmp;
-	auto &stateNew_fc = state_new_fc_[lev];
-
-	auto [fluxArrays, faceVel, fast_mhd_wavespeeds] =
-	    HydroRKPolicy<problem_t>::computeHydroFluxes(*this, stateOld_cc, stateOld_fc, nvars_, nghost_Riemann, lev);
-
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-			ec_emf_components[idim].define(ba_ec, dm, 1, 0);
-		}
-		MHDSystem<problem_t>::ComputeEMF(ec_emf_components, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds, emfReconstructionOrder_,
-						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
-	}
-
-	amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
-	amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
-	redoFlag.setVal(quokka::redoFlag::none);
 
 	HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
 	HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
 	HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
 
-	if (lowLevelDebuggingOutput_ == 1) {
-		std::string plotfile_name = CustomPlotFileName("debug_stage1_rhs_fluxes", istep[lev] + 1);
-		WriteSingleLevelPlotfileSimplified("debug_stage1_rhs_fluxes", rhs, componentNames_cc_, lev, 1);
-
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("Flux_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(fluxArrays[idim], fullprefix);
-		}
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("FaceVel_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(faceVel[idim], fullprefix);
-		}
-	}
-
 	amrex::Gpu::streamSynchronizeAll();
-
-	amrex::Long const ncells_bad = redoFlag.sum(0);
-	if (ncells_bad > 0) {
+	amrex::Long const ncells_bad_after_fofc = redoFlag.sum(0);
+	if (ncells_bad_after_fofc > 0) {
 		if (Verbose()) {
-			amrex::Print() << "[FOFC] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
 			const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
+			amrex::Print() << "[FOFC] Flux correction failed:\n";
 			printCoordinates(lev, cell_idx);
 			amrex::print_state(stateNew_cc, cell_idx);
+			amrex::Print() << "[FOFC] failed for " << ncells_bad_after_fofc << " cells on level " << lev << "\n";
 		}
-
-		redoFlag.FillBoundary(geom[lev].periodicity());
-
-		HydroRKPolicy<problem_t>::replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
-		HydroRKPolicy<problem_t>::replaceFluxes(faceVel, FOfaceVel, redoFlag);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroRKPolicy<problem_t>::replaceEMFs(ec_emf_components, ec_emf_components_fo, redoFlag);
-		}
-
-		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
-		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
-
-		amrex::Gpu::streamSynchronizeAll();
-		amrex::Long const ncells_bad_after_fofc = redoFlag.sum(0);
-		if (ncells_bad_after_fofc > 0) {
-			if (Verbose()) {
-				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-				amrex::Print() << "[FOFC] Flux correction failed:\n";
-				printCoordinates(lev, cell_idx);
-				amrex::print_state(stateNew_cc, cell_idx);
-				amrex::Print() << "[FOFC] failed for " << ncells_bad_after_fofc << " cells on level " << lev << "\n";
-			}
-			if (abortOnFofcFailure_ != 0) {
-				return false;
-			}
+		if (abortOnFofcFailure_ != 0) {
+			return false;
 		}
 	}
+}
 
+if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+	MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components, dt_lev, geom[lev].CellSizeArray());
+}
+
+if (this->useDensityFloorParser_) {
+	auto const density_floor_parser = this->densityFloorParserExe_.value();
+	auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z, amrex::Real base_density_floor) -> amrex::Real {
+		return density_floor_parser(x, y, z, base_density_floor);
+	};
+	HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+} else {
+	auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
+								     amrex::Real base_density_floor) -> amrex::Real {
+		return densityFloor(x, y, z, base_density_floor);
+	};
+	HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+}
+
+if (useDualEnergy_ == 1) {
+	HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
+}
+
+amrex::Gpu::streamSynchronizeAll();
+
+auto burn_success_second = addStrangSplitSourcesWithBuiltin(stateNew_cc, stateNew_fc, lev, time + dt_lev, 0.5 * dt_lev);
+bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+bool const final_success = (cfl_ok && burn_success_second);
+
+if (do_reflux == 1 && final_success) {
+	incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, dt_lev);
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components, dt_lev, geom[lev].CellSizeArray());
+		incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components, lev, -1.0 * dt_lev);
 	}
+}
 
-	if (this->useDensityFloorParser_) {
-		auto const density_floor_parser = this->densityFloorParserExe_.value();
-		auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-									  amrex::Real base_density_floor) -> amrex::Real {
-			return density_floor_parser(x, y, z, base_density_floor);
-		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-	} else {
-		auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-									     amrex::Real base_density_floor) -> amrex::Real {
-			return densityFloor(x, y, z, base_density_floor);
-		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-	}
+if (do_tracers != 0 && final_success) {
+	TracerPC->AdvectWithUmac(faceVel.data(), lev, dt_lev);
+}
 
-	if (useDualEnergy_ == 1) {
-		HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
-	}
-
-	amrex::Gpu::streamSynchronizeAll();
-
-	auto burn_success_second = addStrangSplitSourcesWithBuiltin(stateNew_cc, stateNew_fc, lev, time + dt_lev, 0.5 * dt_lev);
-	bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
-	bool const final_success = (cfl_ok && burn_success_second);
-
-	if (do_reflux == 1 && final_success) {
-		incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, dt_lev);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components, lev, -1.0 * dt_lev);
-		}
-	}
-
-	if (do_tracers != 0 && final_success) {
-		TracerPC->AdvectWithUmac(faceVel.data(), lev, dt_lev);
-	}
-
-	return final_success;
+return final_success;
 }
 
 template <typename problem_t>

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2087,33 +2087,37 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		return burn_success_first;
 	}
 
-	if (integratorOrder_ == 2) {
+	if ((integratorOrder_ == 1) || (integratorOrder_ == 2)) {
 		std::unique_ptr<amrex::FluxRegister> step_fr_as_crse;
 		std::unique_ptr<amrex::FluxRegister> step_fr_as_fine;
 		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_crse;
 		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_fine;
 
 		if (fr_as_crse != nullptr) {
-			step_fr_as_crse = std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1,
-										       nvarTotal_cc_);
+			step_fr_as_crse =
+			    std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1, nvarTotal_cc_);
+			// FluxRegister boundary FABs start life as NaN, so a scratch register must be zeroed before any ADD accumulation.
+			step_fr_as_crse->setVal(0.0);
 		}
 		if (fr_as_fine != nullptr) {
 			step_fr_as_fine = std::make_unique<amrex::FluxRegister>(grids[lev], dmap[lev], refRatio(lev - 1), lev, nvarTotal_cc_);
+			step_fr_as_fine->setVal(0.0);
 		}
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			if (emf_as_crse != nullptr) {
-				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1), dmap[lev],
-												     geom[lev + 1], geom[lev], 1);
+				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1),
+											     dmap[lev], geom[lev + 1], geom[lev], 1);
+				step_emf_as_crse->reset();
 			}
 			if (emf_as_fine != nullptr) {
 				step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
-												     geom[lev], geom[lev - 1], 1);
+											     geom[lev], geom[lev - 1], 1);
+				step_emf_as_fine->reset();
 			}
 		}
 
-		HydroRKPolicy<problem_t> policy{*this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(),
-						step_emf_as_fine.get()};
-		quokka::RKIntegrator<HydroRKPolicy<problem_t>> integrator(policy);
+		HydroRKPolicy<problem_t> policy{
+		    *this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(), step_emf_as_fine.get()};
 
 		quokka::CompositeStateView old_state{};
 		old_state.cc = &state_old_cc_tmp;
@@ -2130,29 +2134,53 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 
-		integrator.define(lev, old_state);
-		bool const rk_success = integrator.advance(old_state, new_state, time, dt_lev);
-		if (!rk_success) {
-			return false;
-		}
+		auto run_integrator = [&](auto scheme_tag) -> bool {
+			using scheme_t = typename decltype(scheme_tag)::type;
+			quokka::RKIntegrator<HydroRKPolicy<problem_t>, scheme_t> integrator(policy);
+
+			integrator.define(lev, old_state);
+			bool const rk_success = integrator.advance(old_state, new_state, time, dt_lev);
+			if (!rk_success) {
+				return false;
+			}
+			if (lowLevelDebuggingOutput_ != 0) {
+				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
+								 std::format("NaN detected after RKIntegrator::advance on level {}", lev));
+			}
 
 			auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
+			if (lowLevelDebuggingOutput_ != 0) {
+				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
+								 std::format("NaN detected after second Strang source step on level {}", lev));
+			}
 			bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
 			bool const final_success = (cfl_ok && burn_success_second);
 
 			if (final_success) {
-				if (step_fr_as_crse) {
-					*flux_reg_[lev + 1] += *step_fr_as_crse;
+				fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, time + dt_lev, quokka::centering::cc, quokka::direction::na,
+						       PreInterpState, PostInterpState);
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+						fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, time + dt_lev,
+								       quokka::centering::fc, quokka::direction{idim}, AMRSimulation<problem_t>::InterpHookNone,
+								       AMRSimulation<problem_t>::InterpHookNone, FillPatchType::fillpatch_function);
+					}
 				}
-				if (step_fr_as_fine) {
-					*flux_reg_[lev] += *step_fr_as_fine;
+			}
+
+			if (final_success) {
+				if (fr_as_crse != nullptr) {
+					*fr_as_crse += *step_fr_as_crse;
+				}
+				if (fr_as_fine != nullptr) {
+					*fr_as_fine += *step_fr_as_fine;
 				}
 				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					if (step_emf_as_crse) {
-						emf_reg_[lev + 1]->plus(*step_emf_as_crse);
+					if (emf_as_crse != nullptr) {
+						emf_as_crse->plus(*step_emf_as_crse);
 					}
-					if (step_emf_as_fine) {
-						emf_reg_[lev]->plus(*step_emf_as_fine);
+					if (emf_as_fine != nullptr) {
+						emf_as_fine->plus(*step_emf_as_fine);
 					}
 				}
 			}
@@ -2162,7 +2190,14 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 				TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
 			}
 
-		return final_success;
+			return final_success;
+		};
+
+		if (integratorOrder_ == 1) {
+			return run_integrator(std::type_identity<quokka::ForwardEulerScheme>{});
+		}
+
+		return run_integrator(std::type_identity<quokka::SSPRK2Scheme>{});
 	}
 
 	// update ghost zones [old timestep]

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2072,13 +2072,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		amrex::ignore_unused(emf_as_crse, emf_as_fine);
 	}
 
-	const int nghost_Riemann =
-	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emfComputingScheme_, emfAveragingScheme_, do_tracers != 0);
-
-	auto ba_cc = grids[lev];
-	auto dm = dmap[lev];
-	auto dx = geom[lev].CellSizeArray();
-
 	// do Strang split source terms (first half-step)
 	auto burn_success_first = addStrangSplitSourcesWithBuiltin(state_old_cc_tmp, state_old_fc_tmp, lev, time, 0.5 * dt_lev);
 
@@ -2087,89 +2080,89 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		return burn_success_first;
 	}
 
-	if ((integratorOrder_ == 1) || (integratorOrder_ == 2)) {
-		std::unique_ptr<amrex::FluxRegister> step_fr_as_crse;
-		std::unique_ptr<amrex::FluxRegister> step_fr_as_fine;
-		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_crse;
-		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_fine;
+	std::unique_ptr<amrex::FluxRegister> step_fr_as_crse;
+	std::unique_ptr<amrex::FluxRegister> step_fr_as_fine;
+	std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_crse;
+	std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_fine;
 
-		if (fr_as_crse != nullptr) {
-			step_fr_as_crse =
-			    std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1, nvarTotal_cc_);
-			// FluxRegister boundary FABs start life as NaN, so a scratch register must be zeroed before any ADD accumulation.
-			step_fr_as_crse->setVal(0.0);
+	if (fr_as_crse != nullptr) {
+		step_fr_as_crse = std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1, nvarTotal_cc_);
+		// FluxRegister boundary FABs start life as NaN, so a scratch register must be zeroed before any ADD accumulation.
+		step_fr_as_crse->setVal(0.0);
+	}
+	if (fr_as_fine != nullptr) {
+		step_fr_as_fine = std::make_unique<amrex::FluxRegister>(grids[lev], dmap[lev], refRatio(lev - 1), lev, nvarTotal_cc_);
+		step_fr_as_fine->setVal(0.0);
+	}
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		if (emf_as_crse != nullptr) {
+			step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1), dmap[lev],
+										     geom[lev + 1], geom[lev], 1);
+			step_emf_as_crse->reset();
 		}
-		if (fr_as_fine != nullptr) {
-			step_fr_as_fine = std::make_unique<amrex::FluxRegister>(grids[lev], dmap[lev], refRatio(lev - 1), lev, nvarTotal_cc_);
-			step_fr_as_fine->setVal(0.0);
+		if (emf_as_fine != nullptr) {
+			step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
+										     geom[lev], geom[lev - 1], 1);
+			step_emf_as_fine->reset();
 		}
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			if (emf_as_crse != nullptr) {
-				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1),
-											     dmap[lev], geom[lev + 1], geom[lev], 1);
-				step_emf_as_crse->reset();
-			}
-			if (emf_as_fine != nullptr) {
-				step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
-											     geom[lev], geom[lev - 1], 1);
-				step_emf_as_fine->reset();
-			}
+	}
+
+	const int nghost_Riemann =
+	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emfComputingScheme_, emfAveragingScheme_, do_tracers != 0);
+
+	HydroRKPolicy<problem_t> policy{
+	    *this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(), step_emf_as_fine.get()};
+
+	quokka::CompositeStateView old_state{};
+	old_state.cc = &state_old_cc_tmp;
+	old_state.fc_data = &state_old_fc_tmp;
+
+	quokka::CompositeStateView new_state{};
+	new_state.cc = &state_new_cc_[lev];
+	new_state.fc_data = &state_new_fc_[lev];
+
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			old_state.fc[idim] = &state_old_fc_tmp[idim];
+			new_state.fc[idim] = &state_new_fc_[lev][idim];
+		}
+	}
+
+	auto run_integrator = [&](auto scheme_tag) -> bool {
+		using scheme_t = typename decltype(scheme_tag)::type;
+		quokka::RKIntegrator<HydroRKPolicy<problem_t>, scheme_t> integrator(policy);
+
+		integrator.define(lev, old_state);
+		bool const rk_success = integrator.advance(old_state, new_state, time, dt_lev);
+		if (!rk_success) {
+			return false;
+		}
+		if (lowLevelDebuggingOutput_ != 0) {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
+							 std::format("NaN detected after RKIntegrator::advance on level {}", lev));
 		}
 
-		HydroRKPolicy<problem_t> policy{
-		    *this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(), step_emf_as_fine.get()};
-
-		quokka::CompositeStateView old_state{};
-		old_state.cc = &state_old_cc_tmp;
-		old_state.fc_data = &state_old_fc_tmp;
-
-		quokka::CompositeStateView new_state{};
-		new_state.cc = &state_new_cc_[lev];
-		new_state.fc_data = &state_new_fc_[lev];
-
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				old_state.fc[idim] = &state_old_fc_tmp[idim];
-				new_state.fc[idim] = &state_new_fc_[lev][idim];
-			}
+		auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
+		if (lowLevelDebuggingOutput_ != 0) {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
+							 std::format("NaN detected after second Strang source step on level {}", lev));
 		}
+		bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+		bool const final_success = (cfl_ok && burn_success_second);
 
-		auto run_integrator = [&](auto scheme_tag) -> bool {
-			using scheme_t = typename decltype(scheme_tag)::type;
-			quokka::RKIntegrator<HydroRKPolicy<problem_t>, scheme_t> integrator(policy);
-
-			integrator.define(lev, old_state);
-			bool const rk_success = integrator.advance(old_state, new_state, time, dt_lev);
-			if (!rk_success) {
-				return false;
+		if (final_success) {
+			if (fr_as_crse != nullptr) {
+				*fr_as_crse += *step_fr_as_crse;
 			}
-			if (lowLevelDebuggingOutput_ != 0) {
-				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
-								 std::format("NaN detected after RKIntegrator::advance on level {}", lev));
+			if (fr_as_fine != nullptr) {
+				*fr_as_fine += *step_fr_as_fine;
 			}
-
-			auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
-			if (lowLevelDebuggingOutput_ != 0) {
-				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!state_new_cc_[lev].contains_nan(0, state_new_cc_[lev].nComp()),
-								 std::format("NaN detected after second Strang source step on level {}", lev));
-			}
-			bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
-			bool const final_success = (cfl_ok && burn_success_second);
-
-			if (final_success) {
-				if (fr_as_crse != nullptr) {
-					*fr_as_crse += *step_fr_as_crse;
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				if (emf_as_crse != nullptr) {
+					emf_as_crse->plus(*step_emf_as_crse);
 				}
-				if (fr_as_fine != nullptr) {
-					*fr_as_fine += *step_fr_as_fine;
-				}
-				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					if (emf_as_crse != nullptr) {
-						emf_as_crse->plus(*step_emf_as_crse);
-					}
-					if (emf_as_fine != nullptr) {
-						emf_as_fine->plus(*step_emf_as_fine);
-					}
+				if (emf_as_fine != nullptr) {
+					emf_as_fine->plus(*step_emf_as_fine);
 				}
 			}
 		}
@@ -2179,181 +2172,14 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
 		}
 
-			return final_success;
-		};
+		return final_success;
+	};
 
-		if (integratorOrder_ == 1) {
-			return run_integrator(std::type_identity<quokka::ForwardEulerScheme>{});
-		}
-
-		return run_integrator(std::type_identity<quokka::SSPRK2Scheme>{});
+	if (integratorOrder_ == 1) {
+		return run_integrator(std::type_identity<quokka::ForwardEulerScheme>{});
 	}
 
-	// update ghost zones [old timestep]
-	fillBoundaryConditions(state_old_cc_tmp, state_old_cc_tmp, lev, time, quokka::centering::cc, quokka::direction::na, PreInterpState, PostInterpState);
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			fillBoundaryConditions(state_old_fc_tmp[idim], state_old_fc_tmp[idim], lev, time, quokka::centering::fc, quokka::direction{idim},
-					       AMRSimulation<problem_t>::InterpHookNone, AMRSimulation<problem_t>::InterpHookNone,
-					       FillPatchType::fillpatch_function);
-		}
-	}
-
-	// LOW LEVEL DEBUGGING: output state_old_cc_tmp (with ghost cells)
-	if (lowLevelDebuggingOutput_ == 1) {
-		// write AMReX plotfile
-		amrex::ParallelDescriptor::Barrier();
-		WriteSingleLevelPlotfile(CustomPlotFileName("debug_stage1_filled_state_old", istep[lev] + 1), state_old_cc_tmp, componentNames_cc_, geom[lev],
-					 time, istep[lev] + 1);
-		amrex::ParallelDescriptor::Barrier();
-	}
-
-	// check state validity
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
-	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
-
-	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] =
-	    HydroRKPolicy<problem_t>::computeFOHydroFluxes(*this, state_old_cc_tmp, state_old_fc_tmp, nvars_, nghost_Riemann, lev);
-
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
-		}
-		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
-	}
-
-	auto const &stateOld_cc = state_old_cc_tmp;
-	auto &stateNew_cc = state_new_cc_[lev];
-
-	auto const &stateOld_fc = state_old_fc_tmp;
-	auto &stateNew_fc = state_new_fc_[lev];
-
-	auto [fluxArrays, faceVel, fast_mhd_wavespeeds] =
-	    HydroRKPolicy<problem_t>::computeHydroFluxes(*this, stateOld_cc, stateOld_fc, nvars_, nghost_Riemann, lev);
-
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-			ec_emf_components[idim].define(ba_ec, dm, 1, 0);
-		}
-		MHDSystem<problem_t>::ComputeEMF(ec_emf_components, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds, emfReconstructionOrder_,
-						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
-	}
-
-	amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
-	amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
-	redoFlag.setVal(quokka::redoFlag::none);
-
-	HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
-	HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
-	HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
-
-	if (lowLevelDebuggingOutput_ == 1) {
-		std::string plotfile_name = CustomPlotFileName("debug_stage1_rhs_fluxes", istep[lev] + 1);
-		WriteSingleLevelPlotfileSimplified("debug_stage1_rhs_fluxes", rhs, componentNames_cc_, lev, 1);
-
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("Flux_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(fluxArrays[idim], fullprefix);
-		}
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("FaceVel_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(faceVel[idim], fullprefix);
-		}
-	}
-
-	amrex::Gpu::streamSynchronizeAll();
-
-	amrex::Long const ncells_bad = redoFlag.sum(0);
-	if (ncells_bad > 0) {
-		if (Verbose()) {
-			amrex::Print() << "[FOFC] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
-			const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-			printCoordinates(lev, cell_idx);
-			amrex::print_state(stateNew_cc, cell_idx);
-		}
-
-		redoFlag.FillBoundary(geom[lev].periodicity());
-
-		HydroRKPolicy<problem_t>::replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
-		HydroRKPolicy<problem_t>::replaceFluxes(faceVel, FOfaceVel, redoFlag);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroRKPolicy<problem_t>::replaceEMFs(ec_emf_components, ec_emf_components_fo, redoFlag);
-		}
-
-		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
-		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
-
-		amrex::Gpu::streamSynchronizeAll();
-		amrex::Long const ncells_bad_after_fofc = redoFlag.sum(0);
-		if (ncells_bad_after_fofc > 0) {
-			if (Verbose()) {
-				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-				amrex::Print() << "[FOFC] Flux correction failed:\n";
-				printCoordinates(lev, cell_idx);
-				amrex::print_state(stateNew_cc, cell_idx);
-				amrex::Print() << "[FOFC] failed for " << ncells_bad_after_fofc << " cells on level " << lev << "\n";
-			}
-			if (abortOnFofcFailure_ != 0) {
-				return false;
-			}
-		}
-	}
-
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components, dt_lev, geom[lev].CellSizeArray());
-	}
-
-	if (this->useDensityFloorParser_) {
-		auto const density_floor_parser = this->densityFloorParserExe_.value();
-		auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-									  amrex::Real base_density_floor) -> amrex::Real {
-			return density_floor_parser(x, y, z, base_density_floor);
-		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-	} else {
-		auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-									     amrex::Real base_density_floor) -> amrex::Real {
-			return densityFloor(x, y, z, base_density_floor);
-		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-	}
-
-	if (useDualEnergy_ == 1) {
-		HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
-	}
-
-	amrex::Gpu::streamSynchronizeAll();
-
-	auto burn_success_second = addStrangSplitSourcesWithBuiltin(stateNew_cc, stateNew_fc, lev, time + dt_lev, 0.5 * dt_lev);
-	bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
-	bool const final_success = (cfl_ok && burn_success_second);
-
-	if (do_reflux == 1 && final_success) {
-		incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, dt_lev);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components, lev, -1.0 * dt_lev);
-		}
-	}
-
-	if (do_tracers != 0 && final_success) {
-		TracerPC->AdvectWithUmac(faceVel.data(), lev, dt_lev);
-	}
-
-	return final_success;
+	return run_integrator(std::type_identity<quokka::SSPRK2Scheme>{});
 }
 
 template <typename problem_t>

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2167,8 +2167,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 		}
 
-		if (do_tracers != 0 && final_success)
-		{
+		if (do_tracers != 0 && final_success) {
 			auto const &accum = integrator.getAccumulators();
 			TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
 		}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -906,13 +906,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::addStrangSplitSo
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computePhotoelectricHeatingRate(amrex::Real current_time) -> amrex::Real
 {
-	amrex::Real heating_rate = 0.0;
+	const amrex::Real heating_rate_default = 0.0;
 
 #if AMREX_SPACEDIM == 3
 	// Check if PE heating tables are initialized
 	// Note that this function is always called as long as cooling is turned on, so it is okay if g_pe_heating_tables_ptr is null
 	if (quokka::g_pe_heating_tables_ptr<> == nullptr || !quokka::g_pe_heating_tables_ptr<>->is_initialized()) {
-		return heating_rate; // Return 0 if tables not loaded
+		return heating_rate_default; // Return 0 if tables not loaded
 	}
 
 	// Get GPU-friendly const tables
@@ -920,16 +920,14 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computePhotoelec
 
 	if (const_sfr_Msun_per_year_per_kpc2_ > 0.0) {
 		// Constant star formation rate
-		heating_rate = quokka::PeHeatingFromConstSfr(const_sfr_Msun_per_year_per_kpc2_, gpu_tables);
-	} else {
-		// Real star formation history
-		heating_rate = particleRegister_.computePhotoelectricHeatingRate(current_time, gpu_tables, sf_area_kpc2_);
+		return quokka::PeHeatingFromConstSfr(const_sfr_Msun_per_year_per_kpc2_, gpu_tables);
 	}
+	// Real star formation history
+	return particleRegister_.computePhotoelectricHeatingRate(current_time, gpu_tables, sf_area_kpc2_);
 #else
 	amrex::ignore_unused(current_time);
+	return heating_rate_default;
 #endif
-
-	return heating_rate;
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeExternalHeatingRate(amrex::Real current_time, amrex::Real dt) -> amrex::Real
@@ -2098,12 +2096,12 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		if (emf_as_crse != nullptr) {
 			step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1), dmap[lev],
 										     geom[lev + 1], geom[lev], 1);
-			step_emf_as_crse->reset();
+			(*step_emf_as_crse).reset();
 		}
 		if (emf_as_fine != nullptr) {
 			step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
 										     geom[lev], geom[lev - 1], 1);
-			step_emf_as_fine->reset();
+			(*step_emf_as_fine).reset();
 		}
 	}
 
@@ -2129,7 +2127,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	}
 
 	auto run_integrator = [&](auto scheme_tag) -> bool {
-		using scheme_t = typename decltype(scheme_tag)::type;
+		using scheme_t = decltype(scheme_tag)::type;
 		quokka::RKIntegrator<HydroRKPolicy<problem_t>, scheme_t> integrator(policy);
 
 		integrator.define(lev, old_state);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -75,6 +75,7 @@ namespace filesystem = experimental::filesystem;
 #include "hydro/hydro_system.hpp"
 #include "hydro/mhd_system.hpp"
 #include "hyperbolic_system.hpp"
+#include "math/RKIntegrator.hpp"
 #include "physics_info.hpp"
 #include "physics_numVars.hpp"
 #include "radiation/radiation_system.hpp"
@@ -378,42 +379,14 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 				    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 	    -> std::tuple<std::array<amrex::FArrayBox, AMREX_SPACEDIM>, std::array<amrex::FArrayBox, AMREX_SPACEDIM>>;
 
-	auto computeHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann,
-				int lev) -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-						       std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
-
-	auto computeFOHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars,
-				  int nghost_Riemann, int lev)
-	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>;
-
-	template <FluxDir DIR>
-	void computeCCPerpBfieldComps(amrex::MultiFab &cc_bfield_perp_comps_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const;
-
 	template <FluxDir DIR>
 	void fluxFunction(amrex::Array4<const amrex::Real> const &consState, amrex::FArrayBox &x1Flux, amrex::FArrayBox &x1FluxDiffusive,
 			  const amrex::Box &indexRange, int nvars, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
-	template <FluxDir DIR>
-	void hydroFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-			       amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
-			       amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
-			       amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct_total, int nvars, int nghost_Riemann);
-
-	template <FluxDir DIR>
-	void hydroFOFluxFunction(amrex::MultiFab &primVar, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState, amrex::MultiFab &rightState,
-				 amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield, amrex::MultiFab &x1Flux, amrex::MultiFab &x1FaceVel,
-				 amrex::MultiFab &x1FSpds, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, int ng_reconstruct_total,
-				 int nvars, int nghost_Riemann);
-
-	void replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
-			   amrex::iMultiFab &redoFlag);
-
-	void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components,
-			 amrex::iMultiFab &redoFlag);
-
 	// void PrintRadEnergySource(amrex::MultiFab const &radEnergySource);
 };
+
+#include "hydro/HydroRKPolicy.hpp"
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::defineComponentNames()
 {
@@ -2099,7 +2072,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		amrex::ignore_unused(emf_as_crse, emf_as_fine);
 	}
 
-	const amrex::Real stage1Weight = (integratorOrder_ == 2) ? 0.5 : 1.0;
 	const int nghost_Riemann =
 	    MinimumHydroRiemannGhost(Physics_Traits<problem_t>::is_mhd_enabled, emfComputingScheme_, emfAveragingScheme_, do_tracers != 0);
 
@@ -2115,39 +2087,82 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		return burn_success_first;
 	}
 
-	// create temporary multifab for intermediate state
-	amrex::MultiFab state_inter_cc_(grids[lev], dmap[lev], Physics_Indices<problem_t>::nvarTotal_cc, nghost_cc_);
-	state_inter_cc_.setVal(0); // prevent assert in fillBoundaryConditions when radiation is enabled
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> state_inter_fc_;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_fc = amrex::convert(ba_cc, amrex::IntVect::TheDimensionVector(idim));
-			state_inter_fc_[idim].define(ba_fc, dm, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_);
-			state_inter_fc_[idim].setVal(0);
-		}
-	}
+	if (integratorOrder_ == 2) {
+		std::unique_ptr<amrex::FluxRegister> step_fr_as_crse;
+		std::unique_ptr<amrex::FluxRegister> step_fr_as_fine;
+		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_crse;
+		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_fine;
 
-	// create temporary multifabs for combined RK2 flux and time-average face velocity
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux_rk2;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> avgFaceVel;
-	const int nghost_vel = 2; // 2 ghost faces are needed for tracer particles
-
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		auto ba_fc = amrex::convert(ba_cc, amrex::IntVect::TheDimensionVector(idim));
-		// initialize flux MultiFab
-		flux_rk2[idim] = amrex::MultiFab(ba_fc, dm, nvars_, 0);
-		flux_rk2[idim].setVal(0);
-		// initialize velocity MultiFab
-		avgFaceVel[idim] = amrex::MultiFab(ba_fc, dm, 1, nghost_vel);
-		avgFaceVel[idim].setVal(0);
-	}
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_ave;
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-			ec_emf_components_rk_ave[idim].define(ba_ec, dm, 1, 0);
-			ec_emf_components_rk_ave[idim].setVal(0.0);
+		if (fr_as_crse != nullptr) {
+			step_fr_as_crse = std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1,
+										       nvarTotal_cc_);
 		}
+		if (fr_as_fine != nullptr) {
+			step_fr_as_fine = std::make_unique<amrex::FluxRegister>(grids[lev], dmap[lev], refRatio(lev - 1), lev, nvarTotal_cc_);
+		}
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			if (emf_as_crse != nullptr) {
+				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1), dmap[lev],
+												     geom[lev + 1], geom[lev], 1);
+			}
+			if (emf_as_fine != nullptr) {
+				step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
+												     geom[lev], geom[lev - 1], 1);
+			}
+		}
+
+		HydroRKPolicy<problem_t> policy{*this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(),
+						step_emf_as_fine.get()};
+		quokka::RKIntegrator<HydroRKPolicy<problem_t>> integrator(policy);
+
+		quokka::CompositeStateView old_state{};
+		old_state.cc = &state_old_cc_tmp;
+		old_state.fc_data = &state_old_fc_tmp;
+
+		quokka::CompositeStateView new_state{};
+		new_state.cc = &state_new_cc_[lev];
+		new_state.fc_data = &state_new_fc_[lev];
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				old_state.fc[idim] = &state_old_fc_tmp[idim];
+				new_state.fc[idim] = &state_new_fc_[lev][idim];
+			}
+		}
+
+		integrator.define(lev, old_state);
+		bool const rk_success = integrator.advance(old_state, new_state, time, dt_lev);
+		if (!rk_success) {
+			return false;
+		}
+
+			auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
+			bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+			bool const final_success = (cfl_ok && burn_success_second);
+
+			if (final_success) {
+				if (step_fr_as_crse) {
+					*flux_reg_[lev + 1] += *step_fr_as_crse;
+				}
+				if (step_fr_as_fine) {
+					*flux_reg_[lev] += *step_fr_as_fine;
+				}
+				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+					if (step_emf_as_crse) {
+						emf_reg_[lev + 1]->plus(*step_emf_as_crse);
+					}
+					if (step_emf_as_fine) {
+						emf_reg_[lev]->plus(*step_emf_as_fine);
+					}
+				}
+			}
+
+			if (do_tracers != 0 && final_success) {
+				auto const &accum = integrator.getAccumulators();
+				TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
+			}
+
+		return final_success;
 	}
 
 	// update ghost zones [old timestep]
@@ -2173,7 +2188,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan(0, state_old_cc_tmp.nComp()));
 	AMREX_ASSERT(!state_old_cc_tmp.contains_nan()); // check ghost cells
 
-	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] = computeFOHydroFluxes(state_old_cc_tmp, state_old_fc_tmp, nvars_, nghost_Riemann, lev);
+	auto [FOfluxArrays, FOfaceVel, FOfast_mhd_wavespeeds] =
+	    HydroRKPolicy<problem_t>::computeFOHydroFluxes(*this, state_old_cc_tmp, state_old_fc_tmp, nvars_, nghost_Riemann, lev);
 
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_fo;
 	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
@@ -2185,397 +2201,135 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 						 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}
 
-	// Stage 1 of RK2-SSP
-	{
-		//  advance all grids on local processor (Stage 1 of integrator)
-		auto const &stateOld_cc = state_old_cc_tmp;
-		auto &stateNew_cc = state_inter_cc_;
+	auto const &stateOld_cc = state_old_cc_tmp;
+	auto &stateNew_cc = state_new_cc_[lev];
 
-		auto const &stateOld_fc = state_old_fc_tmp;
-		auto &stateNew_fc = state_inter_fc_;
+	auto const &stateOld_fc = state_old_fc_tmp;
+	auto &stateNew_fc = state_new_fc_[lev];
 
-		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateOld_cc, stateOld_fc, nvars_, nghost_Riemann, lev);
+	auto [fluxArrays, faceVel, fast_mhd_wavespeeds] =
+	    HydroRKPolicy<problem_t>::computeHydroFluxes(*this, stateOld_cc, stateOld_fc, nvars_, nghost_Riemann, lev);
 
-		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage1;
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-				ec_emf_components_rk_stage1[idim].define(ba_ec, dm, 1, 0);
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+			ec_emf_components[idim].define(ba_ec, dm, 1, 0);
+		}
+		MHDSystem<problem_t>::ComputeEMF(ec_emf_components, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds, emfReconstructionOrder_,
+						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+	}
+
+	amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
+	amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
+	redoFlag.setVal(quokka::redoFlag::none);
+
+	HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
+	HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
+	HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
+
+	if (lowLevelDebuggingOutput_ == 1) {
+		std::string plotfile_name = CustomPlotFileName("debug_stage1_rhs_fluxes", istep[lev] + 1);
+		WriteSingleLevelPlotfileSimplified("debug_stage1_rhs_fluxes", rhs, componentNames_cc_, lev, 1);
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			if (amrex::ParallelDescriptor::IOProcessor()) {
+				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
 			}
-			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage1, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds,
-							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+			std::string fullprefix =
+			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("Flux_") + quokka::face_dir_str[idim]);
+			amrex::VisMF::Write(fluxArrays[idim], fullprefix);
+		}
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			if (amrex::ParallelDescriptor::IOProcessor()) {
+				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
+			}
+			std::string fullprefix =
+			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("FaceVel_") + quokka::face_dir_str[idim]);
+			amrex::VisMF::Write(faceVel[idim], fullprefix);
+		}
+	}
+
+	amrex::Gpu::streamSynchronizeAll();
+
+	amrex::Long const ncells_bad = redoFlag.sum(0);
+	if (ncells_bad > 0) {
+		if (Verbose()) {
+			amrex::Print() << "[FOFC] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
+			const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
+			printCoordinates(lev, cell_idx);
+			amrex::print_state(stateNew_cc, cell_idx);
 		}
 
-		amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
-		amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
-		redoFlag.setVal(quokka::redoFlag::none);
+		redoFlag.FillBoundary(geom[lev].periodicity());
+
+		HydroRKPolicy<problem_t>::replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
+		HydroRKPolicy<problem_t>::replaceFluxes(faceVel, FOfaceVel, redoFlag);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HydroRKPolicy<problem_t>::replaceEMFs(ec_emf_components, ec_emf_components_fo, redoFlag);
+		}
 
 		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
 		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
 		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
 
-		// LOW LEVEL DEBUGGING: output rhs
-		if (lowLevelDebuggingOutput_ == 1) {
-			// write rhs
-			std::string plotfile_name = CustomPlotFileName("debug_stage1_rhs_fluxes", istep[lev] + 1);
-			WriteSingleLevelPlotfileSimplified("debug_stage1_rhs_fluxes", rhs, componentNames_cc_, lev, 1);
-
-			// write fluxes
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				if (amrex::ParallelDescriptor::IOProcessor()) {
-					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-				}
-				std::string fullprefix =
-				    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("Flux_") + quokka::face_dir_str[idim]);
-				amrex::VisMF::Write(fluxArrays[idim], fullprefix);
-			}
-			// write face velocities
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				if (amrex::ParallelDescriptor::IOProcessor()) {
-					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-				}
-				std::string fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
-										       std::string("FaceVel_") + quokka::face_dir_str[idim]);
-				amrex::VisMF::Write(faceVel[idim], fullprefix);
-			}
-		}
-
-		// do first-order flux correction (FOFC)
-		amrex::Gpu::streamSynchronizeAll(); // ensure device-side ops are finished
-
-		amrex::Long const ncells_bad = redoFlag.sum(0);
-		if (ncells_bad > 0) {
+		amrex::Gpu::streamSynchronizeAll();
+		amrex::Long const ncells_bad_after_fofc = redoFlag.sum(0);
+		if (ncells_bad_after_fofc > 0) {
 			if (Verbose()) {
-				amrex::Print() << "[FOFC-1] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
 				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-				// Calculate the coordinates based on the cell index and cell size
+				amrex::Print() << "[FOFC] Flux correction failed:\n";
 				printCoordinates(lev, cell_idx);
 				amrex::print_state(stateNew_cc, cell_idx);
+				amrex::Print() << "[FOFC] failed for " << ncells_bad_after_fofc << " cells on level " << lev << "\n";
 			}
-
-			// synchronize redoFlag across ranks
-			redoFlag.FillBoundary(geom[lev].periodicity());
-
-			replaceFluxes(fluxArrays, FOfluxArrays, redoFlag);
-			replaceFluxes(faceVel, FOfaceVel, redoFlag); // needed for dual energy
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				replaceEMFs(ec_emf_components_rk_stage1, ec_emf_components_fo, redoFlag); // replace emf components
-			}
-
-			// re-do RK update
-			HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, fluxArrays, dx, nvars_);
-			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, faceVel, redoFlag);
-			HydroSystem<problem_t>::PredictStep(stateOld_cc, stateNew_cc, rhs, dt_lev, nvars_, redoFlag);
-
-			amrex::Gpu::streamSynchronizeAll(); // just in case
-			amrex::Long const ncells_bad = static_cast<int>(redoFlag.sum(0));
-			if (ncells_bad > 0) {
-				// FOFC failed
-				if (Verbose()) {
-					const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-					// print cell state
-					amrex::Print() << "[FOFC-1] Flux correction failed:\n";
-					printCoordinates(lev, cell_idx);
-					amrex::print_state(stateNew_cc, cell_idx);
-					amrex::Print() << "[FOFC-1] failed for " << ncells_bad << " cells on level " << lev << "\n";
-				}
-				if (abortOnFofcFailure_ != 0) {
-					return false;
-				}
-			}
-		}
-
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], stage1Weight, ec_emf_components_rk_stage1[idim], 0, 0, 1, 0);
-			}
-			MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components_rk_stage1, dt_lev, geom[lev].CellSizeArray());
-		}
-
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::MultiFab::Saxpy(flux_rk2[idim], stage1Weight, fluxArrays[idim], 0, 0, nvars_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, 0);
-		}
-
-		// prevent vacuum
-		if (this->useDensityFloorParser_) {
-			auto const density_floor_parser = this->densityFloorParserExe_.value();
-			auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-										  amrex::Real base_density_floor) -> amrex::Real {
-				return density_floor_parser(x, y, z, base_density_floor);
-			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-		} else {
-			auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-										     amrex::Real base_density_floor) -> amrex::Real {
-				return densityFloor(x, y, z, base_density_floor);
-			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
-		}
-
-		if (useDualEnergy_ == 1) {
-			// sync internal energy (requires positive density)
-			HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
-		}
-	}
-	amrex::Gpu::streamSynchronizeAll();
-
-	// Stage 2 of RK2-SSP
-	if (integratorOrder_ == 2) {
-		//  update ghost zones [intermediate stage stored in state_inter_cc_]
-		fillBoundaryConditions(state_inter_cc_, state_inter_cc_, lev, time + dt_lev, quokka::centering::cc, quokka::direction::na, PreInterpState,
-				       PostInterpState);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				fillBoundaryConditions(state_inter_fc_[idim], state_inter_fc_[idim], lev, time + dt_lev, quokka::centering::fc,
-						       quokka::direction{idim}, AMRSimulation<problem_t>::InterpHookNone,
-						       AMRSimulation<problem_t>::InterpHookNone, FillPatchType::fillpatch_function);
-			}
-		}
-
-		// check intermediate state validity
-		AMREX_ASSERT(!state_inter_cc_.contains_nan(0, state_inter_cc_.nComp()));
-		AMREX_ASSERT(!state_inter_cc_.contains_nan()); // check ghost zones
-
-		auto const &stateOld_cc = state_old_cc_tmp;
-		auto const &stateInter_cc = state_inter_cc_;
-		auto &stateFinal_cc = state_new_cc_[lev];
-
-		auto const &stateOld_fc = state_old_fc_tmp;
-		auto const &stateInter_fc = state_inter_fc_;
-		auto &stateFinal_fc = state_new_fc_[lev];
-
-		auto [fluxArrays, faceVel, fast_mhd_wavespeeds] = computeHydroFluxes(stateInter_cc, stateInter_fc, nvars_, nghost_Riemann, lev);
-
-		std::array<amrex::MultiFab, AMREX_SPACEDIM> ec_emf_components_rk_stage2;
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
-				ec_emf_components_rk_stage2[idim].define(ba_ec, dm, 1, 0);
-			}
-			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage2, stateInter_cc, faceVel, stateInter_fc, fast_mhd_wavespeeds,
-							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
-		}
-
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::MultiFab::Saxpy(flux_rk2[idim], 0.5, fluxArrays[idim], 0, 0, nvars_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, 0);
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], 0.5, ec_emf_components_rk_stage2[idim], 0, 0, 1, 0);
-			}
-		}
-
-		amrex::MultiFab rhs(grids[lev], dmap[lev], nvars_, 0);
-		amrex::iMultiFab redoFlag(grids[lev], dmap[lev], 1, 1);
-		redoFlag.setVal(quokka::redoFlag::none);
-
-		HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, flux_rk2, dx, nvars_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, avgFaceVel, redoFlag);
-		HydroSystem<problem_t>::PredictStep(stateOld_cc, stateFinal_cc, rhs, dt_lev, nvars_, redoFlag);
-
-		// do first-order flux correction (FOFC)
-		amrex::Gpu::streamSynchronizeAll(); // just in case
-		amrex::Long const ncells_bad = redoFlag.sum(0);
-		if (ncells_bad > 0) {
-			if (Verbose()) {
-				amrex::Print() << "[FOFC-2] flux correcting " << ncells_bad << " cells on level " << lev << "\n";
-				const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-				printCoordinates(lev, cell_idx);
-				amrex::print_state(stateFinal_cc, cell_idx);
-			}
-
-			// synchronize redoFlag across ranks
-			redoFlag.FillBoundary(geom[lev].periodicity());
-
-			replaceFluxes(flux_rk2, FOfluxArrays, redoFlag);
-			replaceFluxes(avgFaceVel, FOfaceVel, redoFlag); // needed for dual energy
-
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				replaceEMFs(ec_emf_components_rk_ave, ec_emf_components_fo, redoFlag); // replaces EMF components
-			}
-
-			// re-do RK update
-			HydroSystem<problem_t>::ComputeRhsFromFluxes(rhs, flux_rk2, dx, nvars_);
-			HydroSystem<problem_t>::AddInternalEnergyPdV(rhs, stateOld_cc, stateOld_fc, dx, avgFaceVel, redoFlag);
-			HydroSystem<problem_t>::PredictStep(stateOld_cc, stateFinal_cc, rhs, dt_lev, nvars_, redoFlag);
-
-			amrex::Gpu::streamSynchronizeAll(); // just in case
-			amrex::Long const ncells_bad = redoFlag.sum(0);
-			if (ncells_bad > 0) {
-				// FOFC failed
-				if (Verbose()) {
-					const amrex::IntVect cell_idx = redoFlag.maxIndex(0);
-					// print cell state
-					amrex::Print() << "[FOFC-2] Flux correction failed:\n";
-					printCoordinates(lev, cell_idx);
-					amrex::print_state(stateFinal_cc, cell_idx);
-					amrex::Print() << "[FOFC-2] failed for " << ncells_bad << " cells on level " << lev << "\n";
-				}
-				if (abortOnFofcFailure_ != 0) {
-					return false;
-				}
-			}
-		}
-
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateFinal_fc, ec_emf_components_rk_ave, dt_lev, geom[lev].CellSizeArray());
-		}
-
-		// prevent vacuum
-		if (this->useDensityFloorParser_) {
-			auto const density_floor_parser = this->densityFloorParserExe_.value();
-			auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-										  amrex::Real base_density_floor) -> amrex::Real {
-				return density_floor_parser(x, y, z, base_density_floor);
-			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
-		} else {
-			auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
-										     amrex::Real base_density_floor) -> amrex::Real {
-				return densityFloor(x, y, z, base_density_floor);
-			};
-			HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateFinal_cc, geom[lev], density_floor_func);
-		}
-
-		if (useDualEnergy_ == 1) {
-			// sync internal energy (requires positive density)
-			HydroSystem<problem_t>::SyncDualEnergy(stateFinal_cc, stateFinal_fc);
-		}
-
-	} else { // we are only doing forward Euler
-		amrex::Copy(state_new_cc_[lev], state_inter_cc_, 0, 0, nvars_, 0);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				amrex::Copy(state_new_fc_[lev][idim], state_inter_fc_[idim], 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, 0);
+			if (abortOnFofcFailure_ != 0) {
+				return false;
 			}
 		}
 	}
+
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		MHDSystem<problem_t>::SolveInductionEqn(stateOld_fc, stateNew_fc, ec_emf_components, dt_lev, geom[lev].CellSizeArray());
+	}
+
+	if (this->useDensityFloorParser_) {
+		auto const density_floor_parser = this->densityFloorParserExe_.value();
+		auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
+									  amrex::Real base_density_floor) -> amrex::Real {
+			return density_floor_parser(x, y, z, base_density_floor);
+		};
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+	} else {
+		auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
+									     amrex::Real base_density_floor) -> amrex::Real {
+			return densityFloor(x, y, z, base_density_floor);
+		};
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, stateNew_cc, geom[lev], density_floor_func);
+	}
+
+	if (useDualEnergy_ == 1) {
+		HydroSystem<problem_t>::SyncDualEnergy(stateNew_cc, stateNew_fc);
+	}
+
 	amrex::Gpu::streamSynchronizeAll();
 
-	// do Strang split source terms (second half-step)
-	auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
-
+	auto burn_success_second = addStrangSplitSourcesWithBuiltin(stateNew_cc, stateNew_fc, lev, time + dt_lev, 0.5 * dt_lev);
 	bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
 	bool const final_success = (cfl_ok && burn_success_second);
 
 	if (do_reflux == 1 && final_success) {
-		incrementFluxRegisters(fr_as_crse, fr_as_fine, flux_rk2, lev, dt_lev);
+		incrementFluxRegisters(fr_as_crse, fr_as_fine, fluxArrays, lev, dt_lev);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			// E = -v x B, our emf is v x B, so we need to pass -dt
-			incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components_rk_ave, lev, -1.0 * dt_lev);
+			incrementEMFRegisters(emf_as_crse, emf_as_fine, ec_emf_components, lev, -1.0 * dt_lev);
 		}
 	}
 
 	if (do_tracers != 0 && final_success) {
-		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
+		TracerPC->AdvectWithUmac(faceVel.data(), lev, dt_lev);
 	}
 
 	return final_success;
-}
-
-template <typename problem_t>
-void QuokkaSimulation<problem_t>::replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
-						amrex::iMultiFab &redoFlag)
-{
-	const BL_PROFILE("QuokkaSimulation::replaceFluxes()");
-
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) { // loop over dimension
-		// ensure that flux arrays have the same number of components
-		AMREX_ASSERT(fluxes[idim].nComp() == FOfluxes[idim].nComp());
-		int ncomp = fluxes[idim].nComp();
-
-		auto const &FOflux_arrs = FOfluxes[idim].const_arrays();
-		auto const &redoFlag_arrs = redoFlag.const_arrays();
-		auto flux_arrs = fluxes[idim].arrays();
-
-		// By convention, the fluxes are defined on the left edge of each zone,
-		// i.e. flux_(i) is the flux *into* zone i through the interface on the
-		// left of zone i, and -1.0*flux(i+1) is the flux *into* zone i through
-		// the interface on the right of zone i.
-
-		amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)}; // must include 1 ghost zone
-
-		amrex::ParallelFor(redoFlag, ng, ncomp, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
-			if (redoFlag_arrs[bx](i, j, k) == quokka::redoFlag::redo) {
-				// replace fluxes with first-order ones at the faces of cell (i,j,k)
-				if (flux_arrs[bx].contains(i, j, k)) {
-					flux_arrs[bx](i, j, k, n) = FOflux_arrs[bx](i, j, k, n);
-				}
-				if (idim == 0) { // x-dir fluxes
-					if (flux_arrs[bx].contains(i + 1, j, k)) {
-						flux_arrs[bx](i + 1, j, k, n) = FOflux_arrs[bx](i + 1, j, k, n);
-					}
-				} else if (idim == 1) { // y-dir fluxes
-					if (flux_arrs[bx].contains(i, j + 1, k)) {
-						flux_arrs[bx](i, j + 1, k, n) = FOflux_arrs[bx](i, j + 1, k, n);
-					}
-				} else if (idim == 2) { // z-dir fluxes
-					if (flux_arrs[bx].contains(i, j, k + 1)) {
-						flux_arrs[bx](i, j, k + 1, n) = FOflux_arrs[bx](i, j, k + 1, n);
-					}
-				}
-			}
-		});
-	}
-}
-
-template <typename problem_t>
-void QuokkaSimulation<problem_t>::replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components,
-					      std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components, amrex::iMultiFab &redoFlag)
-{
-	const BL_PROFILE("QuokkaSimulation::replaceFluxes()");
-
-	for (int iedge = 0; iedge < 3; ++iedge) { // loop over edges
-		// ensure that flux arrays have the same number of components
-		AMREX_ASSERT(emf_components[iedge].nComp() == FO_emf_components[iedge].nComp());
-		int ncomp = emf_components[iedge].nComp();
-
-		auto const &FO_emf_components_arrs = FO_emf_components[iedge].const_arrays();
-		auto const &redoFlag_arrs = redoFlag.const_arrays();
-		auto emf_components_arrs = emf_components[iedge].arrays();
-
-		amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)}; // must include 1 ghost zone ?
-
-		amrex::ParallelFor(redoFlag, ng, ncomp, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
-			if (redoFlag_arrs[bx](i, j, k) == quokka::redoFlag::redo) {
-				// replace fluxes with first-order ones at the faces of cell (i,j,k)
-				if (emf_components_arrs[bx].contains(i, j, k)) {
-					emf_components_arrs[bx](i, j, k, n) = FO_emf_components_arrs[bx](i, j, k, n);
-				}
-				if (iedge == 0) { // x-edge components
-					if (emf_components_arrs[bx].contains(i, j + 1, k)) {
-						emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
-					}
-					if (emf_components_arrs[bx].contains(i, j, k + 1)) {
-						emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
-					}
-					if (emf_components_arrs[bx].contains(i, j + 1, k + 1)) {
-						emf_components_arrs[bx](i, j + 1, k + 1, n) = FO_emf_components_arrs[bx](i, j + 1, k + 1, n);
-					}
-				} else if (iedge == 1) { // y-edge components
-					if (emf_components_arrs[bx].contains(i + 1, j, k)) {
-						emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
-					}
-					if (emf_components_arrs[bx].contains(i, j, k + 1)) {
-						emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
-					}
-					if (emf_components_arrs[bx].contains(i + 1, j, k + 1)) {
-						emf_components_arrs[bx](i + 1, j, k + 1, n) = FO_emf_components_arrs[bx](i + 1, j, k + 1, n);
-					}
-				} else if (iedge == 2) { // z-edge components
-					if (emf_components_arrs[bx].contains(i + 1, j, k)) {
-						emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
-					}
-					if (emf_components_arrs[bx].contains(i, j + 1, k)) {
-						emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
-					}
-					if (emf_components_arrs[bx].contains(i + 1, j + 1, k)) {
-						emf_components_arrs[bx](i + 1, j + 1, k, n) = FO_emf_components_arrs[bx](i + 1, j + 1, k, n);
-					}
-				}
-			}
-		});
-	}
 }
 
 template <typename problem_t>
@@ -2609,303 +2363,6 @@ auto QuokkaSimulation<problem_t>::expandFluxArrays(std::array<amrex::FArrayBox, 
 		return newFlux;
 	};
 	return {AMREX_D_DECL(copyFlux(fluxes[0]), copyFlux(fluxes[1]), copyFlux(fluxes[2]))};
-}
-
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
-						     const int nvars, const int nghost_Riemann, const int lev)
-    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
-{
-	const BL_PROFILE("QuokkaSimulation::computeHydroFluxes()");
-
-	const auto ba = grids[lev];
-	const auto dm = dmap[lev];
-
-	// Reconstruct one extra face layer beyond the requested ghosted Riemann outputs
-	// so the outermost ghost face has left/right interface states.
-	const int reconstructGhost = nghost_Riemann + 1;
-
-	// Shock flattening coefficients are computed one cell farther out than the
-	// reconstructed interfaces and use a +/-2 pressure stencil.
-	const int flatteningGhost = reconstructGhost + 1;
-
-	// allocate temporary MultiFabs
-	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, nghost_cc_);
-	std::array<amrex::MultiFab, 3> flatCoefs;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
-
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		flatCoefs[idim] = amrex::MultiFab(ba, dm, 1, flatteningGhost);
-	}
-
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
-		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
-		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
-		leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
-		rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
-		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost - 1);
-		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructGhost - 1);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost - 1);
-		}
-	}
-
-	// conserved to primitive variables
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
-
-	// compute flattening coefficients
-	AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(primVar, flatCoefs[0], flatteningGhost);
-		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X2>(primVar, flatCoefs[1], flatteningGhost);
-		     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
-
-	// compute flux functions
-	AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0],
-						    flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						    reconstructGhost, nvars, nghost_Riemann);
-		     , hydroFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1],
-						      flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						      reconstructGhost, nvars, nghost_Riemann);
-		     , hydroFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2],
-						      flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0], flatCoefs[1], flatCoefs[2],
-						      reconstructGhost, nvars, nghost_Riemann);)
-
-	// synchronization point to prevent MultiFabs from going out of scope
-	amrex::Gpu::streamSynchronizeAll();
-
-	// write reconstructed states to disk for analysis (includes ghost zones)
-	// this->writeReconstructedStatesToDisk(leftState, rightState, lev, istep[lev]);
-
-	// write face velocities to disk for analysis
-	// this->writeFaceVelocitiesToDisk(facevel, lev, istep[lev]);
-
-	// LOW LEVEL DEBUGGING: output all of the temporary MultiFabs
-	if (lowLevelDebuggingOutput_ == 1) {
-		// write primitive cell-centered state
-		std::string plotfile_name = CustomPlotFileName("debug_reconstruction", istep[lev] + 1);
-		WriteSingleLevelPlotfileSimplified("debug_reconstruction", primVar, componentNames_cc_, lev, 1);
-
-		// write flattening coefficients
-		amrex::Vector<std::string> flatCompNames{"chi"};
-		WriteSingleLevelPlotfileSimplified("debug_flattening_x", flatCoefs[0], flatCompNames, lev, 1);
-		WriteSingleLevelPlotfileSimplified("debug_flattening_y", flatCoefs[1], flatCompNames, lev, 1);
-		WriteSingleLevelPlotfileSimplified("debug_flattening_z", flatCoefs[2], flatCompNames, lev, 1);
-
-		// write L interface states
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string const fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateL_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(leftState[idim], fullprefix);
-		}
-		// write R interface states
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			if (amrex::ParallelDescriptor::IOProcessor()) {
-				std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
-			}
-			std::string const fullprefix =
-			    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateR_") + quokka::face_dir_str[idim]);
-			amrex::VisMF::Write(rightState[idim], fullprefix);
-		}
-	}
-
-	// return flux and face-centered velocities
-	return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
-AMREX_FORCE_INLINE void QuokkaSimulation<problem_t>::computeCCPerpBfieldComps(amrex::MultiFab &cc_bfield_perp_comps_mf,
-									      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc) const
-{
-	// per-direction neighbor offsets for those two components
-	std::array<int, 3> delta_x2{0, 0, 0};
-	std::array<int, 3> delta_x3{0, 0, 0};
-
-	amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
-	amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
-	if constexpr (DIR == FluxDir::X1) {
-		x2State_fc_bfield_in = consVar_fc[1].const_arrays(); // y-faces
-		x3State_fc_bfield_in = consVar_fc[2].const_arrays(); // z-faces
-		delta_x2[1] = 1;
-		delta_x3[2] = 1;
-	} else if constexpr (DIR == FluxDir::X2) {
-		x2State_fc_bfield_in = consVar_fc[2].const_arrays(); // z-faces
-		x3State_fc_bfield_in = consVar_fc[0].const_arrays(); // x-faces
-		delta_x2[2] = 1;
-		delta_x3[0] = 1;
-	} else if constexpr (DIR == FluxDir::X3) {
-		x2State_fc_bfield_in = consVar_fc[0].const_arrays(); // x-faces
-		x3State_fc_bfield_in = consVar_fc[1].const_arrays(); // y-faces
-		delta_x2[0] = 1;
-		delta_x3[1] = 1;
-	}
-
-	auto cc_bfield_perp_comps_out = cc_bfield_perp_comps_mf.arrays();
-	constexpr int b_comp = Physics_Indices<problem_t>::mhdFirstIndex;
-
-	amrex::IntVect ng{AMREX_D_DECL(nghost_fc_, nghost_fc_, nghost_fc_)};
-	amrex::ParallelFor(cc_bfield_perp_comps_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
-		const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, b_comp);
-		const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], b_comp);
-		cc_bfield_perp_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
-
-		const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, b_comp);
-		const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], b_comp);
-		cc_bfield_perp_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
-	});
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState,
-						    amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
-						    amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
-						    std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
-						    amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, const int ng_reconstruct, const int nvars,
-						    const int nghost_Riemann)
-{
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computeCCPerpBfieldComps<DIR>(cc_bfield_perp_comps_mf, consVar_fc);
-	}
-
-	if (reconstructionOrder_ == 5) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-											   ng_reconstruct, 2);
-		}
-	} else if (reconstructionOrder_ == 3) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-											ng_reconstruct, 2);
-		}
-	} else if (reconstructionOrder_ == 2) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars, plmLimiter_);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-											ng_reconstruct, 2, plmLimiter_);
-		}
-	} else if (reconstructionOrder_ == 1) {
-		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-											     ng_reconstruct, 2);
-		}
-	} else {
-		amrex::Abort("Invalid reconstruction order specified!");
-	}
-
-	// cell-centered kernel
-	HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar_mf, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
-
-	// interface-centered kernel
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-											 rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds,
-											 &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
-	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-											 rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr,
-											 nghost_Riemann);
-	}
-}
-
-template <typename problem_t>
-auto QuokkaSimulation<problem_t>::computeFOHydroFluxes(amrex::MultiFab const &consVar_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc,
-						       const int nvars, const int nghost_Riemann, const int lev)
-    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
-{
-	const BL_PROFILE("QuokkaSimulation::computeFOHydroFluxes()");
-
-	const auto ba = grids[lev];
-	const auto dm = dmap[lev];
-
-	// Reconstruct one extra face layer beyond the requested ghosted Riemann outputs
-	// so the outermost ghost face has left/right interface states.
-	const int reconstructRange = nghost_Riemann + 1;
-
-	// allocate temporary MultiFabs
-	amrex::MultiFab primVar(ba, dm, nvars, nghost_cc_);
-	amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, nghost_cc_);
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
-	std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
-
-	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-		auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
-		leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
-		rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
-		leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
-		rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
-		flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
-		facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
-		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange - 1);
-		}
-	}
-
-	// conserved to primitive variables
-	HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, nghost_cc_);
-
-	// compute flux functions
-	AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0], rightState_bfield[0],
-						      flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange, nvars, nghost_Riemann);
-		     , hydroFOFluxFunction<FluxDir::X2>(primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1], rightState_bfield[1],
-							flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange, nvars, nghost_Riemann);
-		     , hydroFOFluxFunction<FluxDir::X3>(primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2], rightState_bfield[2],
-							flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange, nvars, nghost_Riemann);)
-
-	// synchronization point to prevent MultiFabs from going out of scope
-	amrex::Gpu::streamSynchronizeAll();
-
-	// return flux and face-centered velocities
-	return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
-}
-
-template <typename problem_t>
-template <FluxDir DIR>
-void QuokkaSimulation<problem_t>::hydroFOFluxFunction(amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf, amrex::MultiFab &leftState,
-						      amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield, amrex::MultiFab &rightState_bfield,
-						      amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
-						      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &x1ConsVar_fc_mf, const int ng_reconstruct,
-						      const int nvars, const int nghost_Riemann)
-{
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		QuokkaSimulation<problem_t>::template computeCCPerpBfieldComps<DIR>(cc_bfield_perp_comps_mf, x1ConsVar_fc_mf);
-	}
-
-	// donor-cell reconstruction
-	HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
-										2);
-	}
-
-	// LLF solver
-	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-											    rightState_bfield, primVar_mf, artificialViscosityK_, &x1FSpds,
-											    &x1ConsVar_fc_mf[static_cast<int>(DIR)], nghost_Riemann);
-	} else {
-		HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-											rightState_bfield, primVar_mf, artificialViscosityK_, nullptr, nullptr,
-											nghost_Riemann);
-	}
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::swapRadiationState(amrex::MultiFab &stateOld, amrex::MultiFab const &stateNew)

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2094,25 +2094,25 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		std::unique_ptr<amrex::EdgeFluxRegister> step_emf_as_fine;
 
 		if (fr_as_crse != nullptr) {
-			step_fr_as_crse = std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1,
-										       nvarTotal_cc_);
+			step_fr_as_crse =
+			    std::make_unique<amrex::FluxRegister>(boxArray(lev + 1), DistributionMap(lev + 1), refRatio(lev), lev + 1, nvarTotal_cc_);
 		}
 		if (fr_as_fine != nullptr) {
 			step_fr_as_fine = std::make_unique<amrex::FluxRegister>(grids[lev], dmap[lev], refRatio(lev - 1), lev, nvarTotal_cc_);
 		}
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			if (emf_as_crse != nullptr) {
-				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1), dmap[lev],
-												     geom[lev + 1], geom[lev], 1);
+				step_emf_as_crse = std::make_unique<amrex::EdgeFluxRegister>(boxArray(lev + 1), boxArray(lev), DistributionMap(lev + 1),
+											     dmap[lev], geom[lev + 1], geom[lev], 1);
 			}
 			if (emf_as_fine != nullptr) {
 				step_emf_as_fine = std::make_unique<amrex::EdgeFluxRegister>(grids[lev], boxArray(lev - 1), dmap[lev], DistributionMap(lev - 1),
-												     geom[lev], geom[lev - 1], 1);
+											     geom[lev], geom[lev - 1], 1);
 			}
 		}
 
-		HydroRKPolicy<problem_t> policy{*this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(),
-						step_emf_as_fine.get()};
+		HydroRKPolicy<problem_t> policy{
+		    *this, lev, nghost_Riemann, step_fr_as_crse.get(), step_fr_as_fine.get(), step_emf_as_crse.get(), step_emf_as_fine.get()};
 		quokka::RKIntegrator<HydroRKPolicy<problem_t>> integrator(policy);
 
 		quokka::CompositeStateView old_state{};
@@ -2136,31 +2136,31 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			return false;
 		}
 
-			auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
-			bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
-			bool const final_success = (cfl_ok && burn_success_second);
+		auto burn_success_second = addStrangSplitSourcesWithBuiltin(state_new_cc_[lev], state_new_fc_[lev], lev, time + dt_lev, 0.5 * dt_lev);
+		bool const cfl_ok = !isCflViolated(lev, time, dt_lev);
+		bool const final_success = (cfl_ok && burn_success_second);
 
-			if (final_success) {
-				if (step_fr_as_crse) {
-					*flux_reg_[lev + 1] += *step_fr_as_crse;
+		if (final_success) {
+			if (step_fr_as_crse) {
+				*flux_reg_[lev + 1] += *step_fr_as_crse;
+			}
+			if (step_fr_as_fine) {
+				*flux_reg_[lev] += *step_fr_as_fine;
+			}
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				if (step_emf_as_crse) {
+					emf_reg_[lev + 1]->plus(*step_emf_as_crse);
 				}
-				if (step_fr_as_fine) {
-					*flux_reg_[lev] += *step_fr_as_fine;
-				}
-				if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-					if (step_emf_as_crse) {
-						emf_reg_[lev + 1]->plus(*step_emf_as_crse);
-					}
-					if (step_emf_as_fine) {
-						emf_reg_[lev]->plus(*step_emf_as_fine);
-					}
+				if (step_emf_as_fine) {
+					emf_reg_[lev]->plus(*step_emf_as_fine);
 				}
 			}
+		}
 
-			if (do_tracers != 0 && final_success) {
-				auto const &accum = integrator.getAccumulators();
-				TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
-			}
+		if (do_tracers != 0 && final_success) {
+			auto const &accum = integrator.getAccumulators();
+			TracerPC->AdvectWithUmac(const_cast<amrex::MultiFab *>(accum.avg_face_vel.data()), lev, dt_lev);
+		}
 
 		return final_success;
 	}

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -472,42 +472,66 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 	}
 
-	void apply_provisional_update(quokka::CompositeStateView output, quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
-				      amrex::Real dt) const
+	void apply_cell_centered_stage_update(quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+					      quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
+					      quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
 	{
-		HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_, scratch.redo_flag);
+		auto const &old_cc = old_state.cc->const_arrays();
+		auto const &stage_cc = stage_input.cc->const_arrays();
+		auto const &rhs = scratch.rhs_cc.const_arrays();
+		auto out_cc = output.cc->arrays();
+		auto redo_flag = scratch.redo_flag.arrays();
+		const amrex::Real rhs_dt = coeffs.rhs_weight * dt;
+		const amrex::Real old_weight = coeffs.old_state_weight;
+		const amrex::Real stage_weight = coeffs.stage_input_weight;
+
+		amrex::ParallelFor(*output.cc, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+			for (int n = 0; n < QuokkaSimulation<problem_t>::nvars_; ++n) {
+				out_cc[bx](i, j, k, n) =
+				    old_weight * old_cc[bx](i, j, k, n) + stage_weight * stage_cc[bx](i, j, k, n) + rhs_dt * rhs[bx](i, j, k, n);
+			}
+
+			if (!HydroSystem<problem_t>::isStateValid(out_cc[bx], i, j, k)) {
+				redo_flag[bx](i, j, k) = quokka::redoFlag::redo;
+			} else {
+				redo_flag[bx](i, j, k) = quokka::redoFlag::none;
+			}
+		});
 	}
 
-	void apply_stage_update(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-				quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const
+	void apply_face_centered_stage_update(quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+					      quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
+					      quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
 	{
-		if (stage == 1) {
-			HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-							    scratch.redo_flag);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			MHDSystem<problem_t>::SolveInductionEqn(*stage_input.fc_data, *output.fc_data, scratch.emf, coeffs.rhs_weight * dt,
+								sim_.geom[lev_].CellSizeArray());
 
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				MHDSystem<problem_t>::SolveInductionEqn(*stage_input.fc_data, *output.fc_data, scratch.emf, dt,
-									sim_.geom[lev_].CellSizeArray());
-			}
-		} else {
-			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt,
-							     QuokkaSimulation<problem_t>::nvars_, scratch.redo_flag);
-
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
-									sim_.geom[lev_].CellSizeArray());
-				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-					amrex::MultiFab::Saxpy((*output.fc_data)[idim], 0.5, (*stage_input.fc_data)[idim], 0, 0,
+			const amrex::Real stage_adjust = coeffs.stage_input_weight - 1.0;
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				if (coeffs.old_state_weight != 0.0) {
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], coeffs.old_state_weight, (*old_state.fc_data)[idim], 0, 0,
 							       (*output.fc_data)[idim].nComp(), 0);
-					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0, (*output.fc_data)[idim].nComp(),
-							       0);
+				}
+				if (stage_adjust != 0.0) {
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], stage_adjust, (*stage_input.fc_data)[idim], 0, 0,
+							       (*output.fc_data)[idim].nComp(), 0);
 				}
 			}
+		} else {
+			amrex::ignore_unused(output, old_state, stage_input, scratch, coeffs, dt);
 		}
 	}
 
-	void compute_stage(int /*stage*/, quokka::StageScratch &scratch, quokka::CompositeStateView const &input, amrex::Real /*stage_time*/,
-			   amrex::Real /*dt_stage*/) const
+	void apply_stage_update(quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+				quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
+				quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
+	{
+		apply_cell_centered_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
+		apply_face_centered_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
+	}
+
+	void compute_stage(int /*stage*/, quokka::StageScratch &scratch, quokka::CompositeStateView const &input, amrex::Real /*stage_time*/) const
 	{
 		scratch.clearFlags();
 		scratch.redo_flag.setVal(quokka::redoFlag::none);
@@ -539,19 +563,20 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 	}
 
-	void update_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-			  quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const
+	void update_stage(int /*stage*/, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+			  quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
+			  quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
 	{
-		apply_stage_update(stage, output, old_state, stage_input, scratch, dt);
+		apply_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc,
 				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-			    quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const -> bool
+			    quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
+			    quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const -> bool
 	{
-		amrex::ignore_unused(old_state);
-		apply_provisional_update(output, stage_input, scratch, dt);
+		apply_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 		amrex::Gpu::streamSynchronizeAll();
 		amrex::Long const ncells_bad = scratch.redo_flag.sum(0);
 		if (ncells_bad == 0) {
@@ -586,7 +611,7 @@ template <typename problem_t> struct HydroRKPolicy {
 			replaceEMFs(scratch.emf, fo_emf, scratch.redo_flag);
 		}
 
-		apply_provisional_update(output, stage_input, scratch, dt);
+		apply_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 
 		amrex::Gpu::streamSynchronizeAll();
 		amrex::Long const ncells_bad_after_fofc = scratch.redo_flag.sum(0);
@@ -607,8 +632,7 @@ template <typename problem_t> struct HydroRKPolicy {
 		return sim_.abortOnFofcFailure_ == 0;
 	}
 
-	void post_stage(int /*stage*/, quokka::CompositeStateView output, quokka::StageScratch const & /*scratch*/, amrex::Real /*stage_time*/,
-			amrex::Real /*dt*/) const
+	void post_stage(int /*stage*/, quokka::CompositeStateView output, quokka::StageScratch const & /*scratch*/, amrex::Real /*dt*/) const
 	{
 		if (sim_.useDensityFloorParser_) {
 			auto const density_floor_parser = sim_.densityFloorParserExe_.value();
@@ -635,25 +659,22 @@ template <typename problem_t> struct HydroRKPolicy {
 				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
-	void accumulate_stage(int stage, quokka::StageScratch &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const
+	void accumulate_stage(int /*stage*/, quokka::StageScratch &scratch, quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt,
+			      quokka::StepAccumulators &accum) const
 	{
-		amrex::Real weight = 1.0;
-		if (sim_.integratorOrder_ == 2) {
-			weight = quokka::SSPRK2Scheme::stage_integral_weights[stage - 1];
-		}
-
 		if ((step_fr_as_crse_ != nullptr) || (step_fr_as_fine_ != nullptr)) {
-			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, scratch.fluxes_hi, lev_, weight * dt);
+			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, scratch.fluxes_hi, lev_, coeffs.accumulation_weight * dt);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
-					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_, scratch.emf, lev_, -weight * dt);
+					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_, scratch.emf, lev_,
+								   -coeffs.accumulation_weight * dt);
 				}
 			}
 		}
 
 		if (accum.has_avg_face_vel) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				amrex::MultiFab::Saxpy(accum.avg_face_vel[idim], weight, scratch.face_vel[idim], 0, 0, 1, 0);
+				amrex::MultiFab::Saxpy(accum.avg_face_vel[idim], coeffs.accumulation_weight, scratch.face_vel[idim], 0, 0, 1, 0);
 			}
 		}
 	}

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -6,8 +6,7 @@
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
 
-template <typename problem_t> struct HydroRKPolicy
-{
+template <typename problem_t> struct HydroRKPolicy {
 	QuokkaSimulation<problem_t> &sim_;
 	int lev_ = -1;
 	int nghost_Riemann_ = 0;
@@ -85,7 +84,7 @@ template <typename problem_t> struct HydroRKPolicy
 			}
 		} else if (sim.reconstructionOrder_ == 2) {
 			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars,
-												 sim.plmLimiter_);
+											sim.plmLimiter_);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
 												ng_reconstruct, 2, sim.plmLimiter_);
@@ -93,8 +92,8 @@ template <typename problem_t> struct HydroRKPolicy
 		} else if (sim.reconstructionOrder_ == 1) {
 			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-												     ng_reconstruct, 2);
+				HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield,
+												     rightState_bfield, ng_reconstruct, 2);
 			}
 		} else {
 			amrex::Abort("Invalid reconstruction order specified!");
@@ -104,19 +103,18 @@ template <typename problem_t> struct HydroRKPolicy
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
-												 &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												 &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
 		} else {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
-												 nullptr, nghost_Riemann);
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												 nullptr, nullptr, nghost_Riemann);
 		}
 	}
 
 	static auto computeHydroFluxes(QuokkaSimulation<problem_t> &sim, amrex::MultiFab const &consVar_cc,
 				       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
-	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 	{
 		const BL_PROFILE("HydroRKPolicy::computeHydroFluxes()");
 
@@ -185,16 +183,16 @@ template <typename problem_t> struct HydroRKPolicy
 				if (amrex::ParallelDescriptor::IOProcessor()) {
 					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
 				}
-				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
-												 std::string("StateL_") + quokka::face_dir_str[idim]);
+				std::string const fullprefix =
+				    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateL_") + quokka::face_dir_str[idim]);
 				amrex::VisMF::Write(leftState[idim], fullprefix);
 			}
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				if (amrex::ParallelDescriptor::IOProcessor()) {
 					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
 				}
-				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
-												 std::string("StateR_") + quokka::face_dir_str[idim]);
+				std::string const fullprefix =
+				    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateR_") + quokka::face_dir_str[idim]);
 				amrex::VisMF::Write(rightState[idim], fullprefix);
 			}
 		}
@@ -214,25 +212,24 @@ template <typename problem_t> struct HydroRKPolicy
 
 		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
-											2);
+			HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+											ng_reconstruct, 2);
 		}
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												    rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
-												    &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(
+			    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
+			    &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
 		} else {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
-												nullptr, nghost_Riemann);
+												rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												nullptr, nullptr, nghost_Riemann);
 		}
 	}
 
 	static auto computeFOHydroFluxes(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab const &consVar_cc,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
-	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 	{
 		const BL_PROFILE("HydroRKPolicy::computeFOHydroFluxes()");
 
@@ -266,14 +263,14 @@ template <typename problem_t> struct HydroRKPolicy
 		HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, sim.nghost_cc_);
 
 		AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(sim, primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0],
-							      rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
-							      reconstructRange, nvars, nghost_Riemann);
+							      rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange,
+							      nvars, nghost_Riemann);
 			     , hydroFOFluxFunction<FluxDir::X2>(sim, primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1],
-								rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
-								reconstructRange, nvars, nghost_Riemann);
+								rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange,
+								nvars, nghost_Riemann);
 			     , hydroFOFluxFunction<FluxDir::X3>(sim, primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2],
-								rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
-								reconstructRange, nvars, nghost_Riemann);)
+								rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange,
+								nvars, nghost_Riemann);)
 
 		amrex::Gpu::streamSynchronizeAll();
 
@@ -317,8 +314,8 @@ template <typename problem_t> struct HydroRKPolicy
 		}
 	}
 
-	static void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components,
-				std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components, amrex::iMultiFab &redoFlag)
+	static void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components,
+				amrex::iMultiFab &redoFlag)
 	{
 		const BL_PROFILE("HydroRKPolicy::replaceEMFs()");
 
@@ -382,8 +379,8 @@ template <typename problem_t> struct HydroRKPolicy
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				auto ba_ec = amrex::convert(reference.cc->boxArray(),
-							    amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+				auto ba_ec =
+				    amrex::convert(reference.cc->boxArray(), amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
 				scratch.emf[idim].define(ba_ec, reference.cc->DistributionMap(), 1, 0);
 			}
 		}
@@ -399,6 +396,14 @@ template <typename problem_t> struct HydroRKPolicy
 
 	void reset_accumulators(quokka::StepAccumulators &accum) const { accum.reset(); }
 
+	void debugAssertFinite(std::string const &label, amrex::MultiFab const &mf) const
+	{
+		if (sim_.lowLevelDebuggingOutput_ != 0) {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!mf.contains_nan(0, mf.nComp()), label + " (valid cells)");
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!mf.contains_nan(), label + " (including ghosts)");
+		}
+	}
+
 	void fill_boundary(int stage, quokka::CompositeStateView state, amrex::Real stage_time) const
 	{
 		sim_.fillBoundaryConditions(*state.cc, *state.cc, lev_, stage_time, quokka::centering::cc, quokka::direction::na,
@@ -412,6 +417,65 @@ template <typename problem_t> struct HydroRKPolicy
 			}
 		} else {
 			amrex::ignore_unused(stage);
+		}
+
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::fill_boundary cc state on level {}", lev_), *state.cc);
+	}
+
+	void recompute_stage_rhs(quokka::StageScratch &scratch, quokka::CompositeStateView const &input) const
+	{
+		auto const dx = sim_.geom[lev_].CellSizeArray();
+		HydroSystem<problem_t>::ComputeRhsFromFluxes(scratch.rhs_cc, scratch.fluxes_hi, dx, QuokkaSimulation<problem_t>::nvars_);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(scratch.rhs_cc, *input.cc, *input.fc_data, dx, scratch.face_vel, scratch.redo_flag);
+	}
+
+	void compute_stage_emf(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf, quokka::CompositeStateView const &input,
+			       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &face_vel,
+			       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fast_mhd_wavespeeds) const
+	{
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (auto &mf : emf) {
+				mf.setVal(0.0);
+			}
+			MHDSystem<problem_t>::ComputeEMF(emf, *input.cc, face_vel, *input.fc_data, fast_mhd_wavespeeds, sim_.emfReconstructionOrder_,
+							 sim_.emfAveragingScheme_, sim_.mhdPlmLimiter_, sim_.emfComputingScheme_);
+		} else {
+			amrex::ignore_unused(emf, input, face_vel, fast_mhd_wavespeeds);
+		}
+	}
+
+	void apply_provisional_update(quokka::CompositeStateView output, quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch,
+				      amrex::Real dt) const
+	{
+		HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
+						    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+	}
+
+	void apply_stage_update(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+				quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
+	{
+		if (stage == 1) {
+			HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
+							    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				MHDSystem<problem_t>::SolveInductionEqn(*stage_input.fc_data, *output.fc_data, scratch.emf, dt,
+									sim_.geom[lev_].CellSizeArray());
+			}
+		} else {
+			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt,
+							     QuokkaSimulation<problem_t>::nvars_, const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
+									sim_.geom[lev_].CellSizeArray());
+				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], 0.5, (*stage_input.fc_data)[idim], 0, 0,
+							       (*output.fc_data)[idim].nComp(), 0);
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0, (*output.fc_data)[idim].nComp(),
+							       0);
+				}
+			}
 		}
 	}
 
@@ -428,64 +492,89 @@ template <typename problem_t> struct HydroRKPolicy
 		scratch.face_vel = std::move(face_vel);
 		scratch.has_fluxes_hi = true;
 		scratch.has_face_vel = true;
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage fluxes_hi[{}] on level {}", idim, lev_),
+					  scratch.fluxes_hi[idim]);
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage face_vel[{}] on level {}", idim, lev_),
+					  scratch.face_vel[idim]);
+		}
 
-		auto const dx = sim_.geom[lev_].CellSizeArray();
-		HydroSystem<problem_t>::ComputeRhsFromFluxes(scratch.rhs_cc, scratch.fluxes_hi, dx, QuokkaSimulation<problem_t>::nvars_);
-		HydroSystem<problem_t>::AddInternalEnergyPdV(scratch.rhs_cc, *input.cc, *input.fc_data, dx, scratch.face_vel, scratch.redo_flag);
+		recompute_stage_rhs(scratch, input);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage rhs_cc on level {}", lev_), scratch.rhs_cc);
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			for (auto &mf : scratch.emf) {
-				mf.setVal(0.0);
-			}
-			MHDSystem<problem_t>::ComputeEMF(scratch.emf, *input.cc, scratch.face_vel, *input.fc_data, fast_mhd_wavespeeds,
-							 sim_.emfReconstructionOrder_, sim_.emfAveragingScheme_, sim_.mhdPlmLimiter_,
-							 sim_.emfComputingScheme_);
+			compute_stage_emf(scratch.emf, input, scratch.face_vel, fast_mhd_wavespeeds);
 			scratch.has_emf = true;
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage emf[{}] on level {}", idim, lev_),
+						  scratch.emf[idim]);
+			}
 		}
 	}
 
 	void update_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
 			  quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
 	{
-		if (stage == 1) {
-			HydroSystem<problem_t>::PredictStep(*old_state.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-							    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
-
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, dt, sim_.geom[lev_].CellSizeArray());
-			}
-		} else {
-			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-							     const_cast<amrex::iMultiFab &>(scratch.redo_flag));
-
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
-									sim_.geom[lev_].CellSizeArray());
-				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-					amrex::MultiFab::Saxpy((*output.fc_data)[idim], 0.5, (*stage_input.fc_data)[idim], 0, 0,
-							       (*output.fc_data)[idim].nComp(), 0);
-					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0,
-							       (*output.fc_data)[idim].nComp(), 0);
-				}
-			}
-		}
+		apply_stage_update(stage, output, old_state, stage_input, scratch, dt);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc);
 	}
 
-	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const & /*old_state*/,
-			    quokka::CompositeStateView const & /*stage_input*/, quokka::StageScratch &scratch, amrex::Real /*dt*/) const -> bool
+	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+			    quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const -> bool
 	{
+		amrex::ignore_unused(old_state);
+		apply_provisional_update(output, stage_input, scratch, dt);
 		amrex::Gpu::streamSynchronizeAll();
 		amrex::Long const ncells_bad = scratch.redo_flag.sum(0);
-		if (ncells_bad > 0) {
-			if (sim_.Verbose()) {
-				auto const cell_idx = scratch.redo_flag.maxIndex(0);
-				amrex::Print() << "[RK-" << stage << "] invalid hydro state in " << ncells_bad << " cells on level " << lev_ << "\n";
-				sim_.printCoordinates(lev_, cell_idx);
-				amrex::print_state(*output.cc, cell_idx);
-			}
-			return false;
+		if (ncells_bad == 0) {
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage accepted output on level {}", lev_), *output.cc);
+			return true;
 		}
-		return true;
+
+		if (sim_.Verbose()) {
+			auto const cell_idx = scratch.redo_flag.maxIndex(0);
+			amrex::Print() << "[FOFC-" << stage << "] flux correcting " << ncells_bad << " cells on level " << lev_ << "\n";
+			sim_.printCoordinates(lev_, cell_idx);
+			amrex::print_state(*output.cc, cell_idx);
+		}
+
+		scratch.redo_flag.FillBoundary(sim_.geom[lev_].periodicity());
+
+		auto [fo_fluxes, fo_face_vel, fo_fast_mhd_wavespeeds] =
+		    computeFOHydroFluxes(sim_, *stage_input.cc, *stage_input.fc_data, QuokkaSimulation<problem_t>::nvars_, nghost_Riemann_, lev_);
+
+		replaceFluxes(scratch.fluxes_hi, fo_fluxes, scratch.redo_flag);
+		replaceFluxes(scratch.face_vel, fo_face_vel, scratch.redo_flag);
+		recompute_stage_rhs(scratch, stage_input);
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			std::array<amrex::MultiFab, AMREX_SPACEDIM> fo_emf;
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				fo_emf[idim].define(scratch.emf[idim].boxArray(), scratch.emf[idim].DistributionMap(), scratch.emf[idim].nComp(),
+						    scratch.emf[idim].nGrowVect(), amrex::MFInfo(), scratch.emf[idim].Factory());
+			}
+			compute_stage_emf(fo_emf, stage_input, fo_face_vel, fo_fast_mhd_wavespeeds);
+			replaceEMFs(scratch.emf, fo_emf, scratch.redo_flag);
+		}
+
+		apply_provisional_update(output, stage_input, scratch, dt);
+
+		amrex::Gpu::streamSynchronizeAll();
+		amrex::Long const ncells_bad_after_fofc = scratch.redo_flag.sum(0);
+		if (ncells_bad_after_fofc == 0) {
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage FOFC output on level {}", lev_), *output.cc);
+			return true;
+		}
+
+		if (sim_.Verbose()) {
+			auto const cell_idx = scratch.redo_flag.maxIndex(0);
+			amrex::Print() << "[FOFC-" << stage << "] Flux correction failed:\n";
+			sim_.printCoordinates(lev_, cell_idx);
+			amrex::print_state(*output.cc, cell_idx);
+			amrex::Print() << "[FOFC-" << stage << "] failed for " << ncells_bad_after_fofc << " cells on level " << lev_ << "\n";
+		}
+
+		return sim_.abortOnFofcFailure_ == 0;
 	}
 
 	void post_stage(int /*stage*/, quokka::CompositeStateView output, quokka::StageScratch const & /*scratch*/, amrex::Real /*stage_time*/,
@@ -511,20 +600,24 @@ template <typename problem_t> struct HydroRKPolicy
 		if (sim_.useDualEnergy_ == 1) {
 			HydroSystem<problem_t>::SyncDualEnergy(*output.cc, *output.fc_data);
 		}
+
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::post_stage output on level {}", lev_), *output.cc);
 	}
 
 	void accumulate_stage(int stage, quokka::StageScratch const &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const
 	{
-		const amrex::Real weight = quokka::SSPRK2Scheme::stage_integral_weights[stage - 1];
+		amrex::Real weight = 1.0;
+		if (sim_.integratorOrder_ == 2) {
+			weight = quokka::SSPRK2Scheme::stage_integral_weights[stage - 1];
+		}
 
 		if ((step_fr_as_crse_ != nullptr) || (step_fr_as_fine_ != nullptr)) {
-			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi),
-						    lev_, weight * dt);
+			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_,
+						    const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi), lev_, weight * dt);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
 					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_,
-								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_,
-								   -weight * dt);
+								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_, -weight * dt);
 				}
 			}
 		}
@@ -536,8 +629,7 @@ template <typename problem_t> struct HydroRKPolicy
 		}
 	}
 
-	void finalize_step(quokka::CompositeStateView /*new_state*/, amrex::Real /*time*/, amrex::Real dt,
-			   quokka::StepAccumulators const & /*accum*/) const
+	void finalize_step(quokka::CompositeStateView /*new_state*/, amrex::Real /*time*/, amrex::Real dt, quokka::StepAccumulators const & /*accum*/) const
 	{
 		amrex::ignore_unused(dt);
 	}

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -1,0 +1,546 @@
+#ifndef HYDRO_RK_POLICY_HPP_ // NOLINT
+#define HYDRO_RK_POLICY_HPP_
+//==============================================================================
+// Quokka -- a radiation-hydrodynamics code built on AMReX
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+
+template <typename problem_t> struct HydroRKPolicy
+{
+	QuokkaSimulation<problem_t> &sim_;
+	int lev_ = -1;
+	int nghost_Riemann_ = 0;
+	amrex::FluxRegister *step_fr_as_crse_ = nullptr;
+	amrex::FluxRegister *step_fr_as_fine_ = nullptr;
+	amrex::EdgeFluxRegister *step_emf_as_crse_ = nullptr;
+	amrex::EdgeFluxRegister *step_emf_as_fine_ = nullptr;
+
+	[[nodiscard]] auto nghost_cc() const -> int { return sim_.nghost_cc_; }
+	[[nodiscard]] auto nghost_fc() const -> int { return sim_.nghost_fc_; }
+
+	template <FluxDir DIR>
+	static AMREX_FORCE_INLINE void computeCCPerpBfieldComps(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab &cc_bfield_perp_comps_mf,
+								std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc)
+	{
+		std::array<int, 3> delta_x2{0, 0, 0};
+		std::array<int, 3> delta_x3{0, 0, 0};
+
+		amrex::MultiArray4<const amrex::Real> x2State_fc_bfield_in;
+		amrex::MultiArray4<const amrex::Real> x3State_fc_bfield_in;
+		if constexpr (DIR == FluxDir::X1) {
+			x2State_fc_bfield_in = consVar_fc[1].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[2].const_arrays();
+			delta_x2[1] = 1;
+			delta_x3[2] = 1;
+		} else if constexpr (DIR == FluxDir::X2) {
+			x2State_fc_bfield_in = consVar_fc[2].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[0].const_arrays();
+			delta_x2[2] = 1;
+			delta_x3[0] = 1;
+		} else if constexpr (DIR == FluxDir::X3) {
+			x2State_fc_bfield_in = consVar_fc[0].const_arrays();
+			x3State_fc_bfield_in = consVar_fc[1].const_arrays();
+			delta_x2[0] = 1;
+			delta_x3[1] = 1;
+		}
+
+		auto cc_bfield_perp_comps_out = cc_bfield_perp_comps_mf.arrays();
+		constexpr int b_comp = Physics_Indices<problem_t>::mhdFirstIndex;
+
+		amrex::IntVect ng{AMREX_D_DECL(sim.nghost_fc_, sim.nghost_fc_, sim.nghost_fc_)};
+		amrex::ParallelFor(cc_bfield_perp_comps_mf, ng, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+			const amrex::Real bx2_m = x2State_fc_bfield_in[bx](i, j, k, b_comp);
+			const amrex::Real bx2_p = x2State_fc_bfield_in[bx](i + delta_x2[0], j + delta_x2[1], k + delta_x2[2], b_comp);
+			cc_bfield_perp_comps_out[bx](i, j, k, 0) = 0.5 * (bx2_m + bx2_p);
+
+			const amrex::Real bx3_m = x3State_fc_bfield_in[bx](i, j, k, b_comp);
+			const amrex::Real bx3_p = x3State_fc_bfield_in[bx](i + delta_x3[0], j + delta_x3[1], k + delta_x3[2], b_comp);
+			cc_bfield_perp_comps_out[bx](i, j, k, 1) = 0.5 * (bx3_m + bx3_p);
+		});
+	}
+
+	template <FluxDir DIR>
+	static void hydroFluxFunction(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf,
+				      amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield,
+				      amrex::MultiFab &rightState_bfield, amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
+				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, amrex::MultiFab const &x1Flat,
+				      amrex::MultiFab const &x2Flat, amrex::MultiFab const &x3Flat, int ng_reconstruct, int nvars, int nghost_Riemann)
+	{
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			computeCCPerpBfieldComps<DIR>(sim, cc_bfield_perp_comps_mf, consVar_fc);
+		}
+
+		if (sim.reconstructionOrder_ == 5) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+												   ng_reconstruct, 2);
+			}
+		} else if (sim.reconstructionOrder_ == 3) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+												ng_reconstruct, 2);
+			}
+		} else if (sim.reconstructionOrder_ == 2) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars,
+												 sim.plmLimiter_);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+												ng_reconstruct, 2, sim.plmLimiter_);
+			}
+		} else if (sim.reconstructionOrder_ == 1) {
+			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+												     ng_reconstruct, 2);
+			}
+		} else {
+			amrex::Abort("Invalid reconstruction order specified!");
+		}
+
+		HydroSystem<problem_t>::template FlattenShocks<DIR>(primVar_mf, x1Flat, x2Flat, x3Flat, leftState, rightState, ng_reconstruct, nvars);
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
+												 &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+		} else {
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
+												 nullptr, nghost_Riemann);
+		}
+	}
+
+	static auto computeHydroFluxes(QuokkaSimulation<problem_t> &sim, amrex::MultiFab const &consVar_cc,
+				       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	{
+		const BL_PROFILE("HydroRKPolicy::computeHydroFluxes()");
+
+		const auto ba = sim.grids[lev];
+		const auto dm = sim.dmap[lev];
+
+		const int reconstructGhost = nghost_Riemann + 1;
+		const int flatteningGhost = reconstructGhost + 1;
+
+		amrex::MultiFab primVar(ba, dm, nvars, sim.nghost_cc_);
+		amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, sim.nghost_cc_);
+		std::array<amrex::MultiFab, 3> flatCoefs;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			flatCoefs[idim] = amrex::MultiFab(ba, dm, 1, flatteningGhost);
+		}
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
+			leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
+			rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost);
+			leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
+			rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost);
+			flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructGhost - 1);
+			facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructGhost - 1);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructGhost - 1);
+			}
+		}
+
+		HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, sim.nghost_cc_);
+
+		AMREX_D_TERM(HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X1>(primVar, flatCoefs[0], flatteningGhost);
+			     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X2>(primVar, flatCoefs[1], flatteningGhost);
+			     , HydroSystem<problem_t>::template ComputeFlatteningCoefficients<FluxDir::X3>(primVar, flatCoefs[2], flatteningGhost);)
+
+		AMREX_D_TERM(hydroFluxFunction<FluxDir::X1>(sim, primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0],
+							    rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, flatCoefs[0],
+							    flatCoefs[1], flatCoefs[2], reconstructGhost, nvars, nghost_Riemann);
+			     , hydroFluxFunction<FluxDir::X2>(sim, primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1],
+							      rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, flatCoefs[0],
+							      flatCoefs[1], flatCoefs[2], reconstructGhost, nvars, nghost_Riemann);
+			     , hydroFluxFunction<FluxDir::X3>(sim, primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2],
+							      rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, flatCoefs[0],
+							      flatCoefs[1], flatCoefs[2], reconstructGhost, nvars, nghost_Riemann);)
+
+		amrex::Gpu::streamSynchronizeAll();
+
+		if (sim.lowLevelDebuggingOutput_ == 1) {
+			std::string plotfile_name = sim.CustomPlotFileName("debug_reconstruction", sim.istep[lev] + 1);
+			sim.WriteSingleLevelPlotfileSimplified("debug_reconstruction", primVar, sim.componentNames_cc_, lev, 1);
+
+			amrex::Vector<std::string> flatCompNames{"chi"};
+			sim.WriteSingleLevelPlotfileSimplified("debug_flattening_x", flatCoefs[0], flatCompNames, lev, 1);
+			sim.WriteSingleLevelPlotfileSimplified("debug_flattening_y", flatCoefs[1], flatCompNames, lev, 1);
+			sim.WriteSingleLevelPlotfileSimplified("debug_flattening_z", flatCoefs[2], flatCompNames, lev, 1);
+
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				if (amrex::ParallelDescriptor::IOProcessor()) {
+					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
+				}
+				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
+												 std::string("StateL_") + quokka::face_dir_str[idim]);
+				amrex::VisMF::Write(leftState[idim], fullprefix);
+			}
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				if (amrex::ParallelDescriptor::IOProcessor()) {
+					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
+				}
+				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
+												 std::string("StateR_") + quokka::face_dir_str[idim]);
+				amrex::VisMF::Write(rightState[idim], fullprefix);
+			}
+		}
+
+		return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
+	}
+
+	template <FluxDir DIR>
+	static void hydroFOFluxFunction(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab &primVar_mf, amrex::MultiFab &cc_bfield_perp_comps_mf,
+					amrex::MultiFab &leftState, amrex::MultiFab &rightState, amrex::MultiFab &leftState_bfield,
+					amrex::MultiFab &rightState_bfield, amrex::MultiFab &flux, amrex::MultiFab &faceVel, amrex::MultiFab &x1FSpds,
+					std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int ng_reconstruct, int nvars, int nghost_Riemann)
+	{
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			computeCCPerpBfieldComps<DIR>(sim, cc_bfield_perp_comps_mf, consVar_fc);
+		}
+
+		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
+											2);
+		}
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+												    rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
+												    &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+		} else {
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
+												rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
+												nullptr, nghost_Riemann);
+		}
+	}
+
+	static auto computeFOHydroFluxes(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab const &consVar_cc,
+					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
+			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	{
+		const BL_PROFILE("HydroRKPolicy::computeFOHydroFluxes()");
+
+		const auto ba = sim.grids[lev];
+		const auto dm = sim.dmap[lev];
+		const int reconstructRange = nghost_Riemann + 1;
+
+		amrex::MultiFab primVar(ba, dm, nvars, sim.nghost_cc_);
+		amrex::MultiFab cc_bfield_perp_comps(ba, dm, 2, sim.nghost_cc_);
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> flux;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> facevel;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> leftState_bfield;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> rightState_bfield;
+		std::array<amrex::MultiFab, AMREX_SPACEDIM> fast_mhd_wavespeeds;
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			auto ba_face = amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim));
+			leftState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+			rightState[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange);
+			leftState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
+			rightState_bfield[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange);
+			flux[idim] = amrex::MultiFab(ba_face, dm, nvars, reconstructRange - 1);
+			facevel[idim] = amrex::MultiFab(ba_face, dm, 1, reconstructRange - 1);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				fast_mhd_wavespeeds[idim] = amrex::MultiFab(ba_face, dm, 2, reconstructRange - 1);
+			}
+		}
+
+		HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, sim.nghost_cc_);
+
+		AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(sim, primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0],
+							      rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
+							      reconstructRange, nvars, nghost_Riemann);
+			     , hydroFOFluxFunction<FluxDir::X2>(sim, primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1],
+								rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
+								reconstructRange, nvars, nghost_Riemann);
+			     , hydroFOFluxFunction<FluxDir::X3>(sim, primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2],
+								rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
+								reconstructRange, nvars, nghost_Riemann);)
+
+		amrex::Gpu::streamSynchronizeAll();
+
+		return std::make_tuple(std::move(flux), std::move(facevel), std::move(fast_mhd_wavespeeds));
+	}
+
+	static void replaceFluxes(std::array<amrex::MultiFab, AMREX_SPACEDIM> &fluxes, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FOfluxes,
+				  amrex::iMultiFab &redoFlag)
+	{
+		const BL_PROFILE("HydroRKPolicy::replaceFluxes()");
+
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			AMREX_ASSERT(fluxes[idim].nComp() == FOfluxes[idim].nComp());
+			int ncomp = fluxes[idim].nComp();
+
+			auto const &FOflux_arrs = FOfluxes[idim].const_arrays();
+			auto const &redoFlag_arrs = redoFlag.const_arrays();
+			auto flux_arrs = fluxes[idim].arrays();
+			amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
+
+			amrex::ParallelFor(redoFlag, ng, ncomp, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
+				if (redoFlag_arrs[bx](i, j, k) == quokka::redoFlag::redo) {
+					if (flux_arrs[bx].contains(i, j, k)) {
+						flux_arrs[bx](i, j, k, n) = FOflux_arrs[bx](i, j, k, n);
+					}
+					if (idim == 0) {
+						if (flux_arrs[bx].contains(i + 1, j, k)) {
+							flux_arrs[bx](i + 1, j, k, n) = FOflux_arrs[bx](i + 1, j, k, n);
+						}
+					} else if (idim == 1) {
+						if (flux_arrs[bx].contains(i, j + 1, k)) {
+							flux_arrs[bx](i, j + 1, k, n) = FOflux_arrs[bx](i, j + 1, k, n);
+						}
+					} else if (idim == 2) {
+						if (flux_arrs[bx].contains(i, j, k + 1)) {
+							flux_arrs[bx](i, j, k + 1, n) = FOflux_arrs[bx](i, j, k + 1, n);
+						}
+					}
+				}
+			});
+		}
+	}
+
+	static void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components,
+				std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components, amrex::iMultiFab &redoFlag)
+	{
+		const BL_PROFILE("HydroRKPolicy::replaceEMFs()");
+
+		for (int iedge = 0; iedge < 3; ++iedge) {
+			AMREX_ASSERT(emf_components[iedge].nComp() == FO_emf_components[iedge].nComp());
+			int ncomp = emf_components[iedge].nComp();
+
+			auto const &FO_emf_components_arrs = FO_emf_components[iedge].const_arrays();
+			auto const &redoFlag_arrs = redoFlag.const_arrays();
+			auto emf_components_arrs = emf_components[iedge].arrays();
+			amrex::IntVect ng{AMREX_D_DECL(1, 1, 1)};
+
+			amrex::ParallelFor(redoFlag, ng, ncomp, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k, int n) noexcept {
+				if (redoFlag_arrs[bx](i, j, k) == quokka::redoFlag::redo) {
+					if (emf_components_arrs[bx].contains(i, j, k)) {
+						emf_components_arrs[bx](i, j, k, n) = FO_emf_components_arrs[bx](i, j, k, n);
+					}
+					if (iedge == 0) {
+						if (emf_components_arrs[bx].contains(i, j + 1, k)) {
+							emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
+						}
+						if (emf_components_arrs[bx].contains(i, j, k + 1)) {
+							emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
+						}
+						if (emf_components_arrs[bx].contains(i, j + 1, k + 1)) {
+							emf_components_arrs[bx](i, j + 1, k + 1, n) = FO_emf_components_arrs[bx](i, j + 1, k + 1, n);
+						}
+					} else if (iedge == 1) {
+						if (emf_components_arrs[bx].contains(i + 1, j, k)) {
+							emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
+						}
+						if (emf_components_arrs[bx].contains(i, j, k + 1)) {
+							emf_components_arrs[bx](i, j, k + 1, n) = FO_emf_components_arrs[bx](i, j, k + 1, n);
+						}
+						if (emf_components_arrs[bx].contains(i + 1, j, k + 1)) {
+							emf_components_arrs[bx](i + 1, j, k + 1, n) = FO_emf_components_arrs[bx](i + 1, j, k + 1, n);
+						}
+					} else if (iedge == 2) {
+						if (emf_components_arrs[bx].contains(i + 1, j, k)) {
+							emf_components_arrs[bx](i + 1, j, k, n) = FO_emf_components_arrs[bx](i + 1, j, k, n);
+						}
+						if (emf_components_arrs[bx].contains(i, j + 1, k)) {
+							emf_components_arrs[bx](i, j + 1, k, n) = FO_emf_components_arrs[bx](i, j + 1, k, n);
+						}
+						if (emf_components_arrs[bx].contains(i + 1, j + 1, k)) {
+							emf_components_arrs[bx](i + 1, j + 1, k, n) = FO_emf_components_arrs[bx](i + 1, j + 1, k, n);
+						}
+					}
+				}
+			});
+		}
+	}
+
+	void define(int /*lev*/, quokka::CompositeStateView const & /*reference*/) {}
+
+	void define_stage_scratch(quokka::StageScratch &scratch, quokka::CompositeStateView const &reference, int /*lev*/) const
+	{
+		scratch.rhs_cc.define(reference.cc->boxArray(), reference.cc->DistributionMap(), reference.cc->nComp(), 0);
+		scratch.redo_flag.define(reference.cc->boxArray(), reference.cc->DistributionMap(), 1, 1);
+		scratch.has_redo_flag = true;
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				auto ba_ec = amrex::convert(reference.cc->boxArray(),
+							    amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+				scratch.emf[idim].define(ba_ec, reference.cc->DistributionMap(), 1, 0);
+			}
+		}
+	}
+
+	void define_step_accumulators(quokka::StepAccumulators &accum, quokka::CompositeStateView const &reference, int /*lev*/) const
+	{
+		if (sim_.do_tracers != 0) {
+			const int nghost_vel = 2;
+			accum.defineFaceVelocityLike(reference, nghost_vel);
+		}
+	}
+
+	void reset_accumulators(quokka::StepAccumulators &accum) const { accum.reset(); }
+
+	void fill_boundary(int stage, quokka::CompositeStateView state, amrex::Real stage_time) const
+	{
+		sim_.fillBoundaryConditions(*state.cc, *state.cc, lev_, stage_time, quokka::centering::cc, quokka::direction::na,
+					    QuokkaSimulation<problem_t>::PreInterpState, QuokkaSimulation<problem_t>::PostInterpState);
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				sim_.fillBoundaryConditions((*state.fc_data)[idim], (*state.fc_data)[idim], lev_, stage_time, quokka::centering::fc,
+							    quokka::direction{idim}, AMRSimulation<problem_t>::InterpHookNone,
+							    AMRSimulation<problem_t>::InterpHookNone, FillPatchType::fillpatch_function);
+			}
+		} else {
+			amrex::ignore_unused(stage);
+		}
+	}
+
+	void compute_stage(int /*stage*/, quokka::StageScratch &scratch, quokka::CompositeStateView const &input, amrex::Real /*stage_time*/,
+			   amrex::Real /*dt_stage*/) const
+	{
+		scratch.clearFlags();
+		scratch.redo_flag.setVal(quokka::redoFlag::none);
+		scratch.has_redo_flag = true;
+
+		auto [fluxes, face_vel, fast_mhd_wavespeeds] =
+		    computeHydroFluxes(sim_, *input.cc, *input.fc_data, QuokkaSimulation<problem_t>::nvars_, nghost_Riemann_, lev_);
+		scratch.fluxes_hi = std::move(fluxes);
+		scratch.face_vel = std::move(face_vel);
+		scratch.has_fluxes_hi = true;
+		scratch.has_face_vel = true;
+
+		auto const dx = sim_.geom[lev_].CellSizeArray();
+		HydroSystem<problem_t>::ComputeRhsFromFluxes(scratch.rhs_cc, scratch.fluxes_hi, dx, QuokkaSimulation<problem_t>::nvars_);
+		HydroSystem<problem_t>::AddInternalEnergyPdV(scratch.rhs_cc, *input.cc, *input.fc_data, dx, scratch.face_vel, scratch.redo_flag);
+
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			for (auto &mf : scratch.emf) {
+				mf.setVal(0.0);
+			}
+			MHDSystem<problem_t>::ComputeEMF(scratch.emf, *input.cc, scratch.face_vel, *input.fc_data, fast_mhd_wavespeeds,
+							 sim_.emfReconstructionOrder_, sim_.emfAveragingScheme_, sim_.mhdPlmLimiter_,
+							 sim_.emfComputingScheme_);
+			scratch.has_emf = true;
+		}
+	}
+
+	void update_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
+			  quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
+	{
+		if (stage == 1) {
+			HydroSystem<problem_t>::PredictStep(*old_state.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
+							    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, dt, sim_.geom[lev_].CellSizeArray());
+			}
+		} else {
+			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
+							     const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
+									sim_.geom[lev_].CellSizeArray());
+				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], 0.5, (*stage_input.fc_data)[idim], 0, 0,
+							       (*output.fc_data)[idim].nComp(), 0);
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0,
+							       (*output.fc_data)[idim].nComp(), 0);
+				}
+			}
+		}
+	}
+
+	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const & /*old_state*/,
+			    quokka::CompositeStateView const & /*stage_input*/, quokka::StageScratch &scratch, amrex::Real /*dt*/) const -> bool
+	{
+		amrex::Gpu::streamSynchronizeAll();
+		amrex::Long const ncells_bad = scratch.redo_flag.sum(0);
+		if (ncells_bad > 0) {
+			if (sim_.Verbose()) {
+				auto const cell_idx = scratch.redo_flag.maxIndex(0);
+				amrex::Print() << "[RK-" << stage << "] invalid hydro state in " << ncells_bad << " cells on level " << lev_ << "\n";
+				sim_.printCoordinates(lev_, cell_idx);
+				amrex::print_state(*output.cc, cell_idx);
+			}
+			return false;
+		}
+		return true;
+	}
+
+	void post_stage(int /*stage*/, quokka::CompositeStateView output, quokka::StageScratch const & /*scratch*/, amrex::Real /*stage_time*/,
+			amrex::Real /*dt*/) const
+	{
+		if (sim_.useDensityFloorParser_) {
+			auto const density_floor_parser = sim_.densityFloorParserExe_.value();
+			auto const density_floor_func = [=] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
+										  amrex::Real base_density_floor) -> amrex::Real {
+				return density_floor_parser(x, y, z, base_density_floor);
+			};
+			HydroSystem<problem_t>::EnforceLimits(sim_.densityFloor_, sim_.dustDensityFloor_, sim_.tempFloor_, *output.cc, sim_.geom[lev_],
+							      density_floor_func);
+		} else {
+			auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
+										     amrex::Real base_density_floor) -> amrex::Real {
+				return sim_.densityFloor(x, y, z, base_density_floor);
+			};
+			HydroSystem<problem_t>::EnforceLimits(sim_.densityFloor_, sim_.dustDensityFloor_, sim_.tempFloor_, *output.cc, sim_.geom[lev_],
+							      density_floor_func);
+		}
+
+		if (sim_.useDualEnergy_ == 1) {
+			HydroSystem<problem_t>::SyncDualEnergy(*output.cc, *output.fc_data);
+		}
+	}
+
+	void accumulate_stage(int stage, quokka::StageScratch const &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const
+	{
+		const amrex::Real weight = quokka::SSPRK2Scheme::stage_integral_weights[stage - 1];
+
+		if ((step_fr_as_crse_ != nullptr) || (step_fr_as_fine_ != nullptr)) {
+			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi),
+						    lev_, weight * dt);
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
+					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_,
+								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_,
+								   -weight * dt);
+				}
+			}
+		}
+
+		if (accum.has_avg_face_vel) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				amrex::MultiFab::Saxpy(accum.avg_face_vel[idim], weight, scratch.face_vel[idim], 0, 0, 1, 0);
+			}
+		}
+	}
+
+	void finalize_step(quokka::CompositeStateView /*new_state*/, amrex::Real /*time*/, amrex::Real dt,
+			   quokka::StepAccumulators const & /*accum*/) const
+	{
+		amrex::ignore_unused(dt);
+	}
+};
+
+#endif

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -6,8 +6,34 @@
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
 
+#include <array>
+#include <format>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "AMReX_BLProfiler.H"
+#include "AMReX_EdgeFluxRegister.H"
+#include "AMReX_FluxRegister.H"
+#include "AMReX_GpuControl.H"
+#include "AMReX_GpuDevice.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_ParallelDescriptor.H"
+#include "AMReX_PlotFileUtil.H"
+#include "AMReX_Print.H"
+#include "AMReX_VisMF.H"
+#include "AMReX_iMultiFab.H"
+
+#include "hydro/hydro_system.hpp"
+#include "hydro/mhd_system.hpp"
+#include "math/RKIntegrator.hpp"
+#include "simulation.hpp"
+
+template <typename problem_t> class QuokkaSimulation;
+
 template <typename problem_t> struct HydroRKPolicy {
-	QuokkaSimulation<problem_t> &sim_;
+	QuokkaSimulation<problem_t> &sim_; // NOLINT(cppcoreguidelines-avoid-const-or-ref-data-members)
 	int lev_ = -1;
 	int nghost_Riemann_ = 0;
 	amrex::FluxRegister *step_fr_as_crse_ = nullptr;
@@ -446,19 +472,18 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 	}
 
-	void apply_provisional_update(quokka::CompositeStateView output, quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch,
+	void apply_provisional_update(quokka::CompositeStateView output, quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
 				      amrex::Real dt) const
 	{
-		HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-						    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+		HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_, scratch.redo_flag);
 	}
 
 	void apply_stage_update(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-				quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
+				quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const
 	{
 		if (stage == 1) {
 			HydroSystem<problem_t>::PredictStep(*stage_input.cc, *output.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-							    const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+							    scratch.redo_flag);
 
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				MHDSystem<problem_t>::SolveInductionEqn(*stage_input.fc_data, *output.fc_data, scratch.emf, dt,
@@ -466,7 +491,7 @@ template <typename problem_t> struct HydroRKPolicy {
 			}
 		} else {
 			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt,
-							     QuokkaSimulation<problem_t>::nvars_, const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+							     QuokkaSimulation<problem_t>::nvars_, scratch.redo_flag);
 
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
@@ -515,7 +540,7 @@ template <typename problem_t> struct HydroRKPolicy {
 	}
 
 	void update_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-			  quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
+			  quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, amrex::Real dt) const
 	{
 		apply_stage_update(stage, output, old_state, stage_input, scratch, dt);
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc,
@@ -610,7 +635,7 @@ template <typename problem_t> struct HydroRKPolicy {
 				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
-	void accumulate_stage(int stage, quokka::StageScratch const &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const
+	void accumulate_stage(int stage, quokka::StageScratch &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const
 	{
 		amrex::Real weight = 1.0;
 		if (sim_.integratorOrder_ == 2) {
@@ -618,12 +643,10 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 
 		if ((step_fr_as_crse_ != nullptr) || (step_fr_as_fine_ != nullptr)) {
-			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_,
-						    const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi), lev_, weight * dt);
+			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, scratch.fluxes_hi, lev_, weight * dt);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
-					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_,
-								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_, -weight * dt);
+					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_, scratch.emf, lev_, -weight * dt);
 				}
 			}
 		}

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -523,9 +523,8 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 	}
 
-	void apply_stage_update(quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-				quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
-				quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
+	void apply_stage_update(quokka::CompositeStateView output, quokka::CompositeStateView const &old_state, quokka::CompositeStateView const &stage_input,
+				quokka::StageScratch &scratch, quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
 	{
 		apply_cell_centered_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 		apply_face_centered_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
@@ -564,8 +563,8 @@ template <typename problem_t> struct HydroRKPolicy {
 	}
 
 	void update_stage(int /*stage*/, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-			  quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
-			  quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const
+			  quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, quokka::StageAdvanceCoefficients const &coeffs,
+			  amrex::Real dt) const
 	{
 		apply_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc,
@@ -573,8 +572,8 @@ template <typename problem_t> struct HydroRKPolicy {
 	}
 
 	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
-			    quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch,
-			    quokka::StageAdvanceCoefficients const &coeffs, amrex::Real dt) const -> bool
+			    quokka::CompositeStateView const &stage_input, quokka::StageScratch &scratch, quokka::StageAdvanceCoefficients const &coeffs,
+			    amrex::Real dt) const -> bool
 	{
 		apply_stage_update(output, old_state, stage_input, scratch, coeffs, dt);
 		amrex::Gpu::streamSynchronizeAll();
@@ -666,8 +665,7 @@ template <typename problem_t> struct HydroRKPolicy {
 			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, scratch.fluxes_hi, lev_, coeffs.accumulation_weight * dt);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
-					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_, scratch.emf, lev_,
-								   -coeffs.accumulation_weight * dt);
+					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_, scratch.emf, lev_, -coeffs.accumulation_weight * dt);
 				}
 			}
 		}

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -421,7 +421,7 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::fill_boundary cc state on level {}", lev_), *state.cc,
-				 QuokkaSimulation<problem_t>::nvars_);
+				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	void recompute_stage_rhs(quokka::StageScratch &scratch, quokka::CompositeStateView const &input) const
@@ -519,7 +519,7 @@ template <typename problem_t> struct HydroRKPolicy {
 	{
 		apply_stage_update(stage, output, old_state, stage_input, scratch, dt);
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc,
-				 QuokkaSimulation<problem_t>::nvars_);
+				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
@@ -531,7 +531,7 @@ template <typename problem_t> struct HydroRKPolicy {
 		amrex::Long const ncells_bad = scratch.redo_flag.sum(0);
 		if (ncells_bad == 0) {
 			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage accepted output on level {}", lev_), *output.cc,
-					 QuokkaSimulation<problem_t>::nvars_);
+					  QuokkaSimulation<problem_t>::nvars_);
 			return true;
 		}
 
@@ -567,7 +567,7 @@ template <typename problem_t> struct HydroRKPolicy {
 		amrex::Long const ncells_bad_after_fofc = scratch.redo_flag.sum(0);
 		if (ncells_bad_after_fofc == 0) {
 			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage FOFC output on level {}", lev_), *output.cc,
-					 QuokkaSimulation<problem_t>::nvars_);
+					  QuokkaSimulation<problem_t>::nvars_);
 			return true;
 		}
 
@@ -607,7 +607,7 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 
 		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::post_stage output on level {}", lev_), *output.cc,
-				 QuokkaSimulation<problem_t>::nvars_);
+				  QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	void accumulate_stage(int stage, quokka::StageScratch const &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -396,18 +396,19 @@ template <typename problem_t> struct HydroRKPolicy {
 
 	void reset_accumulators(quokka::StepAccumulators &accum) const { accum.reset(); }
 
-	void debugAssertFinite(std::string const &label, amrex::MultiFab const &mf) const
+	void debugAssertFinite(std::string const &label, amrex::MultiFab const &mf, int checked_ncomp = -1) const
 	{
 		if (sim_.lowLevelDebuggingOutput_ != 0) {
-			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!mf.contains_nan(0, mf.nComp()), label + " (valid cells)");
-			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!mf.contains_nan(), label + " (including ghosts)");
+			const int checked_comps = (checked_ncomp >= 0) ? checked_ncomp : mf.nComp();
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!mf.contains_nan(0, checked_comps, mf.nGrowVect()), label + " (including checked ghosts)");
 		}
 	}
 
 	void fill_boundary(int stage, quokka::CompositeStateView state, amrex::Real stage_time) const
 	{
 		sim_.fillBoundaryConditions(*state.cc, *state.cc, lev_, stage_time, quokka::centering::cc, quokka::direction::na,
-					    QuokkaSimulation<problem_t>::PreInterpState, QuokkaSimulation<problem_t>::PostInterpState);
+					    QuokkaSimulation<problem_t>::PreInterpState, QuokkaSimulation<problem_t>::PostInterpState,
+					    FillPatchType::fillpatch_class, QuokkaSimulation<problem_t>::nvars_);
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -419,7 +420,8 @@ template <typename problem_t> struct HydroRKPolicy {
 			amrex::ignore_unused(stage);
 		}
 
-		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::fill_boundary cc state on level {}", lev_), *state.cc);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::fill_boundary cc state on level {}", lev_), *state.cc,
+				 QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	void recompute_stage_rhs(quokka::StageScratch &scratch, quokka::CompositeStateView const &input) const
@@ -516,7 +518,8 @@ template <typename problem_t> struct HydroRKPolicy {
 			  quokka::CompositeStateView const &stage_input, quokka::StageScratch const &scratch, amrex::Real dt) const
 	{
 		apply_stage_update(stage, output, old_state, stage_input, scratch, dt);
-		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::update_stage output on level {}", lev_), *output.cc,
+				 QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	auto validate_stage(int stage, quokka::CompositeStateView output, quokka::CompositeStateView const &old_state,
@@ -527,7 +530,8 @@ template <typename problem_t> struct HydroRKPolicy {
 		amrex::Gpu::streamSynchronizeAll();
 		amrex::Long const ncells_bad = scratch.redo_flag.sum(0);
 		if (ncells_bad == 0) {
-			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage accepted output on level {}", lev_), *output.cc);
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage accepted output on level {}", lev_), *output.cc,
+					 QuokkaSimulation<problem_t>::nvars_);
 			return true;
 		}
 
@@ -562,7 +566,8 @@ template <typename problem_t> struct HydroRKPolicy {
 		amrex::Gpu::streamSynchronizeAll();
 		amrex::Long const ncells_bad_after_fofc = scratch.redo_flag.sum(0);
 		if (ncells_bad_after_fofc == 0) {
-			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage FOFC output on level {}", lev_), *output.cc);
+			debugAssertFinite(std::format("NaN detected in HydroRKPolicy::validate_stage FOFC output on level {}", lev_), *output.cc,
+					 QuokkaSimulation<problem_t>::nvars_);
 			return true;
 		}
 
@@ -601,7 +606,8 @@ template <typename problem_t> struct HydroRKPolicy {
 			HydroSystem<problem_t>::SyncDualEnergy(*output.cc, *output.fc_data);
 		}
 
-		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::post_stage output on level {}", lev_), *output.cc);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::post_stage output on level {}", lev_), *output.cc,
+				 QuokkaSimulation<problem_t>::nvars_);
 	}
 
 	void accumulate_stage(int stage, quokka::StageScratch const &scratch, amrex::Real dt, quokka::StepAccumulators &accum) const

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -550,7 +550,8 @@ template <typename problem_t> struct HydroRKPolicy {
 		}
 
 		recompute_stage_rhs(scratch, input);
-		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage rhs_cc on level {}", lev_), scratch.rhs_cc);
+		debugAssertFinite(std::format("NaN detected in HydroRKPolicy::compute_stage rhs_cc on level {}", lev_), scratch.rhs_cc,
+				  QuokkaSimulation<problem_t>::nvars_);
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			compute_stage_emf(scratch.emf, input, scratch.face_vel, fast_mhd_wavespeeds);

--- a/src/hydro/HydroRKPolicy.hpp
+++ b/src/hydro/HydroRKPolicy.hpp
@@ -6,8 +6,7 @@
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
 
-template <typename problem_t> struct HydroRKPolicy
-{
+template <typename problem_t> struct HydroRKPolicy {
 	QuokkaSimulation<problem_t> &sim_;
 	int lev_ = -1;
 	int nghost_Riemann_ = 0;
@@ -85,7 +84,7 @@ template <typename problem_t> struct HydroRKPolicy
 			}
 		} else if (sim.reconstructionOrder_ == 2) {
 			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars,
-												 sim.plmLimiter_);
+											sim.plmLimiter_);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
 												ng_reconstruct, 2, sim.plmLimiter_);
@@ -93,8 +92,8 @@ template <typename problem_t> struct HydroRKPolicy
 		} else if (sim.reconstructionOrder_ == 1) {
 			HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
-												     ng_reconstruct, 2);
+				HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield,
+												     rightState_bfield, ng_reconstruct, 2);
 			}
 		} else {
 			amrex::Abort("Invalid reconstruction order specified!");
@@ -104,19 +103,18 @@ template <typename problem_t> struct HydroRKPolicy
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
-												 &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												 &x1FSpds, &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
 		} else {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::HLLC, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												 rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
-												 nullptr, nghost_Riemann);
+												 rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												 nullptr, nullptr, nghost_Riemann);
 		}
 	}
 
 	static auto computeHydroFluxes(QuokkaSimulation<problem_t> &sim, amrex::MultiFab const &consVar_cc,
 				       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
-	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 	{
 		const BL_PROFILE("HydroRKPolicy::computeHydroFluxes()");
 
@@ -185,16 +183,16 @@ template <typename problem_t> struct HydroRKPolicy
 				if (amrex::ParallelDescriptor::IOProcessor()) {
 					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
 				}
-				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
-												 std::string("StateL_") + quokka::face_dir_str[idim]);
+				std::string const fullprefix =
+				    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateL_") + quokka::face_dir_str[idim]);
 				amrex::VisMF::Write(leftState[idim], fullprefix);
 			}
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				if (amrex::ParallelDescriptor::IOProcessor()) {
 					std::filesystem::create_directories(plotfile_name + "/raw_fields/Level_" + std::to_string(lev));
 				}
-				std::string const fullprefix = amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_",
-												 std::string("StateR_") + quokka::face_dir_str[idim]);
+				std::string const fullprefix =
+				    amrex::MultiFabFileFullPrefix(lev, plotfile_name, "raw_fields/Level_", std::string("StateR_") + quokka::face_dir_str[idim]);
 				amrex::VisMF::Write(rightState[idim], fullprefix);
 			}
 		}
@@ -214,25 +212,24 @@ template <typename problem_t> struct HydroRKPolicy
 
 		HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar_mf, leftState, rightState, ng_reconstruct, nvars);
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield, ng_reconstruct,
-											2);
+			HydroSystem<problem_t>::template ReconstructStatesConstant<DIR>(cc_bfield_perp_comps_mf, leftState_bfield, rightState_bfield,
+											ng_reconstruct, 2);
 		}
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												    rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
-												    &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
+			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF_MHD, DIR>(
+			    flux, faceVel, leftState, rightState, leftState_bfield, rightState_bfield, primVar_mf, sim.artificialViscosityK_, &x1FSpds,
+			    &consVar_fc[static_cast<int>(DIR)], nghost_Riemann);
 		} else {
 			HydroSystem<problem_t>::template ComputeFluxes<RiemannSolver::LLF, DIR>(flux, faceVel, leftState, rightState, leftState_bfield,
-												rightState_bfield, primVar_mf, sim.artificialViscosityK_, nullptr,
-												nullptr, nghost_Riemann);
+												rightState_bfield, primVar_mf, sim.artificialViscosityK_,
+												nullptr, nullptr, nghost_Riemann);
 		}
 	}
 
 	static auto computeFOHydroFluxes(QuokkaSimulation<problem_t> const &sim, amrex::MultiFab const &consVar_cc,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &consVar_fc, int nvars, int nghost_Riemann, int lev)
-	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>,
-			  std::array<amrex::MultiFab, AMREX_SPACEDIM>>
+	    -> std::tuple<std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>, std::array<amrex::MultiFab, AMREX_SPACEDIM>>
 	{
 		const BL_PROFILE("HydroRKPolicy::computeFOHydroFluxes()");
 
@@ -266,14 +263,14 @@ template <typename problem_t> struct HydroRKPolicy
 		HydroSystem<problem_t>::ConservedToPrimitive(consVar_cc, consVar_fc, primVar, sim.nghost_cc_);
 
 		AMREX_D_TERM(hydroFOFluxFunction<FluxDir::X1>(sim, primVar, cc_bfield_perp_comps, leftState[0], rightState[0], leftState_bfield[0],
-							      rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc,
-							      reconstructRange, nvars, nghost_Riemann);
+							      rightState_bfield[0], flux[0], facevel[0], fast_mhd_wavespeeds[0], consVar_fc, reconstructRange,
+							      nvars, nghost_Riemann);
 			     , hydroFOFluxFunction<FluxDir::X2>(sim, primVar, cc_bfield_perp_comps, leftState[1], rightState[1], leftState_bfield[1],
-								rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc,
-								reconstructRange, nvars, nghost_Riemann);
+								rightState_bfield[1], flux[1], facevel[1], fast_mhd_wavespeeds[1], consVar_fc, reconstructRange,
+								nvars, nghost_Riemann);
 			     , hydroFOFluxFunction<FluxDir::X3>(sim, primVar, cc_bfield_perp_comps, leftState[2], rightState[2], leftState_bfield[2],
-								rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc,
-								reconstructRange, nvars, nghost_Riemann);)
+								rightState_bfield[2], flux[2], facevel[2], fast_mhd_wavespeeds[2], consVar_fc, reconstructRange,
+								nvars, nghost_Riemann);)
 
 		amrex::Gpu::streamSynchronizeAll();
 
@@ -317,8 +314,8 @@ template <typename problem_t> struct HydroRKPolicy
 		}
 	}
 
-	static void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components,
-				std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components, amrex::iMultiFab &redoFlag)
+	static void replaceEMFs(std::array<amrex::MultiFab, AMREX_SPACEDIM> &emf_components, std::array<amrex::MultiFab, AMREX_SPACEDIM> &FO_emf_components,
+				amrex::iMultiFab &redoFlag)
 	{
 		const BL_PROFILE("HydroRKPolicy::replaceEMFs()");
 
@@ -382,8 +379,8 @@ template <typename problem_t> struct HydroRKPolicy
 
 		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				auto ba_ec = amrex::convert(reference.cc->boxArray(),
-							    amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
+				auto ba_ec =
+				    amrex::convert(reference.cc->boxArray(), amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
 				scratch.emf[idim].define(ba_ec, reference.cc->DistributionMap(), 1, 0);
 			}
 		}
@@ -438,8 +435,7 @@ template <typename problem_t> struct HydroRKPolicy
 				mf.setVal(0.0);
 			}
 			MHDSystem<problem_t>::ComputeEMF(scratch.emf, *input.cc, scratch.face_vel, *input.fc_data, fast_mhd_wavespeeds,
-							 sim_.emfReconstructionOrder_, sim_.emfAveragingScheme_, sim_.mhdPlmLimiter_,
-							 sim_.emfComputingScheme_);
+							 sim_.emfReconstructionOrder_, sim_.emfAveragingScheme_, sim_.mhdPlmLimiter_, sim_.emfComputingScheme_);
 			scratch.has_emf = true;
 		}
 	}
@@ -455,8 +451,8 @@ template <typename problem_t> struct HydroRKPolicy
 				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, dt, sim_.geom[lev_].CellSizeArray());
 			}
 		} else {
-			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt, QuokkaSimulation<problem_t>::nvars_,
-							     const_cast<amrex::iMultiFab &>(scratch.redo_flag));
+			HydroSystem<problem_t>::AddFluxesRK2(*output.cc, *old_state.cc, *stage_input.cc, scratch.rhs_cc, dt,
+							     QuokkaSimulation<problem_t>::nvars_, const_cast<amrex::iMultiFab &>(scratch.redo_flag));
 
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				MHDSystem<problem_t>::SolveInductionEqn(*old_state.fc_data, *output.fc_data, scratch.emf, 0.5 * dt,
@@ -464,8 +460,8 @@ template <typename problem_t> struct HydroRKPolicy
 				for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 					amrex::MultiFab::Saxpy((*output.fc_data)[idim], 0.5, (*stage_input.fc_data)[idim], 0, 0,
 							       (*output.fc_data)[idim].nComp(), 0);
-					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0,
-							       (*output.fc_data)[idim].nComp(), 0);
+					amrex::MultiFab::Saxpy((*output.fc_data)[idim], -0.5, (*old_state.fc_data)[idim], 0, 0, (*output.fc_data)[idim].nComp(),
+							       0);
 				}
 			}
 		}
@@ -518,13 +514,12 @@ template <typename problem_t> struct HydroRKPolicy
 		const amrex::Real weight = quokka::SSPRK2Scheme::stage_integral_weights[stage - 1];
 
 		if ((step_fr_as_crse_ != nullptr) || (step_fr_as_fine_ != nullptr)) {
-			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_, const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi),
-						    lev_, weight * dt);
+			sim_.incrementFluxRegisters(step_fr_as_crse_, step_fr_as_fine_,
+						    const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.fluxes_hi), lev_, weight * dt);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				if ((step_emf_as_crse_ != nullptr) || (step_emf_as_fine_ != nullptr)) {
 					sim_.incrementEMFRegisters(step_emf_as_crse_, step_emf_as_fine_,
-								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_,
-								   -weight * dt);
+								   const_cast<std::array<amrex::MultiFab, AMREX_SPACEDIM> &>(scratch.emf), lev_, -weight * dt);
 				}
 			}
 		}
@@ -536,8 +531,7 @@ template <typename problem_t> struct HydroRKPolicy
 		}
 	}
 
-	void finalize_step(quokka::CompositeStateView /*new_state*/, amrex::Real /*time*/, amrex::Real dt,
-			   quokka::StepAccumulators const & /*accum*/) const
+	void finalize_step(quokka::CompositeStateView /*new_state*/, amrex::Real /*time*/, amrex::Real dt, quokka::StepAccumulators const & /*accum*/) const
 	{
 		amrex::ignore_unused(dt);
 	}

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -41,8 +41,7 @@ using Real = amrex::Real;
 
 /// Non-owning view of a composite state with one cell-centered MultiFab and
 /// optional face-centered MultiFabs.
-struct CompositeStateView
-{
+struct CompositeStateView {
 	amrex::MultiFab *cc = nullptr;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> *fc_data = nullptr;
 	std::array<amrex::MultiFab *, AMREX_SPACEDIM> fc{};
@@ -61,8 +60,7 @@ struct CompositeStateView
 };
 
 /// Owned scratch state used by the integrator for intermediate RK stages.
-struct CompositeStateData
-{
+struct CompositeStateData {
 	amrex::MultiFab cc;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fc{};
 	bool has_face_state = false;
@@ -111,8 +109,7 @@ struct CompositeStateData
 };
 
 /// Short-lived temporaries used while constructing and validating one RK stage.
-struct StageScratch
-{
+struct StageScratch {
 	amrex::MultiFab rhs_cc;
 	amrex::iMultiFab redo_flag;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fluxes_hi{};
@@ -137,8 +134,7 @@ struct StageScratch
 };
 
 /// Running quantities that genuinely need to persist across RK stages.
-struct StepAccumulators
-{
+struct StepAccumulators {
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> avg_face_vel{};
 	bool has_avg_face_vel = false;
 
@@ -164,8 +160,18 @@ struct StepAccumulators
 };
 
 /// SSPRK2 stage description for Quokka's hydro update.
-struct SSPRK2Scheme
-{
+struct ForwardEulerScheme {
+	static constexpr int nstages = 1;
+
+	/// Stage time t_n.
+	static constexpr std::array<Real, nstages> c = {Real(0.0)};
+
+	/// Full-step weight for time-integrated face quantities.
+	static constexpr std::array<Real, nstages> stage_integral_weights = {Real(1.0)};
+};
+
+/// SSPRK2 stage description for Quokka's hydro update.
+struct SSPRK2Scheme {
 	static constexpr int nstages = 2;
 
 	/// Stage times t_n + c_s * dt.
@@ -178,15 +184,9 @@ struct SSPRK2Scheme
 
 namespace detail
 {
-template <typename Policy>
-concept HasDefine = requires(Policy &policy, int lev, CompositeStateView const &reference) {
-	{ policy.define(lev, reference) };
-};
+template <typename Policy> concept HasDefine = requires(Policy & policy, int lev, CompositeStateView const &reference) { {policy.define(lev, reference)}; };
 
-template <typename Policy>
-concept HasResetAccumulators = requires(Policy &policy, StepAccumulators &accum) {
-	{ policy.reset_accumulators(accum) };
-};
+template <typename Policy> concept HasResetAccumulators = requires(Policy & policy, StepAccumulators &accum) { {policy.reset_accumulators(accum)}; };
 } // namespace detail
 
 /// Generic stage-driven RK integrator for Quokka composite state.
@@ -199,10 +199,10 @@ concept HasResetAccumulators = requires(Policy &policy, StepAccumulators &accum)
 ///   void define_step_accumulators(StepAccumulators&, CompositeStateView const&, int lev) const;
 ///   void fill_boundary(int stage, CompositeStateView, Real stage_time) const;
 ///   void compute_stage(int stage, StageScratch&, CompositeStateView const&, Real stage_time, Real dt_stage) const;
-///   void update_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
-///                     StageScratch const&, Real dt) const;
 ///   auto validate_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
 ///                       StageScratch&, Real dt) const -> bool;
+///   void update_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
+///                     StageScratch const&, Real dt) const;
 ///   void post_stage(int stage, CompositeStateView, StageScratch const&, Real stage_time, Real dt) const;
 ///   void accumulate_stage(int stage, StageScratch const&, Real dt, StepAccumulators&) const;
 ///   void finalize_step(CompositeStateView, Real time, Real dt, StepAccumulators const&) const;
@@ -246,12 +246,11 @@ template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 
 			policy_.fill_boundary(stage + 1, stage_input, stage_time);
 			policy_.compute_stage(stage + 1, scratch_, stage_input, stage_time, dt_stage);
-			policy_.update_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
-
 			const bool stage_ok = policy_.validate_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
 			if (!stage_ok) {
 				return false;
 			}
+			policy_.update_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
 
 			policy_.post_stage(stage + 1, stage_output, scratch_, stage_time, dt);
 			policy_.accumulate_stage(stage + 1, scratch_, dt, accumulators_);
@@ -278,8 +277,7 @@ template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 /// This is an interface contract, not a base class with virtual dispatch.
 /// A concrete policy can be templated on `problem_t` and hold any Quokka state
 /// needed to compute fluxes, fill boundaries, and update reflux registers.
-struct HydroRKPolicyInterface
-{
+struct HydroRKPolicyInterface {
 	[[nodiscard]] auto nghost_cc() const -> int;
 	[[nodiscard]] auto nghost_fc() const -> int;
 
@@ -292,12 +290,12 @@ struct HydroRKPolicyInterface
 
 	void compute_stage(int stage, StageScratch &scratch, CompositeStateView const &input, Real stage_time, Real dt_stage) const;
 
-	void update_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
-			  StageScratch const &scratch, Real dt) const;
-
-	/// Returns false if the stage failed and the caller should reject the step.
 	auto validate_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
 			    StageScratch &scratch, Real dt) const -> bool;
+
+	/// Commit the accepted stage update after validation/fixup has completed.
+	void update_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
+			  StageScratch const &scratch, Real dt) const;
 
 	void post_stage(int stage, CompositeStateView output, StageScratch const &scratch, Real stage_time, Real dt) const;
 

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -156,29 +156,104 @@ struct StepAccumulators {
 	}
 };
 
-/// SSPRK2 stage description for Quokka's hydro update.
+template <int N> struct ExplicitButcherTableau {
+	std::array<std::array<Real, N>, N> a{};
+	std::array<Real, N> b{};
+	std::array<Real, N> c{};
+};
+
+struct StageAdvanceCoefficients {
+	Real old_state_weight = static_cast<Real>(0.0);
+	Real stage_input_weight = static_cast<Real>(1.0);
+	Real rhs_weight = static_cast<Real>(1.0);
+	Real accumulation_weight = static_cast<Real>(0.0);
+};
+
+namespace detail
+{
+consteval auto abs_constexpr(Real x) -> Real { return (x < static_cast<Real>(0.0)) ? -x : x; }
+
+consteval void require_low_storage_form(bool ok)
+{
+	if (!ok) {
+		throw "RK scheme cannot be represented with a single previous-stage state.";
+	}
+}
+
+template <int N>
+consteval auto derive_stage_advance_coefficients(ExplicitButcherTableau<N> const &tableau) -> std::array<StageAdvanceCoefficients, N>
+{
+	// Reduce an explicit tableau to Quokka's low-storage recurrence
+	// U_out = a * U^n + b * U_in + g * dt * L(U_in), rejecting schemes that
+	// cannot be represented with a single previous-stage state.
+	std::array<StageAdvanceCoefficients, N> coeffs{};
+	constexpr Real eps = static_cast<Real>(1.0e-12);
+
+	for (int stage = 0; stage < N; ++stage) {
+		coeffs[stage].accumulation_weight = tableau.b[stage];
+
+		if (stage == 0) {
+			coeffs[stage].rhs_weight = (N == 1) ? tableau.b[0] : tableau.a[1][0];
+			continue;
+		}
+
+		Real lambda = static_cast<Real>(0.0);
+		bool lambda_set = false;
+
+		for (int j = 0; j < stage; ++j) {
+			const Real prev = tableau.a[stage][j];
+			const Real target = (stage == (N - 1)) ? tableau.b[j] : tableau.a[stage + 1][j];
+			if (abs_constexpr(prev) > eps) {
+				lambda = target / prev;
+				lambda_set = true;
+				break;
+			}
+			require_low_storage_form(abs_constexpr(target) <= eps);
+		}
+
+		require_low_storage_form(lambda_set);
+
+		for (int j = 0; j < stage; ++j) {
+			const Real prev = tableau.a[stage][j];
+			const Real target = (stage == (N - 1)) ? tableau.b[j] : tableau.a[stage + 1][j];
+			require_low_storage_form(abs_constexpr(target - lambda * prev) <= eps);
+		}
+
+		coeffs[stage].old_state_weight = static_cast<Real>(1.0) - lambda;
+		coeffs[stage].stage_input_weight = lambda;
+		coeffs[stage].rhs_weight = (stage == (N - 1)) ? tableau.b[stage] : tableau.a[stage + 1][stage];
+	}
+
+	return coeffs;
+}
+} // namespace detail
+
+/// Forward Euler stage description for Quokka's hydro update.
 struct ForwardEulerScheme {
 	static constexpr int nstages = 1;
-
-	/// Stage time t_n.
-	static constexpr std::array<Real, nstages> c = {static_cast<Real>(0.0)};
-
-	/// Full-step weight for time-integrated face quantities.
-	static constexpr std::array<Real, nstages> stage_integral_weights = {static_cast<Real>(1.0)};
+	static constexpr auto tableau = []() {
+		ExplicitButcherTableau<nstages> t{};
+		t.a = {{{static_cast<Real>(0.0)}}};
+		t.b = {static_cast<Real>(1.0)};
+		t.c = {static_cast<Real>(0.0)};
+		return t;
+	}();
+	static constexpr auto stage_advance = detail::derive_stage_advance_coefficients(tableau);
 };
 
 /// SSPRK2 stage description for Quokka's hydro update.
 struct SSPRK2Scheme {
 	static constexpr int nstages = 2;
-
-	/// Stage times t_n + c_s * dt.
-	static constexpr std::array<Real, nstages> c = {static_cast<Real>(0.0), static_cast<Real>(1.0)};
-
-	/// Weights for time-integrated face quantities accumulated per stage, e.g.
-	/// flux-register increments or average face velocity.
-	static constexpr std::array<Real, nstages> stage_integral_weights = {static_cast<Real>(0.5), static_cast<Real>(0.5)};
+	static constexpr auto tableau = []() {
+		ExplicitButcherTableau<nstages> t{};
+		t.a = {{{static_cast<Real>(0.0), static_cast<Real>(0.0)},
+			{static_cast<Real>(1.0), static_cast<Real>(0.0)}}};
+		t.b = {static_cast<Real>(0.5), static_cast<Real>(0.5)};
+		t.c = {static_cast<Real>(0.0), static_cast<Real>(1.0)};
+		return t;
+	}();
+	static constexpr auto stage_advance = detail::derive_stage_advance_coefficients(tableau);
 };
-
 namespace detail
 {
 template <typename Policy> concept HasDefine = requires(Policy & policy, int lev, CompositeStateView const &reference) { {policy.define(lev, reference)}; };
@@ -195,13 +270,13 @@ template <typename Policy> concept HasResetAccumulators = requires(Policy & poli
 ///   void define_stage_scratch(StageScratch&, CompositeStateView const&, int lev) const;
 ///   void define_step_accumulators(StepAccumulators&, CompositeStateView const&, int lev) const;
 ///   void fill_boundary(int stage, CompositeStateView, Real stage_time) const;
-///   void compute_stage(int stage, StageScratch&, CompositeStateView const&, Real stage_time, Real dt_stage) const;
+///   void compute_stage(int stage, StageScratch&, CompositeStateView const&, Real stage_time) const;
 ///   auto validate_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
-///                       StageScratch&, Real dt) const -> bool;
+///                       StageScratch&, StageAdvanceCoefficients const&, Real dt) const -> bool;
 ///   void update_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
-///                     StageScratch&, Real dt) const;
-///   void post_stage(int stage, CompositeStateView, StageScratch const&, Real stage_time, Real dt) const;
-///   void accumulate_stage(int stage, StageScratch&, Real dt, StepAccumulators&) const;
+///                     StageScratch&, StageAdvanceCoefficients const&, Real dt) const;
+///   void post_stage(int stage, CompositeStateView, StageScratch const&, Real dt) const;
+///   void accumulate_stage(int stage, StageScratch&, StageAdvanceCoefficients const&, Real dt, StepAccumulators&) const;
 ///   void finalize_step(CompositeStateView, Real time, Real dt, StepAccumulators const&) const;
 template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 {
@@ -237,20 +312,20 @@ template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 		CompositeStateView stage_input = old_state;
 
 		for (int stage = 0; stage < Scheme::nstages; ++stage) {
-			const Real stage_time = time + Scheme::c[stage] * dt;
-			const Real dt_stage = Scheme::stage_integral_weights[stage] * dt;
+			auto const &coeffs = Scheme::stage_advance[stage];
+			const Real stage_time = time + Scheme::tableau.c[stage] * dt;
 			CompositeStateView stage_output = (stage == Scheme::nstages - 1) ? new_state : stage_state;
 
 			policy_.fill_boundary(stage + 1, stage_input, stage_time);
-			policy_.compute_stage(stage + 1, scratch_, stage_input, stage_time, dt_stage);
-			const bool stage_ok = policy_.validate_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
+			policy_.compute_stage(stage + 1, scratch_, stage_input, stage_time);
+			const bool stage_ok = policy_.validate_stage(stage + 1, stage_output, old_state, stage_input, scratch_, coeffs, dt);
 			if (!stage_ok) {
 				return false;
 			}
-			policy_.update_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
+			policy_.update_stage(stage + 1, stage_output, old_state, stage_input, scratch_, coeffs, dt);
 
-			policy_.post_stage(stage + 1, stage_output, scratch_, stage_time, dt);
-			policy_.accumulate_stage(stage + 1, scratch_, dt, accumulators_);
+			policy_.post_stage(stage + 1, stage_output, scratch_, dt);
+			policy_.accumulate_stage(stage + 1, scratch_, coeffs, dt, accumulators_);
 			stage_input = stage_output;
 		}
 
@@ -285,20 +360,20 @@ struct HydroRKPolicyInterface {
 
 	void fill_boundary(int stage, CompositeStateView state, Real stage_time) const;
 
-	void compute_stage(int stage, StageScratch &scratch, CompositeStateView const &input, Real stage_time, Real dt_stage) const;
+	void compute_stage(int stage, StageScratch &scratch, CompositeStateView const &input, Real stage_time) const;
 
 	auto validate_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
-			    StageScratch &scratch, Real dt) const -> bool;
+			    StageScratch &scratch, StageAdvanceCoefficients const &coeffs, Real dt) const -> bool;
 
 	/// Commit the accepted stage update after validation/fixup has completed.
 	void update_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
-			  StageScratch &scratch, Real dt) const;
+			  StageScratch &scratch, StageAdvanceCoefficients const &coeffs, Real dt) const;
 
-	void post_stage(int stage, CompositeStateView output, StageScratch const &scratch, Real stage_time, Real dt) const;
+	void post_stage(int stage, CompositeStateView output, StageScratch const &scratch, Real dt) const;
 
 	/// Perform per-stage flux-register / EMF-register increments and update any
 	/// step-spanning accumulators such as time-averaged face velocity.
-	void accumulate_stage(int stage, StageScratch &scratch, Real dt, StepAccumulators &accum) const;
+	void accumulate_stage(int stage, StageScratch &scratch, StageAdvanceCoefficients const &coeffs, Real dt, StepAccumulators &accum) const;
 
 	void finalize_step(CompositeStateView new_state, Real time, Real dt, StepAccumulators const &accum) const;
 };

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <array>
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -173,10 +174,17 @@ namespace detail
 {
 consteval auto abs_constexpr(Real x) -> Real { return (x < static_cast<Real>(0.0)) ? -x : x; }
 
+struct LowStorageFormError : std::exception {
+	[[nodiscard]] auto what() const noexcept -> char const * override
+	{
+		return "RK scheme cannot be represented with a single previous-stage state.";
+	}
+};
+
 consteval void require_low_storage_form(bool ok)
 {
 	if (!ok) {
-		throw "RK scheme cannot be represented with a single previous-stage state.";
+		throw LowStorageFormError{};
 	}
 }
 

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -180,8 +180,7 @@ consteval void require_low_storage_form(bool ok)
 	}
 }
 
-template <int N>
-consteval auto derive_stage_advance_coefficients(ExplicitButcherTableau<N> const &tableau) -> std::array<StageAdvanceCoefficients, N>
+template <int N> consteval auto derive_stage_advance_coefficients(ExplicitButcherTableau<N> const &tableau) -> std::array<StageAdvanceCoefficients, N>
 {
 	// Reduce an explicit tableau to Quokka's low-storage recurrence
 	// U_out = a * U^n + b * U_in + g * dt * L(U_in), rejecting schemes that
@@ -246,8 +245,7 @@ struct SSPRK2Scheme {
 	static constexpr int nstages = 2;
 	static constexpr auto tableau = []() {
 		ExplicitButcherTableau<nstages> t{};
-		t.a = {{{static_cast<Real>(0.0), static_cast<Real>(0.0)},
-			{static_cast<Real>(1.0), static_cast<Real>(0.0)}}};
+		t.a = {{{static_cast<Real>(0.0), static_cast<Real>(0.0)}, {static_cast<Real>(1.0), static_cast<Real>(0.0)}}};
 		t.b = {static_cast<Real>(0.5), static_cast<Real>(0.5)};
 		t.c = {static_cast<Real>(0.0), static_cast<Real>(1.0)};
 		return t;

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -22,6 +22,7 @@
 /// schedules stages and manages temporary storage.
 ///
 
+#include <algorithm>
 #include <array>
 #include <type_traits>
 #include <utility>
@@ -33,6 +34,7 @@
 #include "AMReX_GpuQualifiers.H"
 #include "AMReX_MultiFab.H"
 #include "AMReX_REAL.H"
+#include "AMReX_iMultiFab.H"
 
 namespace quokka
 {
@@ -50,12 +52,7 @@ struct CompositeStateView {
 
 	[[nodiscard]] auto hasFaceState() const -> bool
 	{
-		for (auto *ptr : fc) {
-			if (ptr != nullptr) {
-				return true;
-			}
-		}
-		return false;
+		return std::ranges::any_of(fc, [](auto const *ptr) { return ptr != nullptr; });
 	}
 };
 
@@ -164,10 +161,10 @@ struct ForwardEulerScheme {
 	static constexpr int nstages = 1;
 
 	/// Stage time t_n.
-	static constexpr std::array<Real, nstages> c = {Real(0.0)};
+	static constexpr std::array<Real, nstages> c = {static_cast<Real>(0.0)};
 
 	/// Full-step weight for time-integrated face quantities.
-	static constexpr std::array<Real, nstages> stage_integral_weights = {Real(1.0)};
+	static constexpr std::array<Real, nstages> stage_integral_weights = {static_cast<Real>(1.0)};
 };
 
 /// SSPRK2 stage description for Quokka's hydro update.
@@ -175,11 +172,11 @@ struct SSPRK2Scheme {
 	static constexpr int nstages = 2;
 
 	/// Stage times t_n + c_s * dt.
-	static constexpr std::array<Real, nstages> c = {Real(0.0), Real(1.0)};
+	static constexpr std::array<Real, nstages> c = {static_cast<Real>(0.0), static_cast<Real>(1.0)};
 
 	/// Weights for time-integrated face quantities accumulated per stage, e.g.
 	/// flux-register increments or average face velocity.
-	static constexpr std::array<Real, nstages> stage_integral_weights = {Real(0.5), Real(0.5)};
+	static constexpr std::array<Real, nstages> stage_integral_weights = {static_cast<Real>(0.5), static_cast<Real>(0.5)};
 };
 
 namespace detail
@@ -202,9 +199,9 @@ template <typename Policy> concept HasResetAccumulators = requires(Policy & poli
 ///   auto validate_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
 ///                       StageScratch&, Real dt) const -> bool;
 ///   void update_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
-///                     StageScratch const&, Real dt) const;
+///                     StageScratch&, Real dt) const;
 ///   void post_stage(int stage, CompositeStateView, StageScratch const&, Real stage_time, Real dt) const;
-///   void accumulate_stage(int stage, StageScratch const&, Real dt, StepAccumulators&) const;
+///   void accumulate_stage(int stage, StageScratch&, Real dt, StepAccumulators&) const;
 ///   void finalize_step(CompositeStateView, Real time, Real dt, StepAccumulators const&) const;
 template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 {
@@ -295,13 +292,13 @@ struct HydroRKPolicyInterface {
 
 	/// Commit the accepted stage update after validation/fixup has completed.
 	void update_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
-			  StageScratch const &scratch, Real dt) const;
+			  StageScratch &scratch, Real dt) const;
 
 	void post_stage(int stage, CompositeStateView output, StageScratch const &scratch, Real stage_time, Real dt) const;
 
 	/// Perform per-stage flux-register / EMF-register increments and update any
 	/// step-spanning accumulators such as time-averaged face velocity.
-	void accumulate_stage(int stage, StageScratch const &scratch, Real dt, StepAccumulators &accum) const;
+	void accumulate_stage(int stage, StageScratch &scratch, Real dt, StepAccumulators &accum) const;
 
 	void finalize_step(CompositeStateView new_state, Real time, Real dt, StepAccumulators const &accum) const;
 };

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -41,8 +41,7 @@ using Real = amrex::Real;
 
 /// Non-owning view of a composite state with one cell-centered MultiFab and
 /// optional face-centered MultiFabs.
-struct CompositeStateView
-{
+struct CompositeStateView {
 	amrex::MultiFab *cc = nullptr;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> *fc_data = nullptr;
 	std::array<amrex::MultiFab *, AMREX_SPACEDIM> fc{};
@@ -61,8 +60,7 @@ struct CompositeStateView
 };
 
 /// Owned scratch state used by the integrator for intermediate RK stages.
-struct CompositeStateData
-{
+struct CompositeStateData {
 	amrex::MultiFab cc;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fc{};
 	bool has_face_state = false;
@@ -111,8 +109,7 @@ struct CompositeStateData
 };
 
 /// Short-lived temporaries used while constructing and validating one RK stage.
-struct StageScratch
-{
+struct StageScratch {
 	amrex::MultiFab rhs_cc;
 	amrex::iMultiFab redo_flag;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> fluxes_hi{};
@@ -137,8 +134,7 @@ struct StageScratch
 };
 
 /// Running quantities that genuinely need to persist across RK stages.
-struct StepAccumulators
-{
+struct StepAccumulators {
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> avg_face_vel{};
 	bool has_avg_face_vel = false;
 
@@ -164,8 +160,7 @@ struct StepAccumulators
 };
 
 /// SSPRK2 stage description for Quokka's hydro update.
-struct SSPRK2Scheme
-{
+struct SSPRK2Scheme {
 	static constexpr int nstages = 2;
 
 	/// Stage times t_n + c_s * dt.
@@ -178,15 +173,9 @@ struct SSPRK2Scheme
 
 namespace detail
 {
-template <typename Policy>
-concept HasDefine = requires(Policy &policy, int lev, CompositeStateView const &reference) {
-	{ policy.define(lev, reference) };
-};
+template <typename Policy> concept HasDefine = requires(Policy & policy, int lev, CompositeStateView const &reference) { {policy.define(lev, reference)}; };
 
-template <typename Policy>
-concept HasResetAccumulators = requires(Policy &policy, StepAccumulators &accum) {
-	{ policy.reset_accumulators(accum) };
-};
+template <typename Policy> concept HasResetAccumulators = requires(Policy & policy, StepAccumulators &accum) { {policy.reset_accumulators(accum)}; };
 } // namespace detail
 
 /// Generic stage-driven RK integrator for Quokka composite state.
@@ -278,8 +267,7 @@ template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
 /// This is an interface contract, not a base class with virtual dispatch.
 /// A concrete policy can be templated on `problem_t` and hold any Quokka state
 /// needed to compute fluxes, fill boundaries, and update reflux registers.
-struct HydroRKPolicyInterface
-{
+struct HydroRKPolicyInterface {
 	[[nodiscard]] auto nghost_cc() const -> int;
 	[[nodiscard]] auto nghost_fc() const -> int;
 

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -1,0 +1,313 @@
+#ifndef RKINTEGRATOR_HPP_ // NOLINT
+#define RKINTEGRATOR_HPP_
+//==============================================================================
+// Quokka -- a radiation-hydrodynamics code built on AMReX
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file RKIntegrator.hpp
+/// \brief Generic stage-driven Runge-Kutta integrator skeleton for composite
+///        cell-centered / face-centered AMReX state.
+///
+/// This interface is intentionally higher-level than AMReX_RungeKutta.H. It is
+/// designed for Quokka's hydro/MHD update, where an accepted RK stage depends
+/// on more than a single cell-centered RHS:
+///   - cell-centered conserved state
+///   - optional face-centered state (e.g., magnetic fields)
+///   - stage-local fluxes, face velocities, and EMFs
+///   - optional stage validation/fixup before the stage is accepted
+///   - per-stage flux-register / EMF-register increments
+///
+/// The policy object owns all physics-specific operations. RKIntegrator only
+/// schedules stages and manages temporary storage.
+///
+
+#include <array>
+#include <type_traits>
+#include <utility>
+
+#include "AMReX_Array.H"
+#include "AMReX_BLassert.H"
+#include "AMReX_FArrayBox.H"
+#include "AMReX_FluxRegister.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_REAL.H"
+
+namespace quokka
+{
+
+using Real = amrex::Real;
+
+/// Non-owning view of a composite state with one cell-centered MultiFab and
+/// optional face-centered MultiFabs.
+struct CompositeStateView
+{
+	amrex::MultiFab *cc = nullptr;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> *fc_data = nullptr;
+	std::array<amrex::MultiFab *, AMREX_SPACEDIM> fc{};
+
+	[[nodiscard]] auto hasCellState() const -> bool { return cc != nullptr; }
+
+	[[nodiscard]] auto hasFaceState() const -> bool
+	{
+		for (auto *ptr : fc) {
+			if (ptr != nullptr) {
+				return true;
+			}
+		}
+		return false;
+	}
+};
+
+/// Owned scratch state used by the integrator for intermediate RK stages.
+struct CompositeStateData
+{
+	amrex::MultiFab cc;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> fc{};
+	bool has_face_state = false;
+
+	void defineLike(CompositeStateView const &reference, int nghost_cc, int nghost_fc)
+	{
+		AMREX_ASSERT(reference.cc != nullptr);
+
+		cc.define(reference.cc->boxArray(), reference.cc->DistributionMap(), reference.cc->nComp(), nghost_cc, amrex::MFInfo(),
+			  reference.cc->Factory());
+
+		has_face_state = false;
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			if (reference.fc[dir] != nullptr) {
+				fc[dir].define(reference.fc[dir]->boxArray(), reference.fc[dir]->DistributionMap(), reference.fc[dir]->nComp(), nghost_fc,
+					       amrex::MFInfo(), reference.fc[dir]->Factory());
+				has_face_state = true;
+			}
+		}
+	}
+
+	auto view() -> CompositeStateView
+	{
+		CompositeStateView state{};
+		state.cc = &cc;
+		state.fc_data = &fc;
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			state.fc[dir] = has_face_state ? &fc[dir] : nullptr;
+		}
+		return state;
+	}
+
+	void copyFrom(CompositeStateView const &src, int nghost = 0)
+	{
+		AMREX_ASSERT(src.cc != nullptr);
+		amrex::MultiFab::Copy(cc, *src.cc, 0, 0, cc.nComp(), nghost);
+
+		if (has_face_state) {
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				if (src.fc[dir] != nullptr) {
+					amrex::MultiFab::Copy(fc[dir], *src.fc[dir], 0, 0, fc[dir].nComp(), nghost);
+				}
+			}
+		}
+	}
+};
+
+/// Short-lived temporaries used while constructing and validating one RK stage.
+struct StageScratch
+{
+	amrex::MultiFab rhs_cc;
+	amrex::iMultiFab redo_flag;
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> fluxes_hi{};
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> fluxes_lo{};
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> face_vel{};
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> emf{};
+
+	bool has_redo_flag = false;
+	bool has_fluxes_hi = false;
+	bool has_fluxes_lo = false;
+	bool has_face_vel = false;
+	bool has_emf = false;
+
+	void clearFlags()
+	{
+		has_redo_flag = false;
+		has_fluxes_hi = false;
+		has_fluxes_lo = false;
+		has_face_vel = false;
+		has_emf = false;
+	}
+};
+
+/// Running quantities that genuinely need to persist across RK stages.
+struct StepAccumulators
+{
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> avg_face_vel{};
+	bool has_avg_face_vel = false;
+
+	void defineFaceVelocityLike(CompositeStateView const &reference, int nghost)
+	{
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			AMREX_ASSERT(reference.cc != nullptr);
+			auto ba_fc = amrex::convert(reference.cc->boxArray(), amrex::IntVect::TheDimensionVector(dir));
+			avg_face_vel[dir].define(ba_fc, reference.cc->DistributionMap(), 1, nghost);
+			avg_face_vel[dir].setVal(0.0);
+		}
+		has_avg_face_vel = true;
+	}
+
+	void reset()
+	{
+		if (has_avg_face_vel) {
+			for (auto &mf : avg_face_vel) {
+				mf.setVal(0.0);
+			}
+		}
+	}
+};
+
+/// SSPRK2 stage description for Quokka's hydro update.
+struct SSPRK2Scheme
+{
+	static constexpr int nstages = 2;
+
+	/// Stage times t_n + c_s * dt.
+	static constexpr std::array<Real, nstages> c = {Real(0.0), Real(1.0)};
+
+	/// Weights for time-integrated face quantities accumulated per stage, e.g.
+	/// flux-register increments or average face velocity.
+	static constexpr std::array<Real, nstages> stage_integral_weights = {Real(0.5), Real(0.5)};
+};
+
+namespace detail
+{
+template <typename Policy>
+concept HasDefine = requires(Policy &policy, int lev, CompositeStateView const &reference) {
+	{ policy.define(lev, reference) };
+};
+
+template <typename Policy>
+concept HasResetAccumulators = requires(Policy &policy, StepAccumulators &accum) {
+	{ policy.reset_accumulators(accum) };
+};
+} // namespace detail
+
+/// Generic stage-driven RK integrator for Quokka composite state.
+///
+/// Policy interface expected by this class:
+///   void define(int lev, CompositeStateView const& reference);
+///   int nghost_cc() const;
+///   int nghost_fc() const;
+///   void define_stage_scratch(StageScratch&, CompositeStateView const&, int lev) const;
+///   void define_step_accumulators(StepAccumulators&, CompositeStateView const&, int lev) const;
+///   void fill_boundary(int stage, CompositeStateView, Real stage_time) const;
+///   void compute_stage(int stage, StageScratch&, CompositeStateView const&, Real stage_time, Real dt_stage) const;
+///   void update_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
+///                     StageScratch const&, Real dt) const;
+///   auto validate_stage(int stage, CompositeStateView, CompositeStateView const&, CompositeStateView const&,
+///                       StageScratch&, Real dt) const -> bool;
+///   void post_stage(int stage, CompositeStateView, StageScratch const&, Real stage_time, Real dt) const;
+///   void accumulate_stage(int stage, StageScratch const&, Real dt, StepAccumulators&) const;
+///   void finalize_step(CompositeStateView, Real time, Real dt, StepAccumulators const&) const;
+template <typename Policy, typename Scheme = SSPRK2Scheme> class RKIntegrator
+{
+      public:
+	explicit RKIntegrator(Policy policy) : policy_(std::move(policy)) {}
+
+	void define(int lev, CompositeStateView const &reference)
+	{
+		lev_ = lev;
+		if constexpr (detail::HasDefine<Policy>) {
+			policy_.define(lev, reference);
+		}
+
+		stage_state_.defineLike(reference, policy_.nghost_cc(), policy_.nghost_fc());
+		policy_.define_stage_scratch(scratch_, reference, lev);
+		policy_.define_step_accumulators(accumulators_, reference, lev);
+		defined_ = true;
+	}
+
+	auto advance(CompositeStateView const &old_state, CompositeStateView new_state, Real time, Real dt) -> bool
+	{
+		AMREX_ASSERT(defined_);
+		AMREX_ASSERT(old_state.cc != nullptr);
+		AMREX_ASSERT(new_state.cc != nullptr);
+
+		if constexpr (detail::HasResetAccumulators<Policy>) {
+			policy_.reset_accumulators(accumulators_);
+		} else {
+			accumulators_.reset();
+		}
+
+		auto stage_state = stage_state_.view();
+		CompositeStateView stage_input = old_state;
+
+		for (int stage = 0; stage < Scheme::nstages; ++stage) {
+			const Real stage_time = time + Scheme::c[stage] * dt;
+			const Real dt_stage = Scheme::stage_integral_weights[stage] * dt;
+			CompositeStateView stage_output = (stage == Scheme::nstages - 1) ? new_state : stage_state;
+
+			policy_.fill_boundary(stage + 1, stage_input, stage_time);
+			policy_.compute_stage(stage + 1, scratch_, stage_input, stage_time, dt_stage);
+			policy_.update_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
+
+			const bool stage_ok = policy_.validate_stage(stage + 1, stage_output, old_state, stage_input, scratch_, dt);
+			if (!stage_ok) {
+				return false;
+			}
+
+			policy_.post_stage(stage + 1, stage_output, scratch_, stage_time, dt);
+			policy_.accumulate_stage(stage + 1, scratch_, dt, accumulators_);
+			stage_input = stage_output;
+		}
+
+		policy_.finalize_step(new_state, time, dt, accumulators_);
+		return true;
+	}
+
+	[[nodiscard]] auto getAccumulators() const -> StepAccumulators const & { return accumulators_; }
+
+      private:
+	Policy policy_;
+	int lev_ = -1;
+	bool defined_ = false;
+	CompositeStateData stage_state_;
+	StageScratch scratch_;
+	StepAccumulators accumulators_;
+};
+
+/// Hydro/MHD-oriented policy interface sketch for use with RKIntegrator.
+///
+/// This is an interface contract, not a base class with virtual dispatch.
+/// A concrete policy can be templated on `problem_t` and hold any Quokka state
+/// needed to compute fluxes, fill boundaries, and update reflux registers.
+struct HydroRKPolicyInterface
+{
+	[[nodiscard]] auto nghost_cc() const -> int;
+	[[nodiscard]] auto nghost_fc() const -> int;
+
+	void define(int lev, CompositeStateView const &reference);
+	void define_stage_scratch(StageScratch &scratch, CompositeStateView const &reference, int lev) const;
+	void define_step_accumulators(StepAccumulators &accum, CompositeStateView const &reference, int lev) const;
+	void reset_accumulators(StepAccumulators &accum) const;
+
+	void fill_boundary(int stage, CompositeStateView state, Real stage_time) const;
+
+	void compute_stage(int stage, StageScratch &scratch, CompositeStateView const &input, Real stage_time, Real dt_stage) const;
+
+	void update_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
+			  StageScratch const &scratch, Real dt) const;
+
+	/// Returns false if the stage failed and the caller should reject the step.
+	auto validate_stage(int stage, CompositeStateView output, CompositeStateView const &old_state, CompositeStateView const &stage_input,
+			    StageScratch &scratch, Real dt) const -> bool;
+
+	void post_stage(int stage, CompositeStateView output, StageScratch const &scratch, Real stage_time, Real dt) const;
+
+	/// Perform per-stage flux-register / EMF-register increments and update any
+	/// step-spanning accumulators such as time-averaged face velocity.
+	void accumulate_stage(int stage, StageScratch const &scratch, Real dt, StepAccumulators &accum) const;
+
+	void finalize_step(CompositeStateView new_state, Real time, Real dt, StepAccumulators const &accum) const;
+};
+
+} // namespace quokka
+
+#endif // RKINTEGRATOR_HPP_

--- a/src/math/RKIntegrator.hpp
+++ b/src/math/RKIntegrator.hpp
@@ -175,10 +175,7 @@ namespace detail
 consteval auto abs_constexpr(Real x) -> Real { return (x < static_cast<Real>(0.0)) ? -x : x; }
 
 struct LowStorageFormError : std::exception {
-	[[nodiscard]] auto what() const noexcept -> char const * override
-	{
-		return "RK scheme cannot be represented with a single previous-stage state.";
-	}
+	[[nodiscard]] auto what() const noexcept -> char const * override { return "RK scheme cannot be represented with a single previous-stage state."; }
 };
 
 consteval void require_low_storage_form(bool ok)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -343,7 +343,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	// AMR utility functions
 	template <typename PreInterpHook, typename PostInterpHook>
 	void fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int lev, amrex::Real time, quokka::centering cen, quokka::direction dir,
-				    PreInterpHook const &pre_interp, PostInterpHook const &post_interp, FillPatchType fptype = FillPatchType::fillpatch_class);
+				    PreInterpHook const &pre_interp, PostInterpHook const &post_interp, FillPatchType fptype = FillPatchType::fillpatch_class,
+				    int checked_ncomp = -1);
 
 	template <typename PreInterpHook, typename PostInterpHook>
 	void FillPatchWithData(int lev, amrex::Real time, amrex::MultiFab &mf, amrex::Vector<amrex::MultiFab *> &coarseData,
@@ -3113,7 +3114,7 @@ template <typename problem_t>
 template <typename PreInterpHook, typename PostInterpHook>
 void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled, amrex::MultiFab &state, int const lev, amrex::Real const time,
 						      quokka::centering cen, quokka::direction dir, PreInterpHook const &pre_interp,
-						      PostInterpHook const &post_interp, FillPatchType fptype)
+						      PostInterpHook const &post_interp, FillPatchType fptype, int checked_ncomp)
 {
 	BL_PROFILE("AMRSimulation::fillBoundaryConditions()"); // NOLINT(misc-const-correctness)
 
@@ -3132,6 +3133,11 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 		throw std::runtime_error("Only cell-centred (cc) and face-centred (fc) variables are supported, thus far.");
 	}
 
+	const int checked_comps = (checked_ncomp >= 0) ? checked_ncomp : state.nComp();
+	AMREX_ASSERT(checked_comps > 0);
+	AMREX_ASSERT(checked_comps <= state.nComp());
+	AMREX_ASSERT(checked_comps <= S_filled.nComp());
+
 	amrex::Vector<amrex::BCRec> BCs;
 	if (cen == quokka::centering::cc) {
 		BCs = BCs_cc_;
@@ -3147,11 +3153,11 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 
 		// returns old state, new state, or both depending on 'time'
 		GetData(lev - 1, time, coarseData, coarseTime, cen, dir);
-		AMREX_ASSERT(!state.contains_nan(0, state.nComp()));
+		AMREX_ASSERT(!state.contains_nan(0, checked_comps, state.nGrowVect()));
 
 		for (auto &i : coarseData) {
-			AMREX_ASSERT(!i->contains_nan(0, state.nComp()));
-			AMREX_ASSERT(!i->contains_nan()); // check ghost zones
+			AMREX_ASSERT(checked_comps <= i->nComp());
+			AMREX_ASSERT(!i->contains_nan(0, checked_comps, i->nGrowVect()));
 			amrex::ignore_unused(i);
 		}
 
@@ -3186,11 +3192,7 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 
 	// ensure that there are no NaNs (can happen when domain boundary filling is
 	// unimplemented or malfunctioning)
-	AMREX_ASSERT(!S_filled.contains_nan(0, S_filled.nComp()));
-	AMREX_ASSERT(!S_filled.contains_nan()); // check ghost zones (usually this is caused by
-						// forgetting to fill some components when
-						// using custom Dirichlet BCs, e.g., radiation
-						// variables in a hydro-only problem)
+	AMREX_ASSERT(!S_filled.contains_nan(0, checked_comps, S_filled.nGrowVect()));
 }
 
 // Compute a new multifab 'mf' by copying in state from given data and filling

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3134,6 +3134,9 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 	}
 
 	const int checked_comps = (checked_ncomp >= 0) ? checked_ncomp : state.nComp();
+#if defined(NDEBUG) && !defined(AMREX_USE_ASSERTION)
+	amrex::ignore_unused(checked_comps);
+#endif
 	AMREX_ASSERT(checked_comps > 0);
 	AMREX_ASSERT(checked_comps <= state.nComp());
 	AMREX_ASSERT(checked_comps <= S_filled.nComp());

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3933,7 +3933,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::createRuntimeDerive
 		particleRegister_.depositParticleMassDensity(particleType, deposit_birth_mass, outMF, outLev, outComp, massMin, massMax, hasAgeFilter, tNew_[0],
 							     tAgeMax);
 #else
-		amrex::ignore_unused(depositField, outMF, outLev, outComp, massMin, massMax, hasAgeFilter, tAgeMax);
+		amrex::ignore_unused(particleType, depositField, outMF, outLev, outComp, massMin, massMax, hasAgeFilter, tAgeMax);
 		amrex::Abort("Particle deposition runtime derived fields are supported only in 3D.");
 #endif
 	};

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2276,7 +2276,6 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 
 	if (fr_as_crse != nullptr) {
 		AMREX_ASSERT(lev < finestLevel());
-		AMREX_ASSERT(fr_as_crse == flux_reg_[lev + 1].get());
 		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
 			int const ncomp = fluxArrays[dir].nComp();
 			if (ncomp == 0) {
@@ -2288,7 +2287,6 @@ void AMRSimulation<problem_t>::incrementFluxRegisters(amrex::FluxRegister *fr_as
 
 	if (fr_as_fine != nullptr) {
 		AMREX_ASSERT(lev > 0);
-		AMREX_ASSERT(fr_as_fine == flux_reg_[lev].get());
 		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
 			int const ncomp = fluxArrays[dir].nComp();
 			if (ncomp == 0) {
@@ -2309,14 +2307,12 @@ void AMRSimulation<problem_t>::incrementEMFRegisters(amrex::EdgeFluxRegister *em
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		if (emf_as_crse != nullptr) {
 			AMREX_ASSERT(lev < finestLevel());
-			AMREX_ASSERT(emf_as_crse == emf_reg_[lev + 1].get());
 			emf_as_crse->CrseAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
 					     dt_lev);
 		}
 
 		if (emf_as_fine != nullptr) {
 			AMREX_ASSERT(lev > 0);
-			AMREX_ASSERT(emf_as_fine == emf_reg_[lev].get());
 			emf_as_fine->FineAdd(mfi, {ec_emf_components[0].fabPtr(mfi), ec_emf_components[1].fabPtr(mfi), ec_emf_components[2].fabPtr(mfi)},
 					     dt_lev);
 		}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2413,6 +2413,9 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 	amrex::MultiFab int_state_new_cc(ba, dm, ncomp_cc, nghost_cc);
 	amrex::MultiFab int_state_old_cc(ba, dm, ncomp_cc, nghost_cc);
 	FillPatch(level, time, int_state_new_cc, 0, ncomp_cc, quokka::centering::cc, quokka::direction::na, FillPatchType::fillpatch_function);
+	// Remapped fine data is defined at the current time only. Keep old/new in sync so
+	// the next timestep swap does not expose uninitialized cell-centered state.
+	int_state_old_cc.ParallelCopy(int_state_new_cc, 0, 0, ncomp_cc, nghost_cc, nghost_cc);
 	std::swap(int_state_new_cc, state_new_cc_[level]);
 	std::swap(int_state_old_cc, state_old_cc_[level]);
 
@@ -3156,7 +3159,9 @@ void AMRSimulation<problem_t>::fillBoundaryConditions(amrex::MultiFab &S_filled,
 
 		// returns old state, new state, or both depending on 'time'
 		GetData(lev - 1, time, coarseData, coarseTime, cen, dir);
-		AMREX_ASSERT(!state.contains_nan(0, checked_comps, state.nGrowVect()));
+		// The source MultiFab's valid region must be initialized here, but its ghost cells
+		// may still be undefined because this routine is about to fill them.
+		AMREX_ASSERT(!state.contains_nan(0, checked_comps));
 
 		for (auto &i : coarseData) {
 			AMREX_ASSERT(checked_comps <= i->nComp());


### PR DESCRIPTION
### Description
This introduces a generic `quokka::RKIntegrator` class that can be re-used for multiple physics modules, and rewrites the hydro update function `AdvanceHydroAtLevel` to use it.

Compared to the AMReX RK class, `quokka::RKIntegrator` adds the ability to advance multiple multifabs within the integrator, which is required for MHD. It also allows computing a provisional update, then optionally redoing the update with low-order fluxes surrounding bad cells. Once it is stablized in Quokka, this functionality may be migrated to AMReX's RK integrator for maintainability.

The hydro integrator now does FOFC / fail-safe per-stage, rather than across the whole level step:
  * [Balsara et al. (2025)](https://scixplorer.org/abs/2025ApJ...988..134B/abstract) show that this restores stability to high-order hydro schemes in extreme flows, but
  * May produce a lower-quality solution in the FOFC cells (it's no longer a forward Euler time update in those cells)
  * Significantly lower memory high-water mark
  * Significantly reduced complexity
  * Possible to extend hydro to IMEX in the future

Note that when doing FOFC per-stage, it is critical to use a positivity-preserving Riemann solver with a positivity-preserving timestep near the CFL timestep (e.g. LLF). HLLC/HLLD do not work (positivity preserving if wavespeeds are accurate, but timestep can be arbitrarily small). This may be why my original experiments doing this per-stage did not work. It is also critical to use a time integrator with the SSP property.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
