### PR TITLE
Fix MHD wave convergence tests: enable MPI splits and add TOML parameters

### DIFF
--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -485,7 +485,11 @@ auto problem_main() -> int
 	quokka::richardson::Parameters params{};
 	params.machine_precision_target = 2.0e-10; // limit based on delta_b_magn, smaller values can be used if this is decreased
 	params.nx_initial = 16;
-	params.nx_max = 128; // cap at 256 for quick tests. otherwise, it can take ~1-2 hours for 2048
+	params.nx_max = 128; // default; override with setup.nx_max in the input file.
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("nx_max", params.nx_max);
+	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Alfven Wave";

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -393,7 +393,7 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
 
 

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -483,11 +483,12 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 
 	quokka::richardson::Parameters params{};
-	params.machine_precision_target = 2.0e-10; // limit based on delta_b_magn, smaller values can be used if this is decreased
+	params.machine_precision_target = 2.0e-10; // default; set to 0 via setup.machine_precision_target to disable early exit.
 	params.nx_initial = 16;
 	params.nx_max = 128; // default; override with setup.nx_max in the input file.
 	{
 		amrex::ParmParse const pp("setup");
+		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
 	}
 	params.expected_rate = 2.0;

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -392,6 +392,8 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+
+
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
@@ -421,10 +423,8 @@ auto runWaveTest(int nx) -> double
 	amrex::Vector<int> const ncells = {nx, 8, 8};
 	pp.addarr("n_cell", ncells);
 
-	int blocking_x = std::max(16, ncells[0]);
-	pp.query("blocking_factor_x", blocking_x);
 	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", blocking_x);
+		pp.add("blocking_factor_x", 16);
 	}
 	if (!pp.contains("blocking_factor_y")) {
 		pp.add("blocking_factor_y", 8);
@@ -433,10 +433,8 @@ auto runWaveTest(int nx) -> double
 		pp.add("blocking_factor_z", 8);
 	}
 
-	int max_grid_x = ncells[0];
-	pp.query("max_grid_size", max_grid_x);
 	if (!pp.contains("max_grid_size")) {
-		pp.add("max_grid_size", max_grid_x);
+		pp.add("max_grid_size", 128);
 	}
 
 	pp.add("max_level", 0);

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -392,6 +392,10 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+	if (num_modes_y != 0 || num_modes_z != 0) {
+		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	}
+
 
 
 	// we assume box length = 1.0

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -393,10 +393,9 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort(
+		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
-
-
 
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -538,11 +538,12 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 
 	quokka::richardson::Parameters params{};
-	params.machine_precision_target = 2.0e-9; // limit based on delta_b_magn, smaller values can be used if this is decreased
+	params.machine_precision_target = 2.0e-9; // default; set to 0 via setup.machine_precision_target to disable early exit.
 	params.nx_initial = 16;
 	params.nx_max = 128; // default; override with setup.nx_max in the input file.
 	{
 		amrex::ParmParse const pp("setup");
+		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
 	}
 	params.expected_rate = 2.0;

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -540,7 +540,11 @@ auto problem_main() -> int
 	quokka::richardson::Parameters params{};
 	params.machine_precision_target = 2.0e-9; // limit based on delta_b_magn, smaller values can be used if this is decreased
 	params.nx_initial = 16;
-	params.nx_max = 128; // cap at 256 for quick tests. otherwise, it can take ~1-2 hours for 2048
+	params.nx_max = 128; // default; override with setup.nx_max in the input file.
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("nx_max", params.nx_max);
+	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Fast Wave";

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -447,6 +447,8 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+
+
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
@@ -475,9 +477,8 @@ auto runWaveTest(int nx) -> double
 	amrex::ParmParse pp("amr");
 	amrex::Vector<int> const ncells = {nx, 8, 8};
 
-	const int blocking_x = std::max(16, nx);
 	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", blocking_x);
+		pp.add("blocking_factor_x", 16);
 	}
 	if (!pp.contains("blocking_factor_y")) {
 		pp.add("blocking_factor_y", 8);
@@ -486,9 +487,8 @@ auto runWaveTest(int nx) -> double
 		pp.add("blocking_factor_z", 8);
 	}
 
