### PR TITLE
Extend Richardson: support N-dim refinement via refine_n_dims

### DIFF
--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -360,7 +360,7 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::Mult
 	}
 }
 
-auto runWaveTest(int nx) -> double
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
 	amrex::ParmParse const hpp("setup");
@@ -383,9 +383,11 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
-	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort(
-		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	if (num_modes_y != 0 && ny == 8) {
+		amrex::Abort("num_modes_y != 0 requires refine_n_dims >= 2 to converge.");
+	}
+	if (num_modes_z != 0 && nz == 8) {
+		amrex::Abort("num_modes_z != 0 requires refine_n_dims >= 3 to converge.");
 	}
 
 	// we assume box length = 1.0
@@ -414,17 +416,11 @@ auto runWaveTest(int nx) -> double
 
 	// Set grid dimensions using AMReX parameter system
 	amrex::ParmParse pp("amr");
-	amrex::Vector<int> const ncells = {nx, 8, 8};
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 	pp.addarr("n_cell", ncells);
 
-	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", 16);
-	}
-	if (!pp.contains("blocking_factor_y")) {
-		pp.add("blocking_factor_y", 8);
-	}
-	if (!pp.contains("blocking_factor_z")) {
-		pp.add("blocking_factor_z", 8);
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
 	}
 
 	if (!pp.contains("max_grid_size")) {
@@ -480,11 +476,12 @@ auto problem_main() -> int
 		amrex::ParmParse const pp("setup");
 		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
+		pp.query("refine_n_dims", params.refine_n_dims);
 	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Alfven Wave";
 	params.csv_filename = "alfven_wave_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runWaveTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); });
 }

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -296,7 +296,7 @@ void QuokkaSimulation<EntropyWaveLinear>::computeReferenceSolution_fc(amrex::Mul
 	}
 }
 
-auto runWaveTest(int nx) -> double
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
 	amrex::ParmParse const hpp("setup");
@@ -344,25 +344,15 @@ auto runWaveTest(int nx) -> double
 
 	// Set grid dimensions using AMReX parameter system
 	amrex::ParmParse pp("amr");
-	amrex::Vector<int> const ncells = {nx, 8, 8};
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 	pp.addarr("n_cell", ncells);
 
-	int blocking_x = std::max(16, ncells[0]);
-	pp.query("blocking_factor_x", blocking_x);
-	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", blocking_x);
-	}
-	if (!pp.contains("blocking_factor_y")) {
-		pp.add("blocking_factor_y", 8);
-	}
-	if (!pp.contains("blocking_factor_z")) {
-		pp.add("blocking_factor_z", 8);
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
 	}
 
-	int max_grid_x = ncells[0];
-	pp.query("max_grid_size", max_grid_x);
 	if (!pp.contains("max_grid_size")) {
-		pp.add("max_grid_size", max_grid_x);
+		pp.add("max_grid_size", 128);
 	}
 
 	pp.add("max_level", 0);
@@ -407,13 +397,19 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 
 	quokka::richardson::Parameters params{};
-	params.machine_precision_target = 2.0e-9; // limit based on delta_rho_magn
+	params.machine_precision_target = 2.0e-9; // default; set to 0 via setup.machine_precision_target to disable early exit.
 	params.nx_initial = 16;
-	params.nx_max = 128;
+	params.nx_max = 128; // default; override with setup.nx_max in the input file.
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("machine_precision_target", params.machine_precision_target);
+		pp.query("nx_max", params.nx_max);
+		pp.query("refine_n_dims", params.refine_n_dims);
+	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Entropy Wave";
 	params.csv_filename = "entropy_wave_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runWaveTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); });
 }

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -318,6 +318,13 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
+	if (num_modes_y != 0 && ny == 8) {
+		amrex::Abort("num_modes_y != 0 requires refine_n_dims >= 2 to converge.");
+	}
+	if (num_modes_z != 0 && nz == 8) {
+		amrex::Abort("num_modes_z != 0 requires refine_n_dims >= 3 to converge.");
+	}
+
 	// we assume box length = 1.0
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -411,7 +411,7 @@ void QuokkaSimulation<FastWaveConvergence>::computeReferenceSolution_fc(amrex::M
 	}
 }
 
-auto runWaveTest(int nx) -> double
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
 	amrex::ParmParse const hpp("setup");
