### PR TITLE
Fix checkpoint/restart ghost cell corruption

### DIFF
--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -56,3 +56,57 @@ else
     echo "TEST FAILED: Default number of binary cell data files in checkpoints should match MPI ranks!"
     exit 1
 fi
+
+# [ghost-cell corruption test] verify that checkpoint files do not contain stale
+# ghost-cell data that could corrupt valid cells after restart with a different
+# MPI decomposition.  (See https://github.com/quokka-astro/quokka/issues/1868.)
+#
+# Strategy:
+#   1. Clean up output from the first phase.
+#   2. Run a fresh simulation that writes a checkpoint WITHOUT any prior
+#      plotfile (so ghost cells are never sanitized by fillBoundaryConditions).
+#   3. Save a plotfile written at the same step as the checkpoint.
+#   4. Restart from that checkpoint with a DIFFERENT number of MPI ranks
+#      (triggering re-boxing / load-balancing) and take one step.
+#   5. Compare the restarted plotfile against the saved one.
+#
+# If stale checkpoint ghost cells leak into valid cells after re-boxing,
+# fcompare will report differences.
+
+# Clean up from the first phase
+rm -rf plt* chk* last_chk 2>/dev/null || true
+
+NPROC_ORIG=4
+NPROC_RESTART=2
+
+# Run to generate a checkpoint (with NO prior plotfile sanitization)
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=0 checkpoint_interval=100 amr.checkpoint_nfiles=$NFILES
+
+# Save the checkpoint name
+chkfile_ghost=`ls -1drt chk* | head -1`
+if [ -z "$chkfile_ghost" ]; then
+    echo "TEST FAILED: No checkpoint produced for ghost-cell test!"
+    exit 1
+fi
+
+# Write a reference plotfile at the checkpoint time for later comparison
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=0 plotfile_interval=1 checkpoint_interval=0
+ref_plotfile=`ls -1drt plt* | head -1`
+if [ -z "$ref_plotfile" ]; then
+    echo "TEST FAILED: No reference plotfile produced for ghost-cell test!"
+    exit 1
+fi
+mv "$ref_plotfile" ref_plotfile
+
+# Restart from checkpoint with a DIFFERENT MPI rank count and take one step
+mpirun --use-hwthread-cpus -np $NPROC_RESTART $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=1 plotfile_interval=1 checkpoint_interval=0
+restart_plotfile=`ls -1drt plt* | head -1`
+if [ -z "$restart_plotfile" ]; then
+    echo "TEST FAILED: No restart plotfile produced for ghost-cell test!"
+    exit 1
+fi
+
+# The first plotfile after restart (step 0) must match the reference.
+# If stale ghost cells from the checkpoint leaked into valid cells due to
+# re-boxing, fcompare will report a mismatch.
+$PLOTFILETOOLS_DIR/fcompare.gnu.ex -n 1 -r 0.001 --abs_tol 0.0025 ref_plotfile "$restart_plotfile"

--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -81,7 +81,7 @@ NPROC_ORIG=4
 NPROC_RESTART=2
 
 # Run A: clean reference (normal run with plotfile output to get ground truth)
-mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=0 amr.plot_nfiles=$NFILES
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_timesteps=300 plotfile_interval=300 checkpoint_interval=0 amr.plot_nfiles=$NFILES
 ref_plotfile=`ls -1drt plt* | head -1`
 if [ -z "$ref_plotfile" ]; then
     echo "TEST FAILED: No reference plotfile produced for ghost-cell test!"
@@ -92,7 +92,7 @@ mv "$ref_plotfile" ref_plotfile
 rm -rf plt* 2>/dev/null || true
 
 # Run B: generate a checkpoint with stale ghost cells (NO plotfile output)
-mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=0 checkpoint_interval=100 amr.checkpoint_nfiles=$NFILES
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_timesteps=300 plotfile_interval=0 checkpoint_interval=300 amr.checkpoint_nfiles=$NFILES
 chkfile_ghost=`ls -1drt chk* | head -1`
 if [ -z "$chkfile_ghost" ]; then
     echo "TEST FAILED: No checkpoint produced for ghost-cell test!"

--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -82,7 +82,7 @@ NPROC_RESTART=2
 
 # Run A: clean reference (normal run with plotfile output to get ground truth)
 mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_timesteps=300 plotfile_interval=300 checkpoint_interval=0 amr.plot_nfiles=$NFILES
-ref_plotfile=`ls -1drt plt* | head -1`
+ref_plotfile=`ls -1drt plt* | tail -1`
 if [ -z "$ref_plotfile" ]; then
     echo "TEST FAILED: No reference plotfile produced for ghost-cell test!"
     exit 1
@@ -93,7 +93,7 @@ rm -rf plt* 2>/dev/null || true
 
 # Run B: generate a checkpoint with stale ghost cells (NO plotfile output)
 mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_timesteps=300 plotfile_interval=0 checkpoint_interval=300 amr.checkpoint_nfiles=$NFILES
-chkfile_ghost=`ls -1drt chk* | head -1`
+chkfile_ghost=`ls -1drt chk* | tail -1`
 if [ -z "$chkfile_ghost" ]; then
     echo "TEST FAILED: No checkpoint produced for ghost-cell test!"
     exit 1

--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -98,15 +98,18 @@ if [ -z "$ref_plotfile" ]; then
 fi
 mv "$ref_plotfile" ref_plotfile
 
-# Restart from checkpoint with a DIFFERENT MPI rank count and take one step
-mpirun --use-hwthread-cpus -np $NPROC_RESTART $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=1 plotfile_interval=1 checkpoint_interval=0
+# Restart from checkpoint with a DIFFERENT MPI rank count (no advance).
+# This tests that the initial restarted state is correct; if stale
+# checkpoint ghost cells leak into valid cells after re-boxing,
+# the first plotfile written on restart will differ from the reference.
+mpirun --use-hwthread-cpus -np $NPROC_RESTART $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=0 plotfile_interval=1 checkpoint_interval=0
 restart_plotfile=`ls -1drt plt* | head -1`
 if [ -z "$restart_plotfile" ]; then
     echo "TEST FAILED: No restart plotfile produced for ghost-cell test!"
     exit 1
 fi
 
-# The first plotfile after restart (step 0) must match the reference.
-# If stale ghost cells from the checkpoint leaked into valid cells due to
-# re-boxing, fcompare will report a mismatch.
-$PLOTFILETOOLS_DIR/fcompare.gnu.ex -n 1 -r 0.001 --abs_tol 0.0025 ref_plotfile "$restart_plotfile"
+# The plotfile written immediately after restart (step 0) must match
+# the reference. If stale ghost cells from the checkpoint leaked into
+# valid cells after re-boxing, fcompare will report a mismatch.
+$PLOTFILETOOLS_DIR/fcompare.gnu.ex -a -n 1 -r 0.001 --abs_tol 0.0025 ref_plotfile "$restart_plotfile"

--- a/inputs/checkpoint_restart_test.sh
+++ b/inputs/checkpoint_restart_test.sh
@@ -63,45 +63,45 @@ fi
 #
 # Strategy:
 #   1. Clean up output from the first phase.
-#   2. Run a fresh simulation that writes a checkpoint WITHOUT any prior
-#      plotfile (so ghost cells are never sanitized by fillBoundaryConditions).
-#   3. Save a plotfile written at the same step as the checkpoint.
-#   4. Restart from that checkpoint with a DIFFERENT number of MPI ranks
-#      (triggering re-boxing / load-balancing) and take one step.
-#   5. Compare the restarted plotfile against the saved one.
+#   2. Run A (clean reference): normal run that writes a plotfile at step N.
+#   3. Run B (stale checkpoint): separate run with plotfile_interval=0 that
+#      writes a checkpoint at step N (ghost cells are stale since no prior
+#      plotfile sanitized them).
+#   4. Restart from Run B's checkpoint with a DIFFERENT number of MPI ranks
+#      (triggering re-boxing / load-balancing) and write a plotfile immediately.
+#   5. Compare the restarted plotfile against Run A's clean reference.
 #
 # If stale checkpoint ghost cells leak into valid cells after re-boxing,
 # fcompare will report differences.
 
 # Clean up from the first phase
