### PR TITLE
Fix path filter for 'azp run quick'

### DIFF
--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -10,7 +10,7 @@ pr:
     - development
   paths:
     include:
-    - .ci/azure-pipelines-quick-amdgpu.yml
+    - src/problems/**
 
 jobs:
   - job: Quick_HIP_Build_Test

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -10,7 +10,7 @@ pr:
     - development
   paths:
     include:
-    - .ci/azure-pipelines-quick.yml
+    - src/problems/**
 
 jobs:
   - job: Quick_CUDA_Build_Test

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -5,7 +5,6 @@
 //==============================================================================
 /// \file testAdvection.cpp
 /// \brief Defines a test problem for linear advection.
-/// dummy
 ///
 
 #ifdef HAVE_PYTHON

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -5,6 +5,7 @@
 //==============================================================================
 /// \file testAdvection.cpp
 /// \brief Defines a test problem for linear advection.
+/// dummy
 ///
 
 #ifdef HAVE_PYTHON


### PR DESCRIPTION
### Description

Fixed path filter in quick and rocm-quick CI pipelines. Tested and working. 

### Related issues
`/azp run quick` not triggering CI tests in PRs. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