@@ -438,9 +438,11 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
-	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort(
-		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	if (num_modes_y != 0 && ny == 8) {
+		amrex::Abort("num_modes_y != 0 requires refine_n_dims >= 2 to converge.");
+	}
+	if (num_modes_z != 0 && nz == 8) {
+		amrex::Abort("num_modes_z != 0 requires refine_n_dims >= 3 to converge.");
 	}
 
 	// we assume box length = 1.0
@@ -469,16 +471,10 @@ auto runWaveTest(int nx) -> double
 
 	// Set grid dimensions using AMReX parameter system
 	amrex::ParmParse pp("amr");
-	amrex::Vector<int> const ncells = {nx, 8, 8};
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 
-	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", 16);
-	}
-	if (!pp.contains("blocking_factor_y")) {
-		pp.add("blocking_factor_y", 8);
-	}
-	if (!pp.contains("blocking_factor_z")) {
-		pp.add("blocking_factor_z", 8);
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
 	}
 
 	if (!pp.contains("max_grid_size")) {
@@ -535,11 +531,12 @@ auto problem_main() -> int
 		amrex::ParmParse const pp("setup");
 		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
+		pp.query("refine_n_dims", params.refine_n_dims);
 	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Fast Wave";
 	params.csv_filename = "fast_wave_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runWaveTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); });
 }

--- a/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
+++ b/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
@@ -90,7 +90,7 @@ template <> void QuokkaSimulation<WaveProblem>::setInitialConditionsOnGrid(quokk
 	});
 }
 
-auto runWaveTest(int nx) -> double
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Problem parameters
 	const double CFL_number = 0.1;
@@ -109,12 +109,14 @@ auto runWaveTest(int nx) -> double
 
 	// Set grid dimensions using AMReX parameter system
 	amrex::ParmParse pp("amr");
-	amrex::Vector<int> const ncells = {nx, 8, 8};
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 	pp.add("max_level", 0);
-	pp.add("blocking_factor_x", nx);
-	pp.add("blocking_factor_y", 8);
-	pp.add("blocking_factor_z", 8);
-	pp.add("max_grid_size", nx);
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
+	}
+	if (!pp.contains("max_grid_size")) {
+		pp.add("max_grid_size", 128);
+	}
 	pp.addarr("n_cell", ncells);
 
 	// Set domain bounds using AMReX parameter system
@@ -168,13 +170,19 @@ auto problem_main() -> int
 	quokka::richardson::applyQuietDefaults();
 
 	quokka::richardson::Parameters params{};
-	params.machine_precision_target = 2.0e-11; // limit based on delta_rho_magn
+	params.machine_precision_target = 2.0e-11; // default; set to 0 via setup.machine_precision_target to disable early exit.
 	params.nx_initial = 128;
-	params.nx_max = 2048;
+	params.nx_max = 2048; // default; override with setup.nx_max in the input file.
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("machine_precision_target", params.machine_precision_target);
+		pp.query("nx_max", params.nx_max);
+		pp.query("refine_n_dims", params.refine_n_dims);
+	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Hydro Wave";
 	params.csv_filename = "hydro_wave_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runWaveTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); });
 }

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -420,7 +420,7 @@ void QuokkaSimulation<SlowWaveConvergence>::computeReferenceSolution_fc(amrex::M
 	}
 }
 
-auto runWaveTest(int nx) -> double
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
 	amrex::ParmParse const hpp("setup");
@@ -447,9 +447,11 @@ auto runWaveTest(int nx) -> double
 		amrex::Abort("Invalid k modes: the triplet (0,0,0) is not allowed.");
 	}
 
-	if (num_modes_y != 0 || num_modes_z != 0) {
-		amrex::Abort(
-		    "Oblique modes are not supported: Richardson only refines nx, so transverse resolution is fixed and oblique waves will not converge.");
+	if (num_modes_y != 0 && ny == 8) {
+		amrex::Abort("num_modes_y != 0 requires refine_n_dims >= 2 to converge.");
+	}
+	if (num_modes_z != 0 && nz == 8) {
+		amrex::Abort("num_modes_z != 0 requires refine_n_dims >= 3 to converge.");
 	}
 
 	// we assume box length = 1.0
@@ -478,16 +480,10 @@ auto runWaveTest(int nx) -> double
 
 	// Set grid dimensions using AMReX parameter system
 	amrex::ParmParse pp("amr");
-	amrex::Vector<int> const ncells = {nx, 8, 8};
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 
-	if (!pp.contains("blocking_factor_x")) {
-		pp.add("blocking_factor_x", 16);
-	}
-	if (!pp.contains("blocking_factor_y")) {
-		pp.add("blocking_factor_y", 8);
-	}
-	if (!pp.contains("blocking_factor_z")) {
-		pp.add("blocking_factor_z", 8);
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
 	}
 
 	if (!pp.contains("max_grid_size")) {
@@ -544,11 +540,12 @@ auto problem_main() -> int
 		amrex::ParmParse const pp("setup");
 		pp.query("machine_precision_target", params.machine_precision_target);
 		pp.query("nx_max", params.nx_max);
+		pp.query("refine_n_dims", params.refine_n_dims);
 	}
 	params.expected_rate = 2.0;
 	params.tolerance = 0.3;
 	params.test_name = "Slow Wave";
 	params.csv_filename = "slow_wave_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runWaveTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); });
 }

