### PR TITLE
Add max 'lines changed' limit for pull requests

### DIFF
--- a/.github/workflows/pr-diff-size.yml
+++ b/.github/workflows/pr-diff-size.yml
@@ -1,4 +1,4 @@
-name: PR Diff Size
+name: 📏 PR Diff Size
 
 on:
   pull_request:

--- a/.github/workflows/pr-diff-size.yml
+++ b/.github/workflows/pr-diff-size.yml
@@ -1,0 +1,39 @@
+name: PR Diff Size
+
+on:
+  pull_request:
+    branches:
+      - development
+
+permissions:
+  contents: read
+
+jobs:
+  diff-size:
+    runs-on: ubuntu-latest
+    env:
+      MAX_DIFF_LINES: 5000
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check PR diff size
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          changed_lines=$(git diff --numstat "$BASE_SHA"...HEAD | awk '
+            $1 ~ /^[0-9]+$/ && $2 ~ /^[0-9]+$/ { total += $1 + $2 }
+            END { print total + 0 }
+          ')
+
+          echo "PR diff text lines changed: ${changed_lines}"
+          echo "Maximum allowed text lines changed: ${MAX_DIFF_LINES}"
+
+          if [ "$changed_lines" -gt "$MAX_DIFF_LINES" ]; then
+            echo "::error::PR diff changes ${changed_lines} text lines, which exceeds the ${MAX_DIFF_LINES}-line limit."
+            exit 1
+          fi


### PR DESCRIPTION
### Description
This limits pull requests to less than 5,000 lines of code changes (not counting binary files). This should be more than enough for all reasonable pull requests.

If your PR is larger than this, you should split it into multiple smaller PRs.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
