### PR TITLE
Add dust runtime parameters: grain radius and grain density

### DIFF
--- a/docs/markdown/dust_module.md
+++ b/docs/markdown/dust_module.md
@@ -139,7 +139,7 @@ Users may optionally enable Picard iteration for the local update represented by
 
 For a given problem, users must define a problem-specific dust stopping time by implementing the `DustSources::ComputeReciprocalStoppingTime` function (note that this function should return the reciprocal of the stopping time). An example can be found in the `src/problems/DustDamping` test.
 
-Users can directly use the dust stopping time calculation helper `DustSources::ComputeReciprocalStoppingTimeKwok` to compute the physical dust stopping time, following Kwok (1975) with an optional supersonic correction. Problem setups that use this helper must provide the dust grain radius \\(a\\) and material density \\(\rho_{\mathrm{gr}}\\) for each dust group. The stopping time of dust \\(t_{\mathrm{s}}\\) is given by:
+Users can directly use the dust stopping time calculation helper `DustSources::ComputeReciprocalStoppingTimeKwok` to compute the physical dust stopping time, following Kwok (1975) with an optional supersonic correction. Problem setups that use this helper must provide the dust grain radius \\(a\\) and material density \\(\rho_{\mathrm{gr}}\\) for each dust group. These values can be read from the optional runtime parameters `dust.grain_radius` and `dust.grain_density` by calling `quokka::dust::readDustGrainParams`. The stopping time of dust \\(t_{\mathrm{s}}\\) is given by:
 
 <script type="math/tex; mode=display">
 t_{\mathrm{s}} = \frac{\sqrt{\pi \gamma}}{2\sqrt{2}} \frac{a \rho_{\mathrm{gr}}}{\rho_{\mathrm{g}} c_{\mathrm{s}}} \times 
@@ -170,3 +170,5 @@ The following input parameters tune the dust module and are documented in more d
 - `omega_rk_residual` – controls deposition of the discrete RK energy residual from the combined dust drag-plus-Lorentz source update. It is only relevant when MHD and dust are both enabled.
 - `print_iteration_counts` - switch to turn on/off printing of dust source iteration counts for debugging.
 - `dust.density_floor` - the minimum dust density value allowed in the simulation.
+- `dust.grain_radius` - optional dust grain radius values for problem setups that use the Kwok stopping-time helper.
+- `dust.grain_density` - optional dust grain material density values for problem setups that use the Kwok stopping-time helper.

--- a/docs/markdown/parameters.md
+++ b/docs/markdown/parameters.md
@@ -115,7 +115,7 @@ These parameters are read in the `QuokkaSimulation<problem_t>::readParmParse()` 
 
 ## Dust
 
-These parameters are read in the `QuokkaSimulation<problem_t>::readParmParse()` function in `src/QuokkaSimulation.hpp`.
+These parameters are read in the `QuokkaSimulation<problem_t>::readParmParse()` function in `src/QuokkaSimulation.hpp`, except for optional Kwok stopping-time grain parameters that are read by problem setups that opt into `quokka::dust::readDustGrainParams`.
 
 | Parameter Name              | Type          | Default        | Description                                                                                                                                       |
 |-----------------------------|---------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -124,6 +124,8 @@ These parameters are read in the `QuokkaSimulation<problem_t>::readParmParse()` 
 | dust.omega_rk_residual      | Float         | `0.0`          | Controls deposition of the discrete RK energy residual from the combined dust drag-plus-Lorentz update. Only relevant when dust and MHD are both enabled. |
 | dust.print_iteration_counts | Boolean (0/1) | `0` (Disabled) | If set to 1, prints dust drag or dust drag-plus-Lorentz iteration counts for debugging.                                                           |
 | dust.density_floor          | Float         | `0.0`          | The minimum dust density value allowed in the simulation. Enforced through EnforceLimits.                                                        |
+| dust.grain_radius           | Float or list | Problem default | Optional dust grain radius values used by problem setups that call the Kwok stopping-time helper. Must contain one value per dust group.          |
+| dust.grain_density          | Float or list | Problem default | Optional dust grain material density values used by problem setups that call the Kwok stopping-time helper. Must contain one value per dust group. |
 
 ## Particles
 

