### PR TITLE
[Docs] add how-to guide for writing bug reports

### DIFF
--- a/docs/markdown/SUMMARY.md
+++ b/docs/markdown/SUMMARY.md
@@ -37,6 +37,7 @@
 - [In-situ analysis](insitu_analysis.md)
 - [Postprocessing](postprocessing.md)
 - [Debugging simulation instability](instability.md)
+- [Writing bug report reproducers](bug_report_reproducers.md)
 - [Runtime calculator](runtime_calculator.md)
 
 # Developer Guide

--- a/docs/markdown/bug_report_reproducers.md
+++ b/docs/markdown/bug_report_reproducers.md
@@ -55,7 +55,7 @@ cd quokka-reproducer-<short-description>
 bash run.sh
 ```
 
-Quokka also provides a helper script that creates this directory tree and captures code changes from your current worktree. By default, the patch is generated relative to the merge-base with `origin/development`, so it includes both committed branch changes and uncommitted tracked-file edits. Untracked files are copied separately under `patches/untracked-files/` because `git diff` cannot represent files that Git has never seen.
+Quokka also provides a helper script that creates this directory tree and captures code changes from your current worktree. By default, the patch is generated relative to the merge-base with `origin/development`, so it includes both committed branch changes and uncommitted tracked-file edits. The merge-base commit is recorded in `README.md`, `patches/README.md`, and `run.sh` so the person running the reproducer knows the original base for the patch. Untracked files are copied separately under `patches/untracked-files/` because `git diff` cannot represent files that Git has never seen.
 
 ```bash
 ./scripts/python/create_bug_reproducer.py <short-description> \

--- a/docs/markdown/bug_report_reproducers.md
+++ b/docs/markdown/bug_report_reproducers.md
@@ -10,6 +10,65 @@ A good bug report lets another person run the same case, see the same failure, a
 >
 > A complete small case is more useful than a large production run. If the production run needs a full cluster allocation or terabytes of data, first reduce it to the smallest case that still fails.
 
