### PR TITLE
quokka script: make --source opt-in with optional path arg

### DIFF
--- a/scripts/bash/quokka
+++ b/scripts/bash/quokka
@@ -31,10 +31,12 @@ Options:
   --fpe            Enable floating-point exception traps for direct problem runs (ignored for ctest-based runs)
   --filter <pattern> For run: ctest regex; for build: shell glob over problem names; exclusive with <problem>
                      Quote patterns to avoid expansion by your shell (e.g. --filter 'Rad*')
-  --source [file]  Source an environment file before config/build/run/target commands.
-                   With no argument, sources ~/.config/quokka/quokka.rc (the default rc).
-                   With a path argument, sources that file instead.
-                   Omitting --source entirely skips sourcing (avoids slow 'module load' in active shells).
+  --source [--]    Source ~/.config/quokka/quokka.rc (the default rc).
+                   Use '--source --' when a problem name or other positional argument
+                   immediately follows, to avoid ambiguity (e.g. 'quokka build --source -- MyProblem').
+  --source <file>  Source the specified environment file instead of the default rc.
+                   Omitting --source entirely skips all sourcing (avoids slow 'module load' in active shells).
+                   NOTE: place positional arguments (problem names) before --source when possible.
   --delete         For config only: delete existing preset build directory before reconfiguring
   -D<k>=<v>        For config only: pass extra CMake cache definitions (repeatable)
   -j <N>           Number of parallel jobs for ninja or ctest (default: 8)
@@ -569,7 +571,11 @@ while [ "$#" -gt 0 ]; do
 		shift 2
 		;;
 	--source)
-		if [ $# -gt 1 ] && [[ "${2}" != -* ]]; then
+		if [ "${2:-}" = "--" ]; then
+			# '--source --' is the unambiguous form for "use default rc"
+			SOURCE_FILE="${HOME}/.config/quokka/quokka.rc"
+			shift 2
+		elif [ $# -gt 1 ] && [[ "${2}" != -* ]]; then
 			SOURCE_FILE="$2"
 			shift 2
 		else

--- a/scripts/bash/quokka
+++ b/scripts/bash/quokka
@@ -31,12 +31,9 @@ Options:
   --fpe            Enable floating-point exception traps for direct problem runs (ignored for ctest-based runs)
   --filter <pattern> For run: ctest regex; for build: shell glob over problem names; exclusive with <problem>
                      Quote patterns to avoid expansion by your shell (e.g. --filter 'Rad*')
-  --source [--]    Source ~/.config/quokka/quokka.rc (the default rc).
-                   Use '--source --' when a problem name or other positional argument
-                   immediately follows, to avoid ambiguity (e.g. 'quokka build --source -- MyProblem').
+  --source --      Source ~/.config/quokka/quokka.rc (the default rc).
   --source <file>  Source the specified environment file instead of the default rc.
                    Omitting --source entirely skips all sourcing (avoids slow 'module load' in active shells).
-                   NOTE: place positional arguments (problem names) before --source when possible.
   --delete         For config only: delete existing preset build directory before reconfiguring
   -D<k>=<v>        For config only: pass extra CMake cache definitions (repeatable)
   -j <N>           Number of parallel jobs for ninja or ctest (default: 8)
@@ -571,17 +568,13 @@ while [ "$#" -gt 0 ]; do
 		shift 2
 		;;
 	--source)
-		if [ "${2:-}" = "--" ]; then
-			# '--source --' is the unambiguous form for "use default rc"
+		require_arg "$1" "${2:-}"
+		if [ "$2" = "--" ]; then
 			SOURCE_FILE="${HOME}/.config/quokka/quokka.rc"
-			shift 2
-		elif [ $# -gt 1 ] && [[ "${2}" != -* ]]; then
-			SOURCE_FILE="$2"
-			shift 2
 		else
-			SOURCE_FILE="${HOME}/.config/quokka/quokka.rc"
-			shift
+			SOURCE_FILE="$2"
 		fi
+		shift 2
 		;;
 	--delete)
 		DELETE_BUILD_DIR=1

--- a/scripts/bash/quokka
+++ b/scripts/bash/quokka
@@ -31,7 +31,10 @@ Options:
   --fpe            Enable floating-point exception traps for direct problem runs (ignored for ctest-based runs)
   --filter <pattern> For run: ctest regex; for build: shell glob over problem names; exclusive with <problem>
                      Quote patterns to avoid expansion by your shell (e.g. --filter 'Rad*')
-  --source <file>  Optional environment file to source before config/build/run/target commands
+  --source [file]  Source an environment file before config/build/run/target commands.
+                   With no argument, sources ~/.config/quokka/quokka.rc (the default rc).
+                   With a path argument, sources that file instead.
+                   Omitting --source entirely skips sourcing (avoids slow 'module load' in active shells).
   --delete         For config only: delete existing preset build directory before reconfiguring
   -D<k>=<v>        For config only: pass extra CMake cache definitions (repeatable)
   -j <N>           Number of parallel jobs for ninja or ctest (default: 8)
@@ -527,9 +530,6 @@ INPUT_FILE=""
 ENABLE_FPE=0
 FILTER_REGEX=""
 SOURCE_FILE=""
-if [[ "$COMMAND" == "config" || "$COMMAND" == "build" || "$COMMAND" == "buildrun" || "$COMMAND" == "run" || "$COMMAND" == "target" ]]; then
-	[[ -f "${HOME}/.config/quokka/quokka.rc" ]] && SOURCE_FILE="${HOME}/.config/quokka/quokka.rc"
-fi
 DELETE_BUILD_DIR=0
 JOBS=8
 CMAKE_DEFINES=()
@@ -569,9 +569,13 @@ while [ "$#" -gt 0 ]; do
 		shift 2
 		;;
 	--source)
-		require_arg "$1" "${2:-}"
-		SOURCE_FILE="$2"
-		shift 2
+		if [ $# -gt 1 ] && [[ "${2}" != -* ]]; then
+			SOURCE_FILE="$2"
+			shift 2
+		else
+			SOURCE_FILE="${HOME}/.config/quokka/quokka.rc"
+			shift
+		fi
 		;;
 	--delete)
 		DELETE_BUILD_DIR=1


### PR DESCRIPTION
### Description
Changes the `--source` option in the `quokka` helper script from always-on to opt-in, fixing unnecessary slow `module load` calls on HPC systems when the shell is already configured.

**Before:** the script automatically sourced `~/.config/quokka/quokka.rc` on every `config`/`build`/`buildrun`/`run`/`target` invocation, which triggered slow HPC module load overhead even in already-configured interactive shells.

**After:**
- `--source --` — sources `~/.config/quokka/quokka.rc` (the default rc, explicit opt-in)
- `--source /path/to/file` — sources the specified file
- `--source` with no argument — **fails** with an error (argument is required)
- *(omitting `--source`)* — sources nothing, preserving the current shell environment

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
