### PR TITLE
remove diskgalaxy from regression

### DIFF
--- a/regression/quokka-tests.ini
+++ b/regression/quokka-tests.ini
@@ -166,26 +166,26 @@ particleTypes = tracer_particles
 testSrcTree = .
 ignore_return_code = 0
 
-[DiskGalaxy-GPU]
-buildDir = .
-target = DiskGalaxy
-inputFile = inputs/DiskGalaxy.toml
-link1File = extern/cooling/CloudyData_UVB=HM2012_resampled.h5
-link2File = extern/agora_data/AgoraGalaxy_particles_LOW.txt
-link3File = extern/agora_data/vcirc_with_constant_halo.csv
-dim = 3
-cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
-restartTest = 0
-useMPI = 1
-numprocs = 1
-compileTest = 0
-doVis = 1
-visVar = gasDensity
-compareParticles = 1
-particleTypes = CIC_particles StochasticStellarPop_particles
-runtime_params = max_timesteps=300 checkpoint_interval=-1 plotfile_interval=300
-testSrcTree = .
-ignore_return_code = 0
+# [DiskGalaxy-GPU]
+# buildDir = .
+# target = DiskGalaxy
+# inputFile = inputs/DiskGalaxy.toml
+# link1File = extern/cooling/CloudyData_UVB=HM2012_resampled.h5
+# link2File = extern/agora_data/AgoraGalaxy_particles_LOW.txt
+# link3File = extern/agora_data/vcirc_with_constant_halo.csv
+# dim = 3
+# cmakeSetupOpts = -DAMReX_GPU_BACKEND=CUDA -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache
+# restartTest = 0
+# useMPI = 1
+# numprocs = 1
+# compileTest = 0
+# doVis = 1
+# visVar = gasDensity
+# compareParticles = 1
+# particleTypes = CIC_particles StochasticStellarPop_particles
+# runtime_params = max_timesteps=300 checkpoint_interval=-1 plotfile_interval=300
+# testSrcTree = .
+# ignore_return_code = 0
 
 [LinearAlfvenWave-GPU]
 buildDir = .


### PR DESCRIPTION
### Description
Remove DiskGalaxy from regression until we fix reproducibility issue. 

### Related issues
Regression tests failing: https://quokka-astro.github.io/regression-testing-results/2026-05-14/index.html 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
