### PR TITLE
Make reconstruction array APIs consistent

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3324,16 +3324,16 @@ void QuokkaSimulation<problem_t>::fluxFunction(amrex::Array4<const amrex::Real> 
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM_EP<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(), reconstructRange,
 										   x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 3) {
-		// mixed interface/cell-centered kernel
+		// cell-centered kernel writing face-indexed outputs
 		HyperbolicSystem<problem_t>::template ReconstructStatesPPM<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(), reconstructRange,
 										x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 2) {
-		// PLM and donor cell are interface-centered kernels
+		// cell-centered kernel writing face-indexed outputs
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(primVar.array(), x1LeftState.array(), x1RightState.array(),
-												     x1ReconstructRange, nvars);
+												     reconstructRange, x1ReconstructRange, nvars);
 	} else if (radiationReconstructionOrder_ == 1) {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(primVar.array(), x1LeftState.array(), x1RightState.array(),
-										     x1ReconstructRange, nvars);
+										     reconstructRange, x1ReconstructRange, nvars);
 	} else {
 		amrex::Abort("Invalid reconstruction order for radiation variables! Aborting...");
 	}

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -917,25 +917,25 @@ void MHDSystem<problem_t>::ReconstructTo(FluxDir dir, arrayconst_t &cState, arra
 	} else if (reconstructionOrder == 2) {
 		switch (dir) {
 			case FluxDir::X1:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X1>(cState, lState, rState, box_r, 1, plmLimiter);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X1>(cState, lState, rState, box_r, box_r_x1, 1, plmLimiter);
 				break;
 			case FluxDir::X2:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X2>(cState, lState, rState, box_r, 1, plmLimiter);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X2>(cState, lState, rState, box_r, box_r_x1, 1, plmLimiter);
 				break;
 			case FluxDir::X3:
-				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X3>(cState, lState, rState, box_r, 1, plmLimiter);
+				MHDSystem<problem_t>::template ReconstructStatesPLM<FluxDir::X3>(cState, lState, rState, box_r, box_r_x1, 1, plmLimiter);
 				break;
 		}
 	} else if (reconstructionOrder == 1) {
 		switch (dir) {
 			case FluxDir::X1:
-				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X1>(cState, lState, rState, box_r_x1, 1);
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X1>(cState, lState, rState, box_r, box_r_x1, 1);
 				break;
 			case FluxDir::X2:
-				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X2>(cState, lState, rState, box_r_x1, 1);
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X2>(cState, lState, rState, box_r, box_r_x1, 1);
 				break;
 			case FluxDir::X3:
-				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X3>(cState, lState, rState, box_r_x1, 1);
+				MHDSystem<problem_t>::template ReconstructStatesConstant<FluxDir::X3>(cState, lState, rState, box_r, box_r_x1, 1);
 				break;
 		}
 	} else {

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -90,12 +90,18 @@ template <typename problem_t> class HyperbolicSystem
 		return std::max(std::min(a, b), std::min(std::max(a, b), c));
 	}
 
+	template <FluxDir DIR> static void AssertReconstructionRanges(amrex::Box const &cellRange, amrex::Box const &interfaceRange)
+	{
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(amrex::surroundingNodes(cellRange, static_cast<int>(DIR)) == interfaceRange,
+						 "Reconstruction interfaceRange must equal surroundingNodes(cellRange, dir).");
+	}
+
 	template <FluxDir DIR>
 	static void ReconstructStatesConstant(amrex::MultiFab const &q, amrex::MultiFab &leftState, amrex::MultiFab &rightState, int nghost, int nvars);
 
 	template <FluxDir DIR>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void ReconstructStatesConstant(arrayconst_t &q, array_t &leftState, array_t &rightState,
-										       amrex::Box const &indexRange, int nvars);
+										       amrex::Box const &cellRange, amrex::Box const &interfaceRange, int nvars);
 
 	template <FluxDir DIR>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void
@@ -111,10 +117,11 @@ template <typename problem_t> class HyperbolicSystem
 
 	template <FluxDir DIR, SlopeLimiter limiter>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState,
-										  amrex::Box const &indexRange, int nvars);
+										  amrex::Box const &cellRange, amrex::Box const &interfaceRange, int nvars);
 
 	template <FluxDir DIR>
-	static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState, amrex::Box const &indexRange, int nvars,
+	static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState, amrex::Box const &cellRange,
+					 amrex::Box const &interfaceRange, int nvars,
 					 SlopeLimiter limiter);
 
 	template <FluxDir DIR, SlopeLimiter limiter>