-rm -rf plt* chk* last_chk 2>/dev/null || true
+rm -rf plt* chk* last_chk ref_plotfile 2>/dev/null || true
 
 NPROC_ORIG=4
 NPROC_RESTART=2
 
-# Run to generate a checkpoint (with NO prior plotfile sanitization)
-mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=0 checkpoint_interval=100 amr.checkpoint_nfiles=$NFILES
-
-# Save the checkpoint name
-chkfile_ghost=`ls -1drt chk* | head -1`
-if [ -z "$chkfile_ghost" ]; then
-    echo "TEST FAILED: No checkpoint produced for ghost-cell test!"
-    exit 1
-fi
-
-# Write a reference plotfile at the checkpoint time for later comparison
-mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=0 plotfile_interval=1 checkpoint_interval=0
+# Run A: clean reference (normal run with plotfile output to get ground truth)
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=100 checkpoint_interval=0 amr.plot_nfiles=$NFILES
 ref_plotfile=`ls -1drt plt* | head -1`
 if [ -z "$ref_plotfile" ]; then
     echo "TEST FAILED: No reference plotfile produced for ghost-cell test!"
     exit 1
 fi
 mv "$ref_plotfile" ref_plotfile
+# Clean up any other plotfiles from Run A
+rm -rf plt* 2>/dev/null || true
 
-# Restart from checkpoint with a DIFFERENT MPI rank count (no advance).
-# This tests that the initial restarted state is correct; if stale
-# checkpoint ghost cells leak into valid cells after re-boxing,
-# the first plotfile written on restart will differ from the reference.
+# Run B: generate a checkpoint with stale ghost cells (NO plotfile output)
+mpirun --use-hwthread-cpus -np $NPROC_ORIG $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml max_walltime=0:00:10 plotfile_interval=0 checkpoint_interval=100 amr.checkpoint_nfiles=$NFILES
+chkfile_ghost=`ls -1drt chk* | head -1`
+if [ -z "$chkfile_ghost" ]; then
+    echo "TEST FAILED: No checkpoint produced for ghost-cell test!"
+    exit 1
+fi
+
+# Restart from Run B's checkpoint with a DIFFERENT MPI rank count (no advance).
+# If stale checkpoint ghost cells leak into valid cells after re-boxing,
+# the plotfile written on restart will differ from the clean reference.
 mpirun --use-hwthread-cpus -np $NPROC_RESTART $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D ../inputs/blast_32.toml restartfile=$chkfile_ghost max_timesteps=0 plotfile_interval=1 checkpoint_interval=0
 restart_plotfile=`ls -1drt plt* | head -1`
 if [ -z "$restart_plotfile" ]; then

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -309,7 +309,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 						int lev, int interval) override;
 
 	// compute derived variables
-	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
+	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp, amrex::MultiFab const &state_cc,
+			       amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const override;
 	void ComputeDensityFloorDebug(int lev, amrex::MultiFab &mf, int ncomp) const override;
 
 	// compute projected vars
@@ -1042,13 +1043,18 @@ auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiF
 	return (burn_success && cool_success);
 }
 
-template <typename problem_t> void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
+template <typename problem_t>
+void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
+						    amrex::MultiFab const &state_cc,
+						    amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf' -- user should implement
 	(void)lev;
 	(void)dname;
 	(void)mf;
 	(void)ncomp;
+	(void)state_cc;
+	(void)state_fc;
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::ComputeDensityFloorDebug(int lev, amrex::MultiFab &mf, int ncomp) const

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1044,8 +1044,7 @@ auto QuokkaSimulation<problem_t>::addStrangSplitSourcesWithBuiltin(amrex::MultiF
 }
 
 template <typename problem_t>
-void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
-						    amrex::MultiFab const &state_cc,
+void QuokkaSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp, amrex::MultiFab const &state_cc,
 						    amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf' -- user should implement

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -113,7 +113,8 @@ template <typename problem_t> class AdvectionSimulation : public AMRSimulation<p
 	void applyPoissonGravityAtLevel(amrex::MultiFab const &phi, int lev, amrex::Real dt) override;
 
 	// compute derived variables
-	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const override;
+	void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp, amrex::MultiFab const &state_cc,
+			       amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const override;
 	// compute projected vars
 
 	// compute statistics
@@ -240,9 +241,18 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterT
 	// do nothing -- user should implement using problem-specific template specialization
 }
 
-template <typename problem_t> void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const
+template <typename problem_t>
+void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp,
+						       amrex::MultiFab const &state_cc,
+						       amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// user should implement
+	(void)lev;
+	(void)dname;
+	(void)mf;
+	(void)ncomp;
+	(void)state_cc;
+	(void)state_fc;
 }
 
 template <typename problem_t> auto AdvectionSimulation<problem_t>::ComputeStatistics() -> std::map<std::string, amrex::Real>

--- a/src/linear_advection/AdvectionSimulation.hpp
+++ b/src/linear_advection/AdvectionSimulation.hpp
@@ -242,8 +242,7 @@ template <typename problem_t> void AdvectionSimulation<problem_t>::computeAfterT
 }
 
 template <typename problem_t>
-void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp,
-						       amrex::MultiFab const &state_cc,
+void AdvectionSimulation<problem_t>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp, amrex::MultiFab const &state_cc,
 						       amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// user should implement

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -99,7 +99,10 @@ template <> void QuokkaSimulation<BinaryOrbit>::createInitialCICParticles()
 	}
 }
 
-template <> void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+						      amrex::MultiFab const & /*state_cc*/,
+						      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -564,7 +564,10 @@ template <> void QuokkaSimulation<DiskGalaxy>::refineGrid(int lev, amrex::TagBox
 	amrex::Gpu::streamSynchronize();
 }
 
-template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+						     amrex::MultiFab const &state_cc,
+						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {
@@ -581,7 +584,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				Real const rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
 				Real const x1Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index);
@@ -597,11 +600,10 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 
 	if (dname == "pressure") {
 		const int ncomp = ncomp_cc_in;
-		auto const &state_fc = state_new_fc_[lev];
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const cons_fc{
 			    AMREX_D_DECL(state_fc[0].const_array(iter), state_fc[1].const_array(iter), state_fc[2].const_array(iter))};
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
@@ -617,7 +619,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				Real const rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
 				Real const x1Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index);
@@ -654,9 +656,9 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &bx_fc = state_new_fc_[lev][0].const_array(iter);
-			auto const &by_fc = state_new_fc_[lev][1].const_array(iter);
-			auto const &bz_fc = state_new_fc_[lev][2].const_array(iter);
+			auto const &bx_fc = state_fc[0].const_array(iter);
+			auto const &by_fc = state_fc[1].const_array(iter);
+			auto const &bz_fc = state_fc[2].const_array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				const amrex::Real bx_cc = 0.5 * (bx_fc(i, j, k, 0) + bx_fc(i + 1, j, k, 0));
 				const amrex::Real by_cc = 0.5 * (by_fc(i, j, k, 0) + by_fc(i, j + 1, k, 0));
@@ -674,7 +676,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				const amrex::Real rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
 				const amrex::Real vx = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index) / rho;
@@ -697,7 +699,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::s
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				const amrex::Real rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
 				const amrex::Real vx = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index) / rho;

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -566,8 +566,7 @@ template <> void QuokkaSimulation<DiskGalaxy>::refineGrid(int lev, amrex::TagBox
 
 template <>
 void QuokkaSimulation<DiskGalaxy>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
-						     amrex::MultiFab const &state_cc,
-						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
+						     amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -169,13 +169,15 @@ template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxA
 	}
 }
 
