### PR TITLE
Fix Claude workflows: upgrade to Opus 4.7, increase max-turns, migrate to v1.0 API

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,11 +8,11 @@ on:
         description: 'PR number to review'
         required: true
         type: string
-      
+
   # Trigger on specific comment containing '/claude-review'
   issue_comment:
     types: [created]
-    
+
   # Trigger when 'review-requested' label is added to PR
   pull_request:
     types: [labeled]
@@ -21,24 +21,24 @@ jobs:
   claude-review:
     # Only run if:
     # 1. Manual trigger, OR
-    # 2. Comment contains '/claude-review', OR  
+    # 2. Comment contains '/claude-review', OR
     # 3. Label 'review-requested' was added
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issue_comment' && 
-       github.event.issue.pull_request && 
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
        contains(github.event.comment.body, '/claude-review')) ||
-      (github.event_name == 'pull_request' && 
-       github.event.action == 'labeled' && 
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
        github.event.label.name == 'review-requested')
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
@@ -47,45 +47,21 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@1b8ee3b94104046d71fde52ec3557651ad8c0d71 # beta
+        uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          prompt: |
             Please review this pull request and provide feedback on:
             - Code quality and best practices
             - Potential bugs or issues
             - Performance considerations
             - Test coverage
-            
+
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
 
+          claude_args: |
+            --model claude-opus-4-7
+            --max-turns 30

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           prompt: |
-            You are reviewing a pull request to Quokka, a two-moment radiation hydrodynamics code
+            You are reviewing a pull request to Quokka, a radiation magnetohydrodynamics code
             built on AMReX. Quokka uses C++20 with GPU support (CUDA/HIP) and a single codebase
             that runs on both CPU and GPU.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,13 +52,61 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Test coverage
+            You are reviewing a pull request to Quokka, a two-moment radiation hydrodynamics code
+            built on AMReX. Quokka uses C++20 with GPU support (CUDA/HIP) and a single codebase
+            that runs on both CPU and GPU.
 
-            Be constructive and helpful in your feedback.
+            **Important:** You cannot compile or run the code in this environment. Focus entirely
+            on static analysis: logic, style, correctness, and completeness.
+
+            ## Review checklist
+
+            ### 1. Physics correctness
+            Read the changed source files carefully.
+            - Check that conservation laws, numerical schemes, and physical units are handled correctly.
+            - Flag suspicious math, index errors, or incorrect use of AMReX data structures.
+            - For radiation changes: check energy groups, opacity terms, and flux limiters are consistent.
+            - For hydro changes: check slope limiters, Riemann solvers, and source term coupling.
+            - For new problems: check that initial conditions are physically reasonable and boundary
+              conditions are appropriate.
+
+            ### 2. GPU lambda safety
+            These are the most common GPU bugs in AMReX code — check carefully:
+            - **Never** capture host pointers inside `AMREX_GPU_DEVICE` lambdas or `amrex::ParallelFor`.
+            - Use array forms inside device lambdas: `geom.ProbLoArray()`, `geom.CellSizeArray()`,
+              `geom.InvCellSizeArray()`. Never pass `geom.ProbLo()` or `geom.CellSize()` raw pointers.
+            - Never capture raw pointers from `GeometryData` inside GPU lambdas.
+            - `amrex::GpuArray` and `amrex::Array4` are safe to capture by value.
+
+            ### 3. Code style
+            Quokka uses an LLVM-based clang-format style:
+            - 160-character line limit, indentation with tabs.
+            - Classes: PascalCase (`QuokkaSimulation`). Member variables: camelCase with trailing
+              underscore (`radiationCflNumber_`). Member functions: PascalCase.
+            - Always curly braces, even for single-statement blocks.
+            - Always trailing return types for non-void functions: `auto foo() -> int`.
+            - Always declare variables `const` when not modified after initialization.
+            - Public APIs must have Doxygen-style comments.
+            - Comments explain WHY, never WHAT — no comments restating what the code already says.
+
+            ### 4. AMREX_SPACEDIM handling
+            `AMREX_SPACEDIM` is a compile-time constant (1, 2, or 3):
+            - Prefer `#if (AMREX_SPACEDIM > 1)` preprocessor guards for dimension-dependent code.
+            - If an inline ternary is used instead, require `// NOLINT(misc-redundant-expression)`.
+
+            ### 5. Test completeness
+            - New physics must have a corresponding test in `src/problems/`.
+            - A complete new problem requires: `src/problems/<TestName>/test<TestName>.cpp`,
+              `CMakeLists.txt`, and `inputs/<TestName>.toml`.
+            - Verify `CMakeLists.txt` registers the test with `add_test(...)` and sets `JOB_NAME`.
+            - Test variants (same binary, different `.toml`) are additional `add_test` entries in the
+              same `CMakeLists.txt`, not separate executables.
+
+            ## Output
+            - Post an overall summary as a top-level PR comment.
+            - Use inline comments for specific line-level issues.
+            - Be constructive: explain why something is a problem and suggest a concrete fix.
+            - Do not speculate about runtime behaviour you cannot observe.
 
           use_sticky_comment: true
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,6 +52,8 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           prompt: |
+            ${{ github.event_name == 'workflow_dispatch' && format('Review PR #{0} in {1}.', github.event.inputs.pr_number, github.repository) || '' }}
+
             You are reviewing a pull request to Quokka, a radiation magnetohydrodynamics code
             built on AMReX. Quokka uses C++20 with GPU support (CUDA/HIP) and a single codebase
             that runs on both CPU and GPU.
@@ -111,5 +113,5 @@ jobs:
           use_sticky_comment: true
 
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-4-7
             --max-turns 30

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -111,5 +111,5 @@ jobs:
           use_sticky_comment: true
 
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --max-turns 30

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write
@@ -38,6 +38,6 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-7
+            --model claude-opus-4-8
             --max-turns 30
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,6 +38,6 @@ jobs:
           additional_permissions: |
             actions: read
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-4-7
             --max-turns 30
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
@@ -35,32 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Pass CLI arguments to Claude Code
           claude_args: |
-            --model claude-opus-4-5-20251101
-            --max-turns 10
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+            --model claude-opus-4-7
+            --max-turns 30
 


### PR DESCRIPTION
### Description

Rewrites both Claude GitHub Action workflows to fix persistent failures and use the latest Claude Opus 4.7 model.

The `claude.yml` workflow was hitting the 10-turn limit on any non-trivial request (as seen in PR #1892, where `@claude review` failed with "Reached maximum number of turns (10)"). The `claude-code-review.yml` workflow was still using a pinned beta SHA with deprecated v0.x inputs (`direct_prompt:`, `model:`) that have been removed in the v1.0 API.

**Changes in `claude.yml`:**
- Update model from `claude-opus-4-5-20251101` → `claude-opus-4-7`
- Increase `--max-turns` from 10 → 30 to handle complex PR reviews
- Upgrade permissions to `pull-requests: write` and `issues: write` (required for posting comments)

**Changes in `claude-code-review.yml`:**
- Update action from pinned beta SHA (`1b8ee3b...`) → `@v1` (stable release)
- Migrate deprecated `direct_prompt:` → `prompt:` (v1.0 API)
- Migrate deprecated `model:` input → `claude_args: --model claude-opus-4-7`
- Add `--max-turns 30` to `claude_args`
- Upgrade permissions to `pull-requests: write` and `issues: write`

### Related issues

Closes #1892 (workflow failures observed in PR comments)

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
