### PR TITLE
Validate include_pe attribute shape before H5Aread

### DIFF
--- a/src/util/DataTable.hpp
+++ b/src/util/DataTable.hpp
@@ -1338,6 +1338,12 @@ template <int Ndim, int Nout = 1, OutOfBounds oob_policy = OutOfBounds::clamp> c
 			if (include_pe != nullptr) {
 				if (H5Aexists(metadata_group, "include_pe") > 0) {
 					attr_id = H5Aopen(metadata_group, "include_pe", H5P_DEFAULT);
+					const hid_t attr_space = H5Aget_space(attr_id);
+					AMREX_ALWAYS_ASSERT_WITH_MESSAGE(attr_space != h5_error, "Failed to get include_pe dataspace!");
+					const hssize_t attr_npoints = H5Sget_simple_extent_npoints(attr_space);
+					AMREX_ALWAYS_ASSERT_WITH_MESSAGE(attr_npoints == 1, "include_pe attribute must be scalar!");
+					H5Sclose(attr_space);
+
 					const hid_t attr_type = H5Aget_type(attr_id);
 					if (H5Tget_class(attr_type) == H5T_INTEGER) {
 						status = H5Aread(attr_id, H5T_NATIVE_INT, &include_pe_value);


### PR DESCRIPTION
### Motivation
- The HDF5 `/metadata/include_pe` attribute was read into fixed-size stack buffers without verifying the attribute dataspace, allowing a multi-element attribute to overflow those buffers during `H5Aread`.

### Description
- Add a dataspace check after `H5Aopen` by calling `H5Aget_space` and `H5Sget_simple_extent_npoints` and assert the attribute is scalar (`npoints == 1`) before any `H5Aread` into fixed-size storage.
- Leave the existing integer and string parsing branches unchanged and ensure the attribute dataspace is closed with `H5Sclose` on success.
- Change applied to `src/util/DataTable.hpp` in the `include_pe` attribute handling path.

### Testing
- No automated test suite was executed in this environment due to missing external dependencies (HDF5 and other externs), so no `ctest` or build validation was run against the change.
- The change was committed as `Validate include_pe attribute shape before read` and the modified lines were inspected locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0557be048321aa71345b0b7b46f8)