### PR TITLE
Fix default VisMF output file count

### DIFF
--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -37,3 +37,22 @@ mpirun --use-hwthread-cpus -np $NPROC $BUILD_DIR/src/problems/HydroBlast3D/Hydro
 old_plotfile=`ls -1drt plt*.old.* | head -1`
 plotfile=${old_plotfile%.old.*}
 $PLOTFILETOOLS_DIR/fcompare.gnu.ex $plotfile $old_plotfile
+
+# [default amr.plot_nfiles test] verify that -1 means one binary file per MPI rank
+nfiles_restart_plt_actual=`ls -1 $plotfile/Level_0/Cell_D_* | wc -l | tr -d ' '`
+if [ "$nfiles_restart_plt_actual" = "$NPROC" ]; then
+    echo "default amr.plot_nfiles working as expected."
+else
+    echo "TEST FAILED: Default number of binary cell data files in plotfiles should match MPI ranks!"
+    exit 1
+fi
+
+# [default amr.checkpoint_nfiles test] verify that -1 means one binary file per MPI rank
+chkfile=last_chk
+nfiles_restart_chk_actual=`ls -1 $chkfile/Level_0/Cell_D_* | wc -l | tr -d ' '`
+if [ "$nfiles_restart_chk_actual" = "$NPROC" ]; then
+    echo "default amr.checkpoint_nfiles working as expected."
+else
+    echo "TEST FAILED: Default number of binary cell data files in checkpoints should match MPI ranks!"
+    exit 1
+fi

--- a/src/io/io_utils.hpp
+++ b/src/io/io_utils.hpp
@@ -3,6 +3,7 @@
 // ABOUTME: RAII utilities for managing AMReX I/O settings
 // ABOUTME: Ensures global I/O settings are properly restored after use
 
+#include "AMReX_ParallelDescriptor.H"
 #include "AMReX_VisMF.H"
 
 namespace quokka
@@ -17,8 +18,8 @@ class ScopedVisMFNOutFiles
       public:
 	explicit ScopedVisMFNOutFiles(int nfiles) : originalNOutFiles_(amrex::VisMF::GetNOutFiles())
 	{
-		// Always set the value (including -1 which means one file per process)
-		amrex::VisMF::SetNOutFiles(nfiles);
+		const int nfiles_to_set = (nfiles == -1) ? amrex::ParallelDescriptor::NProcs() : nfiles;
+		amrex::VisMF::SetNOutFiles(nfiles_to_set);
 	}
 
 	~ScopedVisMFNOutFiles()


### PR DESCRIPTION
## Summary

Fix the default `amr.plot_nfiles = -1` / `amr.checkpoint_nfiles = -1` behavior for Quokka's AmrCore output path.

The code intended `-1` to mean one binary output file per MPI rank, matching the documented AMReX `Amr` convention. Quokka passed `-1` directly to `amrex::VisMF::SetNOutFiles`, which clamps negative values to `1`, so default plotfiles and checkpoints wrote a single `Cell_D_00000` per level even on multi-rank runs.

This PR expands `-1` to `amrex::ParallelDescriptor::NProcs()` in `ScopedVisMFNOutFiles` before calling AMReX. Explicit positive values such as `amr.plot_nfiles=2` are unchanged.

## Validation

- Built the affected target:
  - `cmake --build ../build/3d --target HydroBlast3D`
- Smoke-tested default behavior with 4 MPI ranks:
  - `mpirun --use-hwthread-cpus -np 4 .../HydroBlast3D .../inputs/blast_32.toml max_timesteps=0 plotfile_interval=1 checkpoint_interval=1`
  - Verified `plt0000000/Level_0` wrote 4 `Cell_D_*` files.
  - Verified `chk0000000/Level_0` wrote 4 `Cell_D_*` files.
- Smoke-tested explicit tuning still works:
  - same command with `amr.plot_nfiles=2 amr.checkpoint_nfiles=2`
  - Verified plotfile and checkpoint each wrote 2 `Cell_D_*` files.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1575.

### Checklist

_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code. (N/A: no new physics.)
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.