### PR TITLE
add regression tests for AMR particle checkpoint-restart (issue #1544)

### DIFF
--- a/.github/workflows/checkpoint-restart.yml
+++ b/.github/workflows/checkpoint-restart.yml
@@ -76,7 +76,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --parallel 4 --target HydroBlast3D
+      run: cmake --build . --config $BUILD_TYPE --parallel 4 --target HydroBlast3D --target BinaryOrbitCIC
 
     - name: Checkpoint/Restart Test
       working-directory: ${{github.workspace}}/tests

--- a/inputs/BinaryOrbitCICAMR_checkpoint_restart.toml
+++ b/inputs/BinaryOrbitCICAMR_checkpoint_restart.toml
@@ -1,0 +1,37 @@
+# Restart test for particle checkpoint-restart with AMR (issue #1544).
+# Reads chk0000003 written by BinaryOrbitCICAMR (BinaryOrbitAMR.toml).
+# Uses a different blocking_factor than the init run so box arrays differ,
+# exercising the dual-grid restart code path in AMReX.
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo = [-2.5e13, -2.5e13, -2.5e13]
+geometry.prob_hi = [2.5e13, 2.5e13, 2.5e13]
+quokka.bc = ["periodic", "periodic", "reflecting"]
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v = 1  # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell = [32, 32, 32]
+amr.max_level = 1  # number of levels = max_level + 1
+amr.blocking_factor = 8  # different from init run (32) to force different box arrays
+amr.max_grid_size = 8
+amr.n_error_buf = 3  # minimum 3 cell buffer around tagged cells
+amr.grid_eff = 1.0
+
+cfl = 0.3
+stop_time = 5.0e7  # s
+
+do_reflux = 1
+do_subcycle = 0
+
+checkpoint_interval = -1
+plotfile_interval = -1
+derived_vars = "gpot"
+max_timesteps = 23
+restartfile = "chk0000003"

--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -113,3 +113,11 @@ fi
 # the reference. If stale ghost cells from the checkpoint leaked into
 # valid cells after re-boxing, fcompare will report a mismatch.
 $PLOTFILETOOLS_DIR/fcompare.gnu.ex -a -n 1 -r 0.001 --abs_tol 0.0025 ref_plotfile "$restart_plotfile"
+
+# [AMR particle checkpoint-restart test] verify that particles at the finest AMR level
+# survive a checkpoint-restart with a different blocking_factor (issue #1544).
+# Uses blocking_factor=8 (vs 32 in the init) so that under multi-rank execution the
+# level-0 box arrays differ, exercising the dual-grid restart code path in AMReX.
+rm -rf plt* chk* last_chk ref_plotfile 2>/dev/null || true
+$BUILD_DIR/src/problems/BinaryOrbitCIC/BinaryOrbitCIC ../inputs/BinaryOrbitAMR.toml max_timesteps=3 checkpoint_interval=3
+$BUILD_DIR/src/problems/BinaryOrbitCIC/BinaryOrbitCIC ../inputs/BinaryOrbitCICAMR_checkpoint_restart.toml


### PR DESCRIPTION
### Description
Adds regression tests for issue #1544: crash on checkpoint-restart with particles at the finest AMR level when using a different number of MPI ranks.

The crash was already fixed upstream in AMReX by PR [#2276](https://github.com/AMReX-Codes/amrex/pull/2276) (`83de03244`), which is included in the current AMReX submodule. This PR validates that the fix holds by adding two tests to `BinaryOrbitCIC`:

- **`BinaryOrbitCICAMRCheckpointInit`** — runs `BinaryOrbitAMR.toml` for 3 steps with `checkpoint_interval=3`, writing `chk0000003` with particles at the finest AMR level (Level_1).
- **`BinaryOrbitCICAMRCheckpointRestart`** — restarts from that checkpoint with `blocking_factor=8` (vs 32 in the init). Under multi-rank execution this produces different level-0 box arrays, exercising the dual-grid restart code path fixed by AMReX PR #2276. Current CI runs single-rank so `blocking_factor` does not change the actual box decomposition; the test will automatically cover the multi-rank path once MPI unit tests are added.

**Note:** during development a separate, related edge case was found — when restarting with the same number of MPI ranks but a different `blocking_factor`, the dual-grid flag is not set for levels without a `Particle_H` file even though the box arrays differ. This needs to be fixed upstream in AMReX and is not addressed here.

### Related issues
Closes #1544 and #1545

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
