### PR TITLE
fix(ci): use merge base in quick pipelines to detect changed problems

### DIFF
--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -40,8 +40,9 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=1 origin "$TARGET_BRANCH"
-        CHANGED=$(git diff --name-only FETCH_HEAD HEAD)
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -40,8 +40,9 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=1 origin "$TARGET_BRANCH"
-        CHANGED=$(git diff --name-only FETCH_HEAD HEAD)
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -1,5 +1,5 @@
 //==============================================================================
-// TwoMomentRad - a radiation hydrodynamics library for patch-based AMR codes
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
 // Copyright 2020 Benjamin Wibking.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================

--- a/src/problems/Advection/testAdvection.cpp
+++ b/src/problems/Advection/testAdvection.cpp
@@ -1,5 +1,5 @@
 //==============================================================================
-// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// TwoMomentRad - a radiation hydrodynamics library for patch-based AMR codes
 // Copyright 2020 Benjamin Wibking.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================


### PR DESCRIPTION
### Description

Fix the "Detect changed problems" step in the quick CI pipelines to diff against the merge base rather than the tip of the target branch.

Previously, `git diff --name-only FETCH_HEAD HEAD` compared the PR's HEAD to the current tip of `development`. Because most PRs branch off an older commit, any problem files merged into `development` after the branch point also appeared as "changed" — causing the quick pipeline to build and test far more problems than the PR actually touched. The fix fetches enough history (`--deepen=100`) and uses `git merge-base FETCH_HEAD HEAD` to find the true common ancestor, then diffs only from that point to HEAD.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