@@ -207,14 +214,17 @@ void HyperbolicSystem<problem_t>::ReconstructStatesConstant(amrex::MultiFab cons
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesConstant(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-										  amrex::Box const &indexRange, const int nvars)
+										  amrex::Box const &cellRange, amrex::Box const &interfaceRange,
+										  const int nvars)
 {
+	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
+
 	// construct ArrayViews for permuted indices
 	quokka::Array4View<amrex::Real const, DIR> q(q_in);
 	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
 	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
 
-	amrex::ParallelFor(indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	amrex::ParallelFor(cellRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
 		HyperbolicSystem<problem_t>::template ReconstructStatesConstant<DIR>(q, leftState, rightState, n, i_in, j_in, k_in);
 	});
 }
@@ -234,7 +244,7 @@ AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesConstan
 	// is the "left"-side of the interface at the left edge of zone i, and xright_(i) is the
 	// "right"-side of the interface at the *left* edge of zone i. [Indexing note: There are (nx
 	// + 1) interfaces for nx zones.]
-	leftState(i, j, k, n) = q(i - 1, j, k, n);
+	leftState(i + 1, j, k, n) = q(i, j, k, n);
 	rightState(i, j, k, n) = q(i, j, k, n);
 }
 
@@ -286,36 +296,40 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPLM(amrex::MultiFab const &q_
 template <typename problem_t>
 template <FluxDir DIR, SlopeLimiter limiter>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-									     amrex::Box const &indexRange, const int nvars)
+									     amrex::Box const &cellRange, amrex::Box const &interfaceRange,
+									     const int nvars)
 {
+	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
+
 	// construct ArrayViews for permuted indices
 	quokka::Array4View<amrex::Real const, DIR> q(q_in);
 	quokka::Array4View<amrex::Real, DIR> leftState(leftState_in);
 	quokka::Array4View<amrex::Real, DIR> rightState(rightState_in);
 
-	amrex::ParallelFor(indexRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
+	amrex::ParallelFor(cellRange, nvars, [=] AMREX_GPU_DEVICE(int i_in, int j_in, int k_in, int n) noexcept {
 		HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, limiter>(q, leftState, rightState, n, i_in, j_in, k_in);
 	});
 }
 
 template <typename problem_t>
 template <FluxDir DIR>
-void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in, amrex::Box const &indexRange,
-						       const int nvars, SlopeLimiter limiter)
+void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in, amrex::Box const &cellRange,
+						       amrex::Box const &interfaceRange, const int nvars, SlopeLimiter limiter)
 {
 	switch (limiter) {
 		case SlopeLimiter::minmod: {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(q_in, leftState_in, rightState_in, indexRange,
-													      nvars);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::minmod>(q_in, leftState_in, rightState_in, cellRange,
+													      interfaceRange, nvars);
 			break;
 		}
 		case SlopeLimiter::sweby: {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(q_in, leftState_in, rightState_in, indexRange,
-													     nvars);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::sweby>(q_in, leftState_in, rightState_in, cellRange,
+													     interfaceRange, nvars);
 			break;
 		}
 		case SlopeLimiter::mc: {
-			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::mc>(q_in, leftState_in, rightState_in, indexRange, nvars);
+			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::mc>(q_in, leftState_in, rightState_in, cellRange,
+												  interfaceRange, nvars);
 			break;
 		}
 		default: {
@@ -350,10 +364,9 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 
 	// Use piecewise-linear reconstruction
 	// (This converges at second order in spatial resolution.)
-	const auto lslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i, j, k, n) - q(i - 1, j, k, n), q(i - 1, j, k, n) - q(i - 2, j, k, n));
-	const auto rslope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
-	leftState(i, j, k, n) = q(i - 1, j, k, n) + 0.5 * lslope; // NOLINT
-	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * rslope;	  // NOLINT
+	const auto slope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
+	leftState(i + 1, j, k, n) = q(i, j, k, n) + 0.5 * slope; // NOLINT
+	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * slope;	  // NOLINT
 }
 
 template <typename problem_t>