--- a/inputs/DustDampedGyromotion.toml
+++ b/inputs/DustDampedGyromotion.toml
@@ -21,3 +21,6 @@ do_subcycle = 0
 suppress_output = 1
 
 max_timesteps = 10000000
+
+dust.grain_radius = 1.5957691216057308
+dust.grain_density = 1.0

--- a/inputs/DustDampingIterationMHDZeroCharge.toml
+++ b/inputs/DustDampingIterationMHDZeroCharge.toml
@@ -22,3 +22,6 @@ suppress_output = 0
 
 max_timesteps = 10000000
 stop_time = 0.05
+
+dust.grain_radius = [0.02, 0.01]
+dust.grain_density = [1.0, 1.0]

--- a/inputs/DustMagnetizedRDI.toml
+++ b/inputs/DustMagnetizedRDI.toml
@@ -34,6 +34,8 @@ mhd.emf_compute_scheme = "Balsara2025"
 dust.enable_iter_stoptime = 1
 dust.print_iteration_counts = 0
 dust.density_floor = 1.0e-12
+dust.grain_radius = 5.0
+dust.grain_density = 1.0
 
 [problem]
 write_csv = 1

--- a/src/dust/DustRuntimeParams.hpp
+++ b/src/dust/DustRuntimeParams.hpp
@@ -10,8 +10,7 @@
 namespace quokka::dust
 {
 
-template <unsigned int nDustGroups>
-void queryPositiveArray(amrex::ParmParse const &pp, char const *name, amrex::GpuArray<amrex::Real, nDustGroups> &values)
+template <unsigned int nDustGroups> void queryPositiveArray(amrex::ParmParse const &pp, char const *name, amrex::GpuArray<amrex::Real, nDustGroups> &values)
 {
 	static_assert(nDustGroups > 0);
 

--- a/src/dust/DustRuntimeParams.hpp
+++ b/src/dust/DustRuntimeParams.hpp
@@ -1,0 +1,47 @@
+#ifndef DUST_RUNTIME_PARAMS_HPP_
+#define DUST_RUNTIME_PARAMS_HPP_
+
+#include "AMReX_Gpu.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Vector.H"
+#include <cmath>
+#include <string>
+
+namespace quokka::dust
+{
+
+template <unsigned int nDustGroups>
+void queryPositiveArray(amrex::ParmParse const &pp, char const *name, amrex::GpuArray<amrex::Real, nDustGroups> &values)
+{
+	static_assert(nDustGroups > 0);
+
+	amrex::Vector<amrex::Real> parsed_values;
+	if (pp.queryarr(name, parsed_values) != 0) {
+		if (parsed_values.size() != nDustGroups) {
+			amrex::Abort(std::string("dust.") + name + " must contain exactly " + std::to_string(nDustGroups) + " value(s).");
+		}
+
+		for (unsigned int g = 0; g < nDustGroups; ++g) {
+			values[g] = parsed_values[g];
+		}
+	}
+
+	for (unsigned int g = 0; g < nDustGroups; ++g) {
+		if (!std::isfinite(static_cast<double>(values[g])) || values[g] <= 0.0) {
+			amrex::Abort(std::string("dust.") + name + " values must be finite and positive.");
+		}
+	}
+}
+
+// read optional problem-specific grain parameters used by Kwok stopping-time dust problems
+template <unsigned int nDustGroups>
+void readDustGrainParams(amrex::GpuArray<amrex::Real, nDustGroups> &grain_radius, amrex::GpuArray<amrex::Real, nDustGroups> &grain_density)
+{
+	amrex::ParmParse const pp("dust");
+	queryPositiveArray(pp, "grain_radius", grain_radius);
+	queryPositiveArray(pp, "grain_density", grain_density);
+}
+
+} // namespace quokka::dust
+
+#endif // DUST_RUNTIME_PARAMS_HPP_

--- a/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
+++ b/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
@@ -3,6 +3,7 @@
 ///
 
 #include "QuokkaSimulation.hpp"
+#include "dust/DustRuntimeParams.hpp"
 #include "util/fextract.hpp"
 #include <algorithm>
 #include <cmath>
@@ -20,12 +21,14 @@ constexpr double epsilon = 1.0;
 constexpr double rho_dust = epsilon * rho_gas;
 constexpr double sound_speed = 1.0;
 constexpr double initial_drift = 10.0 * sound_speed;
-constexpr double alpha0 = 1.0;
 constexpr double gamma_iso = 1.0;
 constexpr double eta = 9.0 * std::numbers::pi * gamma_iso / 128.0;
-constexpr double dust_grain_density = 1.0;
-constexpr double dust_grain_radius = 1.5957691216057308; // sqrt(8 / pi) gives alpha0 = 1 for gamma = rho_g = c_s = rho_gr = 1.
+constexpr double default_grain_density = 1.0;
+constexpr double default_grain_radius = 1.5957691216057308; // sqrt(8 / pi) gives alpha0 = 1 for gamma = rho_g = c_s = rho_gr = 1.
 constexpr double charge_to_mass_ratio = 1.0;
+
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 1> g_dust_grain_radius = {default_grain_radius}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 1> g_dust_grain_density = {default_grain_density}; // NOLINT
 
 constexpr double gas_velocity_x0 = -epsilon * initial_drift / (1.0 + epsilon);
 constexpr double dust_velocity_x0 = initial_drift / (1.0 + epsilon);
@@ -44,6 +47,12 @@ struct DustGyroHistory {
 	std::vector<double> center_momentum_y_vec_;
 	std::vector<double> center_momentum_z_vec_;
 };
+
+auto computeInitialReciprocalStoppingTime() -> double
+{
+	return (2.0 * std::numbers::sqrt2 * rho_gas * sound_speed) / (std::sqrt(std::numbers::pi * gamma_iso) * g_dust_grain_radius[0] *
+								      g_dust_grain_density[0]);
+}
 } // namespace
 
 struct DustGyroEpsteinNoB {
@@ -139,9 +148,7 @@ AMREX_GPU_HOST_DEVICE auto computeDustGyroReciprocalStoppingTime(amrex::Real rho
 								 amrex::GpuArray<amrex::Real, 1> rel_vel_mag, double cs) -> amrex::GpuArray<amrex::Real, 1>
 {
 	if constexpr (GyroCaseParams<problem_t>::enable_epstein_drag) {
-		amrex::GpuArray<amrex::Real, 1> const grain_radius = {dust_grain_radius};
-		amrex::GpuArray<amrex::Real, 1> const grain_density = {dust_grain_density};
-		return DustSources<problem_t>::ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, grain_radius, grain_density, true);
+		return DustSources<problem_t>::ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density, true);
 	} else {
 		amrex::GpuArray<amrex::Real, 1> alpha{};
 		alpha.fill(0.0);
@@ -348,6 +355,7 @@ template <typename problem_t> auto runDustGyroSimulation() -> SimulationData<pro
 auto analyticEpsteinDrift(double t, double omega_L) -> DriftState
 {
 	const double drift_factor = std::sqrt(1.0 + eta * initial_drift * initial_drift / (sound_speed * sound_speed));
+	const double alpha0 = computeInitialReciprocalStoppingTime();
 	const double tau = (1.0 + epsilon) * alpha0 * t;
 	const double numerator = std::sinh(tau) + drift_factor * std::cosh(tau);
 	const double denominator = std::cosh(tau) + drift_factor * std::sinh(tau);
@@ -447,6 +455,8 @@ void plotDriftX(const DustGyroHistory &data, AnalyticFn analytic, const std::str
 
 auto problem_main() -> int
 {
+	quokka::dust::readDustGrainParams(g_dust_grain_radius, g_dust_grain_density);
+
 	auto epstein_no_b = runDustGyroSimulation<DustGyroEpsteinNoB>();
 	auto gyro_no_drag = runDustGyroSimulation<DustGyroNoDrag>();
 	auto epstein_with_b = runDustGyroSimulation<DustGyroEpsteinWithB>();
@@ -484,6 +494,7 @@ auto problem_main() -> int
 		}
 
 #ifdef HAVE_PYTHON
+		const double alpha0 = computeInitialReciprocalStoppingTime();
 		plotDriftX(epstein_no_b, epstein_no_b_exact, "./dust_gyromotion_PureDamping.pdf", "Pure Damping", alpha0, R"($t/t_{s,0}$)");
 		plotDriftX(gyro_no_drag, gyro_no_drag_exact, "./dust_gyromotion_UndampedGyromotion.pdf", "Undamped Gyromotion",
 			   GyroCaseParams<DustGyroNoDrag>::omega_L, R"($\omega_L t$)");

--- a/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
+++ b/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
@@ -27,7 +27,7 @@ constexpr double default_grain_density = 1.0;
 constexpr double default_grain_radius = 1.5957691216057308; // sqrt(8 / pi) gives alpha0 = 1 for gamma = rho_g = c_s = rho_gr = 1.
 constexpr double charge_to_mass_ratio = 1.0;
 
-AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 1> g_dust_grain_radius = {default_grain_radius}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 1> g_dust_grain_radius = {default_grain_radius};	  // NOLINT
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 1> g_dust_grain_density = {default_grain_density}; // NOLINT
 
 constexpr double gas_velocity_x0 = -epsilon * initial_drift / (1.0 + epsilon);
@@ -50,8 +50,8 @@ struct DustGyroHistory {
 
 auto computeInitialReciprocalStoppingTime() -> double
 {
-	return (2.0 * std::numbers::sqrt2 * rho_gas * sound_speed) / (std::sqrt(std::numbers::pi * gamma_iso) * g_dust_grain_radius[0] *
-								      g_dust_grain_density[0]);
+	return (2.0 * std::numbers::sqrt2 * rho_gas * sound_speed) /
+	       (std::sqrt(std::numbers::pi * gamma_iso) * g_dust_grain_radius[0] * g_dust_grain_density[0]);
 }
 } // namespace
 
@@ -148,7 +148,8 @@ AMREX_GPU_HOST_DEVICE auto computeDustGyroReciprocalStoppingTime(amrex::Real rho
 								 amrex::GpuArray<amrex::Real, 1> rel_vel_mag, double cs) -> amrex::GpuArray<amrex::Real, 1>
 {
 	if constexpr (GyroCaseParams<problem_t>::enable_epstein_drag) {
-		return DustSources<problem_t>::ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density, true);
+		return DustSources<problem_t>::ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density,
+										 true);
 	} else {
 		amrex::GpuArray<amrex::Real, 1> alpha{};
 		alpha.fill(0.0);

--- a/src/problems/DustDampingIteration/testDustDampingIteration.cpp
+++ b/src/problems/DustDampingIteration/testDustDampingIteration.cpp
@@ -64,7 +64,7 @@ namespace
 {
 // problem-specific grain defaults; input files may override them with dust.grain_radius and dust.grain_density
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_radius = {0.02, 0.01}; // NOLINT
-AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0};  // NOLINT
 } // namespace
 static constexpr bool enable_supersonic_correction_with = true;
 static constexpr bool enable_supersonic_correction_without = false;
@@ -109,8 +109,7 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingWithCorrection>::ComputeRecipr
 												 amrex::GpuArray<amrex::Real, nDustGroups_> rel_vel_mag,
 												 double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
-	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density,
-						enable_supersonic_correction_with);
+	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density, enable_supersonic_correction_with);
 }
 
 template <>
