### PR TITLE
Increase DiskGalaxy roundoff digits

### DIFF
--- a/inputs/DiskGalaxy.toml
+++ b/inputs/DiskGalaxy.toml
@@ -81,7 +81,7 @@ quokka.stellarpop_particle_mass.normalization_expr = "1.0/(5.0e6*yr)"
 ## star formation
 particles.eps_ff = 0.01
 particles.low_mass_composite_max_mass = 5.957650359245478e+35   # grams [= 299 Msun]
-particles.reproducibility_roundoff_redundancy = 28
+particles.reproducibility_roundoff_redundancy = 36
 
 
 ###################################


### PR DESCRIPTION
## Summary

Set `particles.reproducibility_roundoff_redundancy` from `28` to `36` for the DiskGalaxy regression input.

## Rationale

Recent DiskGalaxy-GPU nightly regression diffs show stable pass/fail failure but run-to-run variation in the numerical differences, especially at fine levels. Increasing this particle deposition buffer rounding redundancy should make the regression almost-always deterministic by rounding above the observed order-dependent scatter.

## Validation

- Inspected the local diff.
- Not run locally: DiskGalaxy-GPU is a GPU nightly regression case.