@@ -382,10 +395,11 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPPM(amrex::MultiFab const &q_
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-									     amrex::Box const &cellRange, amrex::Box const & /*interfaceRange*/,
+									     amrex::Box const &cellRange, amrex::Box const &interfaceRange,
 									     const int nvars, const int iReadFrom, const int iWriteFrom)
 {
 	const BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM(Arrays)");
+	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
 
 	// construct ArrayViews for permuted indices
 	quokka::Array4View<amrex::Real const, DIR> q(q_in);
@@ -609,10 +623,11 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPPM_EP(amrex::MultiFab const 
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM_EP(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-										amrex::Box const &cellRange, amrex::Box const & /*interfaceRange*/,
+										amrex::Box const &cellRange, amrex::Box const &interfaceRange,
 										const int nvars, const int iReadFrom, const int iWriteFrom)
 {
 	const BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM(Arrays)");
+	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
 
 	// construct ArrayViews for permuted indices
 	quokka::Array4View<amrex::Real const, DIR> q(q_in);

--- a/src/hyperbolic_system.hpp
+++ b/src/hyperbolic_system.hpp
@@ -101,7 +101,8 @@ template <typename problem_t> class HyperbolicSystem
 
 	template <FluxDir DIR>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void ReconstructStatesConstant(arrayconst_t &q, array_t &leftState, array_t &rightState,
-										       amrex::Box const &cellRange, amrex::Box const &interfaceRange, int nvars);
+										       amrex::Box const &cellRange, amrex::Box const &interfaceRange,
+										       int nvars);
 
 	template <FluxDir DIR>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void
@@ -121,8 +122,7 @@ template <typename problem_t> class HyperbolicSystem
 
 	template <FluxDir DIR>
 	static void ReconstructStatesPLM(arrayconst_t &q, array_t &leftState, array_t &rightState, amrex::Box const &cellRange,
-					 amrex::Box const &interfaceRange, int nvars,
-					 SlopeLimiter limiter);
+					 amrex::Box const &interfaceRange, int nvars, SlopeLimiter limiter);
 
 	template <FluxDir DIR, SlopeLimiter limiter>
 	AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE static void
@@ -296,8 +296,7 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPLM(amrex::MultiFab const &q_
 template <typename problem_t>
 template <FluxDir DIR, SlopeLimiter limiter>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-									     amrex::Box const &cellRange, amrex::Box const &interfaceRange,
-									     const int nvars)
+									     amrex::Box const &cellRange, amrex::Box const &interfaceRange, const int nvars)
 {
 	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
 
@@ -329,7 +328,7 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPLM(arrayconst_t &q_in, array
 		}
 		case SlopeLimiter::mc: {
 			HyperbolicSystem<problem_t>::template ReconstructStatesPLM<DIR, SlopeLimiter::mc>(q_in, leftState_in, rightState_in, cellRange,
-												  interfaceRange, nvars);
+													  interfaceRange, nvars);
 			break;
 		}
 		default: {
@@ -366,7 +365,7 @@ HyperbolicSystem<problem_t>::ReconstructStatesPLM(quokka::Array4View<amrex::Real
 	// (This converges at second order in spatial resolution.)
 	const auto slope = HyperbolicSystem<problem_t>::template SlopeFunc<limiter>(q(i + 1, j, k, n) - q(i, j, k, n), q(i, j, k, n) - q(i - 1, j, k, n));
 	leftState(i + 1, j, k, n) = q(i, j, k, n) + 0.5 * slope; // NOLINT
-	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * slope;	  // NOLINT
+	rightState(i, j, k, n) = q(i, j, k, n) - 0.5 * slope;	 // NOLINT
 }
 
 template <typename problem_t>
@@ -395,8 +394,8 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPPM(amrex::MultiFab const &q_
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-									     amrex::Box const &cellRange, amrex::Box const &interfaceRange,
-									     const int nvars, const int iReadFrom, const int iWriteFrom)
+									     amrex::Box const &cellRange, amrex::Box const &interfaceRange, const int nvars,
+									     const int iReadFrom, const int iWriteFrom)
 {
 	const BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM(Arrays)");
 	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);
@@ -623,8 +622,8 @@ void HyperbolicSystem<problem_t>::ReconstructStatesPPM_EP(amrex::MultiFab const 
 template <typename problem_t>
 template <FluxDir DIR>
 AMREX_GPU_HOST_DEVICE void HyperbolicSystem<problem_t>::ReconstructStatesPPM_EP(arrayconst_t &q_in, array_t &leftState_in, array_t &rightState_in,
-										amrex::Box const &cellRange, amrex::Box const &interfaceRange,
-										const int nvars, const int iReadFrom, const int iWriteFrom)
+										amrex::Box const &cellRange, amrex::Box const &interfaceRange, const int nvars,
+										const int iReadFrom, const int iWriteFrom)
 {
 	const BL_PROFILE("HyperbolicSystem::ReconstructStatesPPM(Arrays)");
 	HyperbolicSystem<problem_t>::template AssertReconstructionRanges<DIR>(cellRange, interfaceRange);


### PR DESCRIPTION
### Description
This makes the function arguments for constant, PLM, and (x)PPM reconstructions all identical.

When I originally wrote the code, I used a different API for PLM and PPM reconstruction functions, where PLM accepted a face-centered indexing range, and PPM accepted both a face-centered and cell-centered indexing range. This was a bad design. This changes all reconstruction functions to work like PPM, which fixes an indexing bug that only appeared for PLM.

Bug found and fix originally suggested by @tianninglyu and @mxchen39 in #1807 

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
