### PR TITLE
Add hyper-resistivity to the Quokka2026 EMF scheme

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -147,6 +147,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	using AMRSimulation<problem_t>::enableElectronConduction_;
 	using AMRSimulation<problem_t>::electronConductionKappa0_;
 	using AMRSimulation<problem_t>::conductionCFL;
+	using AMRSimulation<problem_t>::hyperResistivityCoeff_;
+	using AMRSimulation<problem_t>::hyperResistivityCFL;
 
 #if AMREX_SPACEDIM == 3
 	using AMRSimulation<problem_t>::luminosityTables_;
@@ -233,7 +235,6 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
 	amrex::Real artificialViscosityK_ = 0.;    // artificial viscosity coefficient (default == None)
-	amrex::Real hyperResistivityCoeff_ = 0.;   // biharmonic EMF diffusion coefficient (default == 0)
 
 	EMFComputeScheme emfComputingScheme_ = EMFComputeScheme::FelkerStone2017;
 	EMFAvgScheme emfAveragingScheme_ = EMFAvgScheme::LondrilloDelZanna2004; // method to use to average EMF at edges
@@ -627,6 +628,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mhdResistivity_ >= 0.0, "mhd.resistivity must be >= 0.");
 		}
 		hpp.query("hyper_resistivity_coefficient", hyperResistivityCoeff_);
+		hpp.query("hyper_resistivity_cfl", hyperResistivityCFL);
 	}
 
 #ifdef PHOTOCHEMISTRY

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2349,8 +2349,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 				ec_emf_components_rk_stage1[idim].define(ba_ec, dm, 1, 0);
 			}
 			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage1, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds,
-							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx,
-							 mhdResistivity_, hyperResistivityCoeff_);
+							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_,
+							 hyperResistivityCoeff_);
 			MHDSystem<problem_t>::AddResistiveEnergyFlux(fluxArrays, stateOld_fc, dx, mhdResistivity_);
 		}
 
@@ -2483,8 +2483,8 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 				ec_emf_components_rk_stage2[idim].define(ba_ec, dm, 1, 0);
 			}
 			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage2, stateInter_cc, faceVel, stateInter_fc, fast_mhd_wavespeeds,
-							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx,
-							 mhdResistivity_, hyperResistivityCoeff_);
+							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_,
+							 hyperResistivityCoeff_);
 			MHDSystem<problem_t>::AddResistiveEnergyFlux(fluxArrays, stateInter_fc, dx, mhdResistivity_);
 		}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -232,7 +232,8 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	SlopeLimiter mhdPlmLimiter_ = SlopeLimiter::sweby;
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
-	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
+	amrex::Real artificialViscosityK_ = 0.;    // artificial viscosity coefficient (default == None)
+	amrex::Real hyperResistivityCoeff_ = 0.;   // biharmonic EMF diffusion coefficient (default == 0)
 
 	EMFComputeScheme emfComputingScheme_ = EMFComputeScheme::FelkerStone2017;
 	EMFAvgScheme emfAveragingScheme_ = EMFAvgScheme::LondrilloDelZanna2004; // method to use to average EMF at edges
@@ -625,6 +626,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 			hpp.query("resistivity", mhdResistivity_);
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mhdResistivity_ >= 0.0, "mhd.resistivity must be >= 0.");
 		}
+		hpp.query("hyper_resistivity_coefficient", hyperResistivityCoeff_);
 	}
 
 #ifdef PHOTOCHEMISTRY
@@ -2324,7 +2326,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			ec_emf_components_fo[idim].define(ba_ec, dm, 1, 0);
 		}
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, 1,
-						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_);
+						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_, hyperResistivityCoeff_);
 	}
 
 	// Stage 1 of RK2-SSP
@@ -2346,7 +2348,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage1, stateOld_cc, faceVel, stateOld_fc, fast_mhd_wavespeeds,
 							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx,
-							 mhdResistivity_);
+							 mhdResistivity_, hyperResistivityCoeff_);
 			MHDSystem<problem_t>::AddResistiveEnergyFlux(fluxArrays, stateOld_fc, dx, mhdResistivity_);
 		}
 
@@ -2480,7 +2482,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 			}
 			MHDSystem<problem_t>::ComputeEMF(ec_emf_components_rk_stage2, stateInter_cc, faceVel, stateInter_fc, fast_mhd_wavespeeds,
 							 emfReconstructionOrder_, emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx,
-							 mhdResistivity_);
+							 mhdResistivity_, hyperResistivityCoeff_);
 			MHDSystem<problem_t>::AddResistiveEnergyFlux(fluxArrays, stateInter_fc, dx, mhdResistivity_);
 		}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -234,7 +234,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	SlopeLimiter mhdPlmLimiter_ = SlopeLimiter::sweby;
 	int useDualEnergy_ = 1;			// 0 == disabled; 1 == use auxiliary internal energy equation (default)
 	int abortOnFofcFailure_ = 1;		// 0 == keep going, 1 == abort hydro advance if FOFC fails
-	amrex::Real artificialViscosityK_ = 0.;    // artificial viscosity coefficient (default == None)
+	amrex::Real artificialViscosityK_ = 0.; // artificial viscosity coefficient (default == None)
 
 	EMFComputeScheme emfComputingScheme_ = EMFComputeScheme::FelkerStone2017;
 	EMFAvgScheme emfAveragingScheme_ = EMFAvgScheme::LondrilloDelZanna2004; // method to use to average EMF at edges

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -612,7 +612,8 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					// anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3,
 					// so each direction is damped at its own grid scale (reduces to the isotropic
 					// (dw0*dw1)^(3/2) form on cubic cells). v_A = sqrt(B^2 / rho).
-					const double v_hyper = (rho > 0.0) ? hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) : 0.0;
+					const double v_hyper =
+					    (rho > 0.0) ? hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) : 0.0;
 					E2_ave(i, j, k) += v_hyper * (dw0 * dw0 * dw0 * d2j_w0 + dw1 * dw1 * dw1 * d2j_w1);
 				});
 			}

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -587,8 +587,9 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					const double j_p1w1 = (Bw1_p1w0_p1w1 - Bw1_p1w1) / dw0 - (Bw0_p2w1 - Bw0_p1w1) / dw1;
 					const double j_m1w1 = (Bw1_p1w0_m1w1 - Bw1_m1w1) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
 
-					const double laplacian_j = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0) +
-								   (j_p1w1 - 2.0 * j_c + j_m1w1) / (dw1 * dw1);
+					// per-direction second differences of the edge current (anisotropic hyper term)
+					const double d2j_w0 = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0);
+					const double d2j_w1 = (j_p1w1 - 2.0 * j_c + j_m1w1) / (dw1 * dw1);
 
 					// edge B components, averaged over the two reconstructed sides
 					const double Bw0_m = ec_a4_B_w0_m(i, j, k);
@@ -604,9 +605,11 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 								   cc_a4_rho(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]) +
 								   cc_a4_rho(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]) +
 								   cc_a4_rho(i-delta_w0[0]-delta_w1[0], j-delta_w0[1]-delta_w1[1], k-delta_w0[2]-delta_w1[2]));
-					const double eta_hyper = hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) * std::pow(dw0 * dw1, 1.5);
-
-					E2_ave(i, j, k) += eta_hyper * laplacian_j;
+					// anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3,
+					// so each direction is damped at its own grid scale (reduces to the isotropic
+					// (dw0*dw1)^(3/2) form on cubic cells). v_A = sqrt(B^2 / rho).
+					const double v_hyper = hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho);
+					E2_ave(i, j, k) += v_hyper * (dw0 * dw0 * dw0 * d2j_w0 + dw1 * dw1 * dw1 * d2j_w1);
 				});
 			}
 		}

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -67,7 +67,7 @@ template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_
 			       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 			       std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, EMFAvgScheme emf_avg_scheme,
 			       SlopeLimiter plmLimiter, EMFComputeScheme emf_compute_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-			       amrex::Real resistivity = 0.0);