@@ -120,7 +119,7 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingWithoutCorrection>::ComputeRec
 												    double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
 	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density,
-						enable_supersonic_correction_without);
+						 enable_supersonic_correction_without);
 }
 
 template <> void QuokkaSimulation<DustDampingWithCorrection>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)

--- a/src/problems/DustDampingIteration/testDustDampingIteration.cpp
+++ b/src/problems/DustDampingIteration/testDustDampingIteration.cpp
@@ -3,6 +3,7 @@
 ///
 
 #include "QuokkaSimulation.hpp"
+#include "dust/DustRuntimeParams.hpp"
 #include "util/fextract.hpp"
 #include <cmath>
 #include <format>
@@ -59,8 +60,12 @@ constexpr double Egas0_without_corr = P_INITIAL / (quokka::EOS_Traits<DustDampin
 constexpr double Egas0_internal_without_corr = P_INITIAL / (quokka::EOS_Traits<DustDampingWithoutCorrection>::gamma - 1.0);
 
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
-static constexpr amrex::GpuArray<amrex::Real, 2> dust_grain_radius = {0.02, 0.01};
-static constexpr amrex::GpuArray<amrex::Real, 2> dust_grain_density = {1.0, 1.0};
+namespace
+{
+// problem-specific grain defaults; input files may override them with dust.grain_radius and dust.grain_density
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_radius = {0.02, 0.01}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0}; // NOLINT
+} // namespace
 static constexpr bool enable_supersonic_correction_with = true;
 static constexpr bool enable_supersonic_correction_without = false;
 
