### PR TITLE
Rewrite photoionization rhs for performance

### DIFF
--- a/src/networks/photoionization/actual_rhs.H
+++ b/src/networks/photoionization/actual_rhs.H
@@ -111,8 +111,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual_rhs(const burn_t &state, Ar
 	}
 
 	const amrex::Real photoionization_term = chat_sigma_photo * n_HI * n_gamma;
-	amrex::Real collisional_ionization_term = (collisional_ionization_switch != 0) ? n_e * n_HI * get_collisional_ionization_coefficient(state.T) : 0.0_rt;
-	amrex::Real recombination_term = (recombination_switch != 0) ? get_recombination_coefficient(state.T) * n_e * n_HII : 0.0_rt;
+	const amrex::Real collisional_ionization_term = (collisional_ionization_switch != 0) ? n_e * n_HI * get_collisional_ionization_coefficient(state.T) : 0.0_rt;
+	const amrex::Real recombination_term = (recombination_switch != 0) ? get_recombination_coefficient(state.T) * n_e * n_HII : 0.0_rt;
 
 	ydot(1) = photoionization_term + collisional_ionization_term - recombination_term;
 	ydot(2) = -ydot(1);
@@ -182,13 +182,13 @@ template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual
 		molecular_process_switch = 0;
 	}
 
-	amrex::Real d_collisional_ionization_term_dT = collisional_ionization_switch * n_e * n_HI * d_sigma_coll_dT;
-	amrex::Real d_recombination_term_dT = recombination_switch * (d_alpha_rec_dT * n_e * n_HII);
-	amrex::Real d_KI_cooling_dT = molecular_process_switch * KI_cooling_switch * (d_Lambda_KI_dT * n_HI * n_HI);
-	amrex::Real d_recombination_cooling_dT = recombination_cooling_switch * (d_Lambda_rec_dT * n_e * n_HII);
-	amrex::Real d_ion_ff_cooling_dT = ion_ff_cooling_switch * (d_Lambda_ion_ff_dT * n_e * n_HII);
+	const amrex::Real d_collisional_ionization_term_dT = collisional_ionization_switch * n_e * n_HI * d_sigma_coll_dT;
+	const amrex::Real d_recombination_term_dT = recombination_switch * (d_alpha_rec_dT * n_e * n_HII);
+	const amrex::Real d_KI_cooling_dT = molecular_process_switch * KI_cooling_switch * (d_Lambda_KI_dT * n_HI * n_HI);
+	const amrex::Real d_recombination_cooling_dT = recombination_cooling_switch * (d_Lambda_rec_dT * n_e * n_HII);
+	const amrex::Real d_ion_ff_cooling_dT = ion_ff_cooling_switch * (d_Lambda_ion_ff_dT * n_e * n_HII);
 
-	amrex::Real dTde = 1 / state.dedT;
+	const amrex::Real dTde = 1 / state.dedT;
 
 	jac.zero();
 

--- a/src/networks/photoionization/actual_rhs.H
+++ b/src/networks/photoionization/actual_rhs.H
@@ -31,7 +31,7 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE auto get_recombination_coefficient(Real T) ->
 	if (recombination_temperature_dependent == 0) {
 		return 2.6e-13_rt;
 	}
-	return 2.6e-13 * (1.0 + recombination_temperature_dependent * (std::pow(T / 1.0e4, -0.7) - 1.0));
+	return 2.6e-13 * (1.0 + std::pow(T / 1.0e4, -0.7) - 1.0);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE auto dRecombination_coefficient_dT(Real T) -> Real
@@ -111,14 +111,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual_rhs(const burn_t &state, Ar
 	}
 
 	const amrex::Real photoionization_term = chat_sigma_photo * n_HI * n_gamma;
