### PR TITLE
[CI] Docs: scope permissions, remove unpinned Rust action, lock Cargo installs

### DIFF
--- a/.github/workflows/docs-toctree.yml
+++ b/.github/workflows/docs-toctree.yml
@@ -14,7 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rustc cargo
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,10 +12,6 @@ on:
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs
@@ -28,6 +24,8 @@ jobs:
       workflow_file: '.github/workflows/docs.yml'
 
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_docs_changes == 'true' || needs.check_changes.outputs.has_specific_workflow_changes == 'true'
@@ -38,7 +36,9 @@ jobs:
           persist-credentials: false
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends rustc cargo
 
       - name: Install mdBook tooling
         run: ./scripts/bash/install_mdbook.sh
@@ -72,6 +72,9 @@ jobs:
 
   deploy:
     if: github.event_name == 'push' && github.repository == 'quokka-astro/quokka' && github.ref == 'refs/heads/development' && (needs.check_changes.outputs.has_docs_changes == 'true' || needs.check_changes.outputs.has_specific_workflow_changes == 'true')
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: quokka-astro.github.io

--- a/scripts/bash/install_mdbook.sh
+++ b/scripts/bash/install_mdbook.sh
@@ -13,6 +13,6 @@ if ! command -v cargo >/dev/null 2>&1; then
     exit 1
 fi
 
-cargo install mdbook --version "${MDBOOK_VERSION}"
-cargo install mdbook-bib --version "${MDBOOK_BIB_VERSION}"
-cargo install mdbook-plantuml --version "${MDBOOK_PLANTUML_VERSION}"
+cargo install mdbook --locked --version "${MDBOOK_VERSION}"
+cargo install mdbook-bib --locked --version "${MDBOOK_BIB_VERSION}"
+cargo install mdbook-plantuml --locked --version "${MDBOOK_PLANTUML_VERSION}"


### PR DESCRIPTION
### Motivation
- A CI supply-chain finding showed docs workflows executed an unpinned third-party Rust action and ran `cargo install` without `--locked` while build steps inherited elevated `pages: write`/`id-token: write` permissions. 
- The intent is to eliminate the attack surface by scoping permissions, avoiding mutable action refs for setup, and making Cargo installs reproducible.

### Description
- Removed workflow-level `pages: write` and `id-token: write` and limited the `build` job to `contents: read` while granting `pages: write` and `id-token: write` only on the `deploy` job in `.github/workflows/docs.yml`. 
- Replaced `uses: dtolnay/rust-toolchain@stable` with explicit runner-local installation of `rustc`/`cargo` via `apt` in both `.github/workflows/docs.yml` and `.github/workflows/docs-toctree.yml` to avoid a mutable third-party action ref. 
- Made mdBook installs reproducible by adding `--locked` to `cargo install` calls in `scripts/bash/install_mdbook.sh`.

### Testing
- Ran `bash -n scripts/bash/install_mdbook.sh` to validate the script syntax and it passed. 
- Attempted YAML parsing validation with `python`/`yaml.safe_load`, but this check failed in the environment due to missing `PyYAML` (the failure was environmental, not a YAML syntax regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcfc50c9f88321a4838a3f5a2af395)