### PR TITLE
Refactor physics_traits: introduce DefaultPhysicsTraits base struct for default inheritance

### DIFF
--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -13,7 +13,7 @@ enum class UnitSystem { CGS, CONSTANTS, CUSTOM };
 
 // default values for all Physics_Traits fields; specialize Physics_Traits by inheriting from this
 // struct and overriding only the fields that differ from the defaults
-struct PhysicsTraitsDefaults {
+struct DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;
 	static constexpr int numPassiveScalars = numMassScalars + 0;
@@ -35,7 +35,7 @@ struct PhysicsTraitsDefaults {
 };
 
 // this struct is specialized by the user application code.
-template <typename problem_t> struct Physics_Traits : PhysicsTraitsDefaults {};
+template <typename problem_t> struct Physics_Traits : DefaultPhysicsTraits {};
 
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -16,6 +16,9 @@ enum class UnitSystem { CGS, CONSTANTS, CUSTOM };
 struct DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;
+	// NOTE: numPassiveScalars is evaluated at the point of definition of DefaultPhysicsTraits, not
+	// at the point of specialization. If you override numMassScalars, you MUST also explicitly
+	// override numPassiveScalars, or it will silently inherit the pre-evaluated default of 0.
 	static constexpr int numPassiveScalars = numMassScalars + 0;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_dust_enabled = false;

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -11,11 +11,12 @@ using Real = amrex::Real;
 // enum for unit system, one of CGS, CONSTANTS, CUSTOM
 enum class UnitSystem { CGS, CONSTANTS, CUSTOM };
 
-// this struct is specialized by the user application code.
-template <typename problem_t> struct Physics_Traits {
+// default values for all Physics_Traits fields; specialize Physics_Traits by inheriting from this
+// struct and overriding only the fields that differ from the defaults
+struct PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
+	static constexpr int numPassiveScalars = 0;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_dust_enabled = false;
 	static constexpr bool is_self_gravity_enabled = false;
@@ -32,6 +33,9 @@ template <typename problem_t> struct Physics_Traits {
 	static constexpr double unit_time = 1.0;
 	static constexpr double unit_temperature = 1.0;
 };
+
+// this struct is specialized by the user application code.
+template <typename problem_t> struct Physics_Traits : PhysicsTraitsDefaults {};
 
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -16,7 +16,7 @@ enum class UnitSystem { CGS, CONSTANTS, CUSTOM };
 struct PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = 0;
+	static constexpr int numPassiveScalars = numMassScalars + 0;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_dust_enabled = false;
 	static constexpr bool is_self_gravity_enabled = false;

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -35,7 +35,8 @@ struct DefaultPhysicsTraits {
 };
 
 // this struct is specialized by the user application code.
-template <typename problem_t> struct Physics_Traits : DefaultPhysicsTraits {};
+template <typename problem_t> struct Physics_Traits : DefaultPhysicsTraits {
+};
 
 // this struct stores the indices at which quantities start
 template <typename problem_t> struct Physics_Indices {

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -30,7 +30,7 @@
 struct SawtoothProblem {
 };
 
-template <> struct Physics_Traits<SawtoothProblem> {
+template <> struct Physics_Traits<SawtoothProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -30,7 +30,7 @@
 struct SawtoothProblem {
 };
 
-template <> struct Physics_Traits<SawtoothProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SawtoothProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/AdvectionSemiellipse/testAdvectionSemiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/testAdvectionSemiellipse.cpp
@@ -26,7 +26,7 @@
 struct SemiellipseProblem {
 };
 
-template <> struct Physics_Traits<SemiellipseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SemiellipseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/AdvectionSemiellipse/testAdvectionSemiellipse.cpp
+++ b/src/problems/AdvectionSemiellipse/testAdvectionSemiellipse.cpp
@@ -26,7 +26,7 @@
 struct SemiellipseProblem {
 };
 
-template <> struct Physics_Traits<SemiellipseProblem> {
+template <> struct Physics_Traits<SemiellipseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -25,20 +25,11 @@ struct AlfvenWaveCircular {
 template <> struct quokka::EOS_Traits<AlfvenWaveCircular> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<AlfvenWaveCircular> {
+template <> struct Physics_Traits<AlfvenWaveCircular> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // constants

--- a/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
+++ b/src/problems/AlfvenWaveCircular/testAlfvenWaveCircular.cpp
@@ -27,7 +27,7 @@ template <> struct quokka::EOS_Traits<AlfvenWaveCircular> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<AlfvenWaveCircular> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AlfvenWaveCircular> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
+++ b/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
@@ -35,7 +35,7 @@ template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<AlfvenWaveLinear> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AlfvenWaveLinear> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
+++ b/src/problems/AlfvenWaveLinear/testAlfvenWaveLinear.cpp
@@ -33,20 +33,11 @@ struct AlfvenWaveLinear {
 template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<AlfvenWaveLinear> {
+template <> struct Physics_Traits<AlfvenWaveLinear> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double sound_speed = 1.0;

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -39,7 +39,7 @@ template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<AlfvenWaveLinear> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AlfvenWaveLinear> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -37,20 +37,11 @@ struct AlfvenWaveLinear {
 template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<AlfvenWaveLinear> {
+template <> struct Physics_Traits<AlfvenWaveLinear> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double sound_speed = 1.0;

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -49,7 +49,7 @@ template <> struct HydroSystem_Traits<BinaryOrbit> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<BinaryOrbit> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<BinaryOrbit> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -49,7 +49,7 @@ template <> struct HydroSystem_Traits<BinaryOrbit> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<BinaryOrbit> {
+template <> struct Physics_Traits<BinaryOrbit> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/BrioWuShockTube/testBrioWuShockTube.cpp
+++ b/src/problems/BrioWuShockTube/testBrioWuShockTube.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<MHDShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<MHDShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MHDShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/BrioWuShockTube/testBrioWuShockTube.cpp
+++ b/src/problems/BrioWuShockTube/testBrioWuShockTube.cpp
@@ -36,19 +36,9 @@ template <> struct quokka::EOS_Traits<MHDShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<MHDShocktubeProblem> {
-	static constexpr bool is_self_gravity_enabled = false;
-	// cell-centred
+template <> struct Physics_Traits<MHDShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
-	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // left- and right- side shock states

--- a/src/problems/CurrentSheet/testCurrentSheet.cpp
+++ b/src/problems/CurrentSheet/testCurrentSheet.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<CurrentSheet> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<CurrentSheet> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CurrentSheet> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/CurrentSheet/testCurrentSheet.cpp
+++ b/src/problems/CurrentSheet/testCurrentSheet.cpp
@@ -27,20 +27,11 @@ struct CurrentSheet {
 template <> struct quokka::EOS_Traits<CurrentSheet> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<CurrentSheet> {
+template <> struct Physics_Traits<CurrentSheet> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // constants

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -43,7 +43,7 @@ template <> struct quokka::EOS_Traits<DTypeFront> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DTypeFront> {
+template <> struct Physics_Traits<DTypeFront> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -43,7 +43,7 @@ template <> struct quokka::EOS_Traits<DTypeFront> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DTypeFront> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DTypeFront> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -59,10 +59,16 @@ template <> struct HydroSystem_Traits<DiskGalaxy> {
 };
 
 template <> struct Physics_Traits<DiskGalaxy> : DefaultPhysicsTraits {
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
+	static constexpr int nGroups = 1;			     // number of radiation groups
 };
 
 template <> struct Particle_Traits<DiskGalaxy> {

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -52,24 +52,17 @@ static_assert(AMREX_SPACEDIM == 3, "DiskGalaxy problem requires AMREX_SPACEDIM =
 template <> struct quokka::EOS_Traits<DiskGalaxy> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = 0.6 * C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
 template <> struct HydroSystem_Traits<DiskGalaxy> {
 	static constexpr bool reconstruct_eint = true;
 };
 
-template <> struct Physics_Traits<DiskGalaxy> {
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+template <> struct Physics_Traits<DiskGalaxy> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
-	static constexpr int nGroups = 1;			     // number of radiation groups
 };
 
 template <> struct Particle_Traits<DiskGalaxy> {

--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -58,7 +58,7 @@ template <> struct HydroSystem_Traits<DiskGalaxy> {
 	static constexpr bool reconstruct_eint = true;
 };
 
-template <> struct Physics_Traits<DiskGalaxy> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DiskGalaxy> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_mhd_enabled = true;

--- a/src/problems/DustAdvection/testDustAdvection.cpp
+++ b/src/problems/DustAdvection/testDustAdvection.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<DustAdvection> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustAdvection> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustAdvection> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustAdvection/testDustAdvection.cpp
+++ b/src/problems/DustAdvection/testDustAdvection.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<DustAdvection> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustAdvection> {
+template <> struct Physics_Traits<DustAdvection> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustAdvection3D/testDustAdvection3D.cpp
+++ b/src/problems/DustAdvection3D/testDustAdvection3D.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<DustAdvection3D> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustAdvection3D> {
+template <> struct Physics_Traits<DustAdvection3D> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustAdvection3D/testDustAdvection3D.cpp
+++ b/src/problems/DustAdvection3D/testDustAdvection3D.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<DustAdvection3D> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustAdvection3D> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustAdvection3D> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDamping/testDustDamping.cpp
+++ b/src/problems/DustDamping/testDustDamping.cpp
@@ -92,7 +92,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDamping>::gamma - 1
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDamping>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDamping> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDamping> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDamping/testDustDamping.cpp
+++ b/src/problems/DustDamping/testDustDamping.cpp
@@ -92,7 +92,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDamping>::gamma - 1
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDamping>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDamping> {
+template <> struct Physics_Traits<DustDamping> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDampingIteration/testDustDampingIteration.cpp
+++ b/src/problems/DustDampingIteration/testDustDampingIteration.cpp
@@ -69,7 +69,7 @@ AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1
 static constexpr bool enable_supersonic_correction_with = true;
 static constexpr bool enable_supersonic_correction_without = false;
 
-template <> struct Physics_Traits<DustDampingWithCorrection> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingWithCorrection> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -86,7 +86,7 @@ template <> struct Physics_Traits<DustDampingWithCorrection> : PhysicsTraitsDefa
 	static constexpr double radiation_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustDampingWithoutCorrection> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingWithoutCorrection> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDampingIteration/testDustDampingIteration.cpp
+++ b/src/problems/DustDampingIteration/testDustDampingIteration.cpp
@@ -69,7 +69,7 @@ AMREX_GPU_MANAGED amrex::GpuArray<amrex::Real, 2> g_dust_grain_density = {1.0, 1
 static constexpr bool enable_supersonic_correction_with = true;
 static constexpr bool enable_supersonic_correction_without = false;
 
-template <> struct Physics_Traits<DustDampingWithCorrection> {
+template <> struct Physics_Traits<DustDampingWithCorrection> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars
@@ -86,7 +86,7 @@ template <> struct Physics_Traits<DustDampingWithCorrection> {
 	static constexpr double radiation_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustDampingWithoutCorrection> {
+template <> struct Physics_Traits<DustDampingWithoutCorrection> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -70,7 +70,7 @@ template <> struct quokka::EOS_Traits<DustDampingMHDZeroCharge> {
 constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingDragReference>::gamma - 1.0) + 0.5 * rho * v0 * v0;
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingDragReference>::gamma - 1.0);
 
-template <> struct Physics_Traits<DustDampingDragReference> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingDragReference> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;
@@ -87,7 +87,7 @@ template <> struct Physics_Traits<DustDampingDragReference> : PhysicsTraitsDefau
 	static constexpr double radiation_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustDampingMHDZeroCharge> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingMHDZeroCharge> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
+++ b/src/problems/DustDampingIterationMHDZeroCharge/testDustDampingIterationMHDZeroCharge.cpp
@@ -70,7 +70,7 @@ template <> struct quokka::EOS_Traits<DustDampingMHDZeroCharge> {
 constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingDragReference>::gamma - 1.0) + 0.5 * rho * v0 * v0;
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingDragReference>::gamma - 1.0);
 
-template <> struct Physics_Traits<DustDampingDragReference> {
+template <> struct Physics_Traits<DustDampingDragReference> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;
@@ -87,7 +87,7 @@ template <> struct Physics_Traits<DustDampingDragReference> {
 	static constexpr double radiation_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustDampingMHDZeroCharge> {
+template <> struct Physics_Traits<DustDampingMHDZeroCharge> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustDampingMHDZeroB/testDustDampingMHDZeroB.cpp
+++ b/src/problems/DustDampingMHDZeroB/testDustDampingMHDZeroB.cpp
@@ -53,7 +53,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingMHDZeroB>::g
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingMHDZeroB>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDampingMHDZeroB> {
+template <> struct Physics_Traits<DustDampingMHDZeroB> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustDampingMHDZeroB/testDustDampingMHDZeroB.cpp
+++ b/src/problems/DustDampingMHDZeroB/testDustDampingMHDZeroB.cpp
@@ -53,7 +53,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingMHDZeroB>::g
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingMHDZeroB>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDampingMHDZeroB> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingMHDZeroB> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustDampingWithExternalForce/testDustDampingWithExternalForce.cpp
+++ b/src/problems/DustDampingWithExternalForce/testDustDampingWithExternalForce.cpp
@@ -71,7 +71,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingWithExternal
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingWithExternalForce>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDampingWithExternalForce> {
+template <> struct Physics_Traits<DustDampingWithExternalForce> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustDampingWithExternalForce/testDustDampingWithExternalForce.cpp
+++ b/src/problems/DustDampingWithExternalForce/testDustDampingWithExternalForce.cpp
@@ -71,7 +71,7 @@ constexpr double Egas0 = P_INITIAL / (quokka::EOS_Traits<DustDampingWithExternal
 constexpr double Egas0_internal = P_INITIAL / (quokka::EOS_Traits<DustDampingWithExternalForce>::gamma - 1.0);
 constexpr int numDustVars = Physics_NumVars::numDustVarsPerGroup;
 
-template <> struct Physics_Traits<DustDampingWithExternalForce> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustDampingWithExternalForce> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustHallPedersenDrift/testDustHallPedersenDrift.cpp
+++ b/src/problems/DustHallPedersenDrift/testDustHallPedersenDrift.cpp
@@ -55,7 +55,7 @@ template <> struct quokka::EOS_Traits<DustHallPedersenDrift> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustHallPedersenDrift> {
+template <> struct Physics_Traits<DustHallPedersenDrift> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustHallPedersenDrift/testDustHallPedersenDrift.cpp
+++ b/src/problems/DustHallPedersenDrift/testDustHallPedersenDrift.cpp
@@ -55,7 +55,7 @@ template <> struct quokka::EOS_Traits<DustHallPedersenDrift> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustHallPedersenDrift> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustHallPedersenDrift> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
+++ b/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
@@ -664,7 +664,7 @@ template <> struct quokka::EOS_Traits<DustMagnetizedRDI> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustMagnetizedRDI> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustMagnetizedRDI> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
+++ b/src/problems/DustMagnetizedRDI/testDustMagnetizedRDI.cpp
@@ -664,7 +664,7 @@ template <> struct quokka::EOS_Traits<DustMagnetizedRDI> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustMagnetizedRDI> {
+template <> struct Physics_Traits<DustMagnetizedRDI> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustSoundwave/testDustSoundwave.cpp
+++ b/src/problems/DustSoundwave/testDustSoundwave.cpp
@@ -65,7 +65,7 @@ template <> struct quokka::EOS_Traits<DustSoundwave> {
 
 const double cs = quokka::EOS_Traits<DustSoundwave>::cs_isothermal;
 
-template <> struct Physics_Traits<DustSoundwave> {
+template <> struct Physics_Traits<DustSoundwave> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustSoundwave/testDustSoundwave.cpp
+++ b/src/problems/DustSoundwave/testDustSoundwave.cpp
@@ -65,7 +65,7 @@ template <> struct quokka::EOS_Traits<DustSoundwave> {
 
 const double cs = quokka::EOS_Traits<DustSoundwave>::cs_isothermal;
 
-template <> struct Physics_Traits<DustSoundwave> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustSoundwave> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/DustyAlfvenWave/testDustyAlfvenWave.cpp
+++ b/src/problems/DustyAlfvenWave/testDustyAlfvenWave.cpp
@@ -83,7 +83,7 @@ template <> struct quokka::EOS_Traits<DustyAlfvenWave> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustyAlfvenWave> {
+template <> struct Physics_Traits<DustyAlfvenWave> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustyAlfvenWave/testDustyAlfvenWave.cpp
+++ b/src/problems/DustyAlfvenWave/testDustyAlfvenWave.cpp
@@ -83,7 +83,7 @@ template <> struct quokka::EOS_Traits<DustyAlfvenWave> {
 	static constexpr double cs_isothermal = sound_speed;
 };
 
-template <> struct Physics_Traits<DustyAlfvenWave> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustyAlfvenWave> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustyOrszagTang/testDustyOrszagTang.cpp
+++ b/src/problems/DustyOrszagTang/testDustyOrszagTang.cpp
@@ -425,7 +425,7 @@ template <> struct quokka::EOS_Traits<DustyOrszagTang> {
 	static constexpr double boltzmann_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustyOrszagTang> {
+template <> struct Physics_Traits<DustyOrszagTang> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustyOrszagTang/testDustyOrszagTang.cpp
+++ b/src/problems/DustyOrszagTang/testDustyOrszagTang.cpp
@@ -425,7 +425,7 @@ template <> struct quokka::EOS_Traits<DustyOrszagTang> {
 	static constexpr double boltzmann_constant = 1.0;
 };
 
-template <> struct Physics_Traits<DustyOrszagTang> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustyOrszagTang> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustyShock/testDustyShock.cpp
+++ b/src/problems/DustyShock/testDustyShock.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<DustyShock> {
 	static constexpr double cs_isothermal = 1.0; // only used when gamma = 1
 };
 
-template <> struct Physics_Traits<DustyShock> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustyShock> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/DustyShock/testDustyShock.cpp
+++ b/src/problems/DustyShock/testDustyShock.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<DustyShock> {
 	static constexpr double cs_isothermal = 1.0; // only used when gamma = 1
 };
 
-template <> struct Physics_Traits<DustyShock> {
+template <> struct Physics_Traits<DustyShock> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -40,20 +40,11 @@ struct EntropyWaveLinear {
 template <> struct quokka::EOS_Traits<EntropyWaveLinear> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<EntropyWaveLinear> {
+template <> struct Physics_Traits<EntropyWaveLinear> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // Background and perturbation parameters

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -42,7 +42,7 @@ template <> struct quokka::EOS_Traits<EntropyWaveLinear> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<EntropyWaveLinear> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<EntropyWaveLinear> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -36,19 +36,11 @@ template <> struct quokka::EOS_Traits<FCQuantities> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FCQuantities> {
-	static constexpr bool is_self_gravity_enabled = false;
+template <> struct Physics_Traits<FCQuantities> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double rho0 = 1.0;					     // background density

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<FCQuantities> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FCQuantities> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<FCQuantities> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	// face-centred

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<FastWave> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FastWave> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<FastWave> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/FastWave/testFastWave.cpp
+++ b/src/problems/FastWave/testFastWave.cpp
@@ -30,20 +30,11 @@ struct FastWave {
 template <> struct quokka::EOS_Traits<FastWave> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<FastWave> {
+template <> struct Physics_Traits<FastWave> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // constants

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -31,20 +31,11 @@ struct FastWaveConvergence {
 template <> struct quokka::EOS_Traits<FastWaveConvergence> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<FastWaveConvergence> {
+template <> struct Physics_Traits<FastWaveConvergence> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double sound_speed = 1.0;

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -33,7 +33,7 @@ template <> struct quokka::EOS_Traits<FastWaveConvergence> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FastWaveConvergence> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<FastWaveConvergence> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -30,20 +30,11 @@ AMREX_ENUM(RefineOn, Region, MagneticEnergy); // NOLINT
 template <> struct quokka::EOS_Traits<FieldLoop> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<FieldLoop> {
+template <> struct Physics_Traits<FieldLoop> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double A = 1.0e-3;

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<FieldLoop> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FieldLoop> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<FieldLoop> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
+++ b/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
@@ -46,7 +46,7 @@ template <> struct Particle_Traits<ParticleProblem> {
 	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | ParticleSwitch::Rad | ParticleSwitch::CICRad;
 };
 
-template <> struct Physics_Traits<ParticleProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ParticleProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
+++ b/src/problems/GravRadParticle3D/testGravRadParticle3D.cpp
@@ -46,7 +46,7 @@ template <> struct Particle_Traits<ParticleProblem> {
 	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | ParticleSwitch::Rad | ParticleSwitch::CICRad;
 };
 
-template <> struct Physics_Traits<ParticleProblem> {
+template <> struct Physics_Traits<ParticleProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/HydroBlast3D/testHydroBlast3D.cpp
+++ b/src/problems/HydroBlast3D/testHydroBlast3D.cpp
@@ -37,7 +37,7 @@ template <> struct HydroSystem_Traits<SedovProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<SedovProblem> {
+template <> struct Physics_Traits<SedovProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroBlast3D/testHydroBlast3D.cpp
+++ b/src/problems/HydroBlast3D/testHydroBlast3D.cpp
@@ -37,7 +37,7 @@ template <> struct HydroSystem_Traits<SedovProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<SedovProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SedovProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<ContactProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ContactProblem> {
+template <> struct Physics_Traits<ContactProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroContact/testHydroContact.cpp
+++ b/src/problems/HydroContact/testHydroContact.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<ContactProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ContactProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ContactProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -39,7 +39,7 @@ template <> struct quokka::EOS_Traits<HighMachProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<HighMachProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<HighMachProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroHighMach/testHydroHighMach.cpp
+++ b/src/problems/HydroHighMach/testHydroHighMach.cpp
@@ -39,7 +39,7 @@ template <> struct quokka::EOS_Traits<HighMachProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<HighMachProblem> {
+template <> struct Physics_Traits<HighMachProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -41,7 +41,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroLeblanc/testHydroLeblanc.cpp
+++ b/src/problems/HydroLeblanc/testHydroLeblanc.cpp
@@ -41,7 +41,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroQuirk/testHydroQuirk.cpp
+++ b/src/problems/HydroQuirk/testHydroQuirk.cpp
@@ -45,7 +45,7 @@ template <> struct HydroSystem_Traits<QuirkProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<QuirkProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<QuirkProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroQuirk/testHydroQuirk.cpp
+++ b/src/problems/HydroQuirk/testHydroQuirk.cpp
@@ -45,7 +45,7 @@ template <> struct HydroSystem_Traits<QuirkProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<QuirkProblem> {
+template <> struct Physics_Traits<QuirkProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroSMS/testHydroSMS.cpp
+++ b/src/problems/HydroSMS/testHydroSMS.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -39,7 +39,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShocktube/testHydroShocktube.cpp
+++ b/src/problems/HydroShocktube/testHydroShocktube.cpp
@@ -39,7 +39,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShocktubeCMA/testHydroShocktubeCMA.cpp
+++ b/src/problems/HydroShocktubeCMA/testHydroShocktubeCMA.cpp
@@ -44,7 +44,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShocktubeCMA/testHydroShocktubeCMA.cpp
+++ b/src/problems/HydroShocktubeCMA/testHydroShocktubeCMA.cpp
@@ -44,7 +44,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShocktubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroVacuum/testHydroVacuum.cpp
+++ b/src/problems/HydroVacuum/testHydroVacuum.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<ShocktubeProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ShocktubeProblem> {
+template <> struct Physics_Traits<ShocktubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroWave/testHydroWave.cpp
+++ b/src/problems/HydroWave/testHydroWave.cpp
@@ -31,7 +31,7 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<WaveProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<WaveProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroWave/testHydroWave.cpp
+++ b/src/problems/HydroWave/testHydroWave.cpp
@@ -31,7 +31,7 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<WaveProblem> {
+template <> struct Physics_Traits<WaveProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
+++ b/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<WaveProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<WaveProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
+++ b/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<WaveProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<WaveProblem> {
+template <> struct Physics_Traits<WaveProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
+++ b/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<HydrostaticAtmosphereProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<HydrostaticAtmosphereProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<HydrostaticAtmosphereProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
+++ b/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
@@ -29,7 +29,7 @@ template <> struct quokka::EOS_Traits<HydrostaticAtmosphereProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<HydrostaticAtmosphereProblem> {
+template <> struct Physics_Traits<HydrostaticAtmosphereProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;

--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -31,7 +31,7 @@ template <> struct quokka::EOS_Traits<MHDBalsaraVortex> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<MHDBalsaraVortex> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MHDBalsaraVortex> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -29,20 +29,11 @@ struct MHDBalsaraVortex {
 template <> struct quokka::EOS_Traits<MHDBalsaraVortex> {
 	static constexpr double gamma = 5.0 / 3.0;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<MHDBalsaraVortex> {
+template <> struct Physics_Traits<MHDBalsaraVortex> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 // background state

--- a/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
+++ b/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
@@ -36,17 +36,9 @@ template <> struct quokka::EOS_Traits<MHDBitwiseICs> {
 	static constexpr amrex::Real boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<MHDBitwiseICs> {
+template <> struct Physics_Traits<MHDBitwiseICs> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1;
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 AMREX_GPU_DEVICE

--- a/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
+++ b/src/problems/MHDBitwiseICs/testMHDBitwiseICs.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<MHDBitwiseICs> {
 	static constexpr amrex::Real boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<MHDBitwiseICs> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MHDBitwiseICs> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/MHDBlast/testMHDBlast.cpp
+++ b/src/problems/MHDBlast/testMHDBlast.cpp
@@ -28,7 +28,7 @@ template <> struct HydroSystem_Traits<MHDBlast> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<MHDBlast> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MHDBlast> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/MHDBlast/testMHDBlast.cpp
+++ b/src/problems/MHDBlast/testMHDBlast.cpp
@@ -28,17 +28,9 @@ template <> struct HydroSystem_Traits<MHDBlast> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<MHDBlast> {
-	static constexpr bool is_self_gravity_enabled = false;
+template <> struct Physics_Traits<MHDBlast> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> void QuokkaSimulation<MHDBlast>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -45,7 +45,7 @@ template <> struct HydroSystem_Traits<MHDQuirk> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<MHDQuirk> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MHDQuirk> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	// face-centred

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -45,19 +45,11 @@ template <> struct HydroSystem_Traits<MHDQuirk> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<MHDQuirk> {
-	static constexpr bool is_self_gravity_enabled = false;
+template <> struct Physics_Traits<MHDQuirk> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr Real dl = 3.692;

--- a/src/problems/NscbcChannel/testNscbcChannel.cpp
+++ b/src/problems/NscbcChannel/testNscbcChannel.cpp
@@ -54,7 +54,7 @@ template <> struct quokka::EOS_Traits<Channel> {
 	static constexpr double mean_molecular_weight = 28.96 * C::m_u; // air
 };
 
-template <> struct Physics_Traits<Channel> {
+template <> struct Physics_Traits<Channel> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/NscbcChannel/testNscbcChannel.cpp
+++ b/src/problems/NscbcChannel/testNscbcChannel.cpp
@@ -54,7 +54,7 @@ template <> struct quokka::EOS_Traits<Channel> {
 	static constexpr double mean_molecular_weight = 28.96 * C::m_u; // air
 };
 
-template <> struct Physics_Traits<Channel> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<Channel> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/NscbcVortex/testNscbcVortex.cpp
+++ b/src/problems/NscbcVortex/testNscbcVortex.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<Vortex> {
 	static constexpr double mean_molecular_weight = 28.96 * C::m_u; // air
 };
 
-template <> struct Physics_Traits<Vortex> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<Vortex> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/NscbcVortex/testNscbcVortex.cpp
+++ b/src/problems/NscbcVortex/testNscbcVortex.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<Vortex> {
 	static constexpr double mean_molecular_weight = 28.96 * C::m_u; // air
 };
 
-template <> struct Physics_Traits<Vortex> {
+template <> struct Physics_Traits<Vortex> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -43,7 +43,7 @@ template <> struct quokka::EOS_Traits<PhotoionizationStreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<PhotoionizationStreamingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PhotoionizationStreamingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -43,7 +43,7 @@ template <> struct quokka::EOS_Traits<PhotoionizationStreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<PhotoionizationStreamingProblem> {
+template <> struct Physics_Traits<PhotoionizationStreamingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/OrszagTang/testOrszagTang.cpp
+++ b/src/problems/OrszagTang/testOrszagTang.cpp
@@ -32,7 +32,7 @@ template <> struct quokka::EOS_Traits<OrszagTang> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<OrszagTang> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<OrszagTang> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/OrszagTang/testOrszagTang.cpp
+++ b/src/problems/OrszagTang/testOrszagTang.cpp
@@ -30,20 +30,11 @@ struct OrszagTang {
 template <> struct quokka::EOS_Traits<OrszagTang> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<OrszagTang> {
+template <> struct Physics_Traits<OrszagTang> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double B0 = 1.0 / gcem::sqrt(4.0 * PI);

--- a/src/problems/ParticleAccretion/testParticleAccretion.cpp
+++ b/src/problems/ParticleAccretion/testParticleAccretion.cpp
@@ -65,19 +65,12 @@ template <> struct HydroSystem_Traits<AccretionProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<AccretionProblem> {
+template <> struct Physics_Traits<AccretionProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_self_gravity_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<AccretionProblem> {

--- a/src/problems/ParticleAccretion/testParticleAccretion.cpp
+++ b/src/problems/ParticleAccretion/testParticleAccretion.cpp
@@ -65,7 +65,7 @@ template <> struct HydroSystem_Traits<AccretionProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<AccretionProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AccretionProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/ParticleAccretion/testParticleAccretion.cpp
+++ b/src/problems/ParticleAccretion/testParticleAccretion.cpp
@@ -68,9 +68,16 @@ template <> struct HydroSystem_Traits<AccretionProblem> {
 template <> struct Physics_Traits<AccretionProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_self_gravity_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<AccretionProblem> {

--- a/src/problems/ParticleCreation/testParticleCreation.cpp
+++ b/src/problems/ParticleCreation/testParticleCreation.cpp
@@ -51,7 +51,7 @@ template <> struct HydroSystem_Traits<TestParticle> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<TestParticle> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<TestParticle> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_mhd_enabled = true;

--- a/src/problems/ParticleCreation/testParticleCreation.cpp
+++ b/src/problems/ParticleCreation/testParticleCreation.cpp
@@ -51,16 +51,10 @@ template <> struct HydroSystem_Traits<TestParticle> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<TestParticle> {
+template <> struct Physics_Traits<TestParticle> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr int nGroups = 1;			     // number of radiation groups
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr double boltzmann_constant = 1.0;
 	static constexpr double gravitational_constant = 1.0;

--- a/src/problems/ParticleCreation/testParticleCreation.cpp
+++ b/src/problems/ParticleCreation/testParticleCreation.cpp
@@ -54,7 +54,13 @@ template <> struct HydroSystem_Traits<TestParticle> {
 template <> struct Physics_Traits<TestParticle> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr int nGroups = 1;			     // number of radiation groups
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr double boltzmann_constant = 1.0;
 	static constexpr double gravitational_constant = 1.0;

--- a/src/problems/ParticleDeposition/testParticleDeposition.cpp
+++ b/src/problems/ParticleDeposition/testParticleDeposition.cpp
@@ -33,7 +33,7 @@ template <> struct quokka::EOS_Traits<ParticleDepositionProblem> {
 	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<ParticleDepositionProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ParticleDepositionProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/ParticleDeposition/testParticleDeposition.cpp
+++ b/src/problems/ParticleDeposition/testParticleDeposition.cpp
@@ -33,7 +33,7 @@ template <> struct quokka::EOS_Traits<ParticleDepositionProblem> {
 	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<ParticleDepositionProblem> {
+template <> struct Physics_Traits<ParticleDepositionProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/ParticleRadiation/testParticleRadiation.cpp
+++ b/src/problems/ParticleRadiation/testParticleRadiation.cpp
@@ -51,7 +51,7 @@ template <> struct HydroSystem_Traits<ParticleRadiationProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<ParticleRadiationProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ParticleRadiationProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = true;

--- a/src/problems/ParticleRadiation/testParticleRadiation.cpp
+++ b/src/problems/ParticleRadiation/testParticleRadiation.cpp
@@ -51,7 +51,7 @@ template <> struct HydroSystem_Traits<ParticleRadiationProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<ParticleRadiationProblem> {
+template <> struct Physics_Traits<ParticleRadiationProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = true;

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -41,7 +41,7 @@ template <> struct HydroSystem_Traits<ParticleSFProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<ParticleSFProblem> {
+template <> struct Physics_Traits<ParticleSFProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/ParticleSF/testParticleSF.cpp
+++ b/src/problems/ParticleSF/testParticleSF.cpp
@@ -41,7 +41,7 @@ template <> struct HydroSystem_Traits<ParticleSFProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<ParticleSFProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ParticleSFProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -60,8 +60,15 @@ template <> struct Physics_Traits<SinkProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<SinkProblem> {

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -56,19 +56,12 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SinkProblem> {
+template <> struct Physics_Traits<SinkProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<SinkProblem> {

--- a/src/problems/ParticleSink/testParticleSink.cpp
+++ b/src/problems/ParticleSink/testParticleSink.cpp
@@ -56,7 +56,7 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SinkProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SinkProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
+++ b/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
@@ -53,8 +53,15 @@ template <> struct Physics_Traits<SinkProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
+	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> void QuokkaSimulation<SinkProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)

--- a/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
+++ b/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
@@ -49,19 +49,12 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SinkProblem> {
+template <> struct Physics_Traits<SinkProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
-	static constexpr int numPassiveScalars = numMassScalars + 0; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> void QuokkaSimulation<SinkProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)

--- a/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
+++ b/src/problems/ParticleSinkFormation/testParticleSinkFormation.cpp
@@ -49,7 +49,7 @@ template <> struct HydroSystem_Traits<SinkProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SinkProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SinkProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<ScalarProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ScalarProblem> {
+template <> struct Physics_Traits<ScalarProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/PassiveScalar/testPassiveScalar.cpp
+++ b/src/problems/PassiveScalar/testPassiveScalar.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<ScalarProblem> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<ScalarProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ScalarProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/PopIII/testPopIII.cpp
+++ b/src/problems/PopIII/testPopIII.cpp
@@ -42,7 +42,7 @@ template <> struct HydroSystem_Traits<PopIII> {
 	static constexpr bool reconstruct_eint = true;
 };
 
-template <> struct Physics_Traits<PopIII> {
+template <> struct Physics_Traits<PopIII> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/PopIII/testPopIII.cpp
+++ b/src/problems/PopIII/testPopIII.cpp
@@ -42,7 +42,7 @@ template <> struct HydroSystem_Traits<PopIII> {
 	static constexpr bool reconstruct_eint = true;
 };
 
-template <> struct Physics_Traits<PopIII> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PopIII> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/PrimordialChem/testPrimordialChem.cpp
+++ b/src/problems/PrimordialChem/testPrimordialChem.cpp
@@ -44,7 +44,7 @@ using amrex::Real;
 struct PrimordialChemTest {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct Physics_Traits<PrimordialChemTest> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PrimordialChemTest> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/PrimordialChem/testPrimordialChem.cpp
+++ b/src/problems/PrimordialChem/testPrimordialChem.cpp
@@ -44,7 +44,7 @@ using amrex::Real;
 struct PrimordialChemTest {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct Physics_Traits<PrimordialChemTest> {
+template <> struct Physics_Traits<PrimordialChemTest> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadDust/testRadDust.cpp
+++ b/src/problems/RadDust/testRadDust.cpp
@@ -62,7 +62,7 @@ template <> struct ISM_Traits<DustProblem> {
 	static constexpr bool enable_photoelectric_heating = false;
 };
 
-template <> struct Physics_Traits<DustProblem> {
+template <> struct Physics_Traits<DustProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadDust/testRadDust.cpp
+++ b/src/problems/RadDust/testRadDust.cpp
@@ -62,7 +62,7 @@ template <> struct ISM_Traits<DustProblem> {
 	static constexpr bool enable_photoelectric_heating = false;
 };
 
-template <> struct Physics_Traits<DustProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadDustMG/testRadDustMG.cpp
+++ b/src/problems/RadDustMG/testRadDustMG.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<DustProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustProblem> {
+template <> struct Physics_Traits<DustProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadDustMG/testRadDustMG.cpp
+++ b/src/problems/RadDustMG/testRadDustMG.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<DustProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<DustProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<DustProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadForce/testRadForce.cpp
+++ b/src/problems/RadForce/testRadForce.cpp
@@ -56,7 +56,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 	static constexpr double cs_isothermal = a0; // only used when gamma = 1
 };
 
-template <> struct Physics_Traits<TubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<TubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadForce/testRadForce.cpp
+++ b/src/problems/RadForce/testRadForce.cpp
@@ -56,7 +56,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 	static constexpr double cs_isothermal = a0; // only used when gamma = 1
 };
 
-template <> struct Physics_Traits<TubeProblem> {
+template <> struct Physics_Traits<TubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadLineCooling/testRadLineCooling.cpp
+++ b/src/problems/RadLineCooling/testRadLineCooling.cpp
@@ -55,7 +55,7 @@ template <> struct quokka::EOS_Traits<CoolingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<CoolingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CoolingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadLineCooling/testRadLineCooling.cpp
+++ b/src/problems/RadLineCooling/testRadLineCooling.cpp
@@ -55,7 +55,7 @@ template <> struct quokka::EOS_Traits<CoolingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<CoolingProblem> {
+template <> struct Physics_Traits<CoolingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
+++ b/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
@@ -60,7 +60,7 @@ template <> struct quokka::EOS_Traits<CoolingProblemMG> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<CoolingProblemMG> {
+template <> struct Physics_Traits<CoolingProblemMG> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
+++ b/src/problems/RadLineCoolingMG/testRadLineCoolingMG.cpp
@@ -60,7 +60,7 @@ template <> struct quokka::EOS_Traits<CoolingProblemMG> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<CoolingProblemMG> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CoolingProblemMG> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadMarshak/testRadMarshak.cpp
+++ b/src/problems/RadMarshak/testRadMarshak.cpp
@@ -49,7 +49,7 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 	static constexpr int beta_order = 0;
 };
 
-template <> struct Physics_Traits<SuOlsonProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SuOlsonProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshak/testRadMarshak.cpp
+++ b/src/problems/RadMarshak/testRadMarshak.cpp
@@ -49,7 +49,7 @@ template <> struct RadSystem_Traits<SuOlsonProblem> {
 	static constexpr int beta_order = 0;
 };
 
-template <> struct Physics_Traits<SuOlsonProblem> {
+template <> struct Physics_Traits<SuOlsonProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
@@ -44,7 +44,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr int beta_order = 0;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
+++ b/src/problems/RadMarshakAsymptotic/testRadMarshakAsymptotic.cpp
@@ -44,7 +44,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr int beta_order = 0;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakCGS/testRadMarshakCGS.cpp
+++ b/src/problems/RadMarshakCGS/testRadMarshakCGS.cpp
@@ -51,7 +51,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakCGS/testRadMarshakCGS.cpp
+++ b/src/problems/RadMarshakCGS/testRadMarshakCGS.cpp
@@ -51,7 +51,7 @@ template <> struct RadSystem_Traits<SuOlsonProblemCgs> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakDust/testRadMarshakDust.cpp
+++ b/src/problems/RadMarshakDust/testRadMarshakDust.cpp
@@ -52,7 +52,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MarshakProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakDust/testRadMarshakDust.cpp
+++ b/src/problems/RadMarshakDust/testRadMarshakDust.cpp
@@ -52,7 +52,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> {
+template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakDustPE/testRadMarshakDustPE.cpp
+++ b/src/problems/RadMarshakDustPE/testRadMarshakDustPE.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MarshakProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakDustPE/testRadMarshakDustPE.cpp
+++ b/src/problems/RadMarshakDustPE/testRadMarshakDustPE.cpp
@@ -51,7 +51,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> {
+template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakVaytet/testRadMarshakVaytet.cpp
+++ b/src/problems/RadMarshakVaytet/testRadMarshakVaytet.cpp
@@ -106,7 +106,7 @@ template <> struct quokka::EOS_Traits<SuOlsonProblemCgs> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMarshakVaytet/testRadMarshakVaytet.cpp
+++ b/src/problems/RadMarshakVaytet/testRadMarshakVaytet.cpp
@@ -106,7 +106,7 @@ template <> struct quokka::EOS_Traits<SuOlsonProblemCgs> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<SuOlsonProblemCgs> {
+template <> struct Physics_Traits<SuOlsonProblemCgs> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
+++ b/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
@@ -45,7 +45,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<CouplingProblem> {
+template <> struct Physics_Traits<CouplingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
+++ b/src/problems/RadMatterCoupling/testRadMatterCoupling.cpp
@@ -45,7 +45,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<CouplingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CouplingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
+++ b/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
@@ -48,7 +48,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<CouplingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CouplingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
+++ b/src/problems/RadMatterCouplingRSLA/testRadMatterCouplingRSLA.cpp
@@ -48,7 +48,7 @@ template <> struct RadSystem_Traits<CouplingProblem> {
 	static constexpr int beta_order = 1;
 };
 
-template <> struct Physics_Traits<CouplingProblem> {
+template <> struct Physics_Traits<CouplingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StreamingProblem> {
+template <> struct Physics_Traits<StreamingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StreamingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<StreamingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadStreamingY/testRadStreamingY.cpp
+++ b/src/problems/RadStreamingY/testRadStreamingY.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StreamingProblem> {
+template <> struct Physics_Traits<StreamingProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadStreamingY/testRadStreamingY.cpp
+++ b/src/problems/RadStreamingY/testRadStreamingY.cpp
@@ -34,7 +34,7 @@ template <> struct quokka::EOS_Traits<StreamingProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StreamingProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<StreamingProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -62,7 +62,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MarshakProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -62,7 +62,7 @@ template <> struct quokka::EOS_Traits<MarshakProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MarshakProblem> {
+template <> struct Physics_Traits<MarshakProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/RadTube/testRadTube.cpp
+++ b/src/problems/RadTube/testRadTube.cpp
@@ -50,7 +50,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<TubeProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<TubeProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadTube/testRadTube.cpp
+++ b/src/problems/RadTube/testRadTube.cpp
@@ -50,7 +50,7 @@ template <> struct quokka::EOS_Traits<TubeProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<TubeProblem> {
+template <> struct Physics_Traits<TubeProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroBB/testRadhydroBB.cpp
+++ b/src/problems/RadhydroBB/testRadhydroBB.cpp
@@ -111,7 +111,7 @@ template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroBB/testRadhydroBB.cpp
+++ b/src/problems/RadhydroBB/testRadhydroBB.cpp
@@ -111,7 +111,7 @@ template <> struct quokka::EOS_Traits<PulseProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulse/testRadhydroPulse.cpp
+++ b/src/problems/RadhydroPulse/testRadhydroPulse.cpp
@@ -59,7 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -73,7 +73,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> {
+template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulse/testRadhydroPulse.cpp
+++ b/src/problems/RadhydroPulse/testRadhydroPulse.cpp
@@ -59,7 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -73,7 +73,7 @@ template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AdvPulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseDyn/testRadhydroPulseDyn.cpp
+++ b/src/problems/RadhydroPulseDyn/testRadhydroPulseDyn.cpp
@@ -59,7 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -73,7 +73,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> {
+template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseDyn/testRadhydroPulseDyn.cpp
+++ b/src/problems/RadhydroPulseDyn/testRadhydroPulseDyn.cpp
@@ -59,7 +59,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -73,7 +73,7 @@ template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AdvPulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseGrey/testRadhydroPulseGrey.cpp
+++ b/src/problems/RadhydroPulseGrey/testRadhydroPulseGrey.cpp
@@ -60,7 +60,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = 2;
 };
 
-template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -74,7 +74,7 @@ template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<AdvPulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseGrey/testRadhydroPulseGrey.cpp
+++ b/src/problems/RadhydroPulseGrey/testRadhydroPulseGrey.cpp
@@ -60,7 +60,7 @@ template <> struct RadSystem_Traits<AdvPulseProblem> {
 	static constexpr int beta_order = 2;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -74,7 +74,7 @@ template <> struct Physics_Traits<PulseProblem> {
 	static constexpr int nGroups = 1;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<AdvPulseProblem> {
+template <> struct Physics_Traits<AdvPulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseMGconst/testRadhydroPulseMGconst.cpp
+++ b/src/problems/RadhydroPulseMGconst/testRadhydroPulseMGconst.cpp
@@ -93,7 +93,7 @@ template <> struct quokka::EOS_Traits<SGProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<SGProblem> {
+template <> struct Physics_Traits<SGProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -159,7 +159,7 @@ template <> struct quokka::EOS_Traits<MGproblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MGproblem> {
+template <> struct Physics_Traits<MGproblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseMGconst/testRadhydroPulseMGconst.cpp
+++ b/src/problems/RadhydroPulseMGconst/testRadhydroPulseMGconst.cpp
@@ -93,7 +93,7 @@ template <> struct quokka::EOS_Traits<SGProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<SGProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SGProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -159,7 +159,7 @@ template <> struct quokka::EOS_Traits<MGproblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MGproblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MGproblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseMGint/testRadhydroPulseMGint.cpp
+++ b/src/problems/RadhydroPulseMGint/testRadhydroPulseMGint.cpp
@@ -103,7 +103,7 @@ template <> struct quokka::EOS_Traits<ExactProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MGProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<MGProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -117,7 +117,7 @@ template <> struct Physics_Traits<MGProblem> : PhysicsTraitsDefaults {
 	static constexpr int nGroups = n_groups_;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<ExactProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ExactProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroPulseMGint/testRadhydroPulseMGint.cpp
+++ b/src/problems/RadhydroPulseMGint/testRadhydroPulseMGint.cpp
@@ -103,7 +103,7 @@ template <> struct quokka::EOS_Traits<ExactProblem> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<MGProblem> {
+template <> struct Physics_Traits<MGProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
@@ -117,7 +117,7 @@ template <> struct Physics_Traits<MGProblem> {
 	static constexpr int nGroups = n_groups_;
 	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
-template <> struct Physics_Traits<ExactProblem> {
+template <> struct Physics_Traits<ExactProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShell/testRadhydroShell.cpp
+++ b/src/problems/RadhydroShell/testRadhydroShell.cpp
@@ -54,7 +54,7 @@ template <> struct HydroSystem_Traits<ShellProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<ShellProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShellProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShell/testRadhydroShell.cpp
+++ b/src/problems/RadhydroShell/testRadhydroShell.cpp
@@ -54,7 +54,7 @@ template <> struct HydroSystem_Traits<ShellProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<ShellProblem> {
+template <> struct Physics_Traits<ShellProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShock/testRadhydroShock.cpp
+++ b/src/problems/RadhydroShock/testRadhydroShock.cpp
@@ -75,7 +75,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShockProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShock/testRadhydroShock.cpp
+++ b/src/problems/RadhydroShock/testRadhydroShock.cpp
@@ -75,7 +75,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<ShockProblem> {
+template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShockCGS/testRadhydroShockCGS.cpp
+++ b/src/problems/RadhydroShockCGS/testRadhydroShockCGS.cpp
@@ -75,7 +75,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShockProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShockCGS/testRadhydroShockCGS.cpp
+++ b/src/problems/RadhydroShockCGS/testRadhydroShockCGS.cpp
@@ -75,7 +75,7 @@ template <> struct quokka::EOS_Traits<ShockProblem> {
 	static constexpr double gamma = gamma_gas;
 };
 
-template <> struct Physics_Traits<ShockProblem> {
+template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShockMultigroup/testRadhydroShockMultigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/testRadhydroShockMultigroup.cpp
@@ -53,7 +53,7 @@ constexpr double shock_position = 0.0130; // 0.0132; // cm (shock position drift
 					  // we initialize slightly to the left...)
 constexpr double Lx = 0.01575;		  // cm
 
-template <> struct Physics_Traits<ShockProblem> {
+template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroShockMultigroup/testRadhydroShockMultigroup.cpp
+++ b/src/problems/RadhydroShockMultigroup/testRadhydroShockMultigroup.cpp
@@ -53,7 +53,7 @@ constexpr double shock_position = 0.0130; // 0.0132; // cm (shock position drift
 					  // we initialize slightly to the left...)
 constexpr double Lx = 0.01575;		  // cm
 
-template <> struct Physics_Traits<ShockProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShockProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroUniformAdvecting/testRadhydroUniformAdvecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/testRadhydroUniformAdvecting.cpp
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> {
+template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RadhydroUniformAdvecting/testRadhydroUniformAdvecting.cpp
+++ b/src/problems/RadhydroUniformAdvecting/testRadhydroUniformAdvecting.cpp
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<PulseProblem> {
 	static constexpr int beta_order = beta_order_;
 };
 
-template <> struct Physics_Traits<PulseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<PulseProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -27,7 +27,7 @@ struct RandomBlast {
 constexpr double m_H = C::m_p + C::m_e;	     // mass of hydrogen atom
 constexpr double seconds_per_year = 3.154e7; // seconds per year
 
-template <> struct Physics_Traits<RandomBlast> {
+template <> struct Physics_Traits<RandomBlast> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/RandomBlast/testRandomBlast.cpp
+++ b/src/problems/RandomBlast/testRandomBlast.cpp
@@ -27,7 +27,7 @@ struct RandomBlast {
 constexpr double m_H = C::m_p + C::m_e;	     // mass of hydrogen atom
 constexpr double seconds_per_year = 3.154e7; // seconds per year
 
-template <> struct Physics_Traits<RandomBlast> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<RandomBlast> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/RayleighTaylor3D/testRayleighTaylor3D.cpp
+++ b/src/problems/RayleighTaylor3D/testRayleighTaylor3D.cpp
@@ -35,7 +35,7 @@ template <> struct HydroSystem_Traits<RTProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<RTProblem> {
+template <> struct Physics_Traits<RTProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/RayleighTaylor3D/testRayleighTaylor3D.cpp
+++ b/src/problems/RayleighTaylor3D/testRayleighTaylor3D.cpp
@@ -35,7 +35,7 @@ template <> struct HydroSystem_Traits<RTProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<RTProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<RTProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/ResampledCoolingTest/testResampledCoolingTest.cpp
+++ b/src/problems/ResampledCoolingTest/testResampledCoolingTest.cpp
@@ -93,7 +93,7 @@ template <> struct quokka::EOS_Traits<ResampledCoolingTest> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<ResampledCoolingTest> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ResampledCoolingTest> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/ResampledCoolingTest/testResampledCoolingTest.cpp
+++ b/src/problems/ResampledCoolingTest/testResampledCoolingTest.cpp
@@ -93,7 +93,7 @@ template <> struct quokka::EOS_Traits<ResampledCoolingTest> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<ResampledCoolingTest> {
+template <> struct Physics_Traits<ResampledCoolingTest> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numMassScalars = 0;		     // number of mass scalars

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -63,11 +63,18 @@ template <> struct HydroSystem_Traits<SNProblem> {
 };
 
 template <> struct Physics_Traits<SNProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
+	static constexpr bool is_radiation_enabled = false;
+	static constexpr bool is_dust_enabled = false;
+	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr int nGroups = 1; // number of radiation groups
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<SNProblem> {

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -62,19 +62,12 @@ template <> struct HydroSystem_Traits<SNProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SNProblem> {
-	static constexpr bool is_self_gravity_enabled = false;
+template <> struct Physics_Traits<SNProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;		     // number of mass scalars
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars
-	static constexpr bool is_radiation_enabled = false;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1; // number of radiation groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 template <> struct SimulationData<SNProblem> {

--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -62,7 +62,7 @@ template <> struct HydroSystem_Traits<SNProblem> {
 	static constexpr bool reconstruct_eint = true; // need to reconstruct temperature
 };
 
-template <> struct Physics_Traits<SNProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SNProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr int numPassiveScalars = numMassScalars + 1; // number of passive scalars

--- a/src/problems/ShockCloud/testShockCloud.cpp
+++ b/src/problems/ShockCloud/testShockCloud.cpp
@@ -46,7 +46,7 @@ constexpr double solarmass_in_g = C::M_solar;	  // g == 1 Msun
 constexpr double keV_in_ergs = 1000. * C::ev2erg; // ergs == 1 keV
 constexpr double m_H = C::m_p + C::m_e;		  // mass of hydrogen atom
 
-template <> struct Physics_Traits<ShockCloud> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ShockCloud> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/ShockCloud/testShockCloud.cpp
+++ b/src/problems/ShockCloud/testShockCloud.cpp
@@ -46,7 +46,7 @@ constexpr double solarmass_in_g = C::M_solar;	  // g == 1 Msun
 constexpr double keV_in_ergs = 1000. * C::ev2erg; // ergs == 1 keV
 constexpr double m_H = C::m_p + C::m_e;		  // mass of hydrogen atom
 
-template <> struct Physics_Traits<ShockCloud> {
+template <> struct Physics_Traits<ShockCloud> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/SlowWave/testSlowWave.cpp
+++ b/src/problems/SlowWave/testSlowWave.cpp
@@ -34,20 +34,11 @@ struct SlowWave {
 template <> struct quokka::EOS_Traits<SlowWave> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<SlowWave> {
+template <> struct Physics_Traits<SlowWave> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1;
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double sound_speed = 1.0;

--- a/src/problems/SlowWave/testSlowWave.cpp
+++ b/src/problems/SlowWave/testSlowWave.cpp
@@ -36,7 +36,7 @@ template <> struct quokka::EOS_Traits<SlowWave> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<SlowWave> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SlowWave> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -31,20 +31,11 @@ struct SlowWaveConvergence {
 template <> struct quokka::EOS_Traits<SlowWaveConvergence> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
-template <> struct Physics_Traits<SlowWaveConvergence> {
+template <> struct Physics_Traits<SlowWaveConvergence> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
-	static constexpr int numMassScalars = 0;
-	static constexpr int numPassiveScalars = numMassScalars + 0;
-	static constexpr bool is_self_gravity_enabled = false;
-	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = true;
-	static constexpr int nGroups = 1;
-	static constexpr bool is_dust_enabled = false;
-	static constexpr int nDustGroups = 1; // number of dust groups
-	static constexpr UnitSystem unit_system = UnitSystem::CGS;
 };
 
 constexpr double sound_speed = 1.0;

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -33,7 +33,7 @@ template <> struct quokka::EOS_Traits<SlowWaveConvergence> {
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<SlowWaveConvergence> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<SlowWaveConvergence> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };

--- a/src/problems/SphericalCollapse/testSphericalCollapse.cpp
+++ b/src/problems/SphericalCollapse/testSphericalCollapse.cpp
@@ -39,7 +39,7 @@ template <> struct HydroSystem_Traits<CollapseProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<CollapseProblem> {
+template <> struct Physics_Traits<CollapseProblem> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/SphericalCollapse/testSphericalCollapse.cpp
+++ b/src/problems/SphericalCollapse/testSphericalCollapse.cpp
@@ -39,7 +39,7 @@ template <> struct HydroSystem_Traits<CollapseProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<CollapseProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<CollapseProblem> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/StarCluster/testStarCluster.cpp
+++ b/src/problems/StarCluster/testStarCluster.cpp
@@ -46,7 +46,7 @@ template <> struct HydroSystem_Traits<StarCluster> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<StarCluster> {
+template <> struct Physics_Traits<StarCluster> : PhysicsTraitsDefaults {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/StarCluster/testStarCluster.cpp
+++ b/src/problems/StarCluster/testStarCluster.cpp
@@ -46,7 +46,7 @@ template <> struct HydroSystem_Traits<StarCluster> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<StarCluster> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<StarCluster> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_self_gravity_enabled = true;

--- a/src/problems/StromgrenSphere/testStromgrenSphere.cpp
+++ b/src/problems/StromgrenSphere/testStromgrenSphere.cpp
@@ -40,7 +40,7 @@ template <> struct quokka::EOS_Traits<StromgrenSphere> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StromgrenSphere> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<StromgrenSphere> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/StromgrenSphere/testStromgrenSphere.cpp
+++ b/src/problems/StromgrenSphere/testStromgrenSphere.cpp
@@ -40,7 +40,7 @@ template <> struct quokka::EOS_Traits<StromgrenSphere> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StromgrenSphere> {
+template <> struct Physics_Traits<StromgrenSphere> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
+++ b/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
@@ -41,7 +41,7 @@ template <> struct quokka::EOS_Traits<StromgrenSphere> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StromgrenSphere> {
+template <> struct Physics_Traits<StromgrenSphere> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
+++ b/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
@@ -41,7 +41,7 @@ template <> struct quokka::EOS_Traits<StromgrenSphere> {
 	static constexpr double gamma = 5. / 3.;
 };
 
-template <> struct Physics_Traits<StromgrenSphere> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<StromgrenSphere> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = false;

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -69,7 +69,7 @@ template <> struct quokka::EOS_Traits<TheProblem> {
 	static constexpr double mean_molecular_weight = mu;
 };
 
-template <> struct Physics_Traits<TheProblem> {
+template <> struct Physics_Traits<TheProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/TallBoxSf/testTallBoxSf.cpp
+++ b/src/problems/TallBoxSf/testTallBoxSf.cpp
@@ -69,7 +69,7 @@ template <> struct quokka::EOS_Traits<TheProblem> {
 	static constexpr double mean_molecular_weight = mu;
 };
 
-template <> struct Physics_Traits<TheProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<TheProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = true;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;

--- a/src/problems/ThermalConduction/testThermalConduction.cpp
+++ b/src/problems/ThermalConduction/testThermalConduction.cpp
@@ -53,7 +53,7 @@ template <> struct HydroSystem_Traits<ThermalConductionProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<ThermalConductionProblem> {
+template <> struct Physics_Traits<ThermalConductionProblem> : PhysicsTraitsDefaults {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/ThermalConduction/testThermalConduction.cpp
+++ b/src/problems/ThermalConduction/testThermalConduction.cpp
@@ -53,7 +53,7 @@ template <> struct HydroSystem_Traits<ThermalConductionProblem> {
 	static constexpr bool reconstruct_eint = false;
 };
 
-template <> struct Physics_Traits<ThermalConductionProblem> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<ThermalConductionProblem> : DefaultPhysicsTraits {
 	static constexpr bool is_self_gravity_enabled = false;
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;

--- a/src/problems/Turbulence/testTurbulence.cpp
+++ b/src/problems/Turbulence/testTurbulence.cpp
@@ -20,7 +20,7 @@
 struct TurbulentBox {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct Physics_Traits<TurbulentBox> : PhysicsTraitsDefaults {
+template <> struct Physics_Traits<TurbulentBox> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;

--- a/src/problems/Turbulence/testTurbulence.cpp
+++ b/src/problems/Turbulence/testTurbulence.cpp
@@ -20,7 +20,7 @@
 struct TurbulentBox {
 }; // dummy type to allow compile-type polymorphism via template specialization
 
-template <> struct Physics_Traits<TurbulentBox> {
+template <> struct Physics_Traits<TurbulentBox> : PhysicsTraitsDefaults {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_radiation_enabled = false;
 	static constexpr bool is_mhd_enabled = false;


### PR DESCRIPTION
### Description

This PR introduces `DefaultPhysicsTraits`, a simple base struct that holds default values for `Physics_Traits`. This allows problem to only need to specialize and declare fields that differ from the defaults:

```cpp
template <> struct Physics_Traits<BrioWuProblem> : DefaultPhysicsTraits {
    static constexpr bool is_hydro_enabled = true;
    static constexpr bool is_mhd_enabled = true;
    // everything else inherited
};
```

The name `DefaultPhysicsTraits` is chosen to encourage a natural extension pattern: future domain-specific defaults (e.g. `MHDPhysicsTraits`, `RadPhysicsTraits`) can inherit from it and override their common fields, so problems only need to declare what is truly problem-specific.

All MHD-only problem specializations are updated to use this pattern with redundant default-valued fields removed. All other problem specializations are updated to inherit from `DefaultPhysicsTraits` with their existing fields kept in place; I will leave the pruning of redundant fields in those problems for the authors of those problems.

The motivation is the churn encountered in #1913: adding `resistivity_model` required touching every problem file to declare the default value of `none`. With this change, new fields added to `DefaultPhysicsTraits` are automatically available to all problems that don't override them.

### Related issues

- #1948: this PR implements the proposal described there.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.