### PR TITLE
Fix interpolation order of the EMF-FOFC fallback

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2290,8 +2290,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 		// first-order EMF for FOFC: donor-cell (order 1) reconstruction, mirroring the hydro FO path's
 		// ReconstructStatesConstant; the high-order EMF reconstruction is what the FO correction must escape.
-		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 1, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, 1,
+						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}
 
 	// Stage 1 of RK2-SSP

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2291,7 +2291,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		// first-order EMF for FOFC: donor-cell (order 1) reconstruction, mirroring the hydro FO path's
 		// ReconstructStatesConstant; the high-order EMF reconstruction is what the FO correction must escape.
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 /*reconstructionOrder=*/1, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+						 1, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}
 
 	// Stage 1 of RK2-SSP

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2288,8 +2288,6 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
 			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
 		}
-		// first-order EMF for FOFC: donor-cell (order 1) reconstruction, mirroring the hydro FO path's
-		// ReconstructStatesConstant; the high-order EMF reconstruction is what the FO correction must escape.
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, 1,
 						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2288,8 +2288,10 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			auto ba_ec = amrex::convert(ba_cc, amrex::IntVect(AMREX_D_DECL(1, 1, 1)) - amrex::IntVect::TheDimensionVector(idim));
 			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
 		}
+		// first-order EMF for FOFC: donor-cell (order 1) reconstruction, mirroring the hydro FO path's
+		// ReconstructStatesConstant; the high-order EMF reconstruction is what the FO correction must escape.
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds,
-						 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
+						 /*reconstructionOrder=*/1, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_);
 	}
 
 	// Stage 1 of RK2-SSP


### PR DESCRIPTION
### Description

When MHD is enabled, the first-order flux correction (FOFC) computes a fallback EMF using `ComputeEMF`. To be symmetric with the hydro solver, this should be done with a lower order interpolation scheme, namely with piece-wise constant. However, at the moment this is being solved using the user-requested reconstruction order (e.g. order 5 for PPM-EP) used for the higher order branch of the FOFC scheme. To fix this, I reduce the fallback EMF call to use the lowest-order reconstruction (`reconstructionOrder=1`).

### Related issues

Identified while investigating the Quokka2026 EMF instability (#1912).

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.