### PR TITLE
fix: always use step-based filenames in DiagFramePlane

### DIFF
--- a/src/io/DiagFramePlane.H
+++ b/src/io/DiagFramePlane.H
@@ -141,13 +141,8 @@ template <typename problem_t> void DiagFramePlane::processDiag(int a_nstep, cons
 			ref_ratio.push_back(rref);
 		}
 
-		// File name based on step or time
-		std::string diagfile;
-		if (m_per > 0.0) {
-			diagfile = m_diagfile + std::to_string(a_time);
-		} else {
-			diagfile = amrex::Concatenate(m_diagfile, a_nstep, 7);
-		}
+		// File name based on step index
+		std::string const diagfile = amrex::Concatenate(m_diagfile, a_nstep, 7);
 		amrex::Vector<int> const step_array(nlevs, a_nstep);
 		Write2DMultiLevelPlotfile(diagfile, nlevs, GetVecOfConstPtrs(planeData), m_fieldNames, pltGeoms, a_time, step_array, ref_ratio,
 					  simulationMetadata);


### PR DESCRIPTION
### Description
Remove time-based filename generation from `DiagFramePlane::processDiag` since outputting with time-based filenames is never intended in Quokka. This also fixes an inconsistency where `m_per`-triggered outputs used time-based names (`diagfile + std::to_string(a_time)`) while `m_time_interval`-triggered outputs fell through to step-based names — now both always use `amrex::Concatenate(m_diagfile, a_nstep, 7)` with 7-digit zero-padded step indices.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