-template <> void QuokkaSimulation<FieldLoop>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
+template <>
+void QuokkaSimulation<FieldLoop>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
+						    amrex::MultiFab const & /*state_cc*/,
+						    amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "magnetic_divergence") {
 		const amrex::Geometry &geom_lev = geom[lev];
 		const auto dx = geom_lev.CellSizeArray();
-		auto const &state_fc = state_new_fc_[lev];
 		auto output = mf.arrays();
 
 		// Get the face-centered magnetic field arrays

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -171,8 +171,7 @@ template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxA
 
 template <>
 void QuokkaSimulation<FieldLoop>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
-						    amrex::MultiFab const & /*state_cc*/,
-						    amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
+						    amrex::MultiFab const & /*state_cc*/, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "magnetic_divergence") {

--- a/src/problems/MHDBlast/testMHDBlast.cpp
+++ b/src/problems/MHDBlast/testMHDBlast.cpp
@@ -133,8 +133,7 @@ template <> void QuokkaSimulation<MHDBlast>::refineGrid(int lev, amrex::TagBoxAr
 
 template <>
 void QuokkaSimulation<MHDBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
-						   amrex::MultiFab const & /*state_cc*/,
-						   amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
+						   amrex::MultiFab const & /*state_cc*/, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "magnetic_divergence") {

--- a/src/problems/MHDBlast/testMHDBlast.cpp
+++ b/src/problems/MHDBlast/testMHDBlast.cpp
@@ -131,13 +131,15 @@ template <> void QuokkaSimulation<MHDBlast>::refineGrid(int lev, amrex::TagBoxAr
 	}
 }
 
-template <> void QuokkaSimulation<MHDBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp) const
+template <>
+void QuokkaSimulation<MHDBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp,
+						   amrex::MultiFab const & /*state_cc*/,
+						   amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "magnetic_divergence") {
 		const amrex::Geometry &geom_lev = geom[lev];
 		const auto dx = geom_lev.CellSizeArray();
-		auto const &state_fc = state_new_fc_[lev];
 		auto output = mf.arrays();
 
 		// Get the face-centered magnetic field arrays

--- a/src/problems/ParticleDeposition/testParticleDeposition.cpp
+++ b/src/problems/ParticleDeposition/testParticleDeposition.cpp
@@ -153,7 +153,10 @@ template <> void QuokkaSimulation<ParticleDepositionProblem>::computeAfterTimest
 #endif
 }
 
-template <> void QuokkaSimulation<ParticleDepositionProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int /*ncomp*/) const
+template <>
+void QuokkaSimulation<ParticleDepositionProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int /*ncomp*/,
+								    amrex::MultiFab const & /*state_cc*/,
+								    amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 #if AMREX_SPACEDIM == 3
 	if (dname == "particle_mass_density") {

--- a/src/problems/PopIII/testPopIII.cpp
+++ b/src/problems/PopIII/testPopIII.cpp
@@ -365,12 +365,15 @@ template <> void QuokkaSimulation<PopIII>::refineGrid(int lev, amrex::TagBoxArra
 	}
 }
 
-template <> void QuokkaSimulation<PopIII>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<PopIII>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+						 amrex::MultiFab const &state_cc,
+						 amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {
 		const int ncomp = ncomp_cc_in;
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto output = mf.arrays();
 
 		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
@@ -386,7 +389,7 @@ template <> void QuokkaSimulation<PopIII>::ComputeDerivedVar(int lev, std::strin
 	if (dname == "pressure") {
 
 		const int ncomp = ncomp_cc_in;
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto output = mf.arrays();
 
 		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
@@ -398,7 +401,7 @@ template <> void QuokkaSimulation<PopIII>::ComputeDerivedVar(int lev, std::strin
 	if (dname == "velx") {
 
 		const int ncomp = ncomp_cc_in;
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto output = mf.arrays();
 
 		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
@@ -411,7 +414,7 @@ template <> void QuokkaSimulation<PopIII>::ComputeDerivedVar(int lev, std::strin
 	if (dname == "sound_speed") {
 
 		const int ncomp = ncomp_cc_in;
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto output = mf.arrays();
 
 		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {

--- a/src/problems/PopIII/testPopIII.cpp
+++ b/src/problems/PopIII/testPopIII.cpp
@@ -367,8 +367,7 @@ template <> void QuokkaSimulation<PopIII>::refineGrid(int lev, amrex::TagBoxArra
 
 template <>
 void QuokkaSimulation<PopIII>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
-						 amrex::MultiFab const &state_cc,
-						 amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+						 amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -135,7 +135,10 @@ template <> void QuokkaSimulation<RandomBlast>::computeAfterTimestep()
 	userData_.SN_counter_arr.push_back(sn_count_cumulative_); // cumulative number of SNe at current time
 }
 
-template <> void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+						      amrex::MultiFab const &state_cc,
+						      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {
@@ -146,7 +149,7 @@ template <> void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int lev, std::
 		for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 			const amrex::Box &indexRange = iter.validbox();
 			auto const &output = mf.array(iter);
-			auto const &state = state_new_cc_[lev].const_array(iter);
+			auto const &state = state_cc.const_array(iter);
 
 			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				Real const rho = state(i, j, k, HydroSystem<RandomBlast>::density_index);

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -137,8 +137,7 @@ template <> void QuokkaSimulation<RandomBlast>::computeAfterTimestep()
 
 template <>
 void QuokkaSimulation<RandomBlast>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
-						      amrex::MultiFab const &state_cc,
-						      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+						      amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "temperature") {

--- a/src/problems/ShockCloud/testShockCloud.cpp
+++ b/src/problems/ShockCloud/testShockCloud.cpp
@@ -274,8 +274,7 @@ template <> void QuokkaSimulation<ShockCloud>::computeAfterTimestep()
 
 template <>
 void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in,
-						     amrex::MultiFab const &state_cc,
-						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+						     amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 

--- a/src/problems/ShockCloud/testShockCloud.cpp
+++ b/src/problems/ShockCloud/testShockCloud.cpp
@@ -272,7 +272,10 @@ template <> void QuokkaSimulation<ShockCloud>::computeAfterTimestep()
 	}
 }
 
-template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in) const
+template <>
+void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in,
+						     amrex::MultiFab const &state_cc,
+						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 
@@ -280,7 +283,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -297,7 +300,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -314,7 +317,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -326,7 +329,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho_cloud = state[bx](i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
@@ -338,7 +341,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho_wind = state[bx](i, j, k, HydroSystem<ShockCloud>::scalar0_index + 2);
@@ -350,7 +353,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -366,7 +369,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -384,7 +387,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			Real const rho = state[bx](i, j, k, HydroSystem<ShockCloud>::density_index);
@@ -401,7 +404,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 	} else if (dname == "mass") {
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto const dx = geom[lev].CellSizeArray();
 		const Real dvol = dx[0] * dx[1] * dx[2];
 
@@ -413,7 +416,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 	} else if (dname == "cloud_fraction") {
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			// cloud partial density
@@ -429,7 +432,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud diagnostics require resampled cooling tables.");
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 
 		auto tables = resampledTables_.const_tables();
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
@@ -447,7 +450,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 	} else if (dname == "lab_velocity_x") {
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		const Real delta_vx = ::delta_vx;
 
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
@@ -462,7 +465,7 @@ template <> void QuokkaSimulation<ShockCloud>::ComputeDerivedVar(int lev, std::s
 	} else if (dname == "velocity_mag") {
 		const int ncomp = ncomp_in;
 		auto const &output = mf.arrays();
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 
 		amrex::ParallelFor(mf, mf.nGrowVect(), [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 			// compute simulation-frame |v| in km/s

--- a/src/problems/SphericalCollapse/testSphericalCollapse.cpp
+++ b/src/problems/SphericalCollapse/testSphericalCollapse.cpp
@@ -127,7 +127,10 @@ template <> void QuokkaSimulation<CollapseProblem>::refineGrid(int lev, amrex::T
 	}
 }
 
-template <> void QuokkaSimulation<CollapseProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<CollapseProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+							  amrex::MultiFab const & /*state_cc*/,
+							  amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "gpot") {

--- a/src/problems/StarCluster/testStarCluster.cpp
+++ b/src/problems/StarCluster/testStarCluster.cpp
@@ -195,8 +195,7 @@ template <> void QuokkaSimulation<StarCluster>::refineGrid(int lev, amrex::TagBo
 
 template <>
 void QuokkaSimulation<StarCluster>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
-						      amrex::MultiFab const &state_cc,
-						      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+						      amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "log_density") {

--- a/src/problems/StarCluster/testStarCluster.cpp
+++ b/src/problems/StarCluster/testStarCluster.cpp
@@ -193,12 +193,15 @@ template <> void QuokkaSimulation<StarCluster>::refineGrid(int lev, amrex::TagBo
 	});
 }
 
-template <> void QuokkaSimulation<StarCluster>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in) const
+template <>
+void QuokkaSimulation<StarCluster>::ComputeDerivedVar(int /*lev*/, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+						      amrex::MultiFab const &state_cc,
+						      amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	// compute derived variables and save in 'mf'
 	if (dname == "log_density") {
 		const int ncomp = ncomp_cc_in;
-		auto const &state = state_new_cc_[lev].const_arrays();
+		auto const &state = state_cc.const_arrays();
 		auto output = mf.arrays();
 
 		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -297,11 +297,14 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 	});
 }
 
-template <> void QuokkaSimulation<TheProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in) const
+template <>
+void QuokkaSimulation<TheProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in,
+						     amrex::MultiFab const &state_cc,
+						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	const int ncomp = ncomp_in;
 	auto const &output = mf.arrays();
-	auto const &state = state_new_cc_[lev].const_arrays();
+	auto const &state = state_cc.const_arrays();
 
 	if (dname == "gpot") {
 		auto const &phi_arr = phi[lev].const_arrays();

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -299,8 +299,7 @@ template <> void QuokkaSimulation<TheProblem>::setInitialConditionsOnGrid(quokka
 
 template <>
 void QuokkaSimulation<TheProblem>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_in,
-						     amrex::MultiFab const &state_cc,
-						     amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+						     amrex::MultiFab const &state_cc, amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
 {
 	const int ncomp = ncomp_in;
 	auto const &output = mf.arrays();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3673,17 +3673,16 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 	if (included_ghosts > 0) {
 		scratch_cc.define(state_new_cc_[lev].boxArray(), state_new_cc_[lev].DistributionMap(), state_new_cc_[lev].nComp(), included_ghosts);
 		amrex::MultiFab::Copy(scratch_cc, state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
-		fillBoundaryConditions(scratch_cc, scratch_cc, lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
-				       InterpHookNone, FillPatchType::fillpatch_function);
+		fillBoundaryConditions(scratch_cc, scratch_cc, lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone, InterpHookNone,
+				       FillPatchType::fillpatch_function);
 
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				scratch_fc[idim].define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
-						       state_new_fc_[lev][idim].nComp(), included_ghosts);
+							state_new_fc_[lev][idim].nComp(), included_ghosts);
 				amrex::MultiFab::Copy(scratch_fc[idim], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
 				fillBoundaryConditions(scratch_fc[idim], scratch_fc[idim], lev, tNew_[lev], quokka::centering::fc,
-						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone,
-						       FillPatchType::fillpatch_function);
+						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
 			}
 		}
 	}
@@ -3803,8 +3802,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_f
 		scratch_fc.define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(), state_new_fc_[lev][idim].nComp(),
 				  nghost_fc_);
 		amrex::MultiFab::Copy(scratch_fc, state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
-		fillBoundaryConditions(scratch_fc, scratch_fc, lev, tNew_[lev], quokka::centering::fc, static_cast<quokka::direction>(idim),
-				       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		fillBoundaryConditions(scratch_fc, scratch_fc, lev, tNew_[lev], quokka::centering::fc, static_cast<quokka::direction>(idim), InterpHookNone,
+				       InterpHookNone, FillPatchType::fillpatch_function);
 	}
 
 	// copy data from scratch (with filled ghost cells) to plot MF
@@ -4487,8 +4486,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 				amrex::MultiFab chkMF(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
 						      state_new_fc_[lev][idim].nComp(), 0);
 				amrex::MultiFab::Copy(chkMF, state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
-				amrex::VisMF::Write(chkMF, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_",
-											  std::string("Face_") + quokka::face_dir_str[idim]));
+				amrex::VisMF::Write(
+				    chkMF, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", std::string("Face_") + quokka::face_dir_str[idim]));
 				amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 			}
 		}
@@ -4652,8 +4651,7 @@ void AMRSimulation<problem_t>::interpolateFaceMultiFabFromRestart(int lev, const
 			amrex::MultiFab tmp_read;
 			amrex::VisMF::Read(tmp_read,
 					   amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", std::string("Face_") + quokka::face_dir_str[idim]));
-			state_new_fc_[lev][idim].ParallelCopy(tmp_read, 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, amrex::IntVect(0),
-							      amrex::IntVect(0));
+			state_new_fc_[lev][idim].ParallelCopy(tmp_read, 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, amrex::IntVect(0), amrex::IntVect(0));
 			AMREX_ALWAYS_ASSERT(!state_new_fc_[lev][idim].contains_nan(0, state_new_fc_[lev][idim].nComp())); // check valid faces
 		}
 	} else {
@@ -4893,8 +4891,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 	// explicitly populated before the first advance.  (See
 	// https://github.com/quokka-astro/quokka/issues/1868.)
 	for (int lev = 0; lev <= finest_level; ++lev) {
-		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na,
-				       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
+				       InterpHookNone, FillPatchType::fillpatch_function);
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 				fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
@@ -4907,8 +4905,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 		state_old_cc_[lev].ParallelCopy(state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), nghost_cc_, nghost_cc_);
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				state_old_fc_[lev][idim].ParallelCopy(state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), nghost_fc_,
-								      nghost_fc_);
+				state_old_fc_[lev][idim].ParallelCopy(state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), nghost_fc_, nghost_fc_);
 			}
 		}
 	}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -311,8 +311,22 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	virtual void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf,
 							const amrex::Vector<std::string> &compNames, int lev, int interval) = 0;
 