@@ -104,7 +109,8 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingWithCorrection>::ComputeRecipr
 												 amrex::GpuArray<amrex::Real, nDustGroups_> rel_vel_mag,
 												 double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
-	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, dust_grain_radius, dust_grain_density, enable_supersonic_correction_with);
+	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density,
+						enable_supersonic_correction_with);
 }
 
 template <>
@@ -113,7 +119,8 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingWithoutCorrection>::ComputeRec
 												    amrex::GpuArray<amrex::Real, nDustGroups_> rel_vel_mag,
 												    double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
-	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, dust_grain_radius, dust_grain_density, enable_supersonic_correction_without);
+	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density,
+						enable_supersonic_correction_without);
 }
 
 template <> void QuokkaSimulation<DustDampingWithCorrection>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
@@ -432,6 +439,8 @@ auto compute_relative_error(const std::vector<double> &t_test, const std::vector
 
 auto problem_main() -> int
 {
+	quokka::dust::readDustGrainParams(g_dust_grain_radius, g_dust_grain_density);
+
 	// step 1: run the reference solution (non-iterative, fixed small time step, with correction enabled)
 	auto ref_data = run_reference_simulation();
 

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -27,7 +27,7 @@ constexpr double B_Z = 0.5;
 constexpr double MAGNETIC_ENERGY = 0.5 * (B_X * B_X + B_Y * B_Y + B_Z * B_Z);
 
 AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_radius = {0.02, 0.01}; // NOLINT
-AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0};  // NOLINT
 constexpr bool enable_supersonic_correction = true;
 } // namespace
 

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -3,6 +3,7 @@
 ///
 
 #include "QuokkaSimulation.hpp"
