### PR TITLE
keeps the plotfile when a test failed

### DIFF
--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -77,7 +77,7 @@ visVar = gasDensity
 compareParticles = 1
 particleTypes = tracer_particles
 testSrcTree = .
-ignore_return_code = 1
+ignore_return_code = 0
 
 [SedovAMR-GPU]
 buildDir = .
@@ -94,7 +94,7 @@ visVar = gasDensity
 compareParticles = 1
 particleTypes = tracer_particles
 testSrcTree = .
-ignore_return_code = 1
+ignore_return_code = 0
 
 [ShockCloud-GPU]
 buildDir = .
@@ -112,7 +112,7 @@ visVar = temperature
 compareParticles = 1
 particleTypes = tracer_particles
 testSrcTree = .
-ignore_return_code = 1
+ignore_return_code = 0
 
 [RandomBlastAMR-GPU]
 buildDir = .
@@ -215,4 +215,4 @@ compileTest = 0
 doVis = 1
 visVar = gasDensity
 testSrcTree = .
-ignore_return_code = 1
+ignore_return_code = 0


### PR DESCRIPTION
### Description
By setting `ignore_return_code = 0`, regtest.py keeps the plotfile if the test failed.

### Related issues
Plotfile disappeared even if the test failed. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