+			       amrex::Real resistivity = 0.0, double hyper_resistivity_coeff = 0.);
 
 	static void AverageEMF(amrex::Array4<amrex::Real> const &E2_ave, std::array<amrex::FArrayBox, 4> const &ec_fabs_E_q, amrex::Box const &box_ec,
 			       std::array<int, 2> const &extrap_dirs, std::array<amrex::Array4<const amrex::Real>, 3> const &fspds,
@@ -90,7 +90,7 @@ template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, SlopeLimiter plmLimiter,
-					  EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, amrex::Real resistivity = 0.0);
+					  EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, double hyper_resistivity_coeff = 0.);
 
 	static void EMFAverage_LondrilloDelZanna2004(amrex::Array4<amrex::Real> E2_ave, std::array<amrex::FArrayBox, 4> const &ec_fabs_EMF_q,
 						     amrex::Box const &box_ec, std::array<int, 2> const &extrap_dirs,
@@ -143,7 +143,7 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 				      std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, EMFAvgScheme emf_avg_scheme,
 				      SlopeLimiter plmLimiter, EMFComputeScheme emf_compute_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-				      amrex::Real resistivity)
+				      amrex::Real resistivity, double hyper_resistivity_coeff)
 {
 	if (emf_compute_scheme == EMFComputeScheme::FelkerStone2017) {
 		MHDSystem<problem_t>::ComputeEMF_FelkerStone2017(ec_mf_emf_components, cc_mf_cVars, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder, plmLimiter,
@@ -153,7 +153,7 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 							     emf_avg_scheme, dx, resistivity);
 	} else if (emf_compute_scheme == EMFComputeScheme::Quokka2026) {
 		MHDSystem<problem_t>::ComputeEMF_Quokka2026(ec_mf_emf_components, fcx_mf_vel, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder, plmLimiter,
-							    emf_avg_scheme, dx, resistivity);
+							    emf_avg_scheme, dx, hyper_resistivity_coeff);
 	} else {
 		throw std::runtime_error("Unsupported EMF-scheme. Expected either FelkerStone2017, Balsara2025, or Quokka2026.");
 	}
@@ -412,7 +412,7 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder,
 						 SlopeLimiter plmLimiter, EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-						 amrex::Real resistivity)
+						 double hyper_resistivity_coeff)
 {
 	const BL_PROFILE("MHDSystem::ComputeEMF_Quokka2026()");
 
@@ -537,7 +537,57 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 			MHDSystem<problem_t>::AverageEMF(E2_ave, ec_fabs_E_Q, box_ec, field_w_indices, fspds, ec_fabs_Bi_ieside, emf_avg_scheme,
 							 fcx_mf_cVars[field_w_indices[0]][mfi].const_array(bfield_index),
 							 fcx_mf_cVars[field_w_indices[1]][mfi].const_array(bfield_index), dx[field_w_indices[0]],
-							 dx[field_w_indices[1]], resistivity);
+							 dx[field_w_indices[1]], 0.0);
+
+			// Biharmonic resistivity: E2_ave += eta_hyp * laplacian(j)
+			// eta_hyp = c_hyp * c_A * (dx_w0 * dx_w1)^(3/2); always-on, amplitude-independent, N^4 scale selectivity
+			if (hyper_resistivity_coeff > 0.) {
+				const double dx_w0 = dx[field_w_indices[0]];
+				const double dx_w1 = dx[field_w_indices[1]];
+
+				const auto Bw0 = fc_fabs_Bx[field_w_indices[0]].const_array();
+				const auto Bw1 = fc_fabs_Bx[field_w_indices[1]].const_array();
+				const auto rho_w0 = fcx_mf_cVars[field_w_indices[0]][mfi].const_array(HydroSystem<problem_t>::density_index);
+				const auto rho_w1 = fcx_mf_cVars[field_w_indices[1]][mfi].const_array(HydroSystem<problem_t>::density_index);
+
+				const auto B0m = ec_fabs_Bi_ieside[0][0].const_array();
+				const auto B0p = ec_fabs_Bi_ieside[0][1].const_array();
+				const auto B1m = ec_fabs_Bi_ieside[1][0].const_array();
+				const auto B1p = ec_fabs_Bi_ieside[1][1].const_array();
+
+				// unit-vector components for the two perpendicular directions (plain ints for GPU capture)
+				const int d0i = (field_w_indices[0] == 0) ? 1 : 0;
+				const int d0j = (field_w_indices[0] == 1) ? 1 : 0;
+				const int d0k = (field_w_indices[0] == 2) ? 1 : 0;
+				const int d1i = (field_w_indices[1] == 0) ? 1 : 0;
+				const int d1j = (field_w_indices[1] == 1) ? 1 : 0;
+				const int d1k = (field_w_indices[1] == 2) ? 1 : 0;
+
+				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+					// j = (Bw1[+w0] - Bw1[0]) / dx_w0 - (Bw0[+w1] - Bw0[0]) / dx_w1 at the edge and its 4 neighbours
+					const double j_c   = (Bw1(i+d0i,       j+d0j,       k+d0k      ) - Bw1(i,       j,       k     )) / dx_w0
+					                   - (Bw0(i+d1i,       j+d1j,       k+d1k      ) - Bw0(i,       j,       k     )) / dx_w1;
+					const double j_pw0 = (Bw1(i+2*d0i,     j+2*d0j,     k+2*d0k    ) - Bw1(i+d0i,   j+d0j,   k+d0k  )) / dx_w0
+					                   - (Bw0(i+d0i+d1i,   j+d0j+d1j,   k+d0k+d1k  ) - Bw0(i+d0i,   j+d0j,   k+d0k  )) / dx_w1;
+					const double j_mw0 = (Bw1(i,           j,           k          ) - Bw1(i-d0i,   j-d0j,   k-d0k  )) / dx_w0
+					                   - (Bw0(i-d0i+d1i,   j-d0j+d1j,   k-d0k+d1k  ) - Bw0(i-d0i,   j-d0j,   k-d0k  )) / dx_w1;
+					const double j_pw1 = (Bw1(i+d0i+d1i,   j+d0j+d1j,   k+d0k+d1k  ) - Bw1(i+d1i,   j+d1j,   k+d1k  )) / dx_w0
+					                   - (Bw0(i+2*d1i,     j+2*d1j,     k+2*d1k    ) - Bw0(i+d1i,   j+d1j,   k+d1k  )) / dx_w1;
+					const double j_mw1 = (Bw1(i+d0i-d1i,   j+d0j-d1j,   k+d0k-d1k  ) - Bw1(i-d1i,   j-d1j,   k-d1k  )) / dx_w0
+					                   - (Bw0(i,           j,           k          ) - Bw0(i-d1i,   j-d1j,   k-d1k  )) / dx_w1;
+
+					const double lap_j = (j_pw0 - 2.0 * j_c + j_mw0) / (dx_w0 * dx_w0)
+					                   + (j_pw1 - 2.0 * j_c + j_mw1) / (dx_w1 * dx_w1);
+
+					const double b0 = 0.5 * (B0m(i, j, k) + B0p(i, j, k));
+					const double b1 = 0.5 * (B1m(i, j, k) + B1p(i, j, k));
+					const double rho = 0.25 * (rho_w0(i, j, k) + rho_w0(i+d1i, j+d1j, k+d1k)
+					                         + rho_w1(i, j, k) + rho_w1(i+d0i, j+d0j, k+d0k));
+					const double eta_hyp = hyper_resistivity_coeff * std::sqrt((b0 * b0 + b1 * b1) / rho) * std::pow(dx_w0 * dx_w1, 1.5);
+
+					E2_ave(i, j, k) += eta_hyp * lap_j;
+				});
+			}
 		}
 	}
 }

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -565,31 +565,31 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					// B_w1 samples (differenced along w0)
 					const double Bw1_c = fc_a4_B_w1(i, j, k);
 					const double Bw1_p1w0 = fc_a4_B_w1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
-					const double Bw1_p2w0 = fc_a4_B_w1(i + 2 * delta_w0[0], j + 2 * delta_w0[1], k + 2 * delta_w0[2]);
 					const double Bw1_m1w0 = fc_a4_B_w1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