+#include "dust/DustRuntimeParams.hpp"
 #include "util/fextract.hpp"
 #include <algorithm>
 #include <cmath>
@@ -25,8 +26,8 @@ constexpr double B_Y = 0.4;
 constexpr double B_Z = 0.5;
 constexpr double MAGNETIC_ENERGY = 0.5 * (B_X * B_X + B_Y * B_Y + B_Z * B_Z);
 
-constexpr amrex::GpuArray<amrex::Real, 2> dust_grain_radius = {0.02, 0.01};
-constexpr amrex::GpuArray<amrex::Real, 2> dust_grain_density = {1.0, 1.0};
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_radius = {0.02, 0.01}; // NOLINT
+AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1.0}; // NOLINT
 constexpr bool enable_supersonic_correction = true;
 } // namespace
 
@@ -109,7 +110,7 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingDragReference>::ComputeRecipro
 												amrex::GpuArray<amrex::Real, nDustGroups_> rel_vel_mag,
 												double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
-	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, dust_grain_radius, dust_grain_density, enable_supersonic_correction);
+	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density, enable_supersonic_correction);
 }
 
 template <>
@@ -118,7 +119,7 @@ AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingMHDZeroCharge>::ComputeRecipro
 												amrex::GpuArray<amrex::Real, nDustGroups_> rel_vel_mag,
 												double cs) -> amrex::GpuArray<amrex::Real, nDustGroups_>
 {
-	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, dust_grain_radius, dust_grain_density, enable_supersonic_correction);
+	return ComputeReciprocalStoppingTimeKwok(rho_g, rho_d, rel_vel_mag, cs, g_dust_grain_radius, g_dust_grain_density, enable_supersonic_correction);
 }
 
 template <> AMREX_GPU_HOST_DEVICE auto DustSources<DustDampingMHDZeroCharge>::ComputeDustChargeToMassRatio() -> amrex::GpuArray<amrex::Real, nDustGroups_>
