### PR TITLE
Reduce nx in ThermalConduction 

### DIFF
--- a/src/problems/ThermalConduction/testThermalConduction.cpp
+++ b/src/problems/ThermalConduction/testThermalConduction.cpp
@@ -190,8 +190,8 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 	quokka::richardson::Parameters params{};
 	params.machine_precision_target = 2.0e-9; // limit based on delta_b_magn, smaller values can be used if this is decreased
-	params.nx_initial = 64;
-	params.nx_max = 256;
+	params.nx_initial = 32;
+	params.nx_max = 128;
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Thermal Conduction";


### PR DESCRIPTION
### Description
**Trivial to review**

Reduce nx of the ThermalConduction test by 2x so that its runtime drops from 600 sec to 27 sec. 

### Related issues
GPU CI is very slow; the `ThermalConduction` CI takes the longest time. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