-	// compute derived variables
-	virtual void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp) const = 0;
+	/**
+	 * Compute a problem-defined derived plotfile variable.
+	 *
+	 * Implementations must read cell-centered and face-centered simulation state
+	 * from `state_cc` and `state_fc`, not directly from `state_new_cc_` or
+	 * `state_new_fc_`.  Plotfile generation may pass scratch MultiFabs here
+	 * instead of the live simulation state; when plotfile ghost cells are
+	 * requested, those scratch MultiFabs contain freshly filled ghost zones.
+	 * The only permitted side effect is writing the derived field into component
+	 * `ncomp` of `mf`; implementations must not mutate simulation state or the
+	 * provided input state.
+	 * The level index is still provided for level-indexed auxiliary data such as
+	 * geometry, gravitational potential, particles, and problem-owned caches.
+	 */
+	virtual void ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, int ncomp, amrex::MultiFab const &state_cc,
+				       amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc) const = 0;
 	virtual void ComputeDensityFloorDebug(int lev, amrex::MultiFab &mf, int ncomp) const;
 
 	// compute statistics
@@ -3689,7 +3703,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 
 	// Select the source: scratch copies (with filled ghost cells) when
 	// included_ghosts > 0, otherwise the live simulation state directly.
-	amrex::MultiFab &src_cc = (included_ghosts > 0) ? scratch_cc : state_new_cc_[lev];
+	amrex::MultiFab const &src_cc = (included_ghosts > 0) ? scratch_cc : state_new_cc_[lev];
+	amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &src_fc = (included_ghosts > 0) ? scratch_fc : state_new_fc_[lev];
 
 	// Process each variable in the configurable list
 	int comp = 0;
@@ -3714,8 +3729,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 				const int var_idx = fc_comp_flat / AMREX_SPACEDIM; // which variable type
 				const int idim = fc_comp_flat % AMREX_SPACEDIM;	   // which dimension
 				const int fc_comp = var_idx;			   // component index within that dimension's MultiFab
-				amrex::MultiFab &src_fc_dim = (included_ghosts > 0) ? scratch_fc[idim] : state_new_fc_[lev][idim];
-				AverageFCToCC(plotMF, src_fc_dim, idim, comp, fc_comp, 1);
+				AverageFCToCC(plotMF, src_fc[idim], idim, comp, fc_comp, 1);
 				comp++;
 				continue;
 			}
@@ -3734,7 +3748,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 				comp++;
 				continue;
 			}
-			ComputeDerivedVar(lev, varname, plotMF, comp);
+			ComputeDerivedVar(lev, varname, plotMF, comp, src_cc, src_fc);
 			comp++;
 			continue;
 		}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1681,8 +1681,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 	}
 
 	// write final checkpoint
