### PR TITLE
Add startup logging: print Quokka version and dependency git hashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,29 +108,45 @@ execute_process(COMMAND git rev-parse HEAD
     OUTPUT_VARIABLE QUOKKA_GIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-execute_process(COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/amrex
-    OUTPUT_VARIABLE AMREX_GIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(EXISTS "${QuokkaCode_SOURCE_DIR}/extern/amrex/.git")
+    execute_process(COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/amrex
+        OUTPUT_VARIABLE AMREX_GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    set(AMREX_GIT_HASH "unknown")
+endif()
 
-execute_process(COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/Microphysics
-    OUTPUT_VARIABLE MICROPHYSICS_GIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(EXISTS "${QuokkaCode_SOURCE_DIR}/extern/Microphysics/.git")
+    execute_process(COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/Microphysics
+        OUTPUT_VARIABLE MICROPHYSICS_GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    set(MICROPHYSICS_GIT_HASH "unknown")
+endif()
 
-execute_process(COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/AMReX-Hydro
-    OUTPUT_VARIABLE AMREX_HYDRO_GIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(EXISTS "${QuokkaCode_SOURCE_DIR}/extern/AMReX-Hydro/.git")
+    execute_process(COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/AMReX-Hydro
+        OUTPUT_VARIABLE AMREX_HYDRO_GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    set(AMREX_HYDRO_GIT_HASH "unknown")
+endif()
 
-execute_process(COMMAND git rev-parse HEAD
-    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/turbulence
-    OUTPUT_VARIABLE TURBULENCE_GIT_HASH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if(EXISTS "${QuokkaCode_SOURCE_DIR}/extern/turbulence/.git")
+    execute_process(COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/turbulence
+        OUTPUT_VARIABLE TURBULENCE_GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+else()
+    set(TURBULENCE_GIT_HASH "unknown")
+endif()
 
 # Check if the working directory is dirty
 execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,24 @@ execute_process(COMMAND git rev-parse HEAD
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/Microphysics
+    OUTPUT_VARIABLE MICROPHYSICS_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/AMReX-Hydro
+    OUTPUT_VARIABLE AMREX_HYDRO_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${QuokkaCode_SOURCE_DIR}/extern/turbulence
+    OUTPUT_VARIABLE TURBULENCE_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 # Check if the working directory is dirty
 execute_process(
     COMMAND git status --porcelain -uno
@@ -133,11 +151,17 @@ else()
 endif()
 
 # add preprocessor macros for git commits
-add_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
 add_definitions(-DQUOKKA_GIT_HASH="${QUOKKA_GIT_HASH}")
+add_definitions(-DAMREX_GIT_HASH="${AMREX_GIT_HASH}")
+add_definitions(-DMICROPHYSICS_GIT_HASH="${MICROPHYSICS_GIT_HASH}")
+add_definitions(-DAMREX_HYDRO_GIT_HASH="${AMREX_HYDRO_GIT_HASH}")
+add_definitions(-DTURBULENCE_GIT_HASH="${TURBULENCE_GIT_HASH}")
 message(STATUS "Quokka git branch: ${QUOKKA_GIT_BRANCH}")
 message(STATUS "Quokka git commit hash: ${QUOKKA_GIT_HASH}")
 message(STATUS "AMReX git commit hash: ${AMREX_GIT_HASH}")
+message(STATUS "Microphysics git commit hash: ${MICROPHYSICS_GIT_HASH}")
+message(STATUS "AMReX-Hydro git commit hash: ${AMREX_HYDRO_GIT_HASH}")
+message(STATUS "turbulence git commit hash: ${TURBULENCE_GIT_HASH}")
 
 add_subdirectory(${QuokkaCode_SOURCE_DIR}/extern/amrex ${QuokkaCode_BINARY_DIR}/amrex)
 if(QUOKKA_ENABLE_AMREX_HYDRO)

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -808,6 +808,15 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	simulationMetadata_["git_hash_quokka"] = getGitHashForQuokka();
 	simulationMetadata_["git_hash_amrex"] = getGitHashForAmrex();
 
+	// print version and git hashes to stdout
+	amrex::Print() << std::format("Quokka version {} (git: {})\n", QUOKKA_VERSION, getGitHashForQuokka());
+	amrex::Print() << std::format("AMReX git: {}\n", getGitHashForAmrex());
+	amrex::Print() << std::format("Microphysics git: {}\n", MICROPHYSICS_GIT_HASH);
+#if AMREX_SPACEDIM == 3
+	amrex::Print() << std::format("AMReX-Hydro git: {}\n", AMREX_HYDRO_GIT_HASH);
+#endif
+	amrex::Print() << std::format("turbulence git: {}\n", TURBULENCE_GIT_HASH);
+
 	// add units and physics-specific metadata
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
 		initializeSimulationMetadata();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -809,13 +809,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::initialize()
 	simulationMetadata_["git_hash_amrex"] = getGitHashForAmrex();
 
 	// print version and git hashes to stdout
-	amrex::Print() << std::format("Quokka version {} (git: {})\n", QUOKKA_VERSION, getGitHashForQuokka());
-	amrex::Print() << std::format("AMReX git: {}\n", getGitHashForAmrex());
-	amrex::Print() << std::format("Microphysics git: {}\n", MICROPHYSICS_GIT_HASH);
+	amrex::Print() << std::format("\nQuokka version {} (git: {})\n", QUOKKA_VERSION, getGitHashForQuokka());
+	amrex::Print() << std::format("\tAMReX git: {}\n", getGitHashForAmrex());
+	amrex::Print() << std::format("\tMicrophysics git: {}\n", MICROPHYSICS_GIT_HASH);
 #if AMREX_SPACEDIM == 3
-	amrex::Print() << std::format("AMReX-Hydro git: {}\n", AMREX_HYDRO_GIT_HASH);
+	amrex::Print() << std::format("\tAMReX-Hydro git: {}\n", AMREX_HYDRO_GIT_HASH);
 #endif
-	amrex::Print() << std::format("turbulence git: {}\n", TURBULENCE_GIT_HASH);
+	amrex::Print() << std::format("\tTurbGen git: {}\n", TURBULENCE_GIT_HASH);
 
 	// add units and physics-specific metadata
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {


### PR DESCRIPTION
### Description

I added startup logging of the Quokka version and the git hashes of all physics-relevant dependencies. The change has two parts:

- `CMakeLists.txt`: extended the existing git hash capture to cover `extern/Microphysics`, `extern/AMReX-Hydro`, and `extern/turbulence`, defining preprocessor macros for each (`MICROPHYSICS_GIT_HASH`, `AMREX_HYDRO_GIT_HASH`, `TURBULENCE_GIT_HASH`) on the same pattern as the existing `AMREX_GIT_HASH`. All four submodule captures are now wrapped in `if(EXISTS .git)` checks with an `"unknown"` fallback, guarding against uninitialised submodules and source tarball builds. The same guard has been applied to the pre-existing `AMREX_GIT_HASH` block for consistency.
- `simulation.hpp`: added `amrex::Print()` calls at simulation initialisation, alongside the existing plotfile metadata assignment, to print the Quokka version and all dependency hashes to stdout. The `AMReX-Hydro` line is guarded by `#if AMREX_SPACEDIM == 3` since that submodule is only compiled in for 3D builds.

All physics-relevant submodules are printed unconditionally rather than filtering by `Physics_Traits`. The reasoning is forensic: a module that is nominally inactive for a given problem could still harbour a bug through shared infrastructure, and omitting its hash would leave no trace in the job log.

The output at simulation startup (for a 3D build):

```
Initializing AMReX (26.05-63-gc2eb6db7ee79)...
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (26.05-63-gc2eb6db7ee79) initialized

Quokka version 25.03 (git: ea9117fc360560ceef73947295ed85c82203c658)
	AMReX git: c2eb6db7ee7965de0ddfc4c05d40dc2d3d61da93
	Microphysics git: 3fce117e1a6d46ee0175bbdc0774679182c0cd20
	AMReX-Hydro git: 9446740c59feca3bf007a6e6d95a6080816c33ec
	TurbGen git: 654e3ec27d94f9a6bfa5a901717615a865125d07

Coarse STEP 1 at t = 0 (0%) starts ...
```

In 1D/2D builds the `AMReX-Hydro` line is omitted.

### Related issues

- #1995: this PR implements the proposal.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.