+## Preferred format: a self-contained tarball
+
+The preferred way to share a reproducer is to upload a single compressed tarball to the GitHub issue. The tarball should be self-contained: after unpacking it next to a clean Quokka checkout, a maintainer should be able to read `README.md`, run one script, and reproduce the reported behavior.
+
+Use this layout when possible:
+
+```text
+quokka-reproducer-<short-description>/
+|-- README.md
+|-- run.sh
+|-- input/
+|   `-- <problem>.toml
+|-- data/
+|   `-- <tables-or-small-input-files>
+|-- patches/
+|   `-- quokka.patch
+`-- output/
+    |-- failure.log
+    `-- expected.txt
+```
+
+The files should have these roles:
+
+- `README.md`: one-page summary of the bug, the expected behavior, the observed behavior, the Quokka commit, and the exact platform used.
+- `run.sh`: a bash script that configures, compiles, and runs the smallest failing case.
+- `input/`: the complete input deck, with no required parameters omitted.
+- `data/`: every data table or auxiliary input file needed by the run. Keep these files small enough to attach to the issue whenever possible.
+- `patches/quokka.patch`: the local code changes required to reproduce the bug, generated with `git diff`. Omit this file only when the bug reproduces on an unmodified checkout.
+- `output/failure.log`: the full terminal output from the failing run, including the first useful error message.
+- `output/expected.txt`: a short note describing what result you expected instead.
+
+Create the tarball from the parent directory:
+
+```bash
+tar -czf quokka-reproducer-<short-description>.tar.gz quokka-reproducer-<short-description>/
+```
+
+Before uploading it, test the tarball in a fresh directory if practical:
+
+```bash
+tar -xzf quokka-reproducer-<short-description>.tar.gz
+cd quokka-reproducer-<short-description>
+bash run.sh
+```
+
+Quokka also provides a helper script that creates this directory tree and captures code changes from your current worktree. By default, the patch is generated relative to the merge-base with `origin/development`, so it includes both committed branch changes and uncommitted tracked-file edits. Untracked files are copied separately under `patches/untracked-files/` because `git diff` cannot represent files that Git has never seen.
+
+```bash
+./scripts/python/create_bug_reproducer.py <short-description> \
+  --input inputs/MyProblem.toml \
+  --data path/to/table.dat
+```
+
+Review and edit the generated directory before creating the final tarball.
+
+> **Warning**
+>
+> Do not include full build directories, large plotfile series, checkpoints, core dumps, or private machine paths unless they are essential to the bug. If a large artifact is essential, describe why and include the smallest possible version.
+
 ## What to include
 
 Please provide the following items when opening a [GitHub Issue](https://github.com/quokka-astro/quokka/issues):
@@ -19,7 +78,7 @@ Please provide the following items when opening a [GitHub Issue](https://github.
 2. **All required data tables and auxiliary files.**
    Include opacity tables, cooling tables, restart/checkpoint dependencies, particle initial condition files, or any other non-generated data needed by the run. If a file is too large to attach, explain how it was produced and provide a smaller replacement if possible.
 3. **Any code modifications.**
-   If the bug appears only with local edits, provide a patch, a branch, or the exact modified files. Include enough context for maintainers to rebuild the same executable.
+   If the bug appears only with local edits, provide a patch, a branch, or the exact modified files. For tarball reproducers, include the patch as `patches/quokka.patch`.
 4. **Exact build information.**
    Report the Quokka commit hash, submodule state if relevant, dimensionality, build type, compiler, MPI implementation, GPU backend (`CUDA`, `HIP`, or CPU-only), GPU architecture, and important CMake options.
 5. **The exact run command.**
@@ -44,9 +103,9 @@ Before filing the issue, try to reduce the reproducer while preserving the failu
 >
 > Do not shrink the case so far that it no longer demonstrates the reported bug. If a smaller version changes the failure mode, include the smallest faithful reproducer and explain what changed during reduction.
 
-## Prefer a runnable script
+## Write a runnable script
 
-Ideally, attach a short bash script that compiles and runs the failing problem from a clean checkout. This removes ambiguity about paths, presets, MPI rank counts, and environment variables.
+Every tarball should include a short bash script that compiles and runs the failing problem from a clean checkout. This removes ambiguity about paths, presets, MPI rank counts, and environment variables.
 
 For routine local builds, prefer the `scripts/bash/quokka` helper described in the [Contributing Guide](contributing.md#the-quokka-developer-script):
 

--- a/docs/markdown/bug_report_reproducers.md
+++ b/docs/markdown/bug_report_reproducers.md
@@ -1,0 +1,144 @@
+# Writing high-quality bug report reproducers
+
+A good bug report lets another person run the same case, see the same failure, and start debugging without first reconstructing your environment. The best reproducer is **complete**, **small**, and **reliable**:
+
+- **Complete:** it includes the full input deck, required data files, local code changes, build options, run command, and error output.
+- **Small:** it uses the fewest MPI ranks, cells, timesteps, plotfiles, and external files that still demonstrate the bug.
+- **Reliable:** it fails consistently, or it clearly states how often the failure occurs and how many attempts are needed to observe it.
+
+> **Tip**
+>
+> A complete small case is more useful than a large production run. If the production run needs a full cluster allocation or terabytes of data, first reduce it to the smallest case that still fails.
+
+## What to include
+
+Please provide the following items when opening a [GitHub Issue](https://github.com/quokka-astro/quokka/issues):
+
+1. **A full input deck.**
+   Include the complete `.toml` or `.in` file used for the failing run, not only the parameters that changed. If the input depends on another file, include that file too.
+2. **All required data tables and auxiliary files.**
+   Include opacity tables, cooling tables, restart/checkpoint dependencies, particle initial condition files, or any other non-generated data needed by the run. If a file is too large to attach, explain how it was produced and provide a smaller replacement if possible.
+3. **Any code modifications.**
+   If the bug appears only with local edits, provide a patch, a branch, or the exact modified files. Include enough context for maintainers to rebuild the same executable.
+4. **Exact build information.**
+   Report the Quokka commit hash, submodule state if relevant, dimensionality, build type, compiler, MPI implementation, GPU backend (`CUDA`, `HIP`, or CPU-only), GPU architecture, and important CMake options.
+5. **The exact run command.**
+   Include the executable name, input file path, MPI command and process count, environment variables, current working directory, and scheduler options if they matter.
+6. **The observed failure.**
+   Paste the first clear error message, assertion, stack trace, failing diagnostic, or incorrect numerical result. Also state what you expected to happen.
+7. **A note on reliability.**
+   Say whether the reproducer fails every time. For intermittent failures, report the approximate failure rate and whether settings such as `CUDA_LAUNCH_BLOCKING=1` or `HIP_LAUNCH_BLOCKING=1` change the result.
+
+## Make it as small as possible
+
+Before filing the issue, try to reduce the reproducer while preserving the failure:
+
+- Lower `max_timesteps` to the first failing step, or just past it.
+- Reduce the domain size, AMR levels, plotfile frequency, and checkpoint frequency.
+- Use one MPI rank if possible. If the bug requires MPI, use the smallest rank count that still fails.
+- Prefer CPU-only Debug or ASAN builds for memory errors when the same bug appears off-GPU; see the [Debugging](debugging.md) guide.
+- Remove unrelated physics options, derived variables, output fields, and analysis steps one at a time.
+- Replace large tables or initial condition files with the smallest equivalent file that still triggers the issue.
+
+> **Warning**
+>
+> Do not shrink the case so far that it no longer demonstrates the reported bug. If a smaller version changes the failure mode, include the smallest faithful reproducer and explain what changed during reduction.
+
+## Prefer a runnable script
+
+Ideally, attach a short bash script that compiles and runs the failing problem from a clean checkout. This removes ambiguity about paths, presets, MPI rank counts, and environment variables.
+
+For routine local builds, prefer the `scripts/bash/quokka` helper described in the [Contributing Guide](contributing.md#the-quokka-developer-script):
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run from the repository root.
+git rev-parse --short HEAD
+
+./scripts/bash/quokka config -d 3d --delete \
+  -DQUOKKA_PYTHON=OFF
+
+./scripts/bash/quokka build -d 3d MyProblem
+
+mpirun -np 1 ./build/3d/src/problems/MyProblem/MyProblem \
+  ./repro/MyProblem_reproducer.toml \
+  max_timesteps=20
+```
+
+If the bug requires a GPU backend, scheduler command, debug build, or specific environment variables, include them in the script:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CUDA_LAUNCH_BLOCKING=1
+
+./scripts/bash/quokka config -d 3d-cuda --delete \
+  -DAMReX_GPU_ARCH=80
+
+./scripts/bash/quokka build -d 3d-cuda MyProblem
+
+srun -n 2 --gpus-per-task=1 ./build/3d-cuda/src/problems/MyProblem/MyProblem \
+  ./repro/MyProblem_reproducer.toml
+```
+
+The script does not need to be general. It should be specific enough that another developer can run it, see the same failure, and then edit it while debugging.
+
+## Suggested issue layout
+
+You can copy this outline into the issue body:
+
+~~~markdown
+## Summary
+
+What failed, and what should have happened instead?
+
+## Reproducer files
+
+- Input deck:
+- Data tables or auxiliary files:
+- Code modifications or branch:
+- Run script:
+
+## Build and platform
+
+- Quokka commit:
+- AMReX commit:
+- Compiler and version:
+- MPI implementation and version:
+- Build preset or CMake command:
+- GPU backend and hardware, if any:
+
+## Run command
+
+```bash
+<exact command>
+```
+
+## Failure output
+
+```text
+<first useful error message, assertion, stack trace, or diagnostic>
+```
+
+## Reduction notes
+
+- Smallest domain size tested:
+- Smallest MPI rank count tested:
+- First failing timestep:
+- Does it fail every time?
+~~~
+
+## What not to submit by itself
+
+Avoid reports that only include:
+
+- a screenshot of an error message without the text output;
+- a partial parameter list instead of the full input deck;
+- a production job script that depends on private paths, unavailable modules, or large unshared data files;
+- a plotfile or checkpoint without the input and command that produced it;
+- a description such as "the simulation crashes" without the first clear error message.
+
+These details can still be useful as supporting context, but they are not a reproducible bug report on their own.

--- a/docs/markdown/contributing.md
+++ b/docs/markdown/contributing.md
@@ -3,6 +3,7 @@
 Bug fixes, questions, and contributions of new features are welcome!
 
 * Please report bugs using [GitHub Issues](https://github.com/quokka-astro/quokka/issues).
+  When reporting a bug, please include a complete, small, reliable reproducer; see [Writing high-quality bug report reproducers](bug_report_reproducers.md).
 * Ask questions using [GitHub Discussions](https://github.com/quokka-astro/quokka/discussions).
 * All code contributions should be done via [GitHub Pull Requests](https://github.com/quokka-astro/quokka/pulls):
     * *Continuous integration* (CI) testing is used to ensure that any new features or changes produce the right answer and follow all of the code style guidelines.

--- a/scripts/python/create_bug_reproducer.py
+++ b/scripts/python/create_bug_reproducer.py
@@ -127,7 +127,7 @@ bash run.sh
 - Branch: `{branch}`
 - Commit: `{commit}`
 - Patch base ref: `{base_ref}`
-- Patch base commit: `{base_commit}`
+- Patch base commit: `{base_commit}` (merge-base of `HEAD` and `{base_ref}`)
 
 ## Platform
 
@@ -167,37 +167,45 @@ bash run.sh
 """
 
 
-def build_run_script() -> str:
-    return """#!/usr/bin/env bash
+def build_run_script(base_ref: str, base_commit: str) -> str:
+    return f"""#!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${{BASH_SOURCE[0]}}")" && pwd)"
+
+# The patch in patches/quokka.patch was generated relative to this commit.
+PATCH_BASE_REF="{base_ref}"
+PATCH_BASE_COMMIT="{base_commit}"
 
 # Edit these values before uploading the reproducer.
-QUOKKA_ROOT="${QUOKKA_ROOT:-${SCRIPT_DIR}/../quokka}"
-PRESET="${PRESET:-3d}"
-PROBLEM="${PROBLEM:-MyProblem}"
-INPUT="${INPUT:-${SCRIPT_DIR}/input/MyProblem.toml}"
-MPI_RANKS="${MPI_RANKS:-1}"
+QUOKKA_ROOT="${{QUOKKA_ROOT:-${{SCRIPT_DIR}}/../quokka}}"
+PRESET="${{PRESET:-3d}}"
+PROBLEM="${{PROBLEM:-MyProblem}}"
+INPUT="${{INPUT:-${{SCRIPT_DIR}}/input/MyProblem.toml}}"
+MPI_RANKS="${{MPI_RANKS:-1}}"
 
-cd "${QUOKKA_ROOT}"
+cd "${{QUOKKA_ROOT}}"
+
+echo "Patch base ref: ${{PATCH_BASE_REF}}"
+echo "Patch base commit: ${{PATCH_BASE_COMMIT}}"
+echo "Current Quokka commit: $(git rev-parse HEAD)"
 
 # Apply local code changes if this reproducer includes any.
 # The patch was generated relative to the base commit recorded in README.md.
-if [[ -s "${SCRIPT_DIR}/patches/quokka.patch" ]]; then
-  git apply --check "${SCRIPT_DIR}/patches/quokka.patch"
-  git apply "${SCRIPT_DIR}/patches/quokka.patch"
+if [[ -s "${{SCRIPT_DIR}}/patches/quokka.patch" ]]; then
+  git apply --check "${{SCRIPT_DIR}}/patches/quokka.patch"
+  git apply "${{SCRIPT_DIR}}/patches/quokka.patch"
 fi
 
 # Restore untracked files that cannot be represented by git diff.
-if [[ -d "${SCRIPT_DIR}/patches/untracked-files" ]]; then
-  cp -R "${SCRIPT_DIR}/patches/untracked-files/." .
+if [[ -d "${{SCRIPT_DIR}}/patches/untracked-files" ]]; then
+  cp -R "${{SCRIPT_DIR}}/patches/untracked-files/." .
 fi
 
-./scripts/bash/quokka config -d "${PRESET}"
-./scripts/bash/quokka build -d "${PRESET}" "${PROBLEM}"
+./scripts/bash/quokka config -d "${{PRESET}}"
+./scripts/bash/quokka build -d "${{PRESET}}" "${{PROBLEM}}"
 
-mpirun -np "${MPI_RANKS}" "./build/${PRESET}/src/problems/${PROBLEM}/${PROBLEM}" "${INPUT}"
+mpirun -np "${{MPI_RANKS}}" "./build/${{PRESET}}/src/problems/${{PROBLEM}}/${{PROBLEM}}" "${{INPUT}}"
 """
 
 
@@ -231,12 +239,13 @@ def create_reproducer(args: argparse.Namespace) -> Path:
         patches_dir / "README.md",
         f"quokka.patch was generated with: git diff {base_commit} --binary\n"
         f"Base ref used to find that commit: {args.base_ref}\n"
+        f"Base commit is the merge-base of HEAD and {args.base_ref}: {base_commit}\n"
         "Place additional patch notes here if the diff needs explanation.\n",
     )
     copy_untracked_files(untracked, untracked_files_dir, worktree)
 
     write_text(repro_dir / "README.md", build_readme(slug, worktree, branch, commit, args.base_ref, base_commit, status, untracked))
-    write_text(repro_dir / "run.sh", build_run_script(), executable=True)
+    write_text(repro_dir / "run.sh", build_run_script(args.base_ref, base_commit), executable=True)
     write_text(input_dir / "README.md", "Put the complete Quokka input deck here, including every required parameter.\n")
     write_text(data_dir / "README.md", "Put required data tables and auxiliary input files here.\n")
     write_text(output_dir / "failure.log", "Paste the full failing terminal output here.\n")

--- a/scripts/python/create_bug_reproducer.py
+++ b/scripts/python/create_bug_reproducer.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_git(worktree: Path, args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def git_output(worktree: Path, args: list[str]) -> str:
+    return run_git(worktree, args).stdout.strip()
+
+
+def sanitize_slug(text: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", text.strip()).strip("-._")
+    if not slug:
+        raise ValueError("description must contain at least one alphanumeric character")
+    return slug
+
+
+def ensure_quokka_worktree(path: Path) -> Path:
+    worktree = path.resolve()
+    try:
+        root = Path(git_output(worktree, ["rev-parse", "--show-toplevel"])).resolve()
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"{worktree} is not inside a git worktree: {exc.stderr.strip()}") from exc
+
+    if not (root / "src" / "QuokkaSimulation.hpp").exists() or not (root / "scripts" / "bash" / "quokka").exists():
+        raise RuntimeError(f"{root} does not look like a Quokka worktree")
+    return root
+
+
+def write_text(path: Path, content: str, *, executable: bool = False) -> None:
+    path.write_text(content, encoding="utf-8")
+    if executable:
+        path.chmod(0o755)
+
+
+def copy_files(files: list[Path], destination: Path, worktree: Path) -> None:
+    for source in files:
+        source_path = source if source.is_absolute() else worktree / source
+        if not source_path.exists():
+            raise FileNotFoundError(f"{source_path} does not exist")
+        if source_path.is_dir():
+            target = destination / source_path.name
+            shutil.copytree(source_path, target, dirs_exist_ok=True)
+        else:
+            target = destination / source_path.name
+            shutil.copy2(source_path, target)
+
+
+def copy_untracked_files(paths: list[str], destination: Path, worktree: Path) -> None:
+    if not paths:
+        return
+    for path in paths:
+        source = worktree / path
+        if not source.is_file():
+            continue
+        target = destination / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, target)
+
+
+def get_untracked_files(worktree: Path) -> list[str]:
+    output = git_output(worktree, ["ls-files", "--others", "--exclude-standard"])
+    return [line for line in output.splitlines() if line.strip()]
+
+
+def find_base_commit(worktree: Path, base_ref: str) -> str:
+    try:
+        run_git(worktree, ["rev-parse", "--verify", base_ref])
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"base ref {base_ref!r} was not found; fetch the official Quokka remote or pass --base-ref"
+        ) from exc
+    return git_output(worktree, ["merge-base", "HEAD", base_ref])
+
+
+def build_readme(
+    slug: str,
+    worktree: Path,
+    branch: str,
+    commit: str,
+    base_ref: str,
+    base_commit: str,
+    status: str,
+    untracked: list[str],
+) -> str:
+    untracked_text = "\n".join(f"- `{path}`" for path in untracked) if untracked else "- None detected."
+    status_text = status if status else "Clean worktree."
+    return f"""# Quokka bug reproducer: {slug}
+
+## Summary
+
+Describe the bug in one or two paragraphs.
+
+## Expected behavior
+
+Describe what should have happened.
+
+## Observed behavior
+
+Describe what happened instead. Include whether the failure is deterministic.
+
+## How to run
+
+```bash
+bash run.sh
+```
+
+## Source checkout used to create this reproducer
+
+- Quokka worktree: `{worktree}`
+- Branch: `{branch}`
+- Commit: `{commit}`
+- Patch base ref: `{base_ref}`
+- Patch base commit: `{base_commit}`
+
+## Platform
+
+- Host or cluster:
+- Operating system:
+- Compiler and version:
+- MPI implementation and version:
+- GPU backend and hardware, if any:
+- Build preset or CMake command:
+
+## Reduction notes
+
+- Smallest domain size tested:
+- Smallest MPI rank count tested:
+- First failing timestep:
+- Does it fail every time?
+- What was removed from the original production case?
+
+## Included files
+
+- `run.sh`: edit this to configure, build, and run the failing case.
+- `input/`: complete input deck(s).
+- `data/`: required tables and auxiliary input files.
+- `patches/quokka.patch`: code modifications from `git diff {base_commit} --binary`.
+- `output/failure.log`: full output from the failing run.
+- `output/expected.txt`: short expected-result note.
+
+## Worktree status at creation time
+
+```text
+{status_text}
+```
+
+## Untracked files copied separately
+
+{untracked_text}
+"""
+
+
+def build_run_script() -> str:
+    return """#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# Edit these values before uploading the reproducer.
+QUOKKA_ROOT="${QUOKKA_ROOT:-${SCRIPT_DIR}/../quokka}"
+PRESET="${PRESET:-3d}"
+PROBLEM="${PROBLEM:-MyProblem}"
+INPUT="${INPUT:-${SCRIPT_DIR}/input/MyProblem.toml}"
+MPI_RANKS="${MPI_RANKS:-1}"
+
+cd "${QUOKKA_ROOT}"
+
+# Apply local code changes if this reproducer includes any.
+# The patch was generated relative to the base commit recorded in README.md.
+if [[ -s "${SCRIPT_DIR}/patches/quokka.patch" ]]; then
+  git apply --check "${SCRIPT_DIR}/patches/quokka.patch"
+  git apply "${SCRIPT_DIR}/patches/quokka.patch"
+fi
+
+# Restore untracked files that cannot be represented by git diff.
+if [[ -d "${SCRIPT_DIR}/patches/untracked-files" ]]; then
+  cp -R "${SCRIPT_DIR}/patches/untracked-files/." .
+fi
+
+./scripts/bash/quokka config -d "${PRESET}"
+./scripts/bash/quokka build -d "${PRESET}" "${PROBLEM}"
+
+mpirun -np "${MPI_RANKS}" "./build/${PRESET}/src/problems/${PROBLEM}/${PROBLEM}" "${INPUT}"
+"""
+
+
+def create_reproducer(args: argparse.Namespace) -> Path:
+    worktree = ensure_quokka_worktree(args.worktree)
+    slug = sanitize_slug(args.description)
+    repro_dir = args.output_dir.resolve() / f"quokka-reproducer-{slug}"
+    untracked_files_dir = repro_dir / "patches" / "untracked-files"
+
+    if repro_dir.exists():
+        if not args.force:
+            raise FileExistsError(f"{repro_dir} already exists; pass --force to overwrite it")
+        shutil.rmtree(repro_dir)
+
+    branch = git_output(worktree, ["branch", "--show-current"]) or "(detached HEAD)"
+    commit = git_output(worktree, ["rev-parse", "HEAD"])
+    base_commit = find_base_commit(worktree, args.base_ref)
+    status = git_output(worktree, ["status", "--short"])
+    untracked = get_untracked_files(worktree)
+
+    input_dir = repro_dir / "input"
+    data_dir = repro_dir / "data"
+    patches_dir = repro_dir / "patches"
+    output_dir = repro_dir / "output"
+    for directory in (input_dir, data_dir, patches_dir, output_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    diff = run_git(worktree, ["diff", base_commit, "--binary"]).stdout
+    write_text(patches_dir / "quokka.patch", diff)
+    write_text(
+        patches_dir / "README.md",
+        f"quokka.patch was generated with: git diff {base_commit} --binary\n"
+        f"Base ref used to find that commit: {args.base_ref}\n"
+        "Place additional patch notes here if the diff needs explanation.\n",
+    )
+    copy_untracked_files(untracked, untracked_files_dir, worktree)
+
+    write_text(repro_dir / "README.md", build_readme(slug, worktree, branch, commit, args.base_ref, base_commit, status, untracked))
+    write_text(repro_dir / "run.sh", build_run_script(), executable=True)
+    write_text(input_dir / "README.md", "Put the complete Quokka input deck here, including every required parameter.\n")
+    write_text(data_dir / "README.md", "Put required data tables and auxiliary input files here.\n")
+    write_text(output_dir / "failure.log", "Paste the full failing terminal output here.\n")
+    write_text(output_dir / "expected.txt", "Describe the expected result here.\n")
+
+    copy_files(args.input, input_dir, worktree)
+    copy_files(args.data, data_dir, worktree)
+
+    return repro_dir
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Create a skeleton self-contained Quokka bug reproducer directory.",
+    )
+    parser.add_argument(
+        "description",
+        help="Short description used in the directory name, e.g. dtypefront-pil-crash",
+    )
+    parser.add_argument(
+        "--worktree",
+        type=Path,
+        default=Path("."),
+        help="Quokka worktree to capture a patch from (default: current directory)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("."),
+        help="Directory where the reproducer directory is created (default: current directory)",
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        action="append",
+        default=[],
+        help="Input file or directory to copy into input/; may be passed multiple times",
+    )
+    parser.add_argument(
+        "--data",
+        type=Path,
+        action="append",
+        default=[],
+        help="Data file or directory to copy into data/; may be passed multiple times",
+    )
+    parser.add_argument(
+        "--base-ref",
+        default="origin/development",
+        help="Official Quokka development ref used to find the patch base (default: origin/development)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing reproducer directory with the same name",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        repro_dir = create_reproducer(args)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"created {repro_dir}")
+    print("edit README.md, run.sh, input/, data/, and output/ before uploading")
+    print(f"after reviewing the contents: tar -czf {repro_dir.name}.tar.gz {repro_dir.name}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Description
Add a "how-to" guide for writing bug reports that include complete, minimal, and reliable reproducers.

This maximizes the chance that developers will be able to reproduce the reported bug on their machines without time-consuming back and forth discussion between the bug reporter and the developer.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