--- a/src/problems/ThermalConduction/testThermalConduction.cpp
+++ b/src/problems/ThermalConduction/testThermalConduction.cpp
@@ -136,7 +136,7 @@ void QuokkaSimulation<ThermalConductionProblem>::computeReferenceSolution(amrex:
 	}
 }
 
-auto runConductionTest(int nx) -> double
+auto runConductionTest(int nx, int /*ny*/, int /*nz*/) -> double
 {
 	// Read problem parameters
 	const double max_time = 469054.0075444166; // 1 conduction time
@@ -197,5 +197,5 @@ auto problem_main() -> int
 	params.test_name = "Thermal Conduction";
 	params.csv_filename = "thermal_conduction_convergence.csv";
 
-	return quokka::richardson::run(params, [](int nx) { return runConductionTest(nx); });
+	return quokka::richardson::run(params, [](int nx, int ny, int nz) { return runConductionTest(nx, ny, nz); });
 }

--- a/src/util/richardson.hpp
+++ b/src/util/richardson.hpp
@@ -26,6 +26,7 @@ struct Parameters {
 	double machine_precision_target = 0.0;
 	int nx_initial = 0;
 	int nx_max = 0;
+	int refine_n_dims = 1;
 	double expected_rate = 2.0;
 	double tolerance = 0.3;
 	std::string test_name;
@@ -62,7 +63,9 @@ template <typename Callable> auto run(const Parameters &params, Callable &&runTe
 	amrex::Print() << "----------\t----------\n";
 
 	for (int nx = params.nx_initial; nx <= params.nx_max; nx *= 2) {
-		double error = std::forward<Callable>(runTest)(nx);
+		const int ny = (params.refine_n_dims >= 2) ? nx : 8;
+		const int nz = (params.refine_n_dims >= 3) ? nx : 8;
+		double error = std::forward<Callable>(runTest)(nx, ny, nz);
 		amrex::ParallelDescriptor::Bcast(&error, 1, amrex::ParallelDescriptor::IOProcessorNumber());
 
 		resolutions.push_back(nx);

--- a/src/util/richardson.hpp
+++ b/src/util/richardson.hpp
@@ -62,6 +62,10 @@ template <typename Callable> auto run(const Parameters &params, Callable &&runTe
 	amrex::Print() << "Resolution\tError Norm\n";
 	amrex::Print() << "----------\t----------\n";
 
+	if (params.refine_n_dims < 1 || params.refine_n_dims > 3) {
+		amrex::Abort("refine_n_dims must be 1, 2, or 3.");
+	}
+
 	for (int nx = params.nx_initial; nx <= params.nx_max; nx *= 2) {
 		const int ny = (params.refine_n_dims >= 2) ? nx : 8;
 		const int nz = (params.refine_n_dims >= 3) ? nx : 8;


### PR DESCRIPTION
### Description

This PR extends the Richardson convergence infrastructure to work in 2D and 3D setups, by adding `refine_n_dims` (default: 1) to `quokka::richardson::Parameters`. When set to 2 or 3, the harness sets `ny = nx` and `nz = nx`, so that resolution sweeps on square and cubic domains can be run. The default behaviour remains unchanged, since `refine_n_dims = 1` by default.

All five convergence tests are updated to accept `(nx, ny, nz)`, read `setup.refine_n_dims` from the input TOML, and pass the correct grid dimensions to AMReX. Guards are also added to the MHD tests to prevent oblique waves from being set up in domains that would not support them. `HydroWaveConvergence` and `EntropyWaveConvergence` also gain full TOML runtime param support (`setup.machine_precision_target`, `setup.nx_max`, `setup.refine_n_dims`). For simplicity, the blocking factors in spatial dimensions are unified to `amr.blocking_factor = 8` for all five convergence tests.

### Related issues

- #1958: this PR implements the proposal described there.
- #1916: this PR is a prerequisite; the harness needs an explicit notion of domain dimensionality before correctness and convergence tests can be consolidated.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.