@@ -274,6 +275,7 @@ auto run_mhd_zero_charge_simulation() -> SimulationData<DustDampingMHDZeroCharge
 	sim.cflNumber_ = 0.3;
 	sim.constantDt_ = -1.0;
 	sim.enableIterDustStoptime_ = 1;
+	sim.dust_omega_res_ = 1.0;
 	sim.print_dust_counter_ = true;
 
 	sim.setInitialConditions();
@@ -333,6 +335,8 @@ auto max_abs_component(const std::vector<double> &values) -> double
 
 auto problem_main() -> int
 {
+	quokka::dust::readDustGrainParams(g_dust_grain_radius, g_dust_grain_density);
+
 	auto ref_data = run_reference_simulation();
 	auto mhd_data = run_mhd_zero_charge_simulation();
 

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -275,7 +275,7 @@ auto run_mhd_zero_charge_simulation() -> SimulationData<DustDampingMHDZeroCharge
 	sim.cflNumber_ = 0.3;
 	sim.constantDt_ = -1.0;
 	sim.enableIterDustStoptime_ = 1;
-	sim.dust_omega_res_ = 1.0;
+	sim.dust_omega_res_ = 1.0;  // make the energy calculation method in computeDustDragAndLorentz() the same as the reference solution
 	sim.print_dust_counter_ = true;
 
 	sim.setInitialConditions();

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -275,7 +275,7 @@ auto run_mhd_zero_charge_simulation() -> SimulationData<DustDampingMHDZeroCharge
 	sim.cflNumber_ = 0.3;
 	sim.constantDt_ = -1.0;
 	sim.enableIterDustStoptime_ = 1;
-	sim.dust_omega_res_ = 1.0;  // make the energy calculation method in computeDustDragAndLorentz() the same as the reference solution
+	sim.dust_omega_res_ = 1.0; // make the energy calculation method in computeDustDragAndLorentz() the same as the reference solution
 	sim.print_dust_counter_ = true;
 
 	sim.setInitialConditions();

--- a/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
+++ b/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
@@ -57,18 +57,18 @@ std::array<double, 3> g_snapshot_target_times = {0.0, 0.0, 0.0};		   // NOLINT
 double g_equilibrium_ts = 0.0;							   // NOLINT
 
 AMREX_GPU_MANAGED double g_grain_radius = grain_radius_density_param / grain_density0; // NOLINT
-AMREX_GPU_MANAGED double g_grain_density = grain_density0;			    // NOLINT
-AMREX_GPU_MANAGED double g_charge_to_mass = xi_param;			       // NOLINT
-AMREX_GPU_MANAGED double g_noise_amplitude = noise_amplitude_param;	       // NOLINT
-AMREX_GPU_MANAGED double g_Bx0 = 0.0;					       // NOLINT
-AMREX_GPU_MANAGED double g_By0 = 0.0;					       // NOLINT
-AMREX_GPU_MANAGED double g_Bz0 = 1.0;					       // NOLINT
-AMREX_GPU_MANAGED double g_gas_vx0 = 0.0;				       // NOLINT
-AMREX_GPU_MANAGED double g_gas_vy0 = 0.0;				       // NOLINT
-AMREX_GPU_MANAGED double g_gas_vz0 = 0.0;				       // NOLINT
-AMREX_GPU_MANAGED double g_dust_vx0 = 0.0;				       // NOLINT
-AMREX_GPU_MANAGED double g_dust_vy0 = 0.0;				       // NOLINT
-AMREX_GPU_MANAGED double g_dust_vz0 = 0.0;				       // NOLINT
+AMREX_GPU_MANAGED double g_grain_density = grain_density0;			       // NOLINT
+AMREX_GPU_MANAGED double g_charge_to_mass = xi_param;				       // NOLINT
+AMREX_GPU_MANAGED double g_noise_amplitude = noise_amplitude_param;		       // NOLINT
+AMREX_GPU_MANAGED double g_Bx0 = 0.0;						       // NOLINT
+AMREX_GPU_MANAGED double g_By0 = 0.0;						       // NOLINT
+AMREX_GPU_MANAGED double g_Bz0 = 1.0;						       // NOLINT
+AMREX_GPU_MANAGED double g_gas_vx0 = 0.0;					       // NOLINT
+AMREX_GPU_MANAGED double g_gas_vy0 = 0.0;					       // NOLINT
+AMREX_GPU_MANAGED double g_gas_vz0 = 0.0;					       // NOLINT
+AMREX_GPU_MANAGED double g_dust_vx0 = 0.0;					       // NOLINT
+AMREX_GPU_MANAGED double g_dust_vy0 = 0.0;					       // NOLINT
+AMREX_GPU_MANAGED double g_dust_vz0 = 0.0;					       // NOLINT
 
 struct EquilibriumState {
 	Vec3 drift_{};

--- a/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
+++ b/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
@@ -7,6 +7,7 @@
 #include "AMReX_Reduce.H"
 #include "AMReX_Vector.H"
 #include "QuokkaSimulation.hpp"
+#include "dust/DustRuntimeParams.hpp"
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -34,12 +35,12 @@ constexpr double dust_density_floor = 1.0e-12;
 constexpr double supersonic_eta = 9.0 * pi * gamma_iso / 128.0;
 constexpr double time_tolerance = 1.0e-10;
 constexpr double bar_a = 5.0;
-constexpr double epsilon_param = 5.0;
+constexpr double grain_radius_density_param = 5.0;
 constexpr double xi_param = 10.0;
 constexpr double mu_param = 0.01;
 constexpr double beta_param = 2.0;
 constexpr double theta_Ba_deg = 87.0;
-constexpr double grain_density_param = 1.0;
+constexpr double grain_density0 = 1.0;
 constexpr double noise_amplitude_param = 1.0e-7;
 
 constexpr std::array<char const *, 3> snapshot_tags = {"t6p2ts0", "t8p3ts0", "t17p0ts0"};
@@ -55,8 +56,8 @@ std::array<double, 3> g_snapshot_times_over_ts0 = snapshot_times_over_ts0_defaul
 std::array<double, 3> g_snapshot_target_times = {0.0, 0.0, 0.0};		   // NOLINT
 double g_equilibrium_ts = 0.0;							   // NOLINT
 
-AMREX_GPU_MANAGED double g_grain_radius = epsilon_param / grain_density_param; // NOLINT
-AMREX_GPU_MANAGED double g_grain_density = grain_density_param;		       // NOLINT
+AMREX_GPU_MANAGED double g_grain_radius = grain_radius_density_param / grain_density0; // NOLINT
+AMREX_GPU_MANAGED double g_grain_density = grain_density0;			    // NOLINT
 AMREX_GPU_MANAGED double g_charge_to_mass = xi_param;			       // NOLINT
 AMREX_GPU_MANAGED double g_noise_amplitude = noise_amplitude_param;	       // NOLINT
 AMREX_GPU_MANAGED double g_Bx0 = 0.0;					       // NOLINT
@@ -164,9 +165,11 @@ auto makeBackgroundMagneticField(double beta, double theta_Ba_deg) -> Vec3
 	return {Bmag * std::cos(theta), 0.0, Bmag * std::sin(theta)};
 }
 
-auto computeSubsonicStoppingTime(double epsilon_param) -> double
+auto grainRadiusDensityProduct() -> double { return g_grain_radius * g_grain_density; }
+
+auto computeSubsonicStoppingTime() -> double
 {
-	return std::sqrt(pi * gamma_iso) * epsilon_param / (2.0 * std::numbers::sqrt2 * rho_gas0 * sound_speed);
+	return std::sqrt(pi * gamma_iso) * grainRadiusDensityProduct() / (2.0 * std::numbers::sqrt2 * rho_gas0 * sound_speed);
 }
 
 auto solveDriftEquilibrium() -> EquilibriumState
@@ -178,7 +181,7 @@ auto solveDriftEquilibrium() -> EquilibriumState
 
 	Vec3 const acceleration = {bar_a, 0.0, 0.0};
 	Vec3 const b_hat = result.magnetic_field_ / magnetic_field_norm;
-	double const ts_sub = computeSubsonicStoppingTime(epsilon_param);
+	double const ts_sub = computeSubsonicStoppingTime();
 	double const omega_L = xi_param * magnetic_field_norm;
 
 	Vec3 drift = {(ts_sub / (1.0 + mu_param)) * bar_a, 0.0, 0.0};
@@ -211,6 +214,12 @@ auto solveDriftEquilibrium() -> EquilibriumState
 
 void loadProblemParameters()
 {
+	amrex::GpuArray<amrex::Real, 1> grain_radius = {g_grain_radius};
+	amrex::GpuArray<amrex::Real, 1> grain_density = {g_grain_density};
+	quokka::dust::readDustGrainParams(grain_radius, grain_density);
+	g_grain_radius = grain_radius[0];
+	g_grain_density = grain_density[0];
+
 	amrex::ParmParse const pp("problem");
 	pp.query("write_csv", g_write_csv);
 	pp.query("history_dt_over_ts0", g_history_dt_over_ts0);
@@ -406,12 +415,13 @@ void writeSummaryCsv(EquilibriumState const &equilibrium, DustMagnetizedRDIHisto
 	std::ofstream file("dust_magnetized_rdi_summary.csv");
 	file << "key,value\n";
 	file << "bar_a," << bar_a << "\n";
-	file << "epsilon," << epsilon_param << "\n";
+	file << "epsilon," << grainRadiusDensityProduct() << "\n";
 	file << "xi," << xi_param << "\n";
 	file << "mu," << mu_param << "\n";
 	file << "beta," << beta_param << "\n";
 	file << "theta_Ba_deg," << theta_Ba_deg << "\n";
-	file << "grain_density," << grain_density_param << "\n";
+	file << "grain_radius," << g_grain_radius << "\n";
+	file << "grain_density," << g_grain_density << "\n";
 	file << "noise_amplitude," << noise_amplitude_param << "\n";
 	file << "equilibrium_stop_time," << equilibrium.stop_time_ << "\n";
 	file << "equilibrium_tau," << equilibrium.tau_ << "\n";
@@ -797,7 +807,9 @@ auto problem_main() -> int
 
 	amrex::Print() << "DustMagnetizedRDI setup:\n";
 	amrex::Print() << std::format("  bar_a              = {:.6f}\n", bar_a);
-	amrex::Print() << std::format("  epsilon            = {:.6f}\n", epsilon_param);
+	amrex::Print() << std::format("  grain radius       = {:.6f}\n", g_grain_radius);
+	amrex::Print() << std::format("  grain density      = {:.6f}\n", g_grain_density);
+	amrex::Print() << std::format("  a * rho_gr         = {:.6f}\n", grainRadiusDensityProduct());
 	amrex::Print() << std::format("  xi                 = {:.6f}\n", xi_param);
 	amrex::Print() << std::format("  mu                 = {:.6f}\n", mu_param);
 	amrex::Print() << std::format("  beta               = {:.6f}\n", beta_param);


### PR DESCRIPTION
### Description
This PR adds optional runtime parameters `dust.grain_radius` and `dust.grain_density` for dust problems that use the Kwok stopping-time helper. These parameters are read through a small dust runtime helper and allow problem setups to override grain properties from the input file without hard-coding them in the source. If they are not provided, each problem continues to use its local default values. The affected dust test problems were updated to support this interface, and `DustDampingIteration` is kept as an example of the default-in-code usage.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
