### PR TITLE
fix NaN assertions that never fired due to IEEE 754 NaN comparison

### DIFF
--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -168,7 +168,7 @@ auto problem_main() -> int
 	pp.query("refine_half_domain", refine_half_domain);
 	double boost_vel_x = NAN;
 	pp.query("boost_vel_x", boost_vel_x);
-	AMREX_ASSERT_WITH_MESSAGE(std::isfinite(boost_vel_x), "boost_vel_x must be set in the input file");
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::isfinite(boost_vel_x), "boost_vel_x must be set in the input file");
 
 	// Problem initialization
 	QuokkaSimulation<SinkProblem> sim;

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -168,7 +168,7 @@ auto problem_main() -> int
 	pp.query("refine_half_domain", refine_half_domain);
 	double boost_vel_x = NAN;
 	pp.query("boost_vel_x", boost_vel_x);
-	AMREX_ASSERT_WITH_MESSAGE(boost_vel_x != NAN, "boost_vel_x must be set in the input file");
+	AMREX_ASSERT_WITH_MESSAGE(std::isfinite(boost_vel_x), "boost_vel_x must be set in the input file");
 
 	// Problem initialization
 	QuokkaSimulation<SinkProblem> sim;

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1018,10 +1018,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::ComputeRadPressure(const double erad
 		Tnz = T[2][2];
 	}
 
-	AMREX_ASSERT(Fn != NAN);
-	AMREX_ASSERT(Tnx != NAN);
-	AMREX_ASSERT(Tny != NAN);
-	AMREX_ASSERT(Tnz != NAN);
+	AMREX_ASSERT(std::isfinite(Fn));
+	AMREX_ASSERT(std::isfinite(Tnx));
+	AMREX_ASSERT(std::isfinite(Tny));
+	AMREX_ASSERT(std::isfinite(Tnz));
 
 	RadPressureResult result{};
 	result.F = {Fn, Tnx * erad, Tny * erad, Tnz * erad};


### PR DESCRIPTION
### Description
Fix debug assertions that silently passed even when variables held NaN values, due to incorrect use of relational operators with `NAN`.

In IEEE 754, `NaN != NaN` always evaluates to `true`, so `AMREX_ASSERT(x != NAN)` and `AMREX_ASSERT_WITH_MESSAGE(x != NAN, ...)` are no-ops — they never fire regardless of whether `x` is NaN. Two sites were affected:
- `RadSystem::ComputeRadPressure` in `src/radiation/radiation_system.hpp`: four assertions on `Fn`, `Tnx`, `Tny`, `Tnz` that guard against uninitialized flux/pressure-tensor components.
- `problem_main` in `src/problems/ParticleSink/testParticleSink.cpp`: one assertion that `boost_vel_x` was actually read from the input file.

Both sites are replaced with `std::isfinite(value)`, which correctly returns `false` for NaN and infinity.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1857.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
