### PR TITLE
Include passive scalar fluxes in LLF MHD

### DIFF
--- a/src/hydro/LLF_mhd.hpp
+++ b/src/hydro/LLF_mhd.hpp
@@ -62,6 +62,10 @@ AMREX_FORCE_INLINE AMREX_GPU_DEVICE auto LLF_MHD(quokka::HydroState<N_scalars, N
 	u_R.Eint = sR.Eint;
 	u_R.by = sR.by;
 	u_R.bz = sR.bz;
+	for (int n = 0; n < N_scalars; ++n) {
+		u_L.scalar[n] = sL.scalar[n];
+		u_R.scalar[n] = sR.scalar[n];
+	}
 
 	//--- Step 2.  Compute wave speeds in L,R states (see Toro eq. 10.43)
 


### PR DESCRIPTION
### Description
Fixed the passing scalars in LLF-mhd.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1852.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