-	amrex::Real collisional_ionization_term = 0.0_rt;
-	if (collisional_ionization_switch != 0) {
-		collisional_ionization_term = n_e * n_HI * get_collisional_ionization_coefficient(state.T);
-	}
-	amrex::Real recombination_term = 0.0_rt;
-	if (recombination_switch != 0) {
-		recombination_term = get_recombination_coefficient(state.T) * n_e * n_HII;
-	}
+	amrex::Real collisional_ionization_term = (collisional_ionization_switch != 0) ? n_e * n_HI * get_collisional_ionization_coefficient(state.T) : 0.0_rt;
+	amrex::Real recombination_term = (recombination_switch != 0) ? get_recombination_coefficient(state.T) * n_e * n_HII : 0.0_rt;
 
 	ydot(1) = photoionization_term + collisional_ionization_term - recombination_term;
 	ydot(2) = -ydot(1);
@@ -168,24 +162,12 @@ template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual
 
 	const amrex::Real Gamma_photo = ((energy_switch != 0) && (photoheating_switch != 0)) ? get_ionization_heating_coefficient(state.T) : 0.0_rt;
 	const amrex::Real Gamma_KI = ((energy_switch != 0) && (KI_heating_switch != 0)) ? get_KI_heating_coefficient(state.T) : 0.0_rt;
-	amrex::Real Lambda_KI = 0.0_rt;
-	amrex::Real d_Lambda_KI_dT = 0.0_rt;
-	if ((energy_switch != 0) && (KI_cooling_switch != 0)) {
-		Lambda_KI = get_KI_cooling_coefficient(state.T);
-		d_Lambda_KI_dT = dKI_cooling_coefficient_dT(state.T);
-	}
-	amrex::Real Lambda_rec = 0.0_rt;
-	amrex::Real d_Lambda_rec_dT = 0.0_rt;
-	if ((energy_switch != 0) && (recombination_cooling_switch != 0)) {
-		Lambda_rec = get_recombination_cooling_coefficient(state.T);
-		d_Lambda_rec_dT = dRecombination_cooling_coefficient_dT(state.T);
-	}
-	amrex::Real Lambda_ion_ff = 0.0_rt;
-	amrex::Real d_Lambda_ion_ff_dT = 0.0_rt;
-	if ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) {
-		Lambda_ion_ff = get_ion_ff_cooling_coefficient(state.T);
-		d_Lambda_ion_ff_dT = d_ion_ff_cooling_coefficient_dT(state.T);
-	}
+	const amrex::Real Lambda_KI = ((energy_switch != 0) && (KI_cooling_switch != 0)) ? get_KI_cooling_coefficient(state.T) : 0.0_rt;
+	const amrex::Real d_Lambda_KI_dT = ((energy_switch != 0) && (KI_cooling_switch != 0)) ? dKI_cooling_coefficient_dT(state.T) : 0.0_rt;
+	const amrex::Real Lambda_rec = ((energy_switch != 0) && (recombination_cooling_switch != 0)) ? get_recombination_cooling_coefficient(state.T) : 0.0_rt;
+	const amrex::Real d_Lambda_rec_dT = ((energy_switch != 0) && (recombination_cooling_switch != 0)) ? dRecombination_cooling_coefficient_dT(state.T) : 0.0_rt;
+	const amrex::Real Lambda_ion_ff = ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) ? get_ion_ff_cooling_coefficient(state.T) : 0.0_rt;
+	const amrex::Real d_Lambda_ion_ff_dT = ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) ? d_ion_ff_cooling_coefficient_dT(state.T) : 0.0_rt;
 
 	const amrex::Real n_e = state.xn[0];
 	const amrex::Real n_HI = state.xn[1];

--- a/src/networks/photoionization/actual_rhs.H
+++ b/src/networks/photoionization/actual_rhs.H
@@ -111,7 +111,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual_rhs(const burn_t &state, Ar
 	}
 
 	const amrex::Real photoionization_term = chat_sigma_photo * n_HI * n_gamma;
-	const amrex::Real collisional_ionization_term = (collisional_ionization_switch != 0) ? n_e * n_HI * get_collisional_ionization_coefficient(state.T) : 0.0_rt;
+	const amrex::Real collisional_ionization_term =
+	    (collisional_ionization_switch != 0) ? n_e * n_HI * get_collisional_ionization_coefficient(state.T) : 0.0_rt;
 	const amrex::Real recombination_term = (recombination_switch != 0) ? get_recombination_coefficient(state.T) * n_e * n_HII : 0.0_rt;
 
 	ydot(1) = photoionization_term + collisional_ionization_term - recombination_term;

