### PR TITLE
ci: fix /claude-review workflow — pre-approve tools to resolve 22 permission denials

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Bash(git diff *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git blame *)",
+      "Bash(git ls-files *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh issue view *)",
+      "Bash(find *)",
+      "Bash(grep *)",
+      "Bash(ls *)",
+      "Bash(wc *)"
+    ]
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -111,7 +111,6 @@ jobs:
             - Do not speculate about runtime behaviour you cannot observe.
 
           use_sticky_comment: true
-          show_full_output: true
 
           claude_args: |
             --model claude-opus-4-7

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -111,6 +111,7 @@ jobs:
             - Do not speculate about runtime behaviour you cannot observe.
 
           use_sticky_comment: true
+          show_full_output: true
 
           claude_args: |
             --model claude-opus-4-7

--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,8 @@ Backtrace.*
 # !/tests/ascent_actions.yaml
 
 # agent files
-/.claude
+/.claude/*
+!/.claude/settings.json
 /.agent
 /.agents
 

--- a/src/problems/Advection/CMakeLists.txt
+++ b/src/problems/Advection/CMakeLists.txt
@@ -1,2 +1,1 @@
 quokka_add_problem(JOB_NAME Advection)
-# dummy change to test /claude-review workflow

--- a/src/problems/Advection/CMakeLists.txt
+++ b/src/problems/Advection/CMakeLists.txt
@@ -1,1 +1,2 @@
 quokka_add_problem(JOB_NAME Advection)
+# dummy change to test /claude-review workflow


### PR DESCRIPTION
### Description

Fixes the `/claude-review` workflow that was failing with 22 permission denials on every trigger.

When a PR comment contains `/claude-review`, the `claude-code-review.yml` workflow runs Claude Code in headless CI mode. Without pre-approved tools in `.claude/settings.json`, Claude's every tool call hits a permission denial. With the default `--max-turns 30`, all 30 turns are consumed by denials before Claude can do any work, resulting in `error_max_turns`.

**Root cause:** `.claude/` is listed in `.gitignore`, so no `settings.json` was ever committed. Claude Code in CI had no pre-approved tools.

**Fix:**
1. Update `.gitignore` to exclude only the files within `.claude/` (keeping `settings.json` trackable via `!/.claude/settings.json` exception).
2. Add `.claude/settings.json` with read-only tool permissions pre-approved: `Read`, `git diff/log/show/blame/ls-files`, `gh pr view/diff`, `gh issue view`, `find`, `grep`, `ls`, `wc`.
3. Enable `show_full_output: true` in the workflow so future failures are visible in CI logs rather than hidden.

**Validation:** After this fix, a `workflow_dispatch` test on PR #1987 completed in 10 turns with 3 remaining denials (vs. 22 denials + max-turns failure before). The 3 remaining denials will be identifiable via `show_full_output: true` after merging and retesting with an `issue_comment` trigger.

**Note on testing:** The `workflow_dispatch` path cannot post a sticky comment on a specific PR (the action doesn't expose the `pr_number` input to its comment-posting logic for `workflow_dispatch` events). The primary trigger — `issue_comment` containing `/claude-review` — will work correctly after this is merged to `development`, since the action restores `.claude` from the base branch.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
