### PR TITLE
feat(photochem): add SetAtolFromPhysics to derive VODE atol from physical parameters

### DIFF
--- a/docs/markdown/photoionization.md
+++ b/docs/markdown/photoionization.md
@@ -1,0 +1,141 @@
+# Photoionization Module — VODE Tolerance Design
+
+## Overview
+
+Quokka uses VODE (via Microphysics) to integrate the chemistry and internal energy
+source terms. The integrator requires absolute tolerances (`atol`) for each solution
+variable. Rather than hand-tuning these tolerances, `SetAtolFromPhysics<problem_t>()`
+(in `src/radiation/photochem_atol.H`) derives them from high-level physical
+parameters specified in the input file.
+
+## Input parameters
+
+| Parameter                                         | Required | Default | Description                                                                              |
+| ------------------------------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------- |
+| `integrator.typical_n_H`                          | yes      | —       | Representative total H number density (cm⁻³)                                             |
+| `integrator.typical_minimal_radiation_T`          | yes      | —       | Typical temperature of the cold (neutral) gas in the domain (K). Sets the photon density below which radiation is numerically negligible. |
+| `integrator.desired_accuracy_on_T_at_typical_n_H` | no       | 1.0 K   | Desired temperature accuracy at `typical_n_H`                                            |
+| `integrator.spec_abundance_tol`                   | no       | 1e-5    | Species negligibility threshold, as a fraction of `typical_n_H`                          |
+| `integrator.radiation_failure_tolerance`          | no       | 0.05    | Maximum allowed negative photon number density (cm⁻³) before a burn is flagged as failed |
+
+The relative tolerances (`rtol_spec`, `rtol_enuc`, `rtol_rad_num`) are specified directly
+in the input file as usual.
+
+## Physical constants
+
+| Symbol     | Value                                  | Description                                                                                                    |
+| ---------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `a_rad`    | `7.5657e-15 erg cm⁻³ K⁻⁴`              | Radiation constant (from `fundamental_constants.H`)                                                            |
+| `k_B`      | `1.380649e-16 erg K⁻¹`                 | Boltzmann constant                                                                                             |
+| `m_p`      | `1.67262192e-24 g`                     | Proton mass                                                                                                    |
+| `c_v`      | `3/2 × k_B / m_p ≈ 1.24e8 erg g⁻¹ K⁻¹` | Specific heat of monatomic hydrogen gas                                                                        |
+| `E_photon` | problem-dependent                      | Midpoint energy of the first chemistry radiation band (erg), from `RadSystem<problem_t>::GetChemBandQuanta(0)` |
+
+## Derived atol values
+
+Let $T_{\rm min} \equiv$ `typical_minimal_radiation_T` for brevity.
+`SetAtolFromPhysics` computes:
+
+| Variable | Formula | Rationale |
+|---|---|---|
+| `atol_spec` | $\texttt{spec\_abundance\_tol} \times \texttt{typical\_n\_H}$ | Species below this fraction of $n_{\rm H}$ are negligible |
+| `atol_enuc` | $c_v \times \texttt{desired\_accuracy\_on\_T\_at\_typical\_n\_H}$ | Converts temperature accuracy to internal energy tolerance ($c_v = \tfrac{3}{2} k_B / m_p$) |
+| `atol_rad_num` | $10^{-6} \times a_{\rm rad} \times T_{\rm min}^4 / E_{\rm photon}$ | One millionth of the blackbody photon density at $T_{\rm min}$ — radiation below this is negligible |
+
+The `radiation_failure_tolerance` (default 0.05 cm⁻³) and `species_failure_tolerance`
+(see §10) are not derived by `SetAtolFromPhysics`; they are set independently.
+
+## The $10^{-6}$ prefactor
+
+The factor $10^{-6}$ in `atol_rad_num` has a specific physical meaning:
+
+- It sets the tolerance to 1 part per million of the blackbody photon density at $T_{\rm min}$.
+- After roughly $10^6$ VODE steps, the accumulated local error in photon number remains
+  below the physically meaningful radiation level at the minimum temperature.
+- Cells with radiation below this threshold are considered "dark" and VODE
+  returns in a single BDF step.
+
+## radiation_failure_tolerance
+
+This is a **physical guard**, not a numerical tolerance. It defines the maximum allowed
+negative photon number density (cm⁻³) before a burn is declared failed — at most this
+many spurious photons can be "created from nothing" by VODE's Newton overshoot.
+
+Whether this matters depends on two regimes:
+
+1. **Bright cells** ($N_\gamma \gtrsim n_{\rm H}$): the cell is fully ionized. A few
+   percent error in photon count does not change the outcome.
+2. **Dark cells** ($N_\gamma \ll n_{\rm H}$): the spurious ionization is at most
+   $\texttt{radiation\_failure\_tolerance} / n_{\rm H}$. If this ratio is $\ll 1\%$,
+   it is negligible.
+
+The default of 0.05 cm⁻³ is appropriate for galactic disk or GMC environments, where the
+typical ionized gas density is ~10²–10⁴ cm⁻³ (ratio ≤ 5×10⁻⁴). For low-density environments
+such as the CGM or IGM, where the ionized gas density can be ~10⁻⁴–10⁻³ cm⁻³, this
+default competes with the physical ionization equilibrium — override it in the input file.
+
+**Rule of thumb:** set `radiation_failure_tolerance` to at least two orders of magnitude
+below the **typical density of ionized gas** in the problem. This ensures that spurious
+photon creation cannot measurably affect the ionization fraction. The value does not
+scale with `atol_rad_num` because the Newton overshoot in the stiff radiation-chemistry
+system has a floor independent of the tolerance.
+
+## Relationship between `Erad_floor` and `typical_minimal_radiation_T`
+
+These are two distinct parameters that serve different purposes:
+
+| Parameter                     | Where set                                             | Purpose                                                                                                 |
+| ----------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `Erad_floor`                  | `constexpr` in `RadSystem_Traits<problem_t>`          | M1 hyperbolic solver floor — prevents the radiation moment solver from encountering zero energy density |
+| `typical_minimal_radiation_T` | Input file (`integrator.typical_minimal_radiation_T`) | VODE tolerance — set to the typical temperature of the cold (neutral) gas in the domain |
+
+Define the equivalent floor temperature $T_{\rm floor}$ by $E_{\rm rad, floor} \equiv a_{\rm rad} T_{\rm floor}^4$.
+The photon number density at the floor is $N_{\gamma,{\rm floor}} = E_{\rm rad, floor} / E_{\rm photon}$.
+
+Dark cells (where $E_{\rm rad} \approx E_{\rm rad, floor}$) converge in one VODE step when
+$\texttt{atol\_rad\_num} \gg N_{\gamma,{\rm floor}}$.  Since $E_{\rm photon}$ cancels,
+the ratio simplifies to a function of the two temperatures alone:
+
+$$
+\frac{\texttt{atol\_rad\_num}}{N_{\gamma,{\rm floor}}}
+= \frac{10^{-6} \, a_{\rm rad} \, T_{\rm min}^4 / E_{\rm photon}}
+       {a_{\rm rad} \, T_{\rm floor}^4 / E_{\rm photon}}
+= 10^{-6} \left( \frac{T_{\rm min}}{T_{\rm floor}} \right)^{\!4}.
+$$
+
+A ratio of $\geq 10^4$ is sufficient, which requires $T_{\rm floor} \leq T_{\rm min} / 316$.
+
+**Example (DTypeFront):** $T_{\rm min} = 10\ {\rm K}$, $E_{\rm rad, floor} = a_{\rm rad} (0.01\ {\rm K})^4$ → $T_{\rm floor} = 0.01\ {\rm K}$.
+Ratio = $10^{-6} \times (10 / 0.01)^4 = 10^6$ ✓.
+
+## Mutual exclusivity
+
+The `integrator.typical_*` parameters and hand-tuned `integrator.atol_*` parameters
+are **mutually exclusive** — using both triggers an error. Specifying neither also
+triggers an error, because VODE's built-in defaults ($\sim 10^{-10}$) are unusably
+tight for photochemistry and will cause the integrator to stall.
+
+## Setting up a new problem
+
+1. Set `Erad_floor` in `RadSystem_Traits<problem_t>` to a blackbody temperature low
+   enough that it does not produce spurious ionization (typical: $0.01$–$1$ K).
+2. Choose `typical_n_H` as the representative hydrogen density of the problem.
+3. Choose `typical_minimal_radiation_T` as the typical temperature of the cold
+   (neutral) gas in the domain.
+4. Check $10^{-6} \, (T_{\rm min} / T_{\rm floor})^4 \geq 10^4$, i.e.
+   $T_{\rm floor} \leq T_{\rm min} / 316$.
+   If this fails, either lower `Erad_floor` or raise `typical_minimal_radiation_T`.
+5. The $10^{-6}$ prefactor and `desired_accuracy_on_T_at_typical_n_H = 1.0 K$ are
+   reasonable defaults for most problems.
+
+## `species_failure_tolerance`
+
+VODE's internal step uses `species_failure_tolerance` directly; the final interpolated
+state uses $1.5 \times$ `species_failure_tolerance` (via
+`vode_final_state_species_failure_tolerance_factor` in `vode_type.H`). This accounts
+for VODE's non-monotonic interpolation back to the output time, preventing false
+burn failures from interpolation noise.
+
+When using `SetAtolFromPhysics`, set `integrator.species_failure_tolerance` equal to
+`atol_spec` (the species negligibility floor). The $1.5\times$ final-state factor
+absorbs BDF interpolation overshoot without manual inflation.

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -78,6 +78,7 @@ namespace filesystem = experimental::filesystem;
 #include "hyperbolic_system.hpp"
 #include "physics_info.hpp"
 #include "physics_numVars.hpp"
+#include "radiation/photochem_atol.H"
 #include "radiation/photochemistry.hpp"
 #include "radiation/radiation_system.hpp"
 #include "simulation.hpp"
@@ -268,6 +269,11 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 		// set gamma
 		amrex::ParmParse eos("eos");
 		eos.add("eos_gamma", quokka::EOS_Traits<problem_t>::gamma);
+#ifdef PHOTOCHEMISTRY
+		// if integrator.typical_* keys are present, derive atol values and inject them into
+		// ParmParse before init_extern_parameters() reads integrator.atol_*
+		quokka::photochemistry::SetAtolFromPhysics<problem_t>();
+#endif
 		// initialize Microphysics params
 		init_extern_parameters();
 #if defined(PHOTOCHEMISTRY) || defined(CHEMISTRY)

--- a/src/radiation/photochem_atol.H
+++ b/src/radiation/photochem_atol.H
@@ -1,0 +1,126 @@
+#ifndef PHOTOCHEM_ATOL_H_ // NOLINT
+#define PHOTOCHEM_ATOL_H_
+
+#include <cmath>
+
+#include "AMReX.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Print.H"
+
+#include "fundamental_constants.H"
+#include "radiation/radiation_system.hpp"
+
+#ifdef PHOTOCHEMISTRY
+
+namespace quokka::photochemistry
+{
+
+namespace detail
+{
+// Returns true if any integrator.typical_* key appears in the toml
+auto hasTypicalParams() -> bool
+{
+	amrex::ParmParse const pp("integrator");
+	return pp.contains("typical_n_H") || pp.contains("typical_minimal_radiation_T") || pp.contains("desired_accuracy_on_T_at_typical_n_H") ||
+	       pp.contains("spec_abundance_tol");
+}
+
+// Returns true if any integrator.atol_* key appears explicitly in the toml
+auto hasRawAtolParams() -> bool
+{
+	amrex::ParmParse const pp("integrator");
+	return pp.contains("atol_spec") || pp.contains("atol_enuc") || pp.contains("atol_rad_num");
+}
+} // namespace detail
+
+// SetAtolFromPhysics: derive VODE absolute tolerances from physical scales and inject them
+// into ParmParse so init_extern_parameters() picks them up.
+//
+// Call between readParmParse() and init_extern_parameters() in QuokkaSimulation::Initialize().
+// Aborts when neither integrator.typical_* nor integrator.atol_* keys appear in the toml —
+// VODE's built-in defaults (~1e-10) are unusably tight for photochemistry and will cause
+// the integrator to stall.
+//
+// Note: Erad_floor (the M1 radiation floor) is a compile-time constexpr in RadSystem_Traits
+// and is set independently in each problem's specialization. typical_minimal_radiation_T only
+// controls the VODE tolerance, not Erad_floor.
+//
+// radiation_failure_tolerance defaults to 0.05 cm^-3 (physical guard against negative photon
+// density) — overridable in the toml. See docs/markdown/photoionization.md.
+template <typename problem_t> void SetAtolFromPhysics()
+{
+	if (!detail::hasTypicalParams() && !detail::hasRawAtolParams()) {
+		amrex::Abort("No integrator tolerances specified. Either set integrator.typical_* (recommended) "
+			     "or integrator.atol_* parameters. VODE's built-in defaults (~1e-10) are unusably "
+			     "tight for photochemistry and will cause the integrator to stall. "
+			     "See docs/markdown/photoionization.md.");
+	}
+	if (detail::hasTypicalParams() && detail::hasRawAtolParams()) {
+		amrex::Abort("integrator.typical_* and integrator.atol_* are mutually exclusive. Remove one set.");
+	}
+
+	if (!detail::hasTypicalParams()) {
+		return; // user chose hand-tuned atol_*; nothing to derive
+	}
+
+	amrex::ParmParse const pp("integrator");
+
+	if (!pp.contains("typical_n_H")) {
+		amrex::Abort("integrator.typical_n_H is required when using integrator.typical_* parameters.");
+	}
+	if (!pp.contains("typical_minimal_radiation_T")) {
+		amrex::Abort("integrator.typical_minimal_radiation_T is required when using integrator.typical_* parameters.");
+	}
+
+	// --- Read required inputs ---
+	amrex::Real typical_n_H = NAN;
+	pp.get("typical_n_H", typical_n_H);
+
+	amrex::Real typical_minimal_radiation_T = NAN;
+	pp.get("typical_minimal_radiation_T", typical_minimal_radiation_T);
+
+	// --- Read optional inputs ---
+	amrex::Real desired_accuracy_on_T_at_typical_n_H = 1.0; // K
+	pp.query("desired_accuracy_on_T_at_typical_n_H", desired_accuracy_on_T_at_typical_n_H);
+
+	amrex::Real spec_abundance_tol = 1.0e-5; // fraction of n_H
+	pp.query("spec_abundance_tol", spec_abundance_tol);
+
+	// --- Physical constants ---
+	const amrex::Real E_photon = RadSystem<problem_t>::GetChemBandQuanta(0); // midpoint energy of first chem band (erg)
+	const amrex::Real c_v = 1.5 * C::k_B / C::m_p;				 // erg/g/K; monatomic hydrogen
+
+	// --- atol_spec: species negligibility floor ---
+	const amrex::Real atol_spec = spec_abundance_tol * typical_n_H;
+
+	// --- atol_enuc: temperature accuracy requirement ---
+	const amrex::Real atol_enuc = c_v * desired_accuracy_on_T_at_typical_n_H;
+
+	// --- atol_rad_num: photon number density tolerance ---
+	// One millionth of the blackbody photon density at typical_minimal_radiation_T.
+	// A small value keeps Newton steps small in stiff cells, preventing large
+	// overshoots that would trigger the radiation_failure_tolerance guard.
+	const amrex::Real atol_rad_num = 1.0e-6 * C::a_rad * std::pow(typical_minimal_radiation_T, 4.0) / E_photon;
+
+	// --- radiation_failure_tolerance ---
+	// Physical guard: maximum allowed negative photon number density (cm^-3).
+	// Default 0.05 cm^-3 tolerates the worst-case Newton overshoot in stiff
+	// photoionization cells.  Rule of thumb: 2 orders of magnitude below the
+	// typical ionized gas density.  Lower for CGM/IGM.
+	amrex::Real radiation_failure_tolerance = 5.0e-2;
+	pp.query("radiation_failure_tolerance", radiation_failure_tolerance);
+
+	// --- Inject into ParmParse (init_extern_parameters reads these) ---
+	amrex::ParmParse pp_int("integrator");
+	pp_int.add("atol_spec", atol_spec);
+	pp_int.add("atol_enuc", atol_enuc);
+	pp_int.add("atol_rad_num", atol_rad_num);
+	pp_int.add("radiation_failure_tolerance", radiation_failure_tolerance);
+
+	amrex::Print() << "SetAtolFromPhysics: atol_spec=" << atol_spec << " atol_enuc=" << atol_enuc << " atol_rad_num=" << atol_rad_num
+		       << " radiation_failure_tolerance=" << radiation_failure_tolerance << "\n";
+}
+
+} // namespace quokka::photochemistry
+#endif // PHOTOCHEMISTRY
+#endif // PHOTOCHEM_ATOL_H_


### PR DESCRIPTION
### Description

Add `quokka::photochemistry::SetAtolFromPhysics<problem_t>()`, a template function that reads high-level physical parameters (`typical_n_H`, `desired_accuracy_on_T_at_typical_n_H`, `typical_minimal_radiation_T`) from the input `.toml` file and derives VODE absolute tolerances, injecting them into ParmParse before `init_extern_parameters()` reads them.

**This PR is infrastructure only** — it provides the machinery but does not adopt it in any problem. A follow-up PR will convert DTypeFront (and other photoionization problems) from hard-coded `atol_*` values to the `typical_*` interface.

### Summary of changes

| File | Change |
|---|---|
| `src/radiation/photochem_atol.H` | New: `SetAtolFromPhysics<problem_t>()` derives atol from physical scales |
| `src/QuokkaSimulation.hpp` | Call `SetAtolFromPhysics` between `readParmParse()` and `init_extern_parameters()` |

### How it works

1. After `readParmParse()` loads the `.toml` into the AMReX ParmParse database
2. `SetAtolFromPhysics<problem_t>()` checks for `integrator.typical_*` keys
3. If found, derives `atol_spec`, `atol_enuc`, `atol_rad_num`, and `radiation_failure_tolerance` from physical formulas
4. Injects them via `ParmParse::add()` so `init_extern_parameters()` picks them up via `ParmParse::query()`

**Mutual exclusivity:** `integrator.typical_*` and `integrator.atol_*` cannot both be set — using both triggers an error. Using neither also triggers an error, because VODE's built-in defaults (~1e-10) are unusably tight for photochemistry.

### Derivation formulas

| atol variable | Input(s) | Formula |
|---|---|---|
| `atol_spec` | `typical_n_H`, `spec_abundance_tol` (default 1e-5) | `spec_abundance_tol * typical_n_H` |
| `atol_enuc` | `desired_accuracy_on_T_at_typical_n_H` (default 1.0 K) | `(3/2 * k_B / m_p) * desired_accuracy_on_T` |
| `atol_rad_num` | `typical_minimal_radiation_T` | `1e-6 * a_rad * T^4 / E_photon` |
| `radiation_failure_tolerance` | optional (default 0.05 cm^-3) | physical guard, overridable |

`Erad_floor` (the M1 radiation floor) is **not** set by this function — it is a compile-time `constexpr` in each problem's `RadSystem_Traits` specialization and must be set independently.

### Related issues
N/A

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
