### PR TITLE
Fix FOFC EMF fallback to use donor-cell reconstruction

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2288,8 +2288,10 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
 			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
 		}
+		// first-order EMF for FOFC: donor-cell (order 1) reconstruction, mirroring the hydro FO path's
+		// ReconstructStatesConstant; the high-order EMF reconstruction is what the FO correction must escape.
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+						 /*reconstructionOrder=*/1, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}
 
 	// Stage 1 of RK2-SSP


### PR DESCRIPTION
### Description

The first-order flux correction (FOFC) for MHD was computing the fallback EMF at the user-requested reconstruction order (e.g. order 5 for PPM-EP) rather than dropping to first order. This is inconsistent with the hydro fallback path, which uses donor-cell (piecewise-constant) reconstruction and the LLF Riemann solver.

The fix passes `reconstructionOrder=1` to `ComputeEMF` for the FOFC fallback, so it uses the existing donor-cell (`ReconstructStatesConstant`) path — matching what `hydroFOFluxFunction` does on the hydro side.

### Related issues

Identified while investigating the Quokka2026 EMF instability. The order-1 reconstruction path already exists in `MHDSystem::ReconstructTo`; it was simply not being used for FOFC.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.