--- a/src/networks/photoionization/actual_rhs.H
+++ b/src/networks/photoionization/actual_rhs.H
@@ -165,7 +165,8 @@ template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual
 	const amrex::Real Lambda_KI = ((energy_switch != 0) && (KI_cooling_switch != 0)) ? get_KI_cooling_coefficient(state.T) : 0.0_rt;
 	const amrex::Real d_Lambda_KI_dT = ((energy_switch != 0) && (KI_cooling_switch != 0)) ? dKI_cooling_coefficient_dT(state.T) : 0.0_rt;
 	const amrex::Real Lambda_rec = ((energy_switch != 0) && (recombination_cooling_switch != 0)) ? get_recombination_cooling_coefficient(state.T) : 0.0_rt;
-	const amrex::Real d_Lambda_rec_dT = ((energy_switch != 0) && (recombination_cooling_switch != 0)) ? dRecombination_cooling_coefficient_dT(state.T) : 0.0_rt;
+	const amrex::Real d_Lambda_rec_dT =
+	    ((energy_switch != 0) && (recombination_cooling_switch != 0)) ? dRecombination_cooling_coefficient_dT(state.T) : 0.0_rt;
 	const amrex::Real Lambda_ion_ff = ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) ? get_ion_ff_cooling_coefficient(state.T) : 0.0_rt;
 	const amrex::Real d_Lambda_ion_ff_dT = ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) ? d_ion_ff_cooling_coefficient_dT(state.T) : 0.0_rt;
 

--- a/src/networks/photoionization/actual_rhs.H
+++ b/src/networks/photoionization/actual_rhs.H
@@ -28,6 +28,9 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE auto get_photoionization_coefficient(Real T) 
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE auto get_recombination_coefficient(Real T) -> Real
 {
+	if (recombination_temperature_dependent == 0) {
+		return 2.6e-13_rt;
+	}
 	return 2.6e-13 * (1.0 + recombination_temperature_dependent * (std::pow(T / 1.0e4, -0.7) - 1.0));
 }
 