+					const double Bw1_m2w0 = fc_a4_B_w1(i - 2 * delta_w0[0], j - 2 * delta_w0[1], k - 2 * delta_w0[2]);
 					const double Bw1_p1w1 = fc_a4_B_w1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
 					const double Bw1_m1w1 = fc_a4_B_w1(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
-					const double Bw1_p1w0_p1w1 =
-					    fc_a4_B_w1(i + delta_w0[0] + delta_w1[0], j + delta_w0[1] + delta_w1[1], k + delta_w0[2] + delta_w1[2]);
-					const double Bw1_p1w0_m1w1 =
-					    fc_a4_B_w1(i + delta_w0[0] - delta_w1[0], j + delta_w0[1] - delta_w1[1], k + delta_w0[2] - delta_w1[2]);
+					const double Bw1_m1w0_p1w1 =
+					    fc_a4_B_w1(i - delta_w0[0] + delta_w1[0], j - delta_w0[1] + delta_w1[1], k - delta_w0[2] + delta_w1[2]);
+					const double Bw1_m1w0_m1w1 =
+					    fc_a4_B_w1(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
 					// B_w0 samples (differenced along w1)
 					const double Bw0_c = fc_a4_B_w0(i, j, k);
 					const double Bw0_p1w1 = fc_a4_B_w0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
-					const double Bw0_p2w1 = fc_a4_B_w0(i + 2 * delta_w1[0], j + 2 * delta_w1[1], k + 2 * delta_w1[2]);
 					const double Bw0_m1w1 = fc_a4_B_w0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
+					const double Bw0_m2w1 = fc_a4_B_w0(i - 2 * delta_w1[0], j - 2 * delta_w1[1], k - 2 * delta_w1[2]);
 					const double Bw0_p1w0 = fc_a4_B_w0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
 					const double Bw0_m1w0 = fc_a4_B_w0(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
-					const double Bw0_p1w0_p1w1 =
-					    fc_a4_B_w0(i + delta_w0[0] + delta_w1[0], j + delta_w0[1] + delta_w1[1], k + delta_w0[2] + delta_w1[2]);
-					const double Bw0_m1w0_p1w1 =
-					    fc_a4_B_w0(i - delta_w0[0] + delta_w1[0], j - delta_w0[1] + delta_w1[1], k - delta_w0[2] + delta_w1[2]);
-					// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1, built from B samples around the edge
-					const double j_c = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
-					const double j_p1w0 = (Bw1_p2w0 - Bw1_p1w0) / dw0 - (Bw0_p1w0_p1w1 - Bw0_p1w0) / dw1;
-					const double j_m1w0 = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_m1w0_p1w1 - Bw0_m1w0) / dw1;
-					const double j_p1w1 = (Bw1_p1w0_p1w1 - Bw1_p1w1) / dw0 - (Bw0_p2w1 - Bw0_p1w1) / dw1;
-					const double j_m1w1 = (Bw1_p1w0_m1w1 - Bw1_m1w1) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
+					const double Bw0_p1w0_m1w1 =
+					    fc_a4_B_w0(i + delta_w0[0] - delta_w1[0], j + delta_w0[1] - delta_w1[1], k + delta_w0[2] - delta_w1[2]);
+					const double Bw0_m1w0_m1w1 =
+					    fc_a4_B_w0(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
+					// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1; backward differences place j at the edge
+					const double j_c = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
+					const double j_p1w0 = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w0 - Bw0_p1w0_m1w1) / dw1;
+					const double j_m1w0 = (Bw1_m1w0 - Bw1_m2w0) / dw0 - (Bw0_m1w0 - Bw0_m1w0_m1w1) / dw1;
+					const double j_p1w1 = (Bw1_p1w1 - Bw1_m1w0_p1w1) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
+					const double j_m1w1 = (Bw1_m1w1 - Bw1_m1w0_m1w1) / dw0 - (Bw0_m1w1 - Bw0_m2w1) / dw1;
 
 					// per-direction second differences of the edge current (anisotropic hyper term)
 					const double d2j_w0 = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0);
@@ -612,7 +612,7 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					// anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3,
 					// so each direction is damped at its own grid scale (reduces to the isotropic
 					// (dw0*dw1)^(3/2) form on cubic cells). v_A = sqrt(B^2 / rho).
-					const double v_hyper = hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho);
+					const double v_hyper = (rho > 0.0) ? hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) : 0.0;
 					E2_ave(i, j, k) += v_hyper * (dw0 * dw0 * dw0 * d2j_w0 + dw1 * dw1 * dw1 * d2j_w1);
 				});
 			}

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -90,7 +90,11 @@ template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, SlopeLimiter plmLimiter,
-					  EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, double hyper_resistivity_coeff = 0.);
+					  EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
+
+	static void ApplyHyperResistiveCorrection(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
+						  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars, double hyper_resistivity_coeff,
+						  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx);
 
 	static void EMFAverage_LondrilloDelZanna2004(amrex::Array4<amrex::Real> E2_ave, std::array<amrex::FArrayBox, 4> const &ec_fabs_EMF_q,
 						     amrex::Box const &box_ec, std::array<int, 2> const &extrap_dirs,
@@ -153,9 +157,12 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 							     emf_avg_scheme, dx, resistivity);
 	} else if (emf_compute_scheme == EMFComputeScheme::Quokka2026) {
 		MHDSystem<problem_t>::ComputeEMF_Quokka2026(ec_mf_emf_components, cc_mf_cVars, fcx_mf_vel, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder,
-							    plmLimiter, emf_avg_scheme, dx, hyper_resistivity_coeff);
+							    plmLimiter, emf_avg_scheme, dx);
 	} else {
 		throw std::runtime_error("Unsupported EMF-scheme. Expected either FelkerStone2017, Balsara2025, or Quokka2026.");
+	}
+	if (hyper_resistivity_coeff > 0.) {
+		MHDSystem<problem_t>::ApplyHyperResistiveCorrection(ec_mf_emf_components, cc_mf_cVars, fcx_mf_cVars, hyper_resistivity_coeff, dx);
 	}
 }
 
@@ -411,8 +418,7 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder,
-						 SlopeLimiter plmLimiter, EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
-						 double hyper_resistivity_coeff)
+						 SlopeLimiter plmLimiter, EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {
 	const BL_PROFILE("MHDSystem::ComputeEMF_Quokka2026()");
 
@@ -538,85 +544,93 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 							 fcx_mf_cVars[field_w_indices[0]][mfi].const_array(bfield_index),
 							 fcx_mf_cVars[field_w_indices[1]][mfi].const_array(bfield_index), dx[field_w_indices[0]],
 							 dx[field_w_indices[1]], 0.0);
+		}
+	}
+}
 
