### PR TITLE
fix: typo in testSN.cpp comment

### DIFF
--- a/src/problems/SN/testSN.cpp
+++ b/src/problems/SN/testSN.cpp
@@ -1,6 +1,6 @@
 /// \file testSN.cpp
 /// \brief Defines a test problem for supernova feedback.
-/// In this test, two supernova explode and in the end the gas temperature and velocity is checked for
+/// In this test, two supernovae explode and in the end the gas temperature and velocity is checked for
 /// Galilean invariance between a rest frame and a boost frame.
 
 #include "AMReX.H"


### PR DESCRIPTION
### Description
Dummy change to test the `/azp run quick` targeted CI pipeline (PR #1984): fixes a typo in the file header comment (`supernova` → `supernovae`).

### Related issues
N/A

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.