### PR TITLE
check changes in mdBook validation

### DIFF
--- a/.github/workflows/docs-toctree.yml
+++ b/.github/workflows/docs-toctree.yml
@@ -17,7 +17,7 @@ jobs:
     name: Validate mdBook summary and build
     runs-on: ubuntu-latest
     needs: check_changes
-    if: needs.check_changes.outputs.has_docs_changes == 'true' || needs.check_changes.outputs.has_specific_workflow_changes == 'true'
+    if: needs.check_changes.outputs.has_docs_changes == 'true' || needs.check_changes.outputs.has_specific_workflow_changes == 'true' || needs.check_changes.outputs.has_scripts_changes == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Set up Rust

--- a/.github/workflows/docs-toctree.yml
+++ b/.github/workflows/docs-toctree.yml
@@ -8,9 +8,16 @@ on:
   pull_request:
 
 jobs:
+  check_changes:
+    uses: ./.github/workflows/check_changes.yml
+    with:
+      workflow_file: '.github/workflows/docs-toctree.yml'
+
   docs-toctree:
     name: Validate mdBook summary and build
     runs-on: ubuntu-latest
+    needs: check_changes
+    if: needs.check_changes.outputs.has_docs_changes == 'true' || needs.check_changes.outputs.has_specific_workflow_changes == 'true'
     steps:
       - uses: actions/checkout@v6
       - name: Set up Rust


### PR DESCRIPTION
### Description
Run the "📚 mdBook validation" workflow only when there are relevant changes, skipping it for unrelated PRs (e.g. pure C++ changes) to avoid unnecessary CI overhead.

The job now triggers when any of the following change:
- `docs/**` — documentation source files
- `.github/workflows/docs-toctree.yml` — this workflow file itself
- `scripts/**` — docs tooling scripts (`scripts/check_mdbook_summary.py`, `scripts/bash/docs_build.sh`, `scripts/bash/install_mdbook.sh`) that are executed by this workflow

The `scripts/**` condition was added to address a regression in the initial version, which would have silently skipped validation when docs build/check scripts were modified.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.