### PR TITLE
ci: fix /claude-review prompt — inject PR number for issue_comment trigger

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,17 +5,27 @@
       "Bash(git diff *)",
       "Bash(git log *)",
       "Bash(git show *)",
+      "Bash(git fetch *)",
       "Bash(git status)",
       "Bash(git status *)",
       "Bash(git blame *)",
       "Bash(git ls-files *)",
       "Bash(gh pr view *)",
       "Bash(gh pr diff *)",
+      "Bash(gh pr list *)",
       "Bash(gh issue view *)",
+      "Bash(gh api *)",
       "Bash(find *)",
       "Bash(grep *)",
       "Bash(ls *)",
-      "Bash(wc *)"
+      "Bash(wc *)",
+      "Bash(cat *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(echo *)",
+      "Bash(env)",
+      "Bash(printenv)",
+      "Bash(printenv *)"
     ]
   }
 }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           prompt: |
-            ${{ github.event_name == 'workflow_dispatch' && format('Review PR #{0} in {1}.', github.event.inputs.pr_number, github.repository) || '' }}
+            ${{ (github.event_name == 'workflow_dispatch' && format('Review PR #{0} in {1}.', github.event.inputs.pr_number, github.repository)) || (github.event_name == 'issue_comment' && format('Review PR #{0} in {1}.', github.event.issue.number, github.repository)) || (github.event_name == 'pull_request' && format('Review PR #{0} in {1}.', github.event.number, github.repository)) || '' }}
 
             You are reviewing a pull request to Quokka, a radiation magnetohydrodynamics code
             built on AMReX. Quokka uses C++20 with GPU support (CUDA/HIP) and a single codebase


### PR DESCRIPTION
### Description

The \`/claude-review\` workflow was still failing after #1987 because the prompt only included the PR number for \`workflow_dispatch\` events, not for \`issue_comment\` events. Claude received an empty context string and spent all 30 turns trying to discover which PR to review via \`env\`, \`printenv\`, and shell variable expansion (all blocked by the permission system).

**Root cause:** The expression \`${{ github.event_name == 'workflow_dispatch' && format(...) || '' }}\` evaluates to \`''\` for \`issue_comment\` triggers, so Claude gets no PR context.

**Fix:**
1. Extend the prompt expression to inject \`Review PR #N in repo.\` for all three trigger types (\`issue_comment\`, \`pull_request\`, \`workflow_dispatch\`).
2. Expand \`.claude/settings.json\` allowlist with the commands Claude actually needs: \`git fetch\`, \`gh api\`, \`cat\`/\`head\`/\`tail\`/\`echo\`, \`env\`, \`printenv\`.

### Related issues
Follows #1987 (permission denials fix).

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment \`/azp run\`.