### PR TITLE
increase rounding bits for DiskGalaxy regression

### DIFF
--- a/inputs/DiskGalaxy.toml
+++ b/inputs/DiskGalaxy.toml
@@ -81,6 +81,7 @@ quokka.stellarpop_particle_mass.normalization_expr = "1.0/(5.0e6*yr)"
 ## star formation
 particles.eps_ff = 0.01
 particles.low_mass_composite_max_mass = 5.957650359245478e+35   # grams [= 299 Msun]
+particles.reproducibility_roundoff_redundancy = 28
 
 
 ###################################


### PR DESCRIPTION
### Description
Increases the number of mantissa rounding bits to 28 for the DiskGalaxy regression test. This should make it more likely to be bitwise-reproducible.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
