### PR TITLE
Use HLL star state to compute face velocities

### DIFF
--- a/inputs/OrszagTang_Kriel2026_Q26_PPM_LD04.toml
+++ b/inputs/OrszagTang_Kriel2026_Q26_PPM_LD04.toml
@@ -1,0 +1,41 @@
+# Kriel et al. section 3.3 Orszag-Tang stress case.
+# Q26 EMF reconstruction, LD04 EMF averaging, PPM interpolation.
+
+# Problem size and geometry
+geometry.prob_lo = [-0.5, -0.5, -0.5]
+geometry.prob_hi = [0.5, 0.5, 0.5]
+quokka.bc = ["periodic", "periodic", "periodic"]
+
+# Verbosity
+amr.v = 0
+
+# Resolution and refinement
+amr.n_cell = [1024, 1024, 8]
+amr.max_level = 0
+
+amr.max_grid_size = 128
+amr.max_grid_size_z = 8
+amr.blocking_factor_x = 32
+amr.blocking_factor_y = 32
+amr.blocking_factor_z = 8
+
+do_reflux = 0
+do_subcycle = 0
+
+# The paper evolves to t = 1 and shows current-density slices at t = 0.5.
+plotfile_interval = -1
+checkpoint_interval = -1
+cfl = 0.2
+stop_time = 1.0
+max_timesteps = 20000
+
+hydro.rk_integrator_order = 2
+hydro.reconstruction_order = 3  # PPM
+
+# MHD parameters
+mhd.emf_compute_scheme = "Quokka2026"
+mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
+mhd.emf_reconstruction_order = 5
+
+tiny_profiler.enabled = 0
+tiny_profiler.memprof_enabled = 0

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1517,18 +1517,11 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 			F[internalEnergy_index] = 0;
 		}
 
-		// compute face-centered normal velocity
-		double v_norm = 0.0;
-		if (F[density_index] >= 0.) {
-			if (rho_R > 0.) {
-				v_norm = F[density_index] / rho_R;
-			}
-		} else {
-			if (rho_L > 0.) {
-				v_norm = F[density_index] / rho_L;
-			}
-		}
-		x1FaceVel(i, j, k) = v_norm;
+		// compute face-centered normal velocity using HLL star state
+		quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
+		amrex::Real const fspd_m = x1FSpds(i, j, k, 0);
+		amrex::Real const fspd_p = x1FSpds(i, j, k, 1);
+		x1FaceVel(i, j, k) = (fspd_p * sL.u + fspd_m * sR.u) / (fspd_p + fspd_m);
 
 		// use the same logic as above to scale and conserve specie fluxes
 		if (F[density_index] >= 0.) {

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1518,10 +1518,29 @@ void HydroSystem<problem_t>::ComputeFluxes(amrex::MultiFab &x1Flux_mf, amrex::Mu
 		}
 
 		// compute face-centered normal velocity using HLL star state
-		quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
-		amrex::Real const fspd_m = x1FSpds(i, j, k, 0);
-		amrex::Real const fspd_p = x1FSpds(i, j, k, 1);
-		x1FaceVel(i, j, k) = (fspd_p * sL.u + fspd_m * sR.u) / (fspd_p + fspd_m);
+		if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+			quokka::Array4View<amrex::Real, DIR> x1FSpds(x1FSpds_ref);
+			amrex::Real const fspd_m = x1FSpds(i, j, k, 0);
+			amrex::Real const fspd_p = x1FSpds(i, j, k, 1);
+			if (fspd_p + fspd_m > 0.0) {
+				x1FaceVel(i, j, k) = (fspd_p * sL.u + fspd_m * sR.u) / (fspd_p + fspd_m);
+			} else {
+				x1FaceVel(i, j, k) = 0.5 * (sL.u + sR.u);
+			}
+		} else {
+			// compute face-centered normal velocity
+			double v_norm = 0.0;
+			if (F[density_index] >= 0.) {
+				if (rho_R > 0.) {
+					v_norm = F[density_index] / rho_R;
+				}
+			} else {
+				if (rho_L > 0.) {
+					v_norm = F[density_index] / rho_L;
+				}
+			}
+			x1FaceVel(i, j, k) = v_norm;
+		}
 
 		// use the same logic as above to scale and conserve specie fluxes
 		if (F[density_index] >= 0.) {


### PR DESCRIPTION
### Description
When MHD is enabled, the face-centered velocities are now computed using the HLL star state, rather than backing out the velocity implied by the mass flux for the chosen Riemann solver. With this changes, the Quokka2026 EMF update is now equivalent to that of [Mignone & Del Zanna (2021).](https://scixplorer.org/abs/2021JCoPh.42409748M/abstract)

This is not strictly consistent with the Riemann solver, but it makes the EMF update stable. 

Since the face velocities are also used by the dual energy update, this change will also cause a small perturbations to the solution for high-Mach flows when used with MHD.
 
### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/1912.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
