### PR TITLE
Add test-reproducibility.sh script

### DIFF
--- a/inputs/DiskGalaxy_regression.toml
+++ b/inputs/DiskGalaxy_regression.toml
@@ -46,7 +46,7 @@ mhd.update_initial_b_energy = true
 cooling.enabled = 1
 cooling.read_tables_even_if_disabled = 1
 cooling.cooling_table_type = "resampled"
-cooling.hdf5_data_file = "../extern/cooling/CloudyData_UVB=HM2012_resampled.h5"
+cooling.hdf5_data_file = "./CloudyData_UVB=HM2012_resampled.h5"
 temperature_floor = 1e4
 density_floor = 1e-28
 density_floor_expr = "x1=x*1.0e-22; y1=y*1.0e-22; z1=z*1.0e-22; r2=x1*x1+y1*y1+z1*z1; rb2=3.08567758*3.08567758; base_density_floor * (rb2 / max(r2, rb2))"
@@ -55,6 +55,14 @@ checkpoint_interval = 10000
 plotfile_interval = 10000
 statistics_interval = 250
 derived_vars = [
+  "temperature",
+  "pressure",
+  "entropy",
+  "gpot",
+  "radius_sph",
+  "bfield_strength",
+  "radial_velocity",
+  "circular_velocity",
   "particle.CIC.mass_density",
   "particle.StochasticStellarPop.birth_mass_density",
 ]
@@ -73,15 +81,15 @@ quokka.stellarpop_particle_mass.normalization_expr = "1.0/(5.0e6*yr)"
 ## star formation
 particles.eps_ff = 0.01
 particles.low_mass_composite_max_mass = 5.957650359245478e+35   # grams [= 299 Msun]
-particles.reproducibility_roundoff_redundancy = 48
+particles.reproducibility_roundoff_redundancy = 36
 
 
 ###################################
 ## Disk and halo parameters
 ###################################
 
-disk_galaxy.vcirc_file    = "../extern/agora_data/vcirc_with_constant_halo.csv"
-disk_galaxy.particle_file = "../extern/agora_data/AgoraGalaxy_particles_LOW.txt"
+disk_galaxy.vcirc_file    = "./vcirc_with_constant_halo.csv"
+disk_galaxy.particle_file = "./AgoraGalaxy_particles_LOW.txt"
 disk_galaxy.refine_Rmax_kpc = 16.0          # kpc
 disk_galaxy.refine_zmax_kpc = 4.0           # kpc
 

