### PR TITLE
fix: scale passive scalars on sink particle creation

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -320,7 +320,13 @@ AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int n
 	state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
-}
+	// scale passive scalars to conserve mass fractions
+	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
+		for (int n = 0; n < Physics_Traits<problem_t>::numPassiveScalars; ++n) {
+			state_arr(i, j, k, HydroSystem<problem_t>::scalar0_index + n) *= scale_factor;
+		}
+	}
+	}
 } // namespace SinkCreationHelpers
 
 // Specialization for Sink particles

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -326,7 +326,7 @@ AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int n
 			state_arr(i, j, k, HydroSystem<problem_t>::scalar0_index + n) *= scale_factor;
 		}
 	}
-	}
+}
 } // namespace SinkCreationHelpers
 
 // Specialization for Sink particles


### PR DESCRIPTION
### Description
Fix a bug where passive scalars were not scaled when sink particles are created, violating scalar mass fraction conservation. The fix scales passive scalar densities by the same factor used for momentum, energy, and internal energy.

When a sink particle is created in `SinkCreationHelpers::initializeSinkLikeParticles`, the cell gas density is reduced from `cell_density` to the Jeans density `rho_J`, and momentum, total energy, and internal energy are all scaled by `scale_factor = rho_J / cell_density`. However, passive scalars (stored as densities/partial densities) were left unchanged, artificially increasing their mass fraction in the cell.

This fix adds a `if constexpr` block (guarded by `numPassiveScalars > 0`) that scales all passive scalars by `scale_factor`. The same pattern is already used correctly in:
- `UpdateHydroState` during accretion (`particle_accretion.hpp:529-531`)
- `StochasticStellarPop` star-particle creation (`particle_creation.hpp:725-729`)

The fix only affects simulations with both `numPassiveScalars > 0` and sink particles enabled.

### Related issues
Closes #1967

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
