### PR TITLE
Add count_parallelfor.sh script

### DIFF
--- a/scripts/bash/count_parallelfor.sh
+++ b/scripts/bash/count_parallelfor.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+Usage:
+  count_parallelfor.sh [--root <path>] [--output <file>] [--include-problems]
+
+Count ParallelFor call sites in first-party source and emit a CSV listing each
+call site as filename,line.
+
+Options:
+  --root <path>        Repository root to scan (default: git root, otherwise cwd)
+  --output <file>      Write CSV to this file instead of stdout
+  --include-problems   Include src/problems/ in the scan
+  -h, --help           Show this help
+
+The scan always excludes build/ and extern/.
+EOF
+}
+
+die() {
+	echo "Error: $*" >&2
+	exit 1
+}
+
+ROOT=""
+OUTPUT=""
+INCLUDE_PROBLEMS=0
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--root)
+		[ "$#" -ge 2 ] || die "missing value for --root"
+		ROOT="$2"
+		shift 2
+		;;
+	--output)
+		[ "$#" -ge 2 ] || die "missing value for --output"
+		OUTPUT="$2"
+		shift 2
+		;;
+	--include-problems)
+		INCLUDE_PROBLEMS=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "unknown argument '$1'"
+		;;
+	esac
+done
+
+if [ -z "$ROOT" ]; then
+	ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+[ -d "$ROOT" ] || die "root path '$ROOT' is not a directory"
+command -v rg >/dev/null 2>&1 || die "ripgrep (rg) is required"
+
+TMP_CSV="$(mktemp "$ROOT/.parallelfor_callsites.XXXXXX")"
+trap 'rm -f "$TMP_CSV"' EXIT
+
+RG_ARGS=(
+	-n
+	--glob '!build/**'
+	--glob '!extern/**'
+)
+
+if [ "$INCLUDE_PROBLEMS" -eq 0 ]; then
+	RG_ARGS+=(--glob '!src/problems/**')
+fi
+
+{
+	echo "filename,line"
+	(
+		cd "$ROOT"
+		rg "${RG_ARGS[@]}" '\bParallelFor\s*\(' src || true
+	) | awk -F: '{ gsub(/"/, "\"\"", $1); print "\"" $1 "\"," $2 }'
+} >"$TMP_CSV"
+
+COUNT="$(tail -n +2 "$TMP_CSV" | wc -l | tr -d '[:space:]')"
+
+if [ -n "$OUTPUT" ]; then
+	cp "$TMP_CSV" "$OUTPUT"
+else
+	cat "$TMP_CSV"
+fi
+
+echo "ParallelFor call sites: $COUNT" >&2


### PR DESCRIPTION
### Description
Adds a script `count_parallelfor.sh` to count the unique `ParallelFor` kernels in Quokka, excluding problem generators. It also reports the file and line number of each kernel.

This is useful to know how many unique GPU kernels we have, as a rough proxy for code complexity.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