-			// Biharmonic resistivity: E2_ave += eta_hyper * laplacian(j)
-			// eta_hyper = c_hyper * c_A * (dw0 * dw1)^(3/2); always-on, amplitude-independent, N^4 scale selectivity
-			if (hyper_resistivity_coeff > 0.) {
-				const double dw0 = dx[field_w_indices[0]];
-				const double dw1 = dx[field_w_indices[1]];
+template <typename problem_t>
+void MHDSystem<problem_t>::ApplyHyperResistiveCorrection(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components,
+							 amrex::MultiFab const &cc_mf_cVars,
+							 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars, double hyper_resistivity_coeff,
+							 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
+{
+	const BL_PROFILE("MHDSystem::ApplyHyperResistiveCorrection()");
+	constexpr int nstreams = 1;
 
-				const auto fc_a4_B_w0 = fc_fabs_Bx[field_w_indices[0]].const_array();
-				const auto fc_a4_B_w1 = fc_fabs_Bx[field_w_indices[1]].const_array();
-				// density lives on the cell-centred state (face state holds B, not rho); average it to the edge below
-				const auto cc_a4_rho = cc_mf_cVars[mfi].const_array(HydroSystem<problem_t>::density_index);
+	for (amrex::MFIter mfi(cc_mf_cVars, amrex::MFItInfo().SetNumStreams(nstreams)); mfi.isValid(); ++mfi) {
+		const amrex::Box &box_cc = mfi.validbox();
+		const auto cc_a4_rho = cc_mf_cVars[mfi].const_array(HydroSystem<problem_t>::density_index);
 
-				const auto ec_a4_B_w0_m = ec_fabs_Bi_ieside[0][0].const_array();
-				const auto ec_a4_B_w0_p = ec_fabs_Bi_ieside[0][1].const_array();
-				const auto ec_a4_B_w1_m = ec_fabs_Bi_ieside[1][0].const_array();
-				const auto ec_a4_B_w1_p = ec_fabs_Bi_ieside[1][1].const_array();
+		std::array<amrex::FArrayBox, 3> fc_fabs_Bx = {
+		    amrex::FArrayBox(fcx_mf_cVars[0][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		    amrex::FArrayBox(fcx_mf_cVars[1][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		    amrex::FArrayBox(fcx_mf_cVars[2][mfi], amrex::make_alias, MHDSystem<problem_t>::bfield_index, 1),
+		};
 
-				// unit offsets along the two world directions perpendicular to the edge
-				std::array<int, 3> delta_w0 = {0, 0, 0};
-				std::array<int, 3> delta_w1 = {0, 0, 0};
-				delta_w0[field_w_indices[0]] = 1;
-				delta_w1[field_w_indices[1]] = 1;
+		for (int iedge = 0; iedge < 3; ++iedge) {
+			// w0, w1: the two face-normal directions transverse to this edge
+			const std::array<int, 2> field_w_indices = {(iedge + 1) % 3, (iedge + 2) % 3};
 
-				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-					// B_w1 samples (differenced along w0)
-					const double Bw1_c = fc_a4_B_w1(i, j, k);
-					const double Bw1_p1w0 = fc_a4_B_w1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
-					const double Bw1_m1w0 = fc_a4_B_w1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
-					const double Bw1_m2w0 = fc_a4_B_w1(i - 2 * delta_w0[0], j - 2 * delta_w0[1], k - 2 * delta_w0[2]);
-					const double Bw1_p1w1 = fc_a4_B_w1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
-					const double Bw1_m1w1 = fc_a4_B_w1(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
-					const double Bw1_m1w0_p1w1 =
-					    fc_a4_B_w1(i - delta_w0[0] + delta_w1[0], j - delta_w0[1] + delta_w1[1], k - delta_w0[2] + delta_w1[2]);
-					const double Bw1_m1w0_m1w1 =
-					    fc_a4_B_w1(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
-					// B_w0 samples (differenced along w1)
-					const double Bw0_c = fc_a4_B_w0(i, j, k);
-					const double Bw0_p1w1 = fc_a4_B_w0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
-					const double Bw0_m1w1 = fc_a4_B_w0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
-					const double Bw0_m2w1 = fc_a4_B_w0(i - 2 * delta_w1[0], j - 2 * delta_w1[1], k - 2 * delta_w1[2]);
-					const double Bw0_p1w0 = fc_a4_B_w0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
-					const double Bw0_m1w0 = fc_a4_B_w0(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
-					const double Bw0_p1w0_m1w1 =
-					    fc_a4_B_w0(i + delta_w0[0] - delta_w1[0], j + delta_w0[1] - delta_w1[1], k + delta_w0[2] - delta_w1[2]);
-					const double Bw0_m1w0_m1w1 =
-					    fc_a4_B_w0(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
-					// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1; backward differences place j at the edge
-					const double j_c = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
-					const double j_p1w0 = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w0 - Bw0_p1w0_m1w1) / dw1;
-					const double j_m1w0 = (Bw1_m1w0 - Bw1_m2w0) / dw0 - (Bw0_m1w0 - Bw0_m1w0_m1w1) / dw1;
-					const double j_p1w1 = (Bw1_p1w1 - Bw1_m1w0_p1w1) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
-					const double j_m1w1 = (Bw1_m1w1 - Bw1_m1w0_m1w1) / dw0 - (Bw0_m1w1 - Bw0_m2w1) / dw1;
+			std::array<int, 3> delta_w0 = {0, 0, 0};
+			std::array<int, 3> delta_w1 = {0, 0, 0};
+			delta_w0[field_w_indices[0]] = 1;
+			delta_w1[field_w_indices[1]] = 1;
 
-					// per-direction second differences of the edge current (anisotropic hyper term)
-					const double d2j_w0 = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0);
-					const double d2j_w1 = (j_p1w1 - 2.0 * j_c + j_m1w1) / (dw1 * dw1);
+			const amrex::IntVect vec_cc2ec =
+			    amrex::IntVect::TheDimensionVector(field_w_indices[0]) + amrex::IntVect::TheDimensionVector(field_w_indices[1]);
+			const amrex::Box box_ec = amrex::convert(box_cc, vec_cc2ec);
 
-					// edge B components, averaged over the two reconstructed sides
-					const double Bw0_m = ec_a4_B_w0_m(i, j, k);
-					const double Bw0_p = ec_a4_B_w0_p(i, j, k);
-					const double Bw1_m = ec_a4_B_w1_m(i, j, k);
-					const double Bw1_p = ec_a4_B_w1_p(i, j, k);
-					const double ave_Bw0 = 0.5 * (Bw0_m + Bw0_p);
-					const double ave_Bw1 = 0.5 * (Bw1_m + Bw1_p);
-					// density averaged from the four cell-centred cells sharing this edge (cc -> edge).
-					// the edge (i,j,k) is nodal in the two perpendicular directions; the four cells that
-					// share it are (i,j,k) and its neighbours one cell back along w0, w1, and w0+w1.
-					const double rho =
-					    0.25 * (cc_a4_rho(i, j, k) + cc_a4_rho(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]) +
-						    cc_a4_rho(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]) +
-						    cc_a4_rho(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]));
-					// anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3,
-					// so each direction is damped at its own grid scale (reduces to the isotropic
-					// (dw0*dw1)^(3/2) form on cubic cells). v_A = sqrt(B^2 / rho).
-					const double v_hyper =
-					    (rho > 0.0) ? hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) : 0.0;
-					E2_ave(i, j, k) += v_hyper * (dw0 * dw0 * dw0 * d2j_w0 + dw1 * dw1 * dw1 * d2j_w1);
-				});
-			}
+			const double dw0 = dx[field_w_indices[0]];
+			const double dw1 = dx[field_w_indices[1]];
+
+			const auto fc_a4_B_w0 = fc_fabs_Bx[field_w_indices[0]].const_array();
+			const auto fc_a4_B_w1 = fc_fabs_Bx[field_w_indices[1]].const_array();
+			const auto ec_a4_E2_ave = ec_mf_emf_components[iedge][mfi].array();
+
+			amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+				// B_w1 samples (differenced along w0)
+				const double Bw1_c = fc_a4_B_w1(i, j, k);
+				const double Bw1_p1w0 = fc_a4_B_w1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
+				const double Bw1_m1w0 = fc_a4_B_w1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
+				const double Bw1_m2w0 = fc_a4_B_w1(i - 2 * delta_w0[0], j - 2 * delta_w0[1], k - 2 * delta_w0[2]);
+				const double Bw1_p1w1 = fc_a4_B_w1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
+				const double Bw1_m1w1 = fc_a4_B_w1(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
+				const double Bw1_m1w0_p1w1 =
+				    fc_a4_B_w1(i - delta_w0[0] + delta_w1[0], j - delta_w0[1] + delta_w1[1], k - delta_w0[2] + delta_w1[2]);
+				const double Bw1_m1w0_m1w1 =
+				    fc_a4_B_w1(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
+				// B_w0 samples (differenced along w1)
+				const double Bw0_c = fc_a4_B_w0(i, j, k);
+				const double Bw0_p1w1 = fc_a4_B_w0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
+				const double Bw0_m1w1 = fc_a4_B_w0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
+				const double Bw0_m2w1 = fc_a4_B_w0(i - 2 * delta_w1[0], j - 2 * delta_w1[1], k - 2 * delta_w1[2]);
+				const double Bw0_p1w0 = fc_a4_B_w0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
+				const double Bw0_m1w0 = fc_a4_B_w0(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
+				const double Bw0_p1w0_m1w1 =
+				    fc_a4_B_w0(i + delta_w0[0] - delta_w1[0], j + delta_w0[1] - delta_w1[1], k + delta_w0[2] - delta_w1[2]);
+				const double Bw0_m1w0_m1w1 =
+				    fc_a4_B_w0(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]);
+				// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1; backward differences place j at the edge
+				const double j_c = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
+				const double j_p1w0 = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w0 - Bw0_p1w0_m1w1) / dw1;
+				const double j_m1w0 = (Bw1_m1w0 - Bw1_m2w0) / dw0 - (Bw0_m1w0 - Bw0_m1w0_m1w1) / dw1;
+				const double j_p1w1 = (Bw1_p1w1 - Bw1_m1w0_p1w1) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
+				const double j_m1w1 = (Bw1_m1w1 - Bw1_m1w0_m1w1) / dw0 - (Bw0_m1w1 - Bw0_m2w1) / dw1;
+				// per-direction second differences of the edge current (anisotropic biharmonic term)
+				const double d2j_w0 = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0);
+				const double d2j_w1 = (j_p1w1 - 2.0 * j_c + j_m1w1) / (dw1 * dw1);
+				// edge B: average the two adjacent faces in each transverse direction (face -> edge)
+				const double ave_Bw0 = 0.5 * (Bw0_c + Bw0_m1w1);
+				const double ave_Bw1 = 0.5 * (Bw1_c + Bw1_m1w0);
+				// density averaged from the four cc cells sharing this edge (cc -> edge)
+				const double rho =
+				    0.25 * (cc_a4_rho(i, j, k) + cc_a4_rho(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]) +
+					    cc_a4_rho(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]) +
+					    cc_a4_rho(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]));
+				// anisotropic coefficient: eta_d = c_hyper * v_A * dx_d^3; v_A = sqrt(B^2 / rho)
+				const double v_hyper = (rho > 0.0) ? hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) : 0.0;
+				ec_a4_E2_ave(i, j, k) += v_hyper * (dw0 * dw0 * dw0 * d2j_w0 + dw1 * dw1 * dw1 * d2j_w1);
+			});
 		}
 	}
 }

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -549,8 +549,7 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 }
 
 template <typename problem_t>