@@ -91,80 +94,108 @@ AMREX_GPU_HOST_DEVICE AMREX_INLINE auto d_ion_ff_cooling_coefficient_dT(Real T) 
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual_rhs(const burn_t &state, Array1D<Real, 1, INT_NEQS> &ydot)
 {
-	amrex::Real sigma_photo = get_photoionization_coefficient(state.T);
-	amrex::Real sigma_coll = get_collisional_ionization_coefficient(state.T);
-	amrex::Real alpha_rec = get_recombination_coefficient(state.T);
+	const amrex::Real sigma_photo = get_photoionization_coefficient(state.T);
+	const amrex::Real chat_sigma_photo = state.c_hat * sigma_photo;
 
-	amrex::Real Gamma_photo = get_ionization_heating_coefficient(state.T);
-	amrex::Real Gamma_KI = get_KI_heating_coefficient(state.T);
-	amrex::Real Lambda_KI = get_KI_cooling_coefficient(state.T);
-	amrex::Real Lambda_rec = get_recombination_cooling_coefficient(state.T);
-	amrex::Real Lambda_ion_ff = get_ion_ff_cooling_coefficient(state.T);
-
-	amrex::Real c = C::c_light;
-	amrex::Real chat = state.c_hat;
-	amrex::Real frac = chat / c;
-
-	amrex::Real n_e = state.xn[0];
-	amrex::Real n_HI = state.xn[1];
-	amrex::Real n_HII = state.xn[2];
-	amrex::Real n_gamma = state.rn[0];
-	amrex::Real n_gamma_flux = state.rn[1];
+	const amrex::Real n_e = state.xn[0];
+	const amrex::Real n_HI = state.xn[1];
+	const amrex::Real n_HII = state.xn[2];
+	const amrex::Real n_gamma = state.rn[0];
+	const amrex::Real n_gamma_flux = state.rn[1];
 
 	int molecular_process_switch = 1;
 	const amrex::Real n_H_total = n_HI + n_HII;
-	amrex::Real xHII = (n_H_total > 0.0_rt) ? (n_HII / n_H_total) : 0.0_rt;
+	const amrex::Real xHII = (n_H_total > 0.0_rt) ? (n_HII / n_H_total) : 0.0_rt;
 	if ((allow_mixed_cell_cooling == 0) && (xHII > mixed_cell_lb) && (xHII < mixed_cell_ub)) {
 		molecular_process_switch = 0;
 	}
 
-	amrex::Real photoionization_term = c * sigma_photo * n_HI * n_gamma;
-	amrex::Real collisional_ionization_term = collisional_ionization_switch * n_e * n_HI * sigma_coll;
-	amrex::Real recombination_term = recombination_switch * alpha_rec * n_e * n_HII;
-	amrex::Real photoionization_heating = photoheating_switch * Gamma_photo * photoionization_term;
-	amrex::Real KI_heating = molecular_process_switch * KI_heating_switch * Gamma_KI * n_HI;
-	amrex::Real KI_cooling = molecular_process_switch * KI_cooling_switch * Lambda_KI * n_HI * n_HI;
-	amrex::Real recombination_cooling = recombination_cooling_switch * Lambda_rec * n_e * n_HII;
-	amrex::Real ion_ff_cooling = ion_ff_cooling_switch * Lambda_ion_ff * n_e * n_HII;
+	const amrex::Real photoionization_term = chat_sigma_photo * n_HI * n_gamma;
+	amrex::Real collisional_ionization_term = 0.0_rt;
+	if (collisional_ionization_switch != 0) {
+		collisional_ionization_term = n_e * n_HI * get_collisional_ionization_coefficient(state.T);
+	}
+	amrex::Real recombination_term = 0.0_rt;
+	if (recombination_switch != 0) {
+		recombination_term = get_recombination_coefficient(state.T) * n_e * n_HII;
+	}
 
-	ydot(1) = photoionization_term * frac + collisional_ionization_term - recombination_term;
+	ydot(1) = photoionization_term + collisional_ionization_term - recombination_term;
 	ydot(2) = -ydot(1);
 	ydot(3) = ydot(1);
-	ydot(net_ienuc) = energy_switch * (photoionization_heating * frac + KI_heating - recombination_cooling - KI_cooling - ion_ff_cooling) / state.rho;
-	ydot(5) = -photoionization_term * frac;
-	ydot(6) = -n_HI * c * sigma_photo * n_gamma_flux * frac;
+	ydot(net_ienuc) = 0.0_rt;
+	if (energy_switch != 0) {
+		amrex::Real energy_source = 0.0_rt;
+		if (photoheating_switch != 0) {
+			energy_source += get_ionization_heating_coefficient(state.T) * photoionization_term;
+		}
+		if (molecular_process_switch != 0) {
+			if (KI_heating_switch != 0) {
+				energy_source += get_KI_heating_coefficient(state.T) * n_HI;
+			}
+			if (KI_cooling_switch != 0) {
+				energy_source -= get_KI_cooling_coefficient(state.T) * n_HI * n_HI;
+			}
+		}
+		if (recombination_cooling_switch != 0) {
+			energy_source -= get_recombination_cooling_coefficient(state.T) * n_e * n_HII;
+		}
+		if (ion_ff_cooling_switch != 0) {
+			energy_source -= get_ion_ff_cooling_coefficient(state.T) * n_e * n_HII;
+		}
+		ydot(net_ienuc) = energy_source / state.rho;
+	}
+	ydot(5) = -photoionization_term;
+	ydot(6) = -chat_sigma_photo * n_HI * n_gamma_flux;
 }
 
 template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual_jac(const burn_t &state, MatrixType &jac)
 {
-	amrex::Real sigma_photo = get_photoionization_coefficient(state.T);
-	amrex::Real sigma_coll = get_collisional_ionization_coefficient(state.T);
-	amrex::Real d_sigma_coll_dT = dCollisional_ionization_coefficient_dT(state.T);
-	amrex::Real alpha_rec = get_recombination_coefficient(state.T);
-	amrex::Real d_alpha_rec_dT = dRecombination_coefficient_dT(state.T);
+	const amrex::Real sigma_photo = get_photoionization_coefficient(state.T);
+	const amrex::Real chat_sigma_photo = state.c_hat * sigma_photo;
+	amrex::Real sigma_coll = 0.0_rt;
+	amrex::Real d_sigma_coll_dT = 0.0_rt;
+	if (collisional_ionization_switch != 0) {
+		sigma_coll = get_collisional_ionization_coefficient(state.T);
+		d_sigma_coll_dT = dCollisional_ionization_coefficient_dT(state.T);
+	}
+	amrex::Real alpha_rec = 0.0_rt;
+	amrex::Real d_alpha_rec_dT = 0.0_rt;
+	if (recombination_switch != 0) {
+		alpha_rec = get_recombination_coefficient(state.T);
+		d_alpha_rec_dT = dRecombination_coefficient_dT(state.T);
+	}
 
-	amrex::Real Gamma_photo = get_ionization_heating_coefficient(state.T);
-	amrex::Real Gamma_KI = get_KI_heating_coefficient(state.T);
-	amrex::Real Lambda_KI = get_KI_cooling_coefficient(state.T);
-	amrex::Real d_Lambda_KI_dT = dKI_cooling_coefficient_dT(state.T);
-	amrex::Real Lambda_rec = get_recombination_cooling_coefficient(state.T);
-	amrex::Real d_Lambda_rec_dT = dRecombination_cooling_coefficient_dT(state.T);
-	amrex::Real Lambda_ion_ff = get_ion_ff_cooling_coefficient(state.T);
-	amrex::Real d_Lambda_ion_ff_dT = d_ion_ff_cooling_coefficient_dT(state.T);
+	const amrex::Real Gamma_photo = ((energy_switch != 0) && (photoheating_switch != 0)) ? get_ionization_heating_coefficient(state.T) : 0.0_rt;
+	const amrex::Real Gamma_KI = ((energy_switch != 0) && (KI_heating_switch != 0)) ? get_KI_heating_coefficient(state.T) : 0.0_rt;
+	amrex::Real Lambda_KI = 0.0_rt;
+	amrex::Real d_Lambda_KI_dT = 0.0_rt;
+	if ((energy_switch != 0) && (KI_cooling_switch != 0)) {
+		Lambda_KI = get_KI_cooling_coefficient(state.T);
+		d_Lambda_KI_dT = dKI_cooling_coefficient_dT(state.T);
+	}
+	amrex::Real Lambda_rec = 0.0_rt;
+	amrex::Real d_Lambda_rec_dT = 0.0_rt;
+	if ((energy_switch != 0) && (recombination_cooling_switch != 0)) {
+		Lambda_rec = get_recombination_cooling_coefficient(state.T);
+		d_Lambda_rec_dT = dRecombination_cooling_coefficient_dT(state.T);
+	}
+	amrex::Real Lambda_ion_ff = 0.0_rt;
+	amrex::Real d_Lambda_ion_ff_dT = 0.0_rt;
+	if ((energy_switch != 0) && (ion_ff_cooling_switch != 0)) {
+		Lambda_ion_ff = get_ion_ff_cooling_coefficient(state.T);
+		d_Lambda_ion_ff_dT = d_ion_ff_cooling_coefficient_dT(state.T);
+	}
 
-	amrex::Real c = C::c_light;
-	amrex::Real chat = state.c_hat;
-	amrex::Real frac = chat / c;
-
-	amrex::Real n_e = state.xn[0];
-	amrex::Real n_HI = state.xn[1];
-	amrex::Real n_HII = state.xn[2];
-	amrex::Real n_gamma = state.rn[0];
-	amrex::Real n_gamma_flux = state.rn[1];
+	const amrex::Real n_e = state.xn[0];
+	const amrex::Real n_HI = state.xn[1];
+	const amrex::Real n_HII = state.xn[2];
+	const amrex::Real n_gamma = state.rn[0];
+	const amrex::Real n_gamma_flux = state.rn[1];
 
 	int molecular_process_switch = 1;
 	const amrex::Real n_H_total = n_HI + n_HII;
-	amrex::Real xHII = (n_H_total > 0.0_rt) ? (n_HII / n_H_total) : 0.0_rt;
+	const amrex::Real xHII = (n_H_total > 0.0_rt) ? (n_HII / n_H_total) : 0.0_rt;
 	if ((allow_mixed_cell_cooling == 0) && (xHII > mixed_cell_lb) && (xHII < mixed_cell_ub)) {
 		molecular_process_switch = 0;
 	}
@@ -180,10 +211,10 @@ template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual
 	jac.zero();
 
 	jac(1, 1) = (collisional_ionization_switch * n_HI * sigma_coll - recombination_switch * alpha_rec * n_HII);
-	jac(1, 2) = (c * sigma_photo * n_gamma * frac + collisional_ionization_switch * n_e * sigma_coll);
+	jac(1, 2) = (chat_sigma_photo * n_gamma + collisional_ionization_switch * n_e * sigma_coll);
 	jac(1, 3) = -recombination_switch * alpha_rec * n_e;
 	jac(1, net_ienuc) = (d_collisional_ionization_term_dT - d_recombination_term_dT) * dTde;
-	jac(1, 5) = c * sigma_photo * n_HI * frac;
+	jac(1, 5) = chat_sigma_photo * n_HI;
 	jac(1, 6) = 0.0_rt;
 
 	jac(2, 1) = -jac(1, 1);
@@ -201,27 +232,27 @@ template <class MatrixType> AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void actual
 
 	jac(net_ienuc, 1) = energy_switch * (-recombination_cooling_switch * Lambda_rec * n_HII - ion_ff_cooling_switch * Lambda_ion_ff * n_HII) / state.rho;
 	jac(net_ienuc, 2) = energy_switch *
-			    (photoheating_switch * Gamma_photo * c * sigma_photo * n_gamma * frac + molecular_process_switch * KI_heating_switch * Gamma_KI -
+			    (photoheating_switch * Gamma_photo * chat_sigma_photo * n_gamma + molecular_process_switch * KI_heating_switch * Gamma_KI -
 			     2.0_rt * molecular_process_switch * KI_cooling_switch * Lambda_KI * n_HI) /
 			    state.rho;
 	jac(net_ienuc, 3) = energy_switch * (-recombination_cooling_switch * Lambda_rec * n_e - ion_ff_cooling_switch * Lambda_ion_ff * n_e) / state.rho;
 	jac(net_ienuc, net_ienuc) = energy_switch * (-d_recombination_cooling_dT - d_KI_cooling_dT - d_ion_ff_cooling_dT) * dTde / state.rho;
-	jac(net_ienuc, 5) = energy_switch * (photoheating_switch * Gamma_photo * c * sigma_photo * n_HI * frac) / state.rho;
+	jac(net_ienuc, 5) = energy_switch * (photoheating_switch * Gamma_photo * chat_sigma_photo * n_HI) / state.rho;
 	jac(net_ienuc, 6) = 0.0_rt;
 
 	jac(5, 1) = 0.0_rt;
-	jac(5, 2) = -c * sigma_photo * n_gamma * frac;
+	jac(5, 2) = -chat_sigma_photo * n_gamma;
 	jac(5, 3) = 0.0_rt;
 	jac(5, net_ienuc) = 0.0_rt;
-	jac(5, 5) = -c * sigma_photo * n_HI * frac;
+	jac(5, 5) = -chat_sigma_photo * n_HI;
 	jac(5, 6) = 0.0_rt;
 
 	jac(6, 1) = 0.0_rt;
-	jac(6, 2) = -c * sigma_photo * n_gamma_flux * frac;
+	jac(6, 2) = -chat_sigma_photo * n_gamma_flux;
 	jac(6, 3) = 0.0_rt;
 	jac(6, net_ienuc) = 0.0_rt;
 	jac(6, 5) = 0.0_rt;
-	jac(6, 6) = -n_HI * c * sigma_photo * frac;
+	jac(6, 6) = -n_HI * chat_sigma_photo;
 }
 
 #endif

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -44,6 +44,13 @@ auto computePhotoChemistry(amrex::MultiFab &mf, const Real dt, const int stage, 
 	const int firstChemFyIndex = firstChemFxIndex + 1;
 	const int firstChemFzIndex = firstChemFyIndex + 1;
 
+	amrex::GpuArray<Real, NumChemBands> chemBandQuanta{};
+	amrex::GpuArray<Real, NumChemBands> invChemBandQuanta{};
+	for (int nn = 0; nn < NumChemBands; ++nn) {
+		chemBandQuanta[nn] = RadSystem<problem_t>::GetChemBandQuanta(nn);
+		invChemBandQuanta[nn] = 1.0_rt / chemBandQuanta[nn];
+	}
+
 	const BL_PROFILE("PhotoChemistry::computePhotoChemistry()");
 	for (amrex::MFIter iter(mf); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -51,29 +58,6 @@ auto computePhotoChemistry(amrex::MultiFab &mf, const Real dt, const int stage, 
 
 		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 			const Real rho = state(i, j, k, RadSystem<problem_t>::gasDensity_index);
-			const Real xmom = state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index);
-			const Real ymom = state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index);
-			const Real zmom = state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index);
-			const Real Ener = state(i, j, k, RadSystem<problem_t>::gasEnergy_index);
-			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
-
-			Real quanta_energy = 0.0_rt;
-			burn_t photochemstate;
-			photochemstate.success = true;
-			int burn_failed = 0;
-			photochemstate.c_hat = RadSystem_Traits<problem_t>::c_hat_over_c * C::c_light;
-			for (int nn = 0; nn < NumSpec; ++nn) {
-				photochemstate.xn[nn] = state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) / spmasses[nn];
-			}
-			for (int nn = 0; nn < NumChemBands; ++nn) {
-				quanta_energy = RadSystem<problem_t>::GetChemBandQuanta(nn);
-				photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] =
-				    state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) / quanta_energy;
-				photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] = 1.0_rt;
-			}
-			photochemstate.rho = rho;
-			photochemstate.e = Eint / rho;
-
 			// dont do photochemistry in cells with densities below the minimum density specified
 			if (rho < min_density_allowed) {
 				return;
@@ -82,6 +66,27 @@ auto computePhotoChemistry(amrex::MultiFab &mf, const Real dt, const int stage, 
 			if (rho > max_density_allowed) {
 				amrex::Abort("Density exceeded max_density_allowed!");
 			}
+
+			const Real xmom = state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index);
+			const Real ymom = state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index);
+			const Real zmom = state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index);
+			const Real Ener = state(i, j, k, RadSystem<problem_t>::gasEnergy_index);
+			const Real Eint = RadSystem<problem_t>::ComputeEintFromEgas(rho, xmom, ymom, zmom, Ener);
+
+			burn_t photochemstate;
+			photochemstate.success = true;
+			int burn_failed = 0;
+			photochemstate.c_hat = RadSystem_Traits<problem_t>::c_hat_over_c * C::c_light;
+			for (int nn = 0; nn < NumSpec; ++nn) {
+				photochemstate.xn[nn] = state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) / spmasses[nn];
+			}
+			for (int nn = 0; nn < NumChemBands; ++nn) {
+				photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] =
+				    state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) * invChemBandQuanta[nn];
+				photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] = 1.0_rt;
+			}
+			photochemstate.rho = rho;
+			photochemstate.e = Eint / rho;
 
 			// call the EOS to set the temperature
 			eos(eos_input_re, photochemstate);
@@ -120,9 +125,8 @@ auto computePhotoChemistry(amrex::MultiFab &mf, const Real dt, const int stage, 
 				state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) = photochemstate.xn[nn] * spmasses[nn];
 			}
 			for (int nn = 0; nn < NumChemBands; ++nn) {
-				quanta_energy = RadSystem<problem_t>::GetChemBandQuanta(nn);
 				state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
-				    photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * quanta_energy;
+				    photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
 				state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
 				    photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] *
 				    state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn);


### PR DESCRIPTION
### Description
This rewrites how the rhs is evaluated to improve performance.

For the `OneZonePhotoionization` test run with optimizations on built with AppleClang on my M1 Mac laptop:
  - 2.843 s (original) → 2.202 s (this PR)
  - End-to-end speedup: 1.29x
  - End-to-end time reduction: 22.6%

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
