### PR TITLE
docs: add --single-branch to git clone in installation guide

### DIFF
--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -6,7 +6,9 @@ This instruction works on both Linux and macOS. If you come across any issues on
 
 To run Quokka, download this repository and its submodules to your local machine:
 
-    git clone --recursive https://github.com/quokka-astro/quokka.git
+    git clone --branch development --single-branch --recursive https://github.com/quokka-astro/quokka.git
+
+The ``--branch development`` option selects the main development branch, and ``--single-branch`` fetches only the history of that branch. Quokka has a large number of development branches, so omitting ``--single-branch`` would clone the full history of all branches, which can be significantly slower.
 
 Quokka uses CMake (and optionally, Ninja) as its build system. If you don't have CMake and Ninja installed, the easiest way to install them is to run:
 


### PR DESCRIPTION
### Description
Speed up the initial `git clone` by adding `--branch development --single-branch` to the clone command in the installation guide. Quokka has many branches, and cloning the full history of all branches is significantly slower than a single-branch clone.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