-	// IMPORTANT: this MUST be written *after* the plotfile to avoid corruption:
-	// 	https://github.com/quokka-astro/quokka/issues/554
 	if (checkpointInterval_ > 0 && istep[0] > last_chk_file_step) {
 		WriteCheckpointFile();
 	}
@@ -3665,19 +3663,34 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 	const int ncomp_plotMF = plotfileVarsToInclude_cc_.size();
 	amrex::MultiFab plotMF(grids[lev], dmap[lev], ncomp_plotMF, included_ghosts);
 
+	// When ghost cells are requested in the plotfile, fill them into scratch
+	// copies so that we do NOT mutate the live simulation state.  This makes
+	// plotfile generation side-effect-free.  (See
+	// https://github.com/quokka-astro/quokka/issues/1868.)
+	amrex::MultiFab scratch_cc;
+	amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> scratch_fc;
+
 	if (included_ghosts > 0) {
-		// Fill ghost zones for state_new_cc_
-		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
+		scratch_cc.define(state_new_cc_[lev].boxArray(), state_new_cc_[lev].DistributionMap(), state_new_cc_[lev].nComp(), included_ghosts);
+		amrex::MultiFab::Copy(scratch_cc, state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
+		fillBoundaryConditions(scratch_cc, scratch_cc, lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
 				       InterpHookNone, FillPatchType::fillpatch_function);
 
-		// Fill ghost zones for state_new_fc_
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
-						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+				scratch_fc[idim].define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
+						       state_new_fc_[lev][idim].nComp(), included_ghosts);
+				amrex::MultiFab::Copy(scratch_fc[idim], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
+				fillBoundaryConditions(scratch_fc[idim], scratch_fc[idim], lev, tNew_[lev], quokka::centering::fc,
+						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone,
+						       FillPatchType::fillpatch_function);
 			}
 		}
 	}
+
+	// Select the source: scratch copies (with filled ghost cells) when
+	// included_ghosts > 0, otherwise the live simulation state directly.
+	amrex::MultiFab &src_cc = (included_ghosts > 0) ? scratch_cc : state_new_cc_[lev];
 
 	// Process each variable in the configurable list
 	int comp = 0;
@@ -3686,7 +3699,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 		auto cc_it = std::ranges::find(componentNames_cc_, varname);
 		if (cc_it != componentNames_cc_.end()) {
 			int cc_comp = std::distance(componentNames_cc_.begin(), cc_it);
-			amrex::MultiFab::Copy(plotMF, state_new_cc_[lev], cc_comp, comp, 1, included_ghosts);
+			amrex::MultiFab::Copy(plotMF, src_cc, cc_comp, comp, 1, included_ghosts);
 			comp++;
 			continue;
 		}
@@ -3702,7 +3715,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 				const int var_idx = fc_comp_flat / AMREX_SPACEDIM; // which variable type
 				const int idim = fc_comp_flat % AMREX_SPACEDIM;	   // which dimension
 				const int fc_comp = var_idx;			   // component index within that dimension's MultiFab
-				AverageFCToCC(plotMF, state_new_fc_[lev][idim], idim, comp, fc_comp, 1);
+				amrex::MultiFab &src_fc_dim = (included_ghosts > 0) ? scratch_fc[idim] : state_new_fc_[lev][idim];
+				AverageFCToCC(plotMF, src_fc_dim, idim, comp, fc_comp, 1);
 				comp++;
 				continue;
 			}
@@ -3781,15 +3795,21 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_f
 	const int ncomp_plotMF_fc = nvar_dim_tot_fc;
 
 	amrex::MultiFab plotMF_fc(amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim)), dmap[lev], ncomp_plotMF_fc, nghost_fc_);
-	// Fill ghost zones for state_new_fc_
+
+	// Fill ghost zones into a scratch copy so that we do NOT mutate the live
+	// simulation state.  (See https://github.com/quokka-astro/quokka/issues/1868.)
+	amrex::MultiFab scratch_fc;
 	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
-		fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
-				       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		scratch_fc.define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(), state_new_fc_[lev][idim].nComp(),
+				  nghost_fc_);
+		amrex::MultiFab::Copy(scratch_fc, state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
+		fillBoundaryConditions(scratch_fc, scratch_fc, lev, tNew_[lev], quokka::centering::fc, static_cast<quokka::direction>(idim),
+				       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
 	}
 
-	// copy data from face-centred state variables
+	// copy data from scratch (with filled ghost cells) to plot MF
 	for (int i = 0; i < ncomp_plotMF_fc; i++) {
-		amrex::MultiFab::Copy(plotMF_fc, state_new_fc_[lev][idim], i, comp, 1, nghost_fc_);
+		amrex::MultiFab::Copy(plotMF_fc, scratch_fc, i, comp, 1, nghost_fc_);
 		comp++;
 	}
 	return plotMF_fc;
@@ -4450,8 +4470,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	quokka::ScopedVisMFNOutFiles scoped_nfiles(checkpoint_nfiles);
 
 	// write the cell-centred MultiFab data to, e.g., chk0000010/Level_0/
+	// Copy valid cells into zero-ghost MultiFabs before writing so that
+	// checkpoint files never contain stale ghost-cell data.  (See
+	// https://github.com/quokka-astro/quokka/issues/1868.)
 	for (int lev = 0; lev <= finest_level; ++lev) {
-		amrex::VisMF::Write(state_new_cc_[lev], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "Cell"));
+		amrex::MultiFab chkMF(state_new_cc_[lev].boxArray(), state_new_cc_[lev].DistributionMap(), state_new_cc_[lev].nComp(), 0);
+		amrex::MultiFab::Copy(chkMF, state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
+		amrex::VisMF::Write(chkMF, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "Cell"));
 		amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 	}
 
@@ -4459,8 +4484,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteCheckpointFile
 	if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			for (int lev = 0; lev <= finest_level; ++lev) {
-				amrex::VisMF::Write(state_new_fc_[lev][idim], amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_",
-													    std::string("Face_") + quokka::face_dir_str[idim]));
+				amrex::MultiFab chkMF(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
+						      state_new_fc_[lev][idim].nComp(), 0);
+				amrex::MultiFab::Copy(chkMF, state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
+				amrex::VisMF::Write(chkMF, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_",
+											  std::string("Face_") + quokka::face_dir_str[idim]));
 				amrex::ParallelDescriptor::Barrier(); // needed to avoid overwhelming Lustre I/O on Frontier
 			}
 		}