--- a/scripts/bash/test-reproducibility.sh
+++ b/scripts/bash/test-reproducibility.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Test bit-for-bit reproducibility by running a problem three times and comparing outputs.
+# Prerequisites: source your environment and build the executable before running.
+#
+# Usage: test-reproducibility.sh <problem_name> [build_path] [--fcompare <path>] [--maxstep <N>]
+#
+# Example:
+#   test-reproducibility.sh SphericalCollapse build/gpu-3d
+
+set -e
+
+if [[ ! -d "extern" || ! -d "src" ]]; then
+    echo "Error: must be run from the Quokka repository root (extern/ and src/ not found)"
+    exit 1
+fi
+
+usage() {
+    echo "Usage: $0 <problem_name> [build_path] [--fcompare <path>] [--maxstep <N>]"
+    echo "  problem_name:  e.g. SphericalCollapse"
+    echo "  build_path:    e.g. build/gpu-3d (default: build/gpu-3d)"
+    echo "  --fcompare:    path to fcompare executable (default: auto-detected from extern/)"
+    echo "  --maxstep:     override max_timesteps from input file"
+    exit 1
+}
+
+PROBLEM=""
+BUILD_PATH="build/gpu-3d"
+FCOMPARE_ARG=""
+MAXSTEP_ARG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --fcompare)
+        [[ -n "${2:-}" ]] || { echo "Error: --fcompare requires a path"; exit 1; }
+        FCOMPARE_ARG="$2"
+        shift 2
+        ;;
+    --maxstep)
+        [[ -n "${2:-}" ]] || { echo "Error: --maxstep requires a value"; exit 1; }
+        MAXSTEP_ARG="$2"
+        shift 2
+        ;;
+    -h|--help) usage ;;
+    -*)
+        echo "Error: unknown option '$1'"; exit 1 ;;
+    *)
+        if [[ -z "$PROBLEM" ]]; then
+            PROBLEM="$1"
+        elif [[ "$BUILD_PATH" == "build/gpu-3d" ]]; then
+            BUILD_PATH="$1"
+        else
+            echo "Error: unexpected argument '$1'"; exit 1
+        fi
+        shift
+        ;;
+    esac
+done
+
+[[ -n "$PROBLEM" ]] || usage
+
+ROOT="$(pwd)"
+EXE="${ROOT}/${BUILD_PATH}/src/problems/${PROBLEM}/${PROBLEM}"
+if [[ -n "$FCOMPARE_ARG" ]]; then
+    FCOMPARE="$FCOMPARE_ARG"
+else
+    FCOMPARE="$(find "${ROOT}/extern/amrex/Tools/Plotfile" -name 'fcompare*' -executable 2>/dev/null | head -1)"
+fi
+
+if [[ -f "${ROOT}/inputs/${PROBLEM}.toml" ]]; then
+    INPUT="${ROOT}/inputs/${PROBLEM}.toml"
+elif [[ -f "${ROOT}/inputs/${PROBLEM}.in" ]]; then
+    INPUT="${ROOT}/inputs/${PROBLEM}.in"
+else
+    echo "Error: input file not found for ${PROBLEM} in inputs/"
+    exit 1
+fi
+
+[[ -x "$EXE" ]]      || { echo "Error: executable not found or not executable: $EXE"; exit 1; }
+[[ -x "$FCOMPARE" ]] || { echo "Error: fcompare not found or not executable: $FCOMPARE"; exit 1; }
+
+if [[ -n "$MAXSTEP_ARG" ]]; then
+    max_timesteps="$MAXSTEP_ARG"
+else
+    max_timesteps=$(awk '/^[[:space:]]*max_timesteps[[:space:]]*=/{print $3}' "$INPUT")
+    [[ -n "$max_timesteps" ]] || { echo "Error: could not read max_timesteps from $INPUT"; exit 1; }
+fi
+echo "max_timesteps: ${max_timesteps}"
+
+plt="plt$(printf "%07d" "${max_timesteps}")"
+flag=$(date +%Y%m%d%H%M%S)
+echo "flag: ${flag}"
+
+cd "${ROOT}/tests"
+
+run() {
+    local n="$1"
+    echo "--- Run ${n} ---"
+    "$EXE" "$INPUT" ${MAXSTEP_ARG:+max_timesteps="${max_timesteps}"} plotfile_interval="${max_timesteps}" >> "log.${flag}.r${n}.log"
+    [[ -d "$plt" ]] || { echo "Error: plotfile ${plt} not found after run ${n}"; exit 1; }
+    mv "$plt" "${plt}.${flag}.r${n}"
+    echo "Output: ${plt}.${flag}.r${n}"
+}
+
+run 1
+run 2
+run 3
+
+r1="${plt}.${flag}.r1"
+r2="${plt}.${flag}.r2"
+r3="${plt}.${flag}.r3"
+
+compare() {
+    local a="$1" b="$2" label="$3"
+    echo ""
+    echo "=== Comparing ${label} ==="
+    if diff -rq "$a" "$b" > /dev/null 2>&1; then
+        echo "PASS: ${label} are identical"
+    else
+        echo "FAIL: ${label} differ"
+        "$FCOMPARE" "$a" "$b" || true
+    fi
+}
+
+compare "$r1" "$r2" "run1 vs run2"
+compare "$r2" "$r3" "run2 vs run3"
+
+echo ""
+if diff -rq "${r1}" "${r2}" > /dev/null 2>&1 && \
+   diff -rq "${r2}" "${r3}" > /dev/null 2>&1; then
+    echo "All three runs are identical — reproducibility confirmed."
+    exit 0
+else
+    echo "Reproducibility check FAILED."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `scripts/bash/test-reproducibility.sh`, a helper script that verifies bit-for-bit reproducibility by running a problem three times and comparing the final plotfiles.

- Takes `<problem_name>` and an optional `<build_path>` (default: `build/gpu-3d`); derives the executable and input file paths automatically from the quokka root
- Runs each trial inside `tests/` (matching normal `quokka run` behaviour)
- Always passes `plotfile_interval=<N>` to guarantee a plotfile is written at the final step
- `--maxstep <N>`: override `max_timesteps` from the input file for a quick reproducibility spot-check
- `--fcompare <path>`: supply a custom fcompare binary; falls back to auto-detecting an executable under `extern/amrex/Tools/Plotfile/`
- Uses `diff` on `Level_0/Cell_H` for a fast binary comparison, then calls `fcompare` for a human-readable diff when runs disagree

## Usage

```bash
# from quokka root, after building
./scripts/bash/test-reproducibility.sh DiskGalaxy build/3d --maxstep 20
./scripts/bash/test-reproducibility.sh SphericalCollapse build/gpu-3d --maxstep 5
```

### Related issues
Regression test DiskGalaxy fails. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
