### PR TITLE
Fix EMF averaging: gather edge wave speeds from straddling faces

### DIFF
--- a/src/hydro/mhd_system.hpp
+++ b/src/hydro/mhd_system.hpp
@@ -735,10 +735,10 @@ void MHDSystem<problem_t>::EMFAverage_LondrilloDelZanna2004(amrex::Array4<amrex:
 
 	amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		// 	// LondrilloDelZanna2004 scheme:
-		const double a0_m = std::max(fspd_x0(i, j, k, 0), fspd_x0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 0));
-		const double a0_p = std::max(fspd_x0(i, j, k, 1), fspd_x0(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 1));
-		const double a1_m = std::max(fspd_x1(i, j, k, 0), fspd_x1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 0));
-		const double a1_p = std::max(fspd_x1(i, j, k, 1), fspd_x1(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 1));
+		const double a0_m = std::max(fspd_x0(i, j, k, 0), fspd_x0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2], 0));
+		const double a0_p = std::max(fspd_x0(i, j, k, 1), fspd_x0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2], 1));
+		const double a1_m = std::max(fspd_x1(i, j, k, 0), fspd_x1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2], 0));
+		const double a1_p = std::max(fspd_x1(i, j, k, 1), fspd_x1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2], 1));
 
 		const double E2_q0_ = E2_q0(i, j, k);
 		const double E2_q1_ = E2_q1(i, j, k);
@@ -803,10 +803,10 @@ void MHDSystem<problem_t>::EMFAverage_Balsara2025(amrex::Array4<amrex::Real> E2_
 
 	amrex::ParallelFor(box_ec, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		// Wave speeds
-		const double SL = -std::max(fspd_x0(i, j, k, 0), fspd_x0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 0));
-		const double SR = std::max(fspd_x0(i, j, k, 1), fspd_x0(i + delta_w1[0], j + delta_w1[1], k + delta_w1[2], 1));
-		const double SD = -std::max(fspd_x1(i, j, k, 0), fspd_x1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 0));
-		const double SU = std::max(fspd_x1(i, j, k, 1), fspd_x1(i + delta_w0[0], j + delta_w0[1], k + delta_w0[2], 1));
+		const double SL = -std::max(fspd_x0(i, j, k, 0), fspd_x0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2], 0));
+		const double SR = std::max(fspd_x0(i, j, k, 1), fspd_x0(i - delta_w1[0], j - delta_w1[1], k - delta_w1[2], 1));
+		const double SD = -std::max(fspd_x1(i, j, k, 0), fspd_x1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2], 0));
+		const double SU = std::max(fspd_x1(i, j, k, 1), fspd_x1(i - delta_w0[0], j - delta_w0[1], k - delta_w0[2], 1));
 
 		// EMF quadrants
 		const auto E2_LD = E2_q0(i, j, k);


### PR DESCRIPTION
### Description

Both `EMFAverage_LondrilloDelZanna2004` and `EMFAverage_Balsara2025` gather edge-centred wave speeds by taking the max of the face speed at the edge node and a neighbouring face. In both routines the offset pointed in the wrong direction: `ld04` offset along the parallel axis and `b25` along the transverse axis but with the wrong sign. The fix reads the face on the opposite side of the edge node in the transverse direction in both cases, which is the correct straddle and is covariant under point reflection.

I confirmed that this fix does not affect the correctness of any MHD behaviour: the Alfvén wave converges for both `q26+ld04` and `q26+b25`, the Brio-Wu shock tube passes, and most importantly, the Orszag-Tang problem now produces point-symmetric solutions to floating-point precision for both EMF averaging schemes; I tested this for `q26+b25` and `fs17+ld04` at 1024×1024×8 on 4 A100 GPUs. Below I show slices of the current density at t=1, alongside a second version of the same plot with the numerical difference between the domain and its point-reflected counterpart overlaid.

(left panel is `fs17+ld04` and the right panel is `q26+b25`)
<img width="2355" height="1055" alt="ot-fix-cur" src="https://github.com/user-attachments/assets/d3ae4ee1-c383-4c8a-a77b-826fa6c7738a" />
<img width="2731" height="1097" alt="ot-fix" src="https://github.com/user-attachments/assets/60cb083f-8489-471f-9a7d-8e36f263d0f0" />


### Related issues

None.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.