-void MHDSystem<problem_t>::ApplyHyperResistiveCorrection(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components,
-							 amrex::MultiFab const &cc_mf_cVars,
+void MHDSystem<problem_t>::ApplyHyperResistiveCorrection(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
 							 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars, double hyper_resistivity_coeff,
 							 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx)
 {

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -86,7 +86,7 @@ template <typename problem_t> class MHDSystem : public HyperbolicSystem<problem_
 					   std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, SlopeLimiter plmLimiter,
 					   EMFAvgScheme emf_avg_scheme, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, amrex::Real resistivity = 0.0);
 
-	static void ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components,
+	static void ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 					  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder, SlopeLimiter plmLimiter,
@@ -152,8 +152,8 @@ void MHDSystem<problem_t>::ComputeEMF(std::array<amrex::MultiFab, AMREX_SPACEDIM
 		MHDSystem<problem_t>::ComputeEMF_Balsara2025(ec_mf_emf_components, cc_mf_cVars, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder, plmLimiter,
 							     emf_avg_scheme, dx, resistivity);
 	} else if (emf_compute_scheme == EMFComputeScheme::Quokka2026) {
-		MHDSystem<problem_t>::ComputeEMF_Quokka2026(ec_mf_emf_components, fcx_mf_vel, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder, plmLimiter,
-							    emf_avg_scheme, dx, hyper_resistivity_coeff);
+		MHDSystem<problem_t>::ComputeEMF_Quokka2026(ec_mf_emf_components, cc_mf_cVars, fcx_mf_vel, fcx_mf_cVars, fcx_mf_fspds, reconstructionOrder,
+							    plmLimiter, emf_avg_scheme, dx, hyper_resistivity_coeff);
 	} else {
 		throw std::runtime_error("Unsupported EMF-scheme. Expected either FelkerStone2017, Balsara2025, or Quokka2026.");
 	}
@@ -407,7 +407,7 @@ void MHDSystem<problem_t>::ComputeEMF_FelkerStone2017(std::array<amrex::MultiFab
 // uses face-centered Riemann velocity and face-centered magnetic fields extrapolated to the cell-edge to compute the EMF
 
 template <typename problem_t>
-void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components,
+void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMREX_SPACEDIM> &ec_mf_emf_components, amrex::MultiFab const &cc_mf_cVars,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_vel,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_cVars,
 						 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &fcx_mf_fspds, int reconstructionOrder,
@@ -547,8 +547,8 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 
 				const auto fc_a4_B_w0 = fc_fabs_Bx[field_w_indices[0]].const_array();
 				const auto fc_a4_B_w1 = fc_fabs_Bx[field_w_indices[1]].const_array();
-				const auto fc_a4_rho_w0 = fcx_mf_cVars[field_w_indices[0]][mfi].const_array(HydroSystem<problem_t>::density_index);
-				const auto fc_a4_rho_w1 = fcx_mf_cVars[field_w_indices[1]][mfi].const_array(HydroSystem<problem_t>::density_index);
+				// density lives on the cell-centred state (face state holds B, not rho); average it to the edge below
+				const auto cc_a4_rho = cc_mf_cVars[mfi].const_array(HydroSystem<problem_t>::density_index);
 
 				const auto ec_a4_B_w0_m = ec_fabs_Bi_ieside[0][0].const_array();
 				const auto ec_a4_B_w0_p = ec_fabs_Bi_ieside[0][1].const_array();
@@ -597,12 +597,13 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					const double Bw1_p = ec_a4_B_w1_p(i, j, k);
 					const double ave_Bw0 = 0.5 * (Bw0_m + Bw0_p);
 					const double ave_Bw1 = 0.5 * (Bw1_m + Bw1_p);
-					// density averaged from the four faces adjacent to the edge
-					const double rho_w0_c = fc_a4_rho_w0(i, j, k);
-					const double rho_w0_p1w1 = fc_a4_rho_w0(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
-					const double rho_w1_c = fc_a4_rho_w1(i, j, k);
-					const double rho_w1_p1w0 = fc_a4_rho_w1(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
-					const double rho = 0.25 * (rho_w0_c + rho_w0_p1w1 + rho_w1_c + rho_w1_p1w0);
+					// density averaged from the four cell-centred cells sharing this edge (cc -> edge).
+					// the edge (i,j,k) is nodal in the two perpendicular directions; the four cells that
+					// share it are (i,j,k) and its neighbours one cell back along w0, w1, and w0+w1.
+					const double rho = 0.25 * (cc_a4_rho(i, j, k) +
+								   cc_a4_rho(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]) +
+								   cc_a4_rho(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]) +
+								   cc_a4_rho(i-delta_w0[0]-delta_w1[0], j-delta_w0[1]-delta_w1[1], k-delta_w0[2]-delta_w1[2]));
 					const double eta_hyper = hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) * std::pow(dw0 * dw1, 1.5);
 
 					E2_ave(i, j, k) += eta_hyper * laplacian_j;

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -539,53 +539,73 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 							 fcx_mf_cVars[field_w_indices[1]][mfi].const_array(bfield_index), dx[field_w_indices[0]],
 							 dx[field_w_indices[1]], 0.0);
 
