### PR TITLE
[ADR] Optimal AMR subcycling with parabolic operators

### DIFF
--- a/docs/markdown/amr_timestepping.md
+++ b/docs/markdown/amr_timestepping.md
@@ -1,0 +1,240 @@
+# AMR Timestep Selection
+
+This note describes a timestep selection algorithm for AMR simulations that contain both hyperbolic and explicitly integrated parabolic operators. The goal is to choose the coarse timestep and the AMR subcycling factors so that every level uses the largest stable timestep allowed by its own physics, subject to a cap on the number of subcycles between adjacent levels.
+
+The current AMR driver already stores one timestep per level in `dt_` and one integer subcycling factor per level in `nsubsteps`. The recursive advance only requires these subcycling factors to be positive integers. Therefore the timestep policy can choose `nsubsteps[lev]` dynamically instead of fixing it to the spatial refinement ratio.
+
+## Per-level timestep limits
+
+For each active AMR level `l`, compute a single-level stable timestep limit
+
+```text
+tau[l] = min(tau_hyperbolic[l],
+             tau_parabolic[l],
+             tau_particles[l],
+             tau_other_explicit[l],
+             change_max * old_dt[l])
+```
+
+where unavailable physics components report an infinite limit. The hyperbolic limit is the usual CFL condition. For an explicit scalar diffusion operator, a conservative parabolic limit has the form
+
+```text
+tau_parabolic = cfl_parabolic / max_cells(sum_d chi_d / dx_d^2)
+```
+
+where `chi_d` is the directional diffusivity and `cfl_parabolic` is chosen for the actual time integrator and stencil. More general parabolic operators should expose their own timestep estimator and contribute it to the minimum above.
+
+These `tau[l]` values are local stability limits for a single update on level `l`. The AMR scheduler then chooses a synchronized set of level timesteps
+
+```text
+dt[l] = dt[0] / (nsubsteps[1] * ... * nsubsteps[l])
+```
+
+with `dt[l] <= tau[l]` on every level.
+
+## Subcycle cap
+
+Let
+
+```text
+N[l] = MaxRefRatio(l - 1)^2,  l >= 1
+```
+
+be the maximum allowed number of subcycles between level `l - 1` and level `l`. This cap matches the parabolic scaling of an explicit diffusion timestep under refinement. For example, a refinement ratio of 2 permits up to 4 fine steps per coarse step, and a refinement ratio of 4 permits up to 16 fine steps per coarse step.
+
+Define the cumulative maximum subcycling product
+
+```text
+Q[0] = 1
+Q[l] = N[1] * ... * N[l].
+```
+
+Then the finest possible timestep on level `l`, given a coarse timestep `dt0`, is `dt0 / Q[l]`. Stability therefore requires
+
+```text
+dt0 <= Q[l] * tau[l]
+```
+
+for every level.
+
+## Algorithm
+
+First compute all per-level timestep limits `tau[l]`. Then choose the largest feasible coarse timestep:
+
+```text
+dt0 = tau[0]
+Q = 1
+
+for l = 1..finest_level:
+    Q *= N[l]
+    dt0 = min(dt0, Q * tau[l])
+```
+
+Apply root-level user controls to `dt0`, including `max_dt`, `initial_dt` or `init_shrink`, `constant_dt`, and the final `stop_time` clamp. If `constant_dt` is set and exceeds the feasible bound above, the run should abort or emit a fatal diagnostic, because no amount of fine-level subcycling can make level 0 stable.
+
+After the final `dt0` is known, compute the minimum cumulative subcycling product required at each level. Let
+
+```text
+need[l] = minimum required value of P[l] = nsubsteps[1] * ... * nsubsteps[l]
+```
+
+after level `l` has been assigned. The last level requires
+
+```text
+need[L] = dt0 / tau[L]
+```
+
+where `L = finest_level`. Moving from fine to coarse,
+
+```text
+need[l] = max(dt0 / tau[l], need[l + 1] / N[l + 1]).
+```
+
+The first term makes level `l` stable. The second term ensures that all finer levels can still be made stable without exceeding the remaining subcycle caps.
+
+Finally assign the smallest feasible integer factors from coarse to fine:
+
+```text
+nsubsteps[0] = 1
+dt[0] = dt0
+P = 1
+
+for l = 1..finest_level:
+    nsubsteps[l] = ceil_with_roundoff_tolerance(need[l] / P)
+    nsubsteps[l] = max(1, nsubsteps[l])
+    assert(nsubsteps[l] <= N[l])
+
+    P *= nsubsteps[l]
+    dt[l] = dt0 / P
+    assert(dt[l] <= tau[l] * tolerance)
+```
+
+The roundoff-tolerant ceiling should avoid turning values such as `4.000000000000001` into 5 because of floating-point noise. One practical rule is to round down to the nearest integer when the relative difference from that integer is smaller than a small tolerance, then otherwise use `ceil`.
+
+If `do_subcycle == 0`, no dynamic factors are used:
+
+```text
+dt0 = min_l tau[l]
+nsubsteps[l] = 1
+dt[l] = dt0
+```
+
+with the same root-level user controls applied afterward, subject to stability checks.
+
+## Behavior in limiting cases
+
+For a purely hyperbolic operator with spatial refinement ratio `r`,
+
+```text
+tau[l] ~= tau[l - 1] / r.
+```
+
+The algorithm chooses `nsubsteps[l] ~= r`, so it recovers the usual AMR time-subcycling pattern.
+
+For a purely parabolic explicit operator,
+
+```text
+tau[l] ~= tau[l - 1] / r^2.
+```
+
+The algorithm chooses `nsubsteps[l] ~= r^2`, which is exactly the maximum allowed by the cap. The coarse level can therefore use its natural coarse parabolic timestep while the fine level uses its natural fine parabolic timestep.
+
+For mixed hyperbolic and parabolic operators, the optimal ratio can vary by level and by solution state. The same rule chooses the smallest integer factor that keeps the level stable and leaves enough remaining subcycling capacity for finer levels.
+
+## Optimality proof
+
+Consider an AMR hierarchy with levels `0..L`. Let
+
+```text
+P[0] = 1
+P[l] = nsubsteps[1] * ... * nsubsteps[l].
+```
+
+An admissible synchronized timestep schedule must satisfy
+
+```text
+1 <= nsubsteps[l] <= N[l],
+dt[l] = dt0 / P[l],
+dt[l] <= tau[l]
+```
+
+for every level `l`.
+
+### Largest possible coarse timestep
+
+Because each subcycling factor is capped,
+
+```text
+P[l] <= Q[l] = N[1] * ... * N[l].
+```
+
+Stability on level `l` requires
+
+```text
+dt0 / P[l] <= tau[l],
+```
+
+so every admissible schedule must obey
+
+```text
+dt0 <= P[l] * tau[l] <= Q[l] * tau[l].
+```
+
+This bound holds for every level, including `l = 0` where `Q[0] = 1`. Therefore no stable schedule can use
+
+```text
+dt0 > min_l Q[l] * tau[l].
+```
+
+The algorithm sets `dt0` to this minimum, subject only to user-imposed root caps such as `max_dt`, `initial_dt`, and `stop_time`. Thus the selected coarse timestep is the largest stable coarse timestep compatible with the subcycle caps.
+
+### Minimum stable subcycling factors
+
+Fix the selected `dt0`. Define `need[l]` as the smallest cumulative subcycling product `P[l]` that allows levels `l..L` to be completed stably without violating any cap. At the finest level,
+
+```text
+need[L] = dt0 / tau[L],
+```
+
+because no finer cap remains. For an intermediate level `l`, two conditions are necessary:
+
+1. Level `l` itself must be stable:
+
+```text
+P[l] >= dt0 / tau[l].
+```
+
+2. Level `l + 1` and all finer levels must remain feasible. Since `nsubsteps[l + 1] <= N[l + 1]`, the largest cumulative product reachable on the next level is `P[l] * N[l + 1]`. Therefore
+
+```text
+P[l] * N[l + 1] >= need[l + 1],
+```
+
+or
+
+```text
+P[l] >= need[l + 1] / N[l + 1].
+```
+
+Combining these necessary conditions gives
+
+```text
+need[l] >= max(dt0 / tau[l], need[l + 1] / N[l + 1]).
+```
+
+The algorithm defines `need[l]` to be exactly this maximum. This is also sufficient: if `P[l] >= need[l]`, then level `l` is stable, and there exists a capped choice of `nsubsteps[l + 1]` that reaches at least `need[l + 1]`; induction completes the argument for all finer levels.
+
+During the forward pass, levels `0..l-1` have fixed cumulative product `P[l - 1]`. The algorithm chooses
+
+```text
+nsubsteps[l] = ceil(need[l] / P[l - 1]).
+```
+
+This is the smallest integer that makes `P[l] >= need[l]`. Any smaller integer would make level `l` unstable or make some finer level impossible to stabilize under the cap. Any larger integer would reduce `dt[l]` unnecessarily. Therefore, after the maximal feasible `dt0` is chosen, each level receives the largest stable timestep compatible with all finer-level stability requirements and the cap `nsubsteps[l] <= N[l]`.
+
+## Implementation notes
+
+- Compute and apply the final `stop_time` clamp before assigning fine-level subcycling factors. Shortening `dt0` can reduce the required number of subcycles.
+- Recompute the dynamic `nsubsteps` after regridding if new levels are created or if the hierarchy changes before the next timestep.
+- Keep diagnostic output that identifies which level and which operator set `tau[l]`; this is important for mixed hyperbolic/parabolic runs where the limiting operator may change over time.
+- The algorithm assumes the parabolic operators are explicit. Implicit parabolic solves should report either no explicit parabolic restriction or a restriction based on accuracy rather than linear stability.