-	const int max_grid_x = nx;
 	if (!pp.contains("max_grid_size")) {
-		pp.add("max_grid_size", max_grid_x);
+		pp.add("max_grid_size", 128);
 	}
 
 	pp.add("max_level", 0);

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -448,10 +448,9 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort(
+		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
-
-
 
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -448,7 +448,7 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
 
 

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -447,6 +447,10 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+	if (num_modes_y != 0 || num_modes_z != 0) {
+		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	}
+
 
 
 	// we assume box length = 1.0

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -456,6 +456,10 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+	if (num_modes_y != 0 || num_modes_z != 0) {
+		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	}
+
 
 
 	// we assume box length = 1.0

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -457,7 +457,7 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
 
 

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -547,11 +547,12 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 
 	quokka::richardson::Parameters params{};
-	params.machine_precision_target = 2.0e-9; // limit based on delta_b_magn, smaller values can be used if this is decreased
+	params.machine_precision_target = 2.0e-9; // default; set to 0 via setup.machine_precision_target to disable early exit.
 	params.nx_initial = 16;
 	params.nx_max = 128; // default; override with setup.nx_max in the input file.
 	{
 		amrex::ParmParse const pp("setup");
+		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
 	}
 	params.expected_rate = 2.0;

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -457,10 +457,9 @@ auto runWaveTest(int nx) -> double
 	}
 
 	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort("Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+		amrex::Abort(
+		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
 	}
-
-
 
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -456,6 +456,8 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+
+
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
@@ -484,9 +486,8 @@ auto runWaveTest(int nx) -> double
 	amrex::ParmParse pp("amr");
 	amrex::Vector<int> const ncells = {nx, 8, 8};
 
-	const int blocking_x = std::max(16, nx);
 	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", blocking_x);
+		pp.add("blocking_factor_x", 16);
 	}
 	if (!pp.contains("blocking_factor_y")) {
 		pp.add("blocking_factor_y", 8);
@@ -495,9 +496,8 @@ auto runWaveTest(int nx) -> double
 		pp.add("blocking_factor_z", 8);
 	}
 
-	const int max_grid_x = nx;
 	if (!pp.contains("max_grid_size")) {
-		pp.add("max_grid_size", max_grid_x);
+		pp.add("max_grid_size", 128);
 	}
 
 	pp.add("max_level", 0);

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -549,7 +549,11 @@ auto problem_main() -> int
 	quokka::richardson::Parameters params{};
 	params.machine_precision_target = 2.0e-9; // limit based on delta_b_magn, smaller values can be used if this is decreased
 	params.nx_initial = 16;
-	params.nx_max = 128; // cap at 256 for quick tests. otherwise, it can take ~1-2 hours for 2048
+	params.nx_max = 128; // default; override with setup.nx_max in the input file.
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("nx_max", params.nx_max);
+	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Slow Wave";


### PR DESCRIPTION
### Description

The three MHD wave convergence tests (`AlfvenWaveLinearConvergence`, `FastWaveConvergence`, `SlowWaveConvergence`) had two issues. First, `blocking_factor` and `max_grid_size` were unset, which caused AMReX to create a single box covering the entire domain. With a single box, all MPI ranks beyond the first are silently idle; the test ran sequentially regardless of rank count. Setting `blocking_factor_x = 16` and `max_grid_size = 128` allows AMReX to decompose a 512-cell domain into up to 32 boxes, enabling proper MPI parallelism. Second, the Richardson convergence framework only refines `nx`; oblique wave modes (`num_modes_y` or `num_modes_z` nonzero) will not converge under this strategy and previously produced incorrect results silently. An abort guard is added to catch this at startup.

`setup.nx_max` and `setup.machine_precision_target` are also now queryable from the input TOML, so sweep scripts can control the resolution ceiling and early-exit threshold without modifying source code.

### Related issues

N/A

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.