-			// Biharmonic resistivity: E2_ave += eta_hyp * laplacian(j)
-			// eta_hyp = c_hyp * c_A * (dx_w0 * dx_w1)^(3/2); always-on, amplitude-independent, N^4 scale selectivity
+			// Biharmonic resistivity: E2_ave += eta_hyper * laplacian(j)
+			// eta_hyper = c_hyper * c_A * (dw0 * dw1)^(3/2); always-on, amplitude-independent, N^4 scale selectivity
 			if (hyper_resistivity_coeff > 0.) {
-				const double dx_w0 = dx[field_w_indices[0]];
-				const double dx_w1 = dx[field_w_indices[1]];
+				const double dw0 = dx[field_w_indices[0]];
+				const double dw1 = dx[field_w_indices[1]];
 
-				const auto Bw0 = fc_fabs_Bx[field_w_indices[0]].const_array();
-				const auto Bw1 = fc_fabs_Bx[field_w_indices[1]].const_array();
-				const auto rho_w0 = fcx_mf_cVars[field_w_indices[0]][mfi].const_array(HydroSystem<problem_t>::density_index);
-				const auto rho_w1 = fcx_mf_cVars[field_w_indices[1]][mfi].const_array(HydroSystem<problem_t>::density_index);
+				const auto fc_a4_B_w0 = fc_fabs_Bx[field_w_indices[0]].const_array();
+				const auto fc_a4_B_w1 = fc_fabs_Bx[field_w_indices[1]].const_array();
+				const auto fc_a4_rho_w0 = fcx_mf_cVars[field_w_indices[0]][mfi].const_array(HydroSystem<problem_t>::density_index);
+				const auto fc_a4_rho_w1 = fcx_mf_cVars[field_w_indices[1]][mfi].const_array(HydroSystem<problem_t>::density_index);
 
-				const auto B0m = ec_fabs_Bi_ieside[0][0].const_array();
-				const auto B0p = ec_fabs_Bi_ieside[0][1].const_array();
-				const auto B1m = ec_fabs_Bi_ieside[1][0].const_array();
-				const auto B1p = ec_fabs_Bi_ieside[1][1].const_array();
+				const auto ec_a4_B_w0_m = ec_fabs_Bi_ieside[0][0].const_array();
+				const auto ec_a4_B_w0_p = ec_fabs_Bi_ieside[0][1].const_array();
+				const auto ec_a4_B_w1_m = ec_fabs_Bi_ieside[1][0].const_array();
+				const auto ec_a4_B_w1_p = ec_fabs_Bi_ieside[1][1].const_array();
 
-				// unit-vector components for the two perpendicular directions (plain ints for GPU capture)
-				const int d0i = (field_w_indices[0] == 0) ? 1 : 0;
-				const int d0j = (field_w_indices[0] == 1) ? 1 : 0;
-				const int d0k = (field_w_indices[0] == 2) ? 1 : 0;
-				const int d1i = (field_w_indices[1] == 0) ? 1 : 0;
-				const int d1j = (field_w_indices[1] == 1) ? 1 : 0;
-				const int d1k = (field_w_indices[1] == 2) ? 1 : 0;
+				// unit offsets along the two world directions perpendicular to the edge
+				std::array<int, 3> delta_w0 = {0, 0, 0};
+				std::array<int, 3> delta_w1 = {0, 0, 0};
+				delta_w0[field_w_indices[0]] = 1;
+				delta_w1[field_w_indices[1]] = 1;
 
 				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-					// j = (Bw1[+w0] - Bw1[0]) / dx_w0 - (Bw0[+w1] - Bw0[0]) / dx_w1 at the edge and its 4 neighbours
-					const double j_c   = (Bw1(i+d0i,       j+d0j,       k+d0k      ) - Bw1(i,       j,       k     )) / dx_w0
-					                   - (Bw0(i+d1i,       j+d1j,       k+d1k      ) - Bw0(i,       j,       k     )) / dx_w1;
-					const double j_pw0 = (Bw1(i+2*d0i,     j+2*d0j,     k+2*d0k    ) - Bw1(i+d0i,   j+d0j,   k+d0k  )) / dx_w0
-					                   - (Bw0(i+d0i+d1i,   j+d0j+d1j,   k+d0k+d1k  ) - Bw0(i+d0i,   j+d0j,   k+d0k  )) / dx_w1;
-					const double j_mw0 = (Bw1(i,           j,           k          ) - Bw1(i-d0i,   j-d0j,   k-d0k  )) / dx_w0
-					                   - (Bw0(i-d0i+d1i,   j-d0j+d1j,   k-d0k+d1k  ) - Bw0(i-d0i,   j-d0j,   k-d0k  )) / dx_w1;
-					const double j_pw1 = (Bw1(i+d0i+d1i,   j+d0j+d1j,   k+d0k+d1k  ) - Bw1(i+d1i,   j+d1j,   k+d1k  )) / dx_w0
-					                   - (Bw0(i+2*d1i,     j+2*d1j,     k+2*d1k    ) - Bw0(i+d1i,   j+d1j,   k+d1k  )) / dx_w1;
-					const double j_mw1 = (Bw1(i+d0i-d1i,   j+d0j-d1j,   k+d0k-d1k  ) - Bw1(i-d1i,   j-d1j,   k-d1k  )) / dx_w0
-					                   - (Bw0(i,           j,           k          ) - Bw0(i-d1i,   j-d1j,   k-d1k  )) / dx_w1;
+					// B_w1 samples (differenced along w0)
+					const double Bw1_c = fc_a4_B_w1(i, j, k);
+					const double Bw1_p1w0 = fc_a4_B_w1(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
+					const double Bw1_p2w0 = fc_a4_B_w1(i+2*delta_w0[0], j+2*delta_w0[1], k+2*delta_w0[2]);
+					const double Bw1_m1w0 = fc_a4_B_w1(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]);
+					const double Bw1_p1w1 = fc_a4_B_w1(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
+					const double Bw1_m1w1 = fc_a4_B_w1(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]);
+					const double Bw1_p1w0_p1w1 = fc_a4_B_w1(i+delta_w0[0]+delta_w1[0], j+delta_w0[1]+delta_w1[1], k+delta_w0[2]+delta_w1[2]);
+					const double Bw1_p1w0_m1w1 = fc_a4_B_w1(i+delta_w0[0]-delta_w1[0], j+delta_w0[1]-delta_w1[1], k+delta_w0[2]-delta_w1[2]);
+					// B_w0 samples (differenced along w1)
+					const double Bw0_c = fc_a4_B_w0(i, j, k);
+					const double Bw0_p1w1 = fc_a4_B_w0(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
+					const double Bw0_p2w1 = fc_a4_B_w0(i+2*delta_w1[0], j+2*delta_w1[1], k+2*delta_w1[2]);
+					const double Bw0_m1w1 = fc_a4_B_w0(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]);
+					const double Bw0_p1w0 = fc_a4_B_w0(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
+					const double Bw0_m1w0 = fc_a4_B_w0(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]);
+					const double Bw0_p1w0_p1w1 = fc_a4_B_w0(i+delta_w0[0]+delta_w1[0], j+delta_w0[1]+delta_w1[1], k+delta_w0[2]+delta_w1[2]);
+					const double Bw0_m1w0_p1w1 = fc_a4_B_w0(i-delta_w0[0]+delta_w1[0], j-delta_w0[1]+delta_w1[1], k-delta_w0[2]+delta_w1[2]);
+					// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1, built from B samples around the edge
+					const double j_c   = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
+					const double j_p1w0 = (Bw1_p2w0 - Bw1_p1w0) / dw0 - (Bw0_p1w0_p1w1 - Bw0_p1w0) / dw1;
+					const double j_m1w0 = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_m1w0_p1w1 - Bw0_m1w0) / dw1;
+					const double j_p1w1 = (Bw1_p1w0_p1w1 - Bw1_p1w1) / dw0 - (Bw0_p2w1 - Bw0_p1w1) / dw1;
+					const double j_m1w1 = (Bw1_p1w0_m1w1 - Bw1_m1w1) / dw0 - (Bw0_c - Bw0_m1w1) / dw1;
 
-					const double lap_j = (j_pw0 - 2.0 * j_c + j_mw0) / (dx_w0 * dx_w0)
-					                   + (j_pw1 - 2.0 * j_c + j_mw1) / (dx_w1 * dx_w1);
+					const double laplacian_j = (j_p1w0 - 2.0 * j_c + j_m1w0) / (dw0 * dw0) +
+								   (j_p1w1 - 2.0 * j_c + j_m1w1) / (dw1 * dw1);
 
-					const double b0 = 0.5 * (B0m(i, j, k) + B0p(i, j, k));
-					const double b1 = 0.5 * (B1m(i, j, k) + B1p(i, j, k));
-					const double rho = 0.25 * (rho_w0(i, j, k) + rho_w0(i+d1i, j+d1j, k+d1k)
-					                         + rho_w1(i, j, k) + rho_w1(i+d0i, j+d0j, k+d0k));
-					const double eta_hyp = hyper_resistivity_coeff * std::sqrt((b0 * b0 + b1 * b1) / rho) * std::pow(dx_w0 * dx_w1, 1.5);
+					// edge B components, averaged over the two reconstructed sides
+					const double Bw0_m = ec_a4_B_w0_m(i, j, k);
+					const double Bw0_p = ec_a4_B_w0_p(i, j, k);
+					const double Bw1_m = ec_a4_B_w1_m(i, j, k);
+					const double Bw1_p = ec_a4_B_w1_p(i, j, k);
+					const double ave_Bw0 = 0.5 * (Bw0_m + Bw0_p);
+					const double ave_Bw1 = 0.5 * (Bw1_m + Bw1_p);
+					// density averaged from the four faces adjacent to the edge
+					const double rho_w0_c = fc_a4_rho_w0(i, j, k);
+					const double rho_w0_p1w1 = fc_a4_rho_w0(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
+					const double rho_w1_c = fc_a4_rho_w1(i, j, k);
+					const double rho_w1_p1w0 = fc_a4_rho_w1(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
+					const double rho = 0.25 * (rho_w0_c + rho_w0_p1w1 + rho_w1_c + rho_w1_p1w0);
+					const double eta_hyper = hyper_resistivity_coeff * std::sqrt((ave_Bw0 * ave_Bw0 + ave_Bw1 * ave_Bw1) / rho) * std::pow(dw0 * dw1, 1.5);
 
-					E2_ave(i, j, k) += eta_hyp * lap_j;
+					E2_ave(i, j, k) += eta_hyper * laplacian_j;
 				});
 			}
 		}

--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -564,24 +564,28 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 				amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 					// B_w1 samples (differenced along w0)
 					const double Bw1_c = fc_a4_B_w1(i, j, k);
