### PR TITLE
add Context7 chat widget to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ Backtrace.*
 *.png
 
 /docs/site/*
+/docs/.venv/
+/docs/.cache/
 
 # Documentation build directory
 docs/api/

--- a/docs/markdown/developer_onboarding.md
+++ b/docs/markdown/developer_onboarding.md
@@ -26,12 +26,11 @@
 - **Automated tests.** `ninja test` or `ctest` exercises the bundled problem suite; for full GPU coverage, rely on the regression harness described earlier ([installation guide](installation.md), [quokka-tests.ini](https://github.com/quokka-astro/quokka/blob/development/regression/quokka-tests.ini#L65-L146)).
 - **Static analysis.** Run `clang-tidy` manually or via `scripts/tidy.sh` to match the repository’s CI checks, as documented in the How to Use clang-tidy guide ([clang-tidy how-to](howto_clang_tidy.md)).
 - **CUDA builds on macOS or Linux.** To build and test CUDA functionality locally, run `./scripts/bash/run-cuda-container.sh`. This script pulls the appropriate Docker image, launches a container, and performs a CUDA build—useful for catching CUDA-specific issues on your development machine.
-- **Writing and building documentation.** The developer is responsible for updating the documentation site. To build and view the documentation site locally:
+- **Writing and building documentation.** The developer is responsible for updating the documentation site. To start the live-reloading documentation server locally:
 ```bash
-pip install -r docs/requirements.txt
-./scripts/bash/build_and_view_docs.sh
+bash ./scripts/bash/docs_serve.sh
 ```
-Then open `http://[::]:8000/` in your browser to view the documentation locally.
+This uses `docs/.venv` and installs `docs/requirements.txt` automatically on first run. To build the static site without the live server, run `bash ./scripts/bash/docs_build.sh`.
 
 ## Where to dive deeper next
 1. **Physics modules.** Explore `src/hydro/` and `src/radiation/` alongside the corresponding documentation pages (`hydro_integrator.md`, radiation topics) to understand scheme implementations ([QuokkaSimulation.hpp](https://github.com/quokka-astro/quokka/blob/development/src/QuokkaSimulation.hpp#L66-L200), [overview page](index.md)).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,6 +3,7 @@ docs_dir: markdown
 copyright: © Copyright 2020-2025, Ben Wibking and Quokka Developers.
 theme:
   name: material
+  custom_dir: overrides
   favicon: media/quokka-favicon.svg
   font:
     text: Source Sans Pro

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <script
+    src="https://context7.com/widget.js"
+    data-library="/quokka-astro/quokka"
+  ></script>
+{% endblock %}

--- a/scripts/bash/docs_build.sh
+++ b/scripts/bash/docs_build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-set -e # Exit with nonzero exit code if anything fails
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 echo "Build the HTML documentation using MkDocs"
-cd docs
-mkdocs build
+bash "$SCRIPT_DIR/docs_mkdocs.sh" build "$@"

--- a/scripts/bash/docs_build_and_view.sh
+++ b/scripts/bash/docs_build_and_view.sh
@@ -1,16 +1,18 @@
 #!/bin/bash
-set -e # Exit with nonzero exit code if anything fails
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
 
 echo "Build the HTML documentation using MkDocs"
-cd docs
-mkdocs build
+bash "$SCRIPT_DIR/docs_mkdocs.sh" build "$@"
 
-cd site
+cd "$REPO_ROOT/docs/site"
 
 # Find an available port with smart port selection
-if [ -n "$PORT" ]; then
+if [ -n "${PORT:-}" ]; then
     # User specified a port via environment variable
-    if lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; then
         echo "Error: Specified port $PORT is already in use"
         exit 1
     fi
@@ -24,12 +26,12 @@ else
     done
 
     # If no common ports available, find next available port starting from 8080
-    if [ -z "$PORT" ]; then
+    if [ -z "${PORT:-}" ]; then
         PORT=8080
         MAX_ATTEMPTS=100
         attempts=0
 
-        while lsof -Pi :$PORT -sTCP:LISTEN -t >/dev/null 2>&1; do
+        while lsof -Pi :"$PORT" -sTCP:LISTEN -t >/dev/null 2>&1; do
             PORT=$((PORT + 1))
             attempts=$((attempts + 1))
             if [ $attempts -ge $MAX_ATTEMPTS ]; then
@@ -41,4 +43,4 @@ else
 fi
 
 echo "Serving documentation on http://localhost:$PORT"
-python3 -m http.server $PORT
+python3 -m http.server "$PORT"

--- a/scripts/bash/docs_mkdocs.sh
+++ b/scripts/bash/docs_mkdocs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/../.." && pwd)
+DOCS_DIR="$REPO_ROOT/docs"
+VENV_DIR="$DOCS_DIR/.venv"
+PYTHON_BIN="$VENV_DIR/bin/python"
+MKDOCS_BIN="$VENV_DIR/bin/mkdocs"
+STAMP_FILE="$VENV_DIR/.docs-requirements.sha256"
+REQUIREMENTS_FILE="$DOCS_DIR/requirements.txt"
+CACHE_DIR="$DOCS_DIR/.cache"
+
+mkdir -p "$CACHE_DIR/pip" "$VENV_DIR/.pycache"
+export PIP_CACHE_DIR="$CACHE_DIR/pip"
+export PYTHONPYCACHEPREFIX="$VENV_DIR/.pycache"
+export XDG_CACHE_HOME="$CACHE_DIR"
+
+if [ ! -x "$PYTHON_BIN" ]; then
+	echo "Creating Python virtual environment in $VENV_DIR"
+	python3 -m venv "$VENV_DIR"
+fi
+
+if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+	echo "Bootstrapping pip in $VENV_DIR"
+	"$PYTHON_BIN" -m ensurepip --upgrade
+fi
+
+requirements_hash=$(shasum -a 256 "$REQUIREMENTS_FILE" | awk '{print $1}')
+install_requirements=false
+
+if [ ! -x "$MKDOCS_BIN" ]; then
+	install_requirements=true
+elif [ ! -f "$STAMP_FILE" ] || [ "$(cat "$STAMP_FILE")" != "$requirements_hash" ]; then
+	install_requirements=true
+elif ! "$PYTHON_BIN" -c "import mermaid2" >/dev/null 2>&1; then
+	install_requirements=true
+fi
+
+if [ "$install_requirements" = true ]; then
+	echo "Installing documentation dependencies from $REQUIREMENTS_FILE"
+	"$PYTHON_BIN" -m pip install -r "$REQUIREMENTS_FILE"
+	printf '%s\n' "$requirements_hash" >"$STAMP_FILE"
+fi
+
+cd "$DOCS_DIR"
+exec "$MKDOCS_BIN" "$@"

--- a/scripts/bash/docs_serve.sh
+++ b/scripts/bash/docs_serve.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+echo "Starting the MkDocs development server"
+bash "$SCRIPT_DIR/docs_mkdocs.sh" serve "$@"


### PR DESCRIPTION
### Description
Adds the Context7 chat widget to the documentation. Users can use this to ask the AI questions about Quokka while browsing the documentation website.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
