### PR TITLE
fix: use 7-digit indices consistently across all diagnostics

### DIFF
--- a/src/io/DiagFramePlane.H
+++ b/src/io/DiagFramePlane.H
@@ -146,7 +146,7 @@ template <typename problem_t> void DiagFramePlane::processDiag(int a_nstep, cons
 		if (m_per > 0.0) {
 			diagfile = m_diagfile + std::to_string(a_time);
 		} else {
-			diagfile = amrex::Concatenate(m_diagfile, a_nstep, 6);
+			diagfile = amrex::Concatenate(m_diagfile, a_nstep, 7);
 		}
 		amrex::Vector<int> const step_array(nlevs, a_nstep);
 		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio,

--- a/src/io/DiagPDF.cpp
+++ b/src/io/DiagPDF.cpp
@@ -130,7 +130,7 @@ void DiagPDF::writePDFToFile(int a_nstep, const amrex::Real &a_time, const amrex
 	if (m_per > 0.0) {
 		diagfile = m_diagfile + std::to_string(a_time);
 	} else {
-		diagfile = amrex::Concatenate(m_diagfile, a_nstep, 6);
+		diagfile = amrex::Concatenate(m_diagfile, a_nstep, 7);
 	}
 	diagfile = diagfile + ".dat";
 


### PR DESCRIPTION
### Description
Standardise diagnostic output filenames to consistently use 7-digit zero-padded step indices across all diagnostic types.

`DiagFramePlane` and `DiagPDF` were using 6-digit indices (`amrex::Concatenate(..., 6)`), while `DiagPlotfile`, `DiagParticleTxt`, `DiagProjectionPlot`, and the core simulation plotfile/checkpoint code all used 7 digits. This inconsistency caused frame-plane slice directories (e.g. `slicez_plt000001`) and PDF files to sort differently from plotfiles (`plt0000001`) and checkpoints when the step count reached 7 digits or when tools glob across output types.

The fix is two single-character changes:
- `src/io/DiagFramePlane.H`: `Concatenate(..., 6)` → `Concatenate(..., 7)`
- `src/io/DiagPDF.cpp`: `Concatenate(..., 6)` → `Concatenate(..., 7)`

Validated by building and running `ParticleSinkFormation` (3D), which exercises both `DiagFramePlane` and `DiagParticleTxt`. Output directories (`slicex_plt0000000`, `slicez_plt0000000`) confirm 7-digit padding.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