-					const double Bw1_p1w0 = fc_a4_B_w1(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
-					const double Bw1_p2w0 = fc_a4_B_w1(i+2*delta_w0[0], j+2*delta_w0[1], k+2*delta_w0[2]);
-					const double Bw1_m1w0 = fc_a4_B_w1(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]);
-					const double Bw1_p1w1 = fc_a4_B_w1(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
-					const double Bw1_m1w1 = fc_a4_B_w1(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]);
-					const double Bw1_p1w0_p1w1 = fc_a4_B_w1(i+delta_w0[0]+delta_w1[0], j+delta_w0[1]+delta_w1[1], k+delta_w0[2]+delta_w1[2]);
-					const double Bw1_p1w0_m1w1 = fc_a4_B_w1(i+delta_w0[0]-delta_w1[0], j+delta_w0[1]-delta_w1[1], k+delta_w0[2]-delta_w1[2]);
+					const double Bw1_p1w0 = fc_a4_B_w1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
+					const double Bw1_p2w0 = fc_a4_B_w1(i + 2 * delta_w0[0], j + 2 * delta_w0[1], k + 2 * delta_w0[2]);
+					const double Bw1_m1w0 = fc_a4_B_w1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
+					const double Bw1_p1w1 = fc_a4_B_w1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
+					const double Bw1_m1w1 = fc_a4_B_w1(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
+					const double Bw1_p1w0_p1w1 =
+					    fc_a4_B_w1(i + delta_w0[0] + delta_w1[0], j + delta_w0[1] + delta_w1[1], k + delta_w0[2] + delta_w1[2]);
+					const double Bw1_p1w0_m1w1 =
+					    fc_a4_B_w1(i + delta_w0[0] - delta_w1[0], j + delta_w0[1] - delta_w1[1], k + delta_w0[2] - delta_w1[2]);
 					// B_w0 samples (differenced along w1)
 					const double Bw0_c = fc_a4_B_w0(i, j, k);
-					const double Bw0_p1w1 = fc_a4_B_w0(i+delta_w1[0], j+delta_w1[1], k+delta_w1[2]);
-					const double Bw0_p2w1 = fc_a4_B_w0(i+2*delta_w1[0], j+2*delta_w1[1], k+2*delta_w1[2]);
-					const double Bw0_m1w1 = fc_a4_B_w0(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]);
-					const double Bw0_p1w0 = fc_a4_B_w0(i+delta_w0[0], j+delta_w0[1], k+delta_w0[2]);
-					const double Bw0_m1w0 = fc_a4_B_w0(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]);
-					const double Bw0_p1w0_p1w1 = fc_a4_B_w0(i+delta_w0[0]+delta_w1[0], j+delta_w0[1]+delta_w1[1], k+delta_w0[2]+delta_w1[2]);
-					const double Bw0_m1w0_p1w1 = fc_a4_B_w0(i-delta_w0[0]+delta_w1[0], j-delta_w0[1]+delta_w1[1], k-delta_w0[2]+delta_w1[2]);
+					const double Bw0_p1w1 = fc_a4_B_w0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2]);
+					const double Bw0_p2w1 = fc_a4_B_w0(i + 2 * delta_w1[0], j + 2 * delta_w1[1], k + 2 * delta_w1[2]);
+					const double Bw0_m1w1 = fc_a4_B_w0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]);
+					const double Bw0_p1w0 = fc_a4_B_w0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2]);
+					const double Bw0_m1w0 = fc_a4_B_w0(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]);
+					const double Bw0_p1w0_p1w1 =
+					    fc_a4_B_w0(i + delta_w0[0] + delta_w1[0], j + delta_w0[1] + delta_w1[1], k + delta_w0[2] + delta_w1[2]);
+					const double Bw0_m1w0_p1w1 =
+					    fc_a4_B_w0(i - delta_w0[0] + delta_w1[0], j - delta_w0[1] + delta_w1[1], k - delta_w0[2] + delta_w1[2]);
 					// edge current j = d(B_w1)/dw0 - d(B_w0)/dw1, built from B samples around the edge
-					const double j_c   = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
+					const double j_c = (Bw1_p1w0 - Bw1_c) / dw0 - (Bw0_p1w1 - Bw0_c) / dw1;
 					const double j_p1w0 = (Bw1_p2w0 - Bw1_p1w0) / dw0 - (Bw0_p1w0_p1w1 - Bw0_p1w0) / dw1;
 					const double j_m1w0 = (Bw1_c - Bw1_m1w0) / dw0 - (Bw0_m1w0_p1w1 - Bw0_m1w0) / dw1;
 					const double j_p1w1 = (Bw1_p1w0_p1w1 - Bw1_p1w1) / dw0 - (Bw0_p2w1 - Bw0_p1w1) / dw1;
@@ -601,10 +605,10 @@ void MHDSystem<problem_t>::ComputeEMF_Quokka2026(std::array<amrex::MultiFab, AMR
 					// density averaged from the four cell-centred cells sharing this edge (cc -> edge).
 					// the edge (i,j,k) is nodal in the two perpendicular directions; the four cells that
 					// share it are (i,j,k) and its neighbours one cell back along w0, w1, and w0+w1.
-					const double rho = 0.25 * (cc_a4_rho(i, j, k) +
-								   cc_a4_rho(i-delta_w0[0], j-delta_w0[1], k-delta_w0[2]) +
-								   cc_a4_rho(i-delta_w1[0], j-delta_w1[1], k-delta_w1[2]) +
-								   cc_a4_rho(i-delta_w0[0]-delta_w1[0], j-delta_w0[1]-delta_w1[1], k-delta_w0[2]-delta_w1[2]));
+					const double rho =
+					    0.25 * (cc_a4_rho(i, j, k) + cc_a4_rho(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2]) +
+						    cc_a4_rho(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2]) +
+						    cc_a4_rho(i - delta_w0[0] - delta_w1[0], j - delta_w0[1] - delta_w1[1], k - delta_w0[2] - delta_w1[2]));
 					// anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3,
 					// so each direction is damped at its own grid scale (reduces to the isotropic
 					// (dw0*dw1)^(3/2) form on cubic cells). v_A = sqrt(B^2 / rho).

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -231,6 +231,10 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	amrex::Real conductionCFL = 0.2;	      // default
 	int enableElectronConduction_ = 0;	      // default
 
+	// Hyper-resistivity (biharmonic EMF diffusion) parameters
+	amrex::Real hyperResistivityCoeff_ = 0.0; // c_hyper; 0 == off
+	amrex::Real hyperResistivityCFL = 0.015;  // 4th-order stability coeff (von Neumann, RK2; safety-factored)
+
 	amrex::Real densityFloor_ = 0.0;     // default
 	amrex::Real dustDensityFloor_ = 0.0; // default
 	amrex::Real tempFloor_ = 0.0;	     // default
@@ -1264,6 +1268,28 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 		}
 	}
 
+	// compute timestep based on hyper-resistivity (4th-order biharmonic EMF diffusion)
+	amrex::ValLocPair<amrex::Real, amrex::IntVect> hyper_resistivity_dt{.value = std::numeric_limits<amrex::Real>::max(),
+									   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+	if (hyperResistivityCoeff_ > 0.0) {
+		// eta_hyper = c_hyper * speed * (dx*dy)^(3/2)  [see MHDSystem::ComputeEMF_Quokka2026]. The local
+		// speed (v_A, or max(v_A,c_s) once floored) is bounded above by the domain max signal speed already
+		// computed for the hydro step, so reuse it -- no extra reduction. The (dw0*dw1) factor is bounded
+		// over all edge orientations by the largest pairwise cell-area = cell_volume / smallest edge, which
+		// stays tight on anisotropic (slab) grids. MHD (hence hyper-resistivity) is 3D-only, but this base
+		// routine also compiles for lower-D problems, so use AMREX_D_TERM rather than a literal dx[2].
+		const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+		const amrex::Real max_area = cell_volume / dx_min;
+		const amrex::Real eta_hyper_max = hyperResistivityCoeff_ * domain_signal_max * std::pow(max_area, 1.5);
+		// explicit 4th-order stability limit: dt < hyperResistivityCFL * dx_min^4 / eta_hyper
+		hyper_resistivity_dt.value = hyperResistivityCFL * std::pow(dx_min, 4) / eta_hyper_max;
+		hyper_resistivity_dt.index = domain_signal_maxloc;
+
+		if (verbose) {
+			amrex::Print() << std::format("...[level {}] \testimated hyper-resistivity timestep: {:e}\n", lev, hyper_resistivity_dt.value);
+		}
+	}
+
 	// compute maximum particle speed on level 'lev'
 	amrex::ValLocPair<amrex::Real, amrex::IntVect> particle_dt{.value = std::numeric_limits<amrex::Real>::max(),
 								   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
@@ -1292,7 +1318,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 #endif
 
 	// compute minimum timestep
-	std::vector<dtloc_t *> dts = {&hydro_dt, &conduction_dt, &particle_dt};
+	std::vector<dtloc_t *> dts = {&hydro_dt, &conduction_dt, &particle_dt, &hyper_resistivity_dt};
 	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end(), [](dtloc_t *const p1, dtloc_t *const p2) { return p1->value < p2->value; });
 
 	if (verbose) {
@@ -1303,6 +1329,8 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			amrex::Print() << std::format("...[level {}] timestep limited by PARTICLES\n", lev);
 		} else if (dt_min_ptr == &conduction_dt) {
 			amrex::Print() << std::format("...[level {}] timestep limited by CONDUCTION\n", lev);
+		} else if (dt_min_ptr == &hyper_resistivity_dt) {
+			amrex::Print() << std::format("...[level {}] timestep limited by HYPER-RESISTIVITY\n", lev);
 		}
 	}
 