--- a/scripts/python/amr_timestep_demo.py
+++ b/scripts/python/amr_timestep_demo.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Demonstrate capped AMR timestep selection for advection and diffusion.
+
+The examples use a one-dimensional scalar equation with explicit advection and
+diffusion operators,
+
+    u_t + a u_x = D u_xx,
+
+on a nested AMR hierarchy.  The per-level stable timestep is
+
+    tau[l] = min(cfl_adv * dx[l] / |a|,
+                 cfl_diff * dx[l]**2 / D).
+
+The AMR scheduler then chooses the largest stable coarse timestep and the
+smallest stable integer subcycling factors, with
+
+    nsubsteps[l] <= ref_ratio[l - 1]**2.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+
+@dataclass(frozen=True)
+class LevelLimit:
+    level: int
+    dx: float
+    advection_dt: float
+    diffusion_dt: float
+
+    @property
+    def tau(self) -> float:
+        return min(self.advection_dt, self.diffusion_dt)
+
+    @property
+    def limiter(self) -> str:
+        if self.advection_dt < self.diffusion_dt:
+            return "advection"
+        if self.diffusion_dt < self.advection_dt:
+            return "diffusion"
+        return "tie"
+
+
+@dataclass(frozen=True)
+class Schedule:
+    dt0: float
+    dt: List[float]
+    nsubsteps: List[int]
+    caps: List[int]
+    need: List[float]
+    coarse_limiter_level: int
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    speed: float
+    diffusivity: float
+    expected_limiters: Sequence[str]
+
+
+def ceil_with_tolerance(value: float, rel_tol: float = 1.0e-12, abs_tol: float = 1.0e-14) -> int:
+    """Return ceil(value), but do not round up values that are already integral."""
+    if value <= 0.0:
+        return 0
+
+    nearest = round(value)
+    if math.isclose(value, nearest, rel_tol=rel_tol, abs_tol=abs_tol):
+        return int(nearest)
+    return math.ceil(value)
+
+
+def compute_level_limits(
+    *,
+    dx0: float,
+    ref_ratios: Sequence[int],
+    speed: float,
+    diffusivity: float,
+    cfl_adv: float,
+    cfl_diff: float,
+) -> List[LevelLimit]:
+    """Compute advection, diffusion, and combined timestep limits on all levels."""
+    if dx0 <= 0.0:
+        raise ValueError("dx0 must be positive.")
+    if speed <= 0.0:
+        raise ValueError("speed must be positive for this demo.")
+    if diffusivity <= 0.0:
+        raise ValueError("diffusivity must be positive for this demo.")
+    if cfl_adv <= 0.0 or cfl_diff <= 0.0:
+        raise ValueError("CFL numbers must be positive.")
+    if any(r < 1 for r in ref_ratios):
+        raise ValueError("refinement ratios must be positive integers.")
+
+    limits: List[LevelLimit] = []
+    dx = dx0
+    for level in range(len(ref_ratios) + 1):
+        limits.append(
+            LevelLimit(
+                level=level,
+                dx=dx,
+                advection_dt=cfl_adv * dx / abs(speed),
+                diffusion_dt=cfl_diff * dx * dx / diffusivity,
+            )
+        )
+        if level < len(ref_ratios):
+            dx /= ref_ratios[level]
+
+    return limits
+
+
+def select_capped_amr_schedule(
+    tau: Sequence[float],
+    ref_ratios: Sequence[int],
+    *,
+    max_dt: float = math.inf,
+    constant_dt: float | None = None,
+) -> Schedule:
+    """Select dt0 and nsubsteps with nsubsteps[l] <= ref_ratio[l - 1]**2."""
+    nlevels = len(tau)
+    if nlevels == 0:
+        raise ValueError("At least one AMR level is required.")
+    if len(ref_ratios) != nlevels - 1:
+        raise ValueError("ref_ratios must contain one entry between each adjacent level.")
+    if any(limit <= 0.0 or not math.isfinite(limit) for limit in tau):
+        raise ValueError("All timestep limits must be positive finite values.")
+    if max_dt <= 0.0:
+        raise ValueError("max_dt must be positive.")
+
+    caps = [1] + [ratio * ratio for ratio in ref_ratios]
+
+    feasible_dt0 = min(tau[0], max_dt)
+    coarse_limiter_level = 0
+    cumulative_cap = 1
+    for level in range(1, nlevels):
+        cumulative_cap *= caps[level]
+        candidate = cumulative_cap * tau[level]
+        if candidate < feasible_dt0:
+            feasible_dt0 = candidate
+            coarse_limiter_level = level
+
+    if constant_dt is not None:
+        if constant_dt <= 0.0:
+            raise ValueError("constant_dt must be positive.")
+        if constant_dt > feasible_dt0 and not math.isclose(constant_dt, feasible_dt0, rel_tol=1.0e-12, abs_tol=1.0e-14):
+            raise ValueError(
+                f"constant_dt={constant_dt:.16e} exceeds the largest feasible stable dt0={feasible_dt0:.16e}."
+            )
+        dt0 = constant_dt
+    else:
+        dt0 = feasible_dt0
+
+    need = [1.0] * nlevels
+    need[-1] = dt0 / tau[-1]
+    for level in range(nlevels - 2, 0, -1):
+        need[level] = max(dt0 / tau[level], need[level + 1] / caps[level + 1])
+
+    nsubsteps = [1] * nlevels
+    dt = [dt0] + [math.nan] * (nlevels - 1)
+    cumulative_product = 1
+    for level in range(1, nlevels):
+        factor = max(1, ceil_with_tolerance(need[level] / cumulative_product))
+        if factor > caps[level]:
+            raise RuntimeError(
+                f"Internal error: level {level} needs {factor} substeps, exceeding cap {caps[level]}."
+            )
+        nsubsteps[level] = factor
+        cumulative_product *= factor
+        dt[level] = dt0 / cumulative_product
+
+    for level, (dt_level, tau_level) in enumerate(zip(dt, tau)):
+        if dt_level > tau_level and not math.isclose(dt_level, tau_level, rel_tol=1.0e-12, abs_tol=1.0e-14):
+            raise RuntimeError(f"Internal error: level {level} has unstable dt={dt_level} > tau={tau_level}.")
+
+    return Schedule(
+        dt0=dt0,
+        dt=dt,
+        nsubsteps=nsubsteps,
+        caps=caps,
+        need=need,
+        coarse_limiter_level=coarse_limiter_level,
+    )
+
+
+def format_float(value: float) -> str:
+    return f"{value:.6e}"
+
+
+def print_table(limits: Sequence[LevelLimit], schedule: Schedule) -> None:
+    header = (
+        "lev  dx            dt_adv        dt_diff       limiter    tau           "
+        "cap  nsub  dt_level      dt/tau"
+    )
+    print(header)
+    print("-" * len(header))
+    for limit, cap, nsub, dt_level in zip(limits, schedule.caps, schedule.nsubsteps, schedule.dt):
+        print(
+            f"{limit.level:3d}  "
+            f"{format_float(limit.dx):>12}  "
+            f"{format_float(limit.advection_dt):>12}  "
+            f"{format_float(limit.diffusion_dt):>12}  "
+            f"{limit.limiter:<9}  "
+            f"{format_float(limit.tau):>12}  "
+            f"{cap:3d}  "
+            f"{nsub:4d}  "
+            f"{format_float(dt_level):>12}  "
+            f"{dt_level / limit.tau:7.4f}"
+        )
+
+
+def assert_limiters(name: str, observed: Iterable[str], expected: Sequence[str]) -> None:
+    observed_list = list(observed)
+    if observed_list != list(expected):
+        raise AssertionError(f"{name}: expected limiters {list(expected)}, got {observed_list}")
+
+
+def run_scenario(
+    scenario: Scenario,
+    *,
+    dx0: float,
+    ref_ratios: Sequence[int],
+    cfl_adv: float,
+    cfl_diff: float,
+) -> None:
+    limits = compute_level_limits(
+        dx0=dx0,
+        ref_ratios=ref_ratios,
+        speed=scenario.speed,
+        diffusivity=scenario.diffusivity,
+        cfl_adv=cfl_adv,
+        cfl_diff=cfl_diff,
+    )
+    assert_limiters(scenario.name, (limit.limiter for limit in limits), scenario.expected_limiters)
+
+    schedule = select_capped_amr_schedule([limit.tau for limit in limits], ref_ratios)
+
+    print(f"\n{scenario.name}")
+    print(f"speed = {scenario.speed:g}, diffusivity = {scenario.diffusivity:g}")
+    print(f"dt0 = {format_float(schedule.dt0)}; coarse dt bound set by level {schedule.coarse_limiter_level}")
+    print_table(limits, schedule)
+
+
+def main() -> int:
+    dx0 = 1.0
+    ref_ratios = [2, 2, 2]
+    cfl_adv = 0.5
+    cfl_diff = 0.45
+
+    scenarios = [
+        Scenario(
+            name="Case 1: every level is advection-limited",
+            speed=1.0,
+            diffusivity=0.02,
+            expected_limiters=["advection", "advection", "advection", "advection"],
+        ),
+        Scenario(
+            name="Case 2: every level is diffusion-limited",
+            speed=1.0,
+            diffusivity=2.0,
+            expected_limiters=["diffusion", "diffusion", "diffusion", "diffusion"],
+        ),
+        Scenario(
+            name="Case 3: coarse levels are advection-limited, fine levels are diffusion-limited",
+            speed=1.0,
+            diffusivity=0.3,
+            expected_limiters=["advection", "advection", "diffusion", "diffusion"],
+        ),
+    ]
+
+    print("Capped AMR timestep demo for u_t + a u_x = D u_xx")
+    print(f"dx0 = {dx0:g}, ref_ratios = {ref_ratios}, cfl_adv = {cfl_adv:g}, cfl_diff = {cfl_diff:g}")
+    print("Subcycle cap: nsubsteps[l] <= ref_ratio[l - 1]^2")
+
+    for scenario in scenarios:
+        run_scenario(scenario, dx0=dx0, ref_ratios=ref_ratios, cfl_adv=cfl_adv, cfl_diff=cfl_diff)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Description
This proposes a new scheme to select the coarse and level timesteps when doing AMR subcycling that is compatible with using both hyperbolic and parabolic operators in the same simulation.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