@@ -4592,8 +4620,10 @@ void AMRSimulation<problem_t>::interpolateMultiFabFromRestart(amrex::MultiFab &t
 							      const amrex::Vector<amrex::BCRec> &bcs)
 {
 	if (!context.needs_refinement()) {
-		// if not refining, ParallelCopy
-		target.ParallelCopy(source, 0, 0, source.nComp(), target.nGrowVect(), source.nGrowVect());
+		// Copy only valid cells from checkpoint.  Ghost cells are treated as
+		// non-authoritative and are filled later by fillBoundaryConditions().
+		// (See https://github.com/quokka-astro/quokka/issues/1868.)
+		target.ParallelCopy(source, 0, 0, source.nComp(), amrex::IntVect(0), amrex::IntVect(0));
 	} else {
 		// if refining, InterpFromCoarseLevel
 		amrex::IntVect restart_ref_ratio{AMREX_D_DECL(context.refinement_factor, context.refinement_factor, context.refinement_factor)};
@@ -4615,12 +4645,15 @@ void AMRSimulation<problem_t>::interpolateFaceMultiFabFromRestart(int lev, const
 								  amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> &restart_fc)
 {
 	if (!context.needs_refinement()) {
-		// if not refining, we can read level-by-level and ParallelCopy to state_new_fc_[lev]
+		// Copy only valid cells from checkpoint.  Ghost cells are treated as
+		// non-authoritative and are filled later by fillBoundaryConditions().
+		// (See https://github.com/quokka-astro/quokka/issues/1868.)
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::MultiFab tmp_read;
 			amrex::VisMF::Read(tmp_read,
 					   amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", std::string("Face_") + quokka::face_dir_str[idim]));
-			state_new_fc_[lev][idim].ParallelCopy(tmp_read, 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, nghost_fc_, nghost_fc_);
+			state_new_fc_[lev][idim].ParallelCopy(tmp_read, 0, 0, Physics_Indices<problem_t>::nvarPerDim_fc, amrex::IntVect(0),
+							      amrex::IntVect(0));
 			AMREX_ALWAYS_ASSERT(!state_new_fc_[lev][idim].contains_nan(0, state_new_fc_[lev][idim].nComp())); // check valid faces
 		}
 	} else {
@@ -4732,8 +4765,8 @@ template <typename problem_t> void AMRSimulation<problem_t>::loadMultiFabData(co
 					amrex::MultiFab tmp_read;
 					amrex::VisMF::Read(tmp_read, amrex::MultiFabFileFullPrefix(chklev, restart_chkfile, "Level_",
 												   std::string("Face_") + quokka::face_dir_str[idim]));
-					restart_fc[chklev][idim].define(tmp_read.boxArray(), tmp_read.DistributionMap(), tmp_read.nComp(), nghost_fc_);
-					restart_fc[chklev][idim].ParallelCopy(tmp_read);
+					restart_fc[chklev][idim].define(tmp_read.boxArray(), tmp_read.DistributionMap(), tmp_read.nComp(), 0);
+					restart_fc[chklev][idim].ParallelCopy(tmp_read, 0, 0, tmp_read.nComp(), amrex::IntVect(0), amrex::IntVect(0));
 					AMREX_ALWAYS_ASSERT(!restart_fc[chklev][idim].contains_nan(0, restart_fc[chklev][idim].nComp())); // check valid faces
 				}
 			}
@@ -4854,6 +4887,32 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 
 	// 5. Load MultiFab data with refinement handling
 	loadMultiFabData(refinement_context);
+
+	// 6. Fill ghost cells using the normal boundary/fillpatch machinery.
+	// Checkpoint files only contain valid-cell data, so ghost zones must be
+	// explicitly populated before the first advance.  (See
+	// https://github.com/quokka-astro/quokka/issues/1868.)
+	for (int lev = 0; lev <= finest_level; ++lev) {
+		fillBoundaryConditions(state_new_cc_[lev], state_new_cc_[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na,
+				       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				fillBoundaryConditions(state_new_fc_[lev][idim], state_new_fc_[lev][idim], lev, tNew_[lev], quokka::centering::fc,
+						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+			}
+		}
+	}
+	// Copy to state_old_cc_ (including ghost zones)
+	for (int lev = 0; lev <= finest_level; ++lev) {
+		state_old_cc_[lev].ParallelCopy(state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), nghost_cc_, nghost_cc_);
+		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				state_old_fc_[lev][idim].ParallelCopy(state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), nghost_fc_,
+								      nghost_fc_);
+			}
+		}
+	}
+
 	// NOTE: postInitialization (including magnetic projection) is only for fresh ICs, not restarts.
 
 	// read particle data

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3687,7 +3687,7 @@ void AMRSimulation<problem_t>::FillPlotFileScratchFaceData(const int finest_lev_
 
 	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
 		scratch_fc.reserve(finest_lev_to_fill + 1);
-		quokka::direction const dir = static_cast<quokka::direction>(idim);
+		auto const dir = static_cast<quokka::direction>(idim);
 
 		for (int lev = 0; lev <= finest_lev_to_fill; ++lev) {
 			scratch_fc.emplace_back(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
@@ -3753,7 +3753,7 @@ void AMRSimulation<problem_t>::FillPlotFileScratchData(const int finest_lev_to_f
 							     state_new_fc_[lev][idim].nComp(), included_ghosts);
 				amrex::MultiFab::Copy(scratch_fc[lev][idim], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
 
-				quokka::direction const dir = static_cast<quokka::direction>(idim);
+				auto const dir = static_cast<quokka::direction>(idim);
 				if (lev == 0) {
 					fillBoundaryConditions(scratch_fc[lev][idim], scratch_fc[lev][idim], lev, tNew_[lev], quokka::centering::fc, dir,
 							       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3705,8 +3705,8 @@ void AMRSimulation<problem_t>::FillPlotFileScratchFaceData(const int finest_lev_
 				amrex::Vector<amrex::BCRec> BCs = BCs_fc_;
 				quokka::centering cen = quokka::centering::fc;
 
-				FillPatchWithData(lev, tNew_[lev], scratch_fc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_fc[lev].nComp(),
-						  BCs, cen, dir, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
+				FillPatchWithData(lev, tNew_[lev], scratch_fc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_fc[lev].nComp(), BCs,
+						  cen, dir, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
 			}
 
 			AMREX_ASSERT(!scratch_fc[lev].contains_nan(0, scratch_fc[lev].nComp()));
@@ -3730,8 +3730,8 @@ void AMRSimulation<problem_t>::FillPlotFileScratchData(const int finest_lev_to_f
 		amrex::MultiFab::Copy(scratch_cc[lev], state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
 
 		if (lev == 0) {
-			fillBoundaryConditions(scratch_cc[lev], scratch_cc[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na,
-					       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+			fillBoundaryConditions(scratch_cc[lev], scratch_cc[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone,
+					       InterpHookNone, FillPatchType::fillpatch_function);
 		} else {
 			amrex::Vector<amrex::MultiFab *> coarseData{&scratch_cc[lev - 1]};
 			amrex::Vector<amrex::Real> coarseTime{tNew_[lev - 1]};
@@ -3740,8 +3740,8 @@ void AMRSimulation<problem_t>::FillPlotFileScratchData(const int finest_lev_to_f
 			amrex::Vector<amrex::BCRec> BCs = BCs_cc_;
 			quokka::centering cen = quokka::centering::cc;
 
-			FillPatchWithData(lev, tNew_[lev], scratch_cc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_cc[lev].nComp(), BCs,
-					  cen, quokka::direction::na, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
+			FillPatchWithData(lev, tNew_[lev], scratch_cc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_cc[lev].nComp(), BCs, cen,
+					  quokka::direction::na, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
 		}
 
 		AMREX_ASSERT(!scratch_cc[lev].contains_nan(0, scratch_cc[lev].nComp()));
@@ -3755,8 +3755,8 @@ void AMRSimulation<problem_t>::FillPlotFileScratchData(const int finest_lev_to_f
 
 				quokka::direction const dir = static_cast<quokka::direction>(idim);
 				if (lev == 0) {
-					fillBoundaryConditions(scratch_fc[lev][idim], scratch_fc[lev][idim], lev, tNew_[lev], quokka::centering::fc,
-							       dir, InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+					fillBoundaryConditions(scratch_fc[lev][idim], scratch_fc[lev][idim], lev, tNew_[lev], quokka::centering::fc, dir,
+							       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
 				} else {
 					amrex::Vector<amrex::MultiFab *> coarseData{&scratch_fc[lev - 1][idim]};
 					amrex::Vector<amrex::Real> coarseTime{tNew_[lev - 1]};
@@ -3791,7 +3791,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_c
 
 template <typename problem_t>
 auto AMRSimulation<problem_t>::PlotFileMFAtLevel_cc(const int lev, const int included_ghosts, const amrex::MultiFab &src_cc,
-						   const amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &src_fc) -> amrex::MultiFab
+						    const amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &src_fc) -> amrex::MultiFab
 {
 	const int ncomp_plotMF = plotfileVarsToInclude_cc_.size();
 	amrex::MultiFab plotMF(grids[lev], dmap[lev], ncomp_plotMF, included_ghosts);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -474,8 +474,14 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	[[nodiscard]] auto GetPlotfileVarNames_fc() const -> std::array<amrex::Vector<std::string>, AMREX_SPACEDIM>;
 	[[nodiscard]] auto PlotFileMF_cc(int included_ghosts) -> amrex::Vector<amrex::MultiFab>;
 	[[nodiscard]] auto PlotFileMFAtLevel_cc(int lev, int included_ghosts) -> amrex::MultiFab;
+	[[nodiscard]] auto PlotFileMFAtLevel_cc(int lev, int included_ghosts, const amrex::MultiFab &src_cc,
+						const amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &src_fc) -> amrex::MultiFab;
 	[[nodiscard]] auto PlotFileMF_fc(int nghost_fc_) -> std::array<amrex::Vector<amrex::MultiFab>, AMREX_SPACEDIM>;
 	[[nodiscard]] auto PlotFileMFAtLevel_fc(int lev, int idim, int nghost_fc_) -> amrex::MultiFab;
+	[[nodiscard]] auto PlotFileMFAtLevel_fc(int lev, int idim, int nghost_fc_, const amrex::MultiFab &src_fc) -> amrex::MultiFab;
+	void FillPlotFileScratchData(int finest_lev_to_fill, int included_ghosts, amrex::Vector<amrex::MultiFab> &scratch_cc,
+				     amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> &scratch_fc);
+	void FillPlotFileScratchFaceData(int finest_lev_to_fill, int nghost_fc_, int idim, amrex::Vector<amrex::MultiFab> &scratch_fc);
 	void AverageDownDerived(const amrex::Vector<amrex::MultiFab *> &mfs, const amrex::Vector<std::string> &varnames) const;
 	void createDiagnostics();
 	void createRuntimeDerivedFields();
@@ -3672,39 +3678,123 @@ void AMRSimulation<problem_t>::AverageFCToCC(amrex::MultiFab &mf_cc, const amrex
 	amrex::Gpu::streamSynchronize();
 }
 
-template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_cc(const int lev, const int included_ghosts) -> amrex::MultiFab
+template <typename problem_t>
+void AMRSimulation<problem_t>::FillPlotFileScratchFaceData(const int finest_lev_to_fill, const int nghost_fc_, const int idim,
+							   amrex::Vector<amrex::MultiFab> &scratch_fc)
 {
-	const int ncomp_plotMF = plotfileVarsToInclude_cc_.size();
-	amrex::MultiFab plotMF(grids[lev], dmap[lev], ncomp_plotMF, included_ghosts);
+	AMREX_ASSERT(finest_lev_to_fill <= finest_level);
+	scratch_fc.clear();
 
-	// When ghost cells are requested in the plotfile, fill them into scratch
-	// copies so that we do NOT mutate the live simulation state.  This makes
-	// plotfile generation side-effect-free.  (See
-	// https://github.com/quokka-astro/quokka/issues/1868.)
-	amrex::MultiFab scratch_cc;
-	amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> scratch_fc;
+	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
+		scratch_fc.reserve(finest_lev_to_fill + 1);
+		quokka::direction const dir = static_cast<quokka::direction>(idim);
 
-	if (included_ghosts > 0) {
-		scratch_cc.define(state_new_cc_[lev].boxArray(), state_new_cc_[lev].DistributionMap(), state_new_cc_[lev].nComp(), included_ghosts);
-		amrex::MultiFab::Copy(scratch_cc, state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
-		fillBoundaryConditions(scratch_cc, scratch_cc, lev, tNew_[lev], quokka::centering::cc, quokka::direction::na, InterpHookNone, InterpHookNone,
-				       FillPatchType::fillpatch_function);
+		for (int lev = 0; lev <= finest_lev_to_fill; ++lev) {
+			scratch_fc.emplace_back(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
+						state_new_fc_[lev][idim].nComp(), nghost_fc_);
+			amrex::MultiFab::Copy(scratch_fc[lev], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
+
+			if (lev == 0) {
+				fillBoundaryConditions(scratch_fc[lev], scratch_fc[lev], lev, tNew_[lev], quokka::centering::fc, dir, InterpHookNone,
+						       InterpHookNone, FillPatchType::fillpatch_function);
+			} else {
+				amrex::Vector<amrex::MultiFab *> coarseData{&scratch_fc[lev - 1]};
+				amrex::Vector<amrex::Real> coarseTime{tNew_[lev - 1]};
+				amrex::Vector<amrex::MultiFab *> fineData{&scratch_fc[lev]};
+				amrex::Vector<amrex::Real> fineTime{tNew_[lev]};
+				amrex::Vector<amrex::BCRec> BCs = BCs_fc_;
+				quokka::centering cen = quokka::centering::fc;
+
+				FillPatchWithData(lev, tNew_[lev], scratch_fc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_fc[lev].nComp(),
+						  BCs, cen, dir, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
+			}
+
+			AMREX_ASSERT(!scratch_fc[lev].contains_nan(0, scratch_fc[lev].nComp()));
+			AMREX_ASSERT(!scratch_fc[lev].contains_nan());
+		}
+	}
+}
+
+template <typename problem_t>
+void AMRSimulation<problem_t>::FillPlotFileScratchData(const int finest_lev_to_fill, const int included_ghosts, amrex::Vector<amrex::MultiFab> &scratch_cc,
+						       amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> &scratch_fc)
+{
+	AMREX_ASSERT(finest_lev_to_fill <= finest_level);
+	scratch_cc.clear();
+	scratch_fc.clear();
+	scratch_cc.reserve(finest_lev_to_fill + 1);
+	scratch_fc.resize(finest_lev_to_fill + 1);
+
+	for (int lev = 0; lev <= finest_lev_to_fill; ++lev) {
+		scratch_cc.emplace_back(state_new_cc_[lev].boxArray(), state_new_cc_[lev].DistributionMap(), state_new_cc_[lev].nComp(), included_ghosts);
+		amrex::MultiFab::Copy(scratch_cc[lev], state_new_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
+
+		if (lev == 0) {
+			fillBoundaryConditions(scratch_cc[lev], scratch_cc[lev], lev, tNew_[lev], quokka::centering::cc, quokka::direction::na,
+					       InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+		} else {
+			amrex::Vector<amrex::MultiFab *> coarseData{&scratch_cc[lev - 1]};
+			amrex::Vector<amrex::Real> coarseTime{tNew_[lev - 1]};
+			amrex::Vector<amrex::MultiFab *> fineData{&scratch_cc[lev]};
+			amrex::Vector<amrex::Real> fineTime{tNew_[lev]};
+			amrex::Vector<amrex::BCRec> BCs = BCs_cc_;
+			quokka::centering cen = quokka::centering::cc;
+
+			FillPatchWithData(lev, tNew_[lev], scratch_cc[lev], coarseData, coarseTime, fineData, fineTime, 0, scratch_cc[lev].nComp(), BCs,
+					  cen, quokka::direction::na, FillPatchType::fillpatch_function, InterpHookNone, InterpHookNone);
+		}
+
+		AMREX_ASSERT(!scratch_cc[lev].contains_nan(0, scratch_cc[lev].nComp()));
+		AMREX_ASSERT(!scratch_cc[lev].contains_nan());
 
 		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-				scratch_fc[idim].define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
-							state_new_fc_[lev][idim].nComp(), included_ghosts);
-				amrex::MultiFab::Copy(scratch_fc[idim], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
-				fillBoundaryConditions(scratch_fc[idim], scratch_fc[idim], lev, tNew_[lev], quokka::centering::fc,
-						       static_cast<quokka::direction>(idim), InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+				scratch_fc[lev][idim].define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(),
+							     state_new_fc_[lev][idim].nComp(), included_ghosts);
+				amrex::MultiFab::Copy(scratch_fc[lev][idim], state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
+
+				quokka::direction const dir = static_cast<quokka::direction>(idim);
+				if (lev == 0) {
+					fillBoundaryConditions(scratch_fc[lev][idim], scratch_fc[lev][idim], lev, tNew_[lev], quokka::centering::fc,
+							       dir, InterpHookNone, InterpHookNone, FillPatchType::fillpatch_function);
+				} else {
+					amrex::Vector<amrex::MultiFab *> coarseData{&scratch_fc[lev - 1][idim]};
+					amrex::Vector<amrex::Real> coarseTime{tNew_[lev - 1]};
+					amrex::Vector<amrex::MultiFab *> fineData{&scratch_fc[lev][idim]};
+					amrex::Vector<amrex::Real> fineTime{tNew_[lev]};
+					amrex::Vector<amrex::BCRec> BCs = BCs_fc_;
+					quokka::centering cen = quokka::centering::fc;
+
+					FillPatchWithData(lev, tNew_[lev], scratch_fc[lev][idim], coarseData, coarseTime, fineData, fineTime, 0,
+							  scratch_fc[lev][idim].nComp(), BCs, cen, dir, FillPatchType::fillpatch_function, InterpHookNone,
+							  InterpHookNone);
+				}
+
+				AMREX_ASSERT(!scratch_fc[lev][idim].contains_nan(0, scratch_fc[lev][idim].nComp()));
+				AMREX_ASSERT(!scratch_fc[lev][idim].contains_nan());
 			}
 		}
 	}
+}
 
-	// Select the source: scratch copies (with filled ghost cells) when
-	// included_ghosts > 0, otherwise the live simulation state directly.
-	amrex::MultiFab const &src_cc = (included_ghosts > 0) ? scratch_cc : state_new_cc_[lev];
-	amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const &src_fc = (included_ghosts > 0) ? scratch_fc : state_new_fc_[lev];
+template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_cc(const int lev, const int included_ghosts) -> amrex::MultiFab
+{
+	if (included_ghosts > 0) {
+		amrex::Vector<amrex::MultiFab> scratch_cc;
+		amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> scratch_fc;
+		FillPlotFileScratchData(lev, included_ghosts, scratch_cc, scratch_fc);
+		return PlotFileMFAtLevel_cc(lev, included_ghosts, scratch_cc[lev], scratch_fc[lev]);
+	}
+
+	return PlotFileMFAtLevel_cc(lev, included_ghosts, state_new_cc_[lev], state_new_fc_[lev]);
+}
+
+template <typename problem_t>
+auto AMRSimulation<problem_t>::PlotFileMFAtLevel_cc(const int lev, const int included_ghosts, const amrex::MultiFab &src_cc,
+						   const amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> &src_fc) -> amrex::MultiFab
+{
+	const int ncomp_plotMF = plotfileVarsToInclude_cc_.size();
+	amrex::MultiFab plotMF(grids[lev], dmap[lev], ncomp_plotMF, included_ghosts);
 
 	// Process each variable in the configurable list
 	int comp = 0;
@@ -3800,6 +3890,20 @@ template <typename problem_t> void AMRSimulation<problem_t>::ComputeDensityFloor
 
 template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_fc(const int lev, int idim, const int nghost_fc_) -> amrex::MultiFab
 {
+	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
+		if (nghost_fc_ > 0) {
+			amrex::Vector<amrex::MultiFab> scratch_fc;
+			FillPlotFileScratchFaceData(lev, nghost_fc_, idim, scratch_fc);
+			return PlotFileMFAtLevel_fc(lev, idim, nghost_fc_, scratch_fc[lev]);
+		}
+	}
+
+	return PlotFileMFAtLevel_fc(lev, idim, nghost_fc_, state_new_fc_[lev][idim]);
+}
+
+template <typename problem_t>
+auto AMRSimulation<problem_t>::PlotFileMFAtLevel_fc(const int lev, int idim, const int nghost_fc_, const amrex::MultiFab &src_fc) -> amrex::MultiFab
+{
 	int comp = 0;
 	int nvar_dim_tot_fc = 0;
 	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
@@ -3809,20 +3913,9 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMFAtLevel_f
 
 	amrex::MultiFab plotMF_fc(amrex::convert(grids[lev], amrex::IntVect::TheDimensionVector(idim)), dmap[lev], ncomp_plotMF_fc, nghost_fc_);
 
-	// Fill ghost zones into a scratch copy so that we do NOT mutate the live
-	// simulation state.  (See https://github.com/quokka-astro/quokka/issues/1868.)
-	amrex::MultiFab scratch_fc;
-	if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
-		scratch_fc.define(state_new_fc_[lev][idim].boxArray(), state_new_fc_[lev][idim].DistributionMap(), state_new_fc_[lev][idim].nComp(),
-				  nghost_fc_);
-		amrex::MultiFab::Copy(scratch_fc, state_new_fc_[lev][idim], 0, 0, state_new_fc_[lev][idim].nComp(), 0);
-		fillBoundaryConditions(scratch_fc, scratch_fc, lev, tNew_[lev], quokka::centering::fc, static_cast<quokka::direction>(idim), InterpHookNone,
-				       InterpHookNone, FillPatchType::fillpatch_function);
-	}
-
 	// copy data from scratch (with filled ghost cells) to plot MF
 	for (int i = 0; i < ncomp_plotMF_fc; i++) {
-		amrex::MultiFab::Copy(plotMF_fc, scratch_fc, i, comp, 1, nghost_fc_);
+		amrex::MultiFab::Copy(plotMF_fc, src_fc, i, comp, 1, nghost_fc_);
 		comp++;
 	}
 	return plotMF_fc;
@@ -3857,8 +3950,17 @@ void AMRSimulation<problem_t>::AverageDownDerived(const amrex::Vector<amrex::Mul
 template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMF_cc(const int included_ghosts) -> amrex::Vector<amrex::MultiFab>
 {
 	amrex::Vector<amrex::MultiFab> r;
-	for (int i = 0; i <= finest_level; ++i) {
-		r.push_back(PlotFileMFAtLevel_cc(i, included_ghosts));
+	if (included_ghosts > 0) {
+		amrex::Vector<amrex::MultiFab> scratch_cc;
+		amrex::Vector<amrex::Array<amrex::MultiFab, AMREX_SPACEDIM>> scratch_fc;
+		FillPlotFileScratchData(finest_level, included_ghosts, scratch_cc, scratch_fc);
+		for (int i = 0; i <= finest_level; ++i) {
+			r.push_back(PlotFileMFAtLevel_cc(i, included_ghosts, scratch_cc[i], scratch_fc[i]));
+		}
+	} else {
+		for (int i = 0; i <= finest_level; ++i) {
+			r.push_back(PlotFileMFAtLevel_cc(i, included_ghosts, state_new_cc_[i], state_new_fc_[i]));
+		}
 	}
 	amrex::Vector<amrex::MultiFab *> r_ptrs;
 	r_ptrs.reserve(r.size());
@@ -3878,8 +3980,19 @@ template <typename problem_t> auto AMRSimulation<problem_t>::PlotFileMF_fc(const
 {
 	std::array<amrex::Vector<amrex::MultiFab>, AMREX_SPACEDIM> r_fc;
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		if constexpr (Physics_Indices<problem_t>::nvarPerDim_fc > 0) {
+			if (nghost_fc_ > 0) {
+				amrex::Vector<amrex::MultiFab> scratch_fc;
+				FillPlotFileScratchFaceData(finest_level, nghost_fc_, idim, scratch_fc);
+				for (int i = 0; i <= finest_level; ++i) {
+					r_fc[idim].push_back(PlotFileMFAtLevel_fc(i, idim, nghost_fc_, scratch_fc[i]));
+				}
+				continue;
+			}
+		}
+
 		for (int i = 0; i <= finest_level; ++i) {
-			r_fc[idim].push_back(PlotFileMFAtLevel_fc(i, idim, nghost_fc_));
+			r_fc[idim].push_back(PlotFileMFAtLevel_fc(i, idim, nghost_fc_, state_new_fc_[i][idim]));
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1868 and #1275.

Checkpoint/restart previously depended on a plotfile side effect to sanitize ghost cells before checkpointing (workaround from #554). This PR makes checkpoint files self-consistent independently of plotfile generation by:

1. **Writing checkpoints with zero ghost cells**: Copy valid cells into scratch zero-ghost MultiFabs before `VisMF::Write()`, so checkpoint files never contain stale ghost-cell data.

2. **Reading only valid cells on restart**: Change `ParallelCopy` calls to use `src_nghost=0, dst_nghost=0`, preventing stale checkpoint ghost cells from migrating into valid cells after re-boxing/load-balancing.

3. **Explicitly filling ghost cells after restart**: Call `fillBoundaryConditions()` on all levels after loading checkpoint data, then copy to `state_old_cc_`/`state_old_fc_` (mirroring the fresh-IC path in `setInitialConditionsAtLevel_cc`).

4. **Making plotfile construction side-effect-free**: Call `fillBoundaryConditions()` on scratch copies instead of mutating `state_new_cc_`/`state_new_fc_` directly. Also calls `ComputeDerivedVars()` with scratch copies instead of modifying `state_new_cc_`/`state_new_fc_`.

5. **Removing the fragile ordering workaround**: The comment requiring plotfile-before-checkpoint (added in #558) is no longer needed.

## Validation

- Adds a restart test case that would have caught this bug to the `CheckpointRestart` CI action