@@ -1345,6 +1373,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 		if (enableElectronConduction_ == 1) {
 			// Conduction timestep scales as dx^2, so we need to use n_factor^2 here instead of n_factor.
 			effective_factor = static_cast<amrex::Real>(n_factor) * static_cast<amrex::Real>(n_factor);
+		}
+		if (hyperResistivityCoeff_ > 0.0) {
+			// Hyper-resistivity timestep scales as dx^4, so use n_factor^4 (steepest; assumes it is the limiter).
+			const auto nf = static_cast<amrex::Real>(n_factor);
+			effective_factor = nf * nf * nf * nf;
 		}
 
 		const amrex::Real dt_0_old = dt_0; // save old dt_0

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -233,7 +233,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 
 	// Hyper-resistivity (biharmonic EMF diffusion) parameters
 	amrex::Real hyperResistivityCoeff_ = 0.0; // c_hyper; 0 == off
-	amrex::Real hyperResistivityCFL = 0.015;  // 4th-order stability coeff (von Neumann, RK2; safety-factored)
+	amrex::Real hyperResistivityCFL = 1.5;	  // safety * integrator real-axis radius (RK2 ~ 2); geometry is in `stiffness`
 
 	amrex::Real densityFloor_ = 0.0;     // default
 	amrex::Real dustDensityFloor_ = 0.0; // default
@@ -1272,17 +1272,16 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	amrex::ValLocPair<amrex::Real, amrex::IntVect> hyper_resistivity_dt{.value = std::numeric_limits<amrex::Real>::max(),
 									   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 	if (hyperResistivityCoeff_ > 0.0) {
-		// eta_hyper = c_hyper * speed * (dx*dy)^(3/2)  [see MHDSystem::ComputeEMF_Quokka2026]. The local
-		// speed (v_A, or max(v_A,c_s) once floored) is bounded above by the domain max signal speed already
-		// computed for the hydro step, so reuse it -- no extra reduction. The (dw0*dw1) factor is bounded
-		// over all edge orientations by the largest pairwise cell-area = cell_volume / smallest edge, which
-		// stays tight on anisotropic (slab) grids. MHD (hence hyper-resistivity) is 3D-only, but this base
-		// routine also compiles for lower-D problems, so use AMREX_D_TERM rather than a literal dx[2].
-		const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
-		const amrex::Real max_area = cell_volume / dx_min;
-		const amrex::Real eta_hyper_max = hyperResistivityCoeff_ * domain_signal_max * std::pow(max_area, 1.5);
-		// explicit 4th-order stability limit: dt < hyperResistivityCFL * dx_min^4 / eta_hyper
-		hyper_resistivity_dt.value = hyperResistivityCFL * std::pow(dx_min, 4) / eta_hyper_max;
+		// Anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3
+		// [see MHDSystem::ComputeEMF_Quokka2026]. The stiffest biharmonic symbol of the discrete operator
+		// is an upper bound |K|^2_max * max_edge|L| = [4*sum_d 1/dx_d^2] * [4*(two largest dx_d)], verified
+		// against the von Neumann scan (96 cubic, 1056 for a 32:1 slab). v_A <= domain_signal_max (already
+		// computed for the hydro step), so reuse it -- no extra reduction. hyperResistivityCFL is the
+		// safety-factored integrator real-axis radius (~2 for RK2); all geometry is in `stiffness`.
+		const amrex::Real inv_dx2_sum = AMREX_D_TERM(1.0 / (dx[0] * dx[0]), +1.0 / (dx[1] * dx[1]), +1.0 / (dx[2] * dx[2]));
+		const amrex::Real dx_sum = AMREX_D_TERM(dx[0], +dx[1], +dx[2]);
+		const amrex::Real stiffness = 16.0 * inv_dx2_sum * (dx_sum - dx_min); // max biharmonic symbol / (c_hyper*v_A)
+		hyper_resistivity_dt.value = hyperResistivityCFL / (hyperResistivityCoeff_ * domain_signal_max * stiffness);
 		hyper_resistivity_dt.index = domain_signal_maxloc;
 
 		if (verbose) {
@@ -1374,11 +1373,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 			// Conduction timestep scales as dx^2, so we need to use n_factor^2 here instead of n_factor.
 			effective_factor = static_cast<amrex::Real>(n_factor) * static_cast<amrex::Real>(n_factor);
 		}
-		if (hyperResistivityCoeff_ > 0.0) {
-			// Hyper-resistivity timestep scales as dx^4, so use n_factor^4 (steepest; assumes it is the limiter).
-			const auto nf = static_cast<amrex::Real>(n_factor);
-			effective_factor = nf * nf * nf * nf;
-		}
+		// Note: hyper-resistivity needs no special subcycling factor -- its self-scaling coefficient
+		// (eta_d ~ dx_d^3) makes the hyper timestep scale as dx^1 (advection-like), so the default
+		// n_factor already applies.
 
 		const amrex::Real dt_0_old = dt_0; // save old dt_0
 		dt_0 = std::min(dt_0, effective_factor * dt_tmp[level]);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1270,7 +1270,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 
 	// compute timestep based on hyper-resistivity (4th-order biharmonic EMF diffusion)
 	amrex::ValLocPair<amrex::Real, amrex::IntVect> hyper_resistivity_dt{.value = std::numeric_limits<amrex::Real>::max(),
-									   .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
+									    .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
 	if (hyperResistivityCoeff_ > 0.0) {
 		// Anisotropic hyper resistivity: per-direction coefficient eta_d = c_hyper * v_A * dx_d^3
 		// [see MHDSystem::ComputeEMF_Quokka2026]. The stiffest biharmonic symbol of the discrete operator


### PR DESCRIPTION
### Description

This is a proof-of-concept of a 4th-order hyper-resistivity operator to stabilise instabilities in the `Quokka2026` EMF compute scheme. The hyper term takes the form `E += eta_hyper * lap(J)`, where `J = curl(B)` is the current density on the edge, which gives `dB/dt = -eta_hyper * nabla^4 B`. Here the `k^4` term acts as a damper that suppresses grid-scale modes while leaving resolved scales largely untouched.

I experimented, and found that an anisotropic coefficient (`eta_dynamic = c_hyper * v_A * dx_d^3` per direction), correctly reduces to the isotropic `(dx*dy)^(3/2)` form on cubic cells and avoids timestep collapse on slab domains (like the semi-1D SlowWave test and semi-2D Orszag Tang problems). I have also drafted an explicit 4th-order timestep limiter. The coefficient is set via `mhd.hyper_resistivity_coefficient` in the TOML input.

This implementation has been tested on both th slow MHD wave and the Orszag-Tang, where `c_hyper ~ 1e-3` stabilises the `Quokka2026` instability for both. This PR is purely a proof of concept, since another, simpler solutions was found in in #1937.

Here is the evolution of the `SlowWave` run with `512x8x8`:
<img width="3329" height="2070" alt="mag-profiles" src="https://github.com/user-attachments/assets/e967e194-688f-4545-94af-7bbeaaadc158" />

Here are current density slices of the `Orszag Tang` run at `512x512x8` at t=0.6 and 1.0, respectively:
<img width="1088" height="791" alt="cur-slice-index=0004358" src="https://github.com/user-attachments/assets/0e9dd99e-703a-4f4c-92a2-bd6c93607d51" />
<img width="1088" height="793" alt="cur-slice-index=0008068" src="https://github.com/user-attachments/assets/062743a4-a081-4e13-8a87-07bc07802c77" />

**Known issues to resolve before merge:**
- The hyper term is applied in a separate `amrex::ParallelFor` kernel after `AverageEMF`, adding a third kernel launch per edge per timestep. It should be fused into the averaging kernel.

### Related issues

#1912

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.