### PR TITLE
fix SN Galilean-invariance validation skipped without Python

### DIFF
--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -297,9 +297,8 @@ auto problem_main() -> int
 	std::vector<double> x(nx);
 	std::vector<double> vx(nx);
 
-	// plot the temperature and vx profile along the x axis at the center
+	// extract the temperature and vx profile along the x axis at the center
 	if (amrex::ParallelDescriptor::IOProcessor()) {
-#ifdef HAVE_PYTHON
 		for (int i = 0; i < nx; ++i) {
 			const double rho = values.at(HydroSystem<SNProblem>::density_index)[i];
 			const double Eint = values.at(HydroSystem<SNProblem>::internalEnergy_index)[i];
@@ -308,7 +307,6 @@ auto problem_main() -> int
 			x[i] = position[i];
 			vx[i] = vx_val;
 		}
-#endif
 	}
 
 	QuokkaSimulation<SNProblem> sim2;
@@ -339,9 +337,8 @@ auto problem_main() -> int
 
 	int status = 0;
 
-	// plot the temperature and vx profile along the x axis at the center
+	// validate Galilean invariance and optionally plot profiles
 	if (amrex::ParallelDescriptor::IOProcessor()) {
-#ifdef HAVE_PYTHON
 		double v_value_norm = 0.0;
 		double v_err_norm = 0.0;
 		double T_value_norm = 0.0;
@@ -383,6 +380,7 @@ auto problem_main() -> int
 			status = 1;
 		}
 
+#ifdef HAVE_PYTHON
 		matplotlibcpp::clf();
 		matplotlibcpp::plot(x, T, {{"label", "base"}, {"color", "C0"}});
 		matplotlibcpp::plot(x2, T2, {{"label", "boosted"}, {"color", "C1"}, {"linestyle", "--"}});

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -365,7 +365,7 @@ auto problem_main() -> int
 			T2[index_] = Eint / (rho * CV); // simplified, but good enough for the purpose
 			x2[i] = position2[i] - drift;
 			vx2_rel[index_] = vx_val - boost_vel_x;
-			v_value_norm += std::abs(vx[index_]); // normalize by rest-frame velocity to avoid masking errors
+			v_value_norm += std::abs(vx_val); // use raw vx_val to account for the large boost velocity
 			v_err_norm += std::abs(vx2_rel[index_] - vx[index_]);
 			T_value_norm += std::abs(T[index_]);
 			T_err_norm += std::abs(T2[index_] - T[index_]);
@@ -377,6 +377,7 @@ auto problem_main() -> int
 		amrex::Print() << std::format("Relative L1 norm for vx = {}, tolerance = {}\n", v_rel_err_norm, v_rel_err_tol);
 		amrex::Print() << std::format("Relative L1 norm for T = {}, tolerance = {}\n", T_rel_err_norm, T_rel_err_tol);
 		if (!(v_rel_err_norm < v_rel_err_tol) || !(T_rel_err_norm < T_rel_err_tol)) {
+			amrex::Print() << "FAIL: Velocity or T error not within tolerance\n";
 			status = 1;
 		}
 
@@ -398,7 +399,7 @@ auto problem_main() -> int
 		matplotlibcpp::xlabel("x (cm)");
 		matplotlibcpp::ylabel("vx (cm/s)");
 		matplotlibcpp::title(std::format("time t = {:.4g}", sim2.tNew_[0]));
-		matplotlibcpp::save(std::format("sn_velocity_profile_n0_{:.1g}.pdf", n_amb, boost_vel_x));
+		matplotlibcpp::save(std::format("sn_velocity_profile_n0_{:.1g}_boost_vel_{:.1g}.pdf", n_amb, boost_vel_x));
 #endif
 	}
 

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -402,10 +402,6 @@ auto problem_main() -> int
 #endif
 	}
 
-	// Synchronize status across all MPI ranks (only IO processor sets these)
-	amrex::ParallelDescriptor::ReduceIntMax(status);
-	amrex::ParallelDescriptor::ReduceIntMax(scalar_validation_status);
-
 	// Return combined status (Galilean invariance + scalar validation)
 	return status + scalar_validation_status;
 }

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -365,7 +365,7 @@ auto problem_main() -> int
 			T2[index_] = Eint / (rho * CV); // simplified, but good enough for the purpose
 			x2[i] = position2[i] - drift;
 			vx2_rel[index_] = vx_val - boost_vel_x;
-			v_value_norm += std::abs(vx_val); // use raw vx to account for the large boost velocity
+			v_value_norm += std::abs(vx[index_]); // normalize by rest-frame velocity to avoid masking errors
 			v_err_norm += std::abs(vx2_rel[index_] - vx[index_]);
 			T_value_norm += std::abs(T[index_]);
 			T_err_norm += std::abs(T2[index_] - T[index_]);
@@ -401,6 +401,10 @@ auto problem_main() -> int
 		matplotlibcpp::save(std::format("sn_velocity_profile_n0_{:.1g}.pdf", n_amb, boost_vel_x));
 #endif
 	}
+
+	// Synchronize status across all MPI ranks (only IO processor sets these)
+	amrex::ParallelDescriptor::ReduceIntMax(status);
+	amrex::ParallelDescriptor::ReduceIntMax(scalar_validation_status);
 
 	// Return combined status (Galilean invariance + scalar validation)
 	return status + scalar_validation_status;


### PR DESCRIPTION
### Description
Fix the SN Galilean-invariance validation being silently skipped in non-Python builds.

The profile extraction, error-norm calculation, and `status = 1` assignment in `testSN.cpp` were all inside `#ifdef HAVE_PYTHON`, so any build without matplotlib would pass the test unconditionally regardless of correctness. The fix moves these blocks outside the guard so validation always runs on the IO processor; only the `matplotlibcpp` plot calls remain inside `#ifdef HAVE_PYTHON`.

### Related issues
Closes #1860

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
