### PR TITLE
Use Rosenbrock solver for photoionization

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 	url = https://github.com/AMReX-Codes/amrex.git
 [submodule "extern/Microphysics"]
 	path = extern/Microphysics
-	url = https://github.com/chongchonghe/Microphysics-fork.git
-	branch = photochemistry
+	url = https://github.com/AMReX-Astro/Microphysics.git
+	branch = development
 [submodule "extern/yaml-cpp"]
 	path = extern/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 	url = https://github.com/AMReX-Codes/amrex.git
 [submodule "extern/Microphysics"]
 	path = extern/Microphysics
-	url = https://github.com/AMReX-Astro/Microphysics.git
-	branch = development
+	url = https://github.com/chongchonghe/Microphysics-fork.git
+	branch = photochemistry
 [submodule "extern/yaml-cpp"]
 	path = extern/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git

--- a/inputs/DTypeFront.toml
+++ b/inputs/DTypeFront.toml
@@ -66,3 +66,5 @@ integrator.radiation_failure_tolerance   = 0.5      # cm^-3; must exceed max N_g
 integrator.rtol_spec     = 1e-2
 integrator.rtol_rad_num  = 1e-2
 integrator.rtol_enuc     = 1e-2
+
+integrator.rosenbrock_tableau = 3

--- a/inputs/OneZonePhotoionization.toml
+++ b/inputs/OneZonePhotoionization.toml
@@ -46,6 +46,8 @@ integrator.rtol_spec     = 1e-14
 integrator.rtol_rad_num  = 1e-14
 integrator.rtol_enuc     = 1e-14
 
+integrator.rosenbrock_tableau = 3
+
 network.energy_switch = 0
 network.collisional_ionization_switch = 0
 network.recombination_temperature_dependent = 0

--- a/inputs/OneZonePhotoionizationWithEnergy.toml
+++ b/inputs/OneZonePhotoionizationWithEnergy.toml
@@ -46,6 +46,8 @@ integrator.rtol_spec     = 1e-14
 integrator.rtol_rad_num  = 1e-14
 integrator.rtol_enuc     = 1e-14
 
+integrator.rosenbrock_tableau = 3
+
 network.energy_switch = 1
 network.KI_heating_switch = 0
 network.KI_cooling_switch = 0

--- a/inputs/StromgrenNoRecombination.toml
+++ b/inputs/StromgrenNoRecombination.toml
@@ -33,6 +33,7 @@ integrator.jacobian = 1
 integrator.renormalize_abundances = 0
 integrator.subtract_internal_energy = 0
 integrator.X_reject_buffer = 1e100
+integrator.rosenbrock_tableau = 3
 
 integrator.atol_spec                     = 1.0e-2   # cm^-3; spec_abundance_tol (1e-5) × n_H (1000)
 integrator.atol_enuc                     = 1.24e8   # erg/g; c_v × 1 K temperature accuracy

--- a/inputs/StromgrenRSLA.toml
+++ b/inputs/StromgrenRSLA.toml
@@ -33,6 +33,7 @@ integrator.jacobian = 1
 integrator.renormalize_abundances = 0
 integrator.subtract_internal_energy = 0
 integrator.X_reject_buffer = 1e100
+integrator.rosenbrock_tableau = 3
 
 plotfile_interval = 500
 plotfile_prefix = "StrmConstRecRSLA"

--- a/inputs/StromgrenTempIndependentRecombination.toml
+++ b/inputs/StromgrenTempIndependentRecombination.toml
@@ -33,6 +33,7 @@ integrator.jacobian = 1
 integrator.renormalize_abundances = 0
 integrator.subtract_internal_energy = 0
 integrator.X_reject_buffer = 1e100
+integrator.rosenbrock_tableau = 3
 
 plotfile_interval = 50
 plotfile_prefix = "StrmConstRec"

--- a/src/problems/DTypeFront/CMakeLists.txt
+++ b/src/problems/DTypeFront/CMakeLists.txt
@@ -4,7 +4,8 @@ if(AMReX_SPACEDIM GREATER_EQUAL 2)
                                                   # photoionization for this
                                                   # directory only
   setup_target_for_microphysics_compilation(${microphysics_network_name}
-                                            "${CMAKE_CURRENT_BINARY_DIR}/")
+                                            "${CMAKE_CURRENT_BINARY_DIR}/"
+                                            "Rosenbrock")
 
   # use the BEFORE keyword so that these files get priority in compilation for
   # targets in this directory this is critical to ensure the correct Microphysics

--- a/src/problems/OneZonePhotoionization/CMakeLists.txt
+++ b/src/problems/OneZonePhotoionization/CMakeLists.txt
@@ -3,7 +3,8 @@ set(microphysics_network_name "photoionization") # this will override
                                                  # photoionization for this
                                                  # directory only
 setup_target_for_microphysics_compilation(${microphysics_network_name}
-                                          "${CMAKE_CURRENT_BINARY_DIR}/")
+                                          "${CMAKE_CURRENT_BINARY_DIR}/"
+                                          "Rosenbrock")
 
 # use the BEFORE keyword so that these files get priority in compilation for
 # targets in this directory this is critical to ensure the correct Microphysics

--- a/src/problems/StromgrenSphere/CMakeLists.txt
+++ b/src/problems/StromgrenSphere/CMakeLists.txt
@@ -4,7 +4,8 @@ if(AMReX_SPACEDIM EQUAL 3)
                                                   # photoionization for this
                                                   # directory only
   setup_target_for_microphysics_compilation(${microphysics_network_name}
-                                            "${CMAKE_CURRENT_BINARY_DIR}/")
+                                            "${CMAKE_CURRENT_BINARY_DIR}/"
+                                            "Rosenbrock")
 
   # use the BEFORE keyword so that these files get priority in compilation for
   # targets in this directory this is critical to ensure the correct Microphysics

--- a/src/problems/StromgrenSphereRSLA/CMakeLists.txt
+++ b/src/problems/StromgrenSphereRSLA/CMakeLists.txt
@@ -4,7 +4,8 @@ if(AMReX_SPACEDIM GREATER_EQUAL 2)
                                                   # photoionization for this
                                                   # directory only
   setup_target_for_microphysics_compilation(${microphysics_network_name}
-                                            "${CMAKE_CURRENT_BINARY_DIR}/")
+                                            "${CMAKE_CURRENT_BINARY_DIR}/"
+                                            "Rosenbrock")
 
   # use the BEFORE keyword so that these files get priority in compilation for
   # targets in this directory this is critical to ensure the correct Microphysics


### PR DESCRIPTION
### Description
Switch from VODE to Rosenbrock solver with `rosenbrock_tableau = 3` (3-stage ROS2S tableau). Update all photoionization test problem to use this new solver. 


#### Performance results from Ben's tests

From @BenWibking 's message on Slack:

Ok, I've re-tested the performance of all the integrators following @ChongChong He’s tolerance changes. all of them are now fast, but Rosenbrock with ROS2S is fastest, about 20% faster than VODE:

```  ┌─────────┬─────────────┬───────────┬───────────┬────────┬────────┬─────────────┬─────────┬──────────────┬──────────────────┬────────┐
  │ Method  │ FoM us/zone │ Mupdate/s │ TP wall s │ Chem s │ Chem % │ Rad-noODE % │ Hydro % │ Hydro-only x │ RadSub/HydroStep │ Subcyc │
  ├─────────┼─────────────┼───────────┼───────────┼────────┼────────┼─────────────┼─────────┼──────────────┼──────────────────┼────────┤
  │ ROS2S   │      0.0877 │     11.40 │     19.24 │   6.47 │  33.65 │       42.80 │   14.78 │         6.77 │             0.52 │   9.99 │
  │ Rodas3P │      0.0895 │     11.17 │     19.30 │   7.07 │  36.62 │       41.82 │   14.43 │         6.93 │             0.54 │   9.99 │
  │ Rodas4P │      0.0957 │     10.45 │     20.73 │   7.95 │  38.35 │       40.64 │   13.51 │         7.40 │             0.58 │   9.99 │
  │ VODE    │      0.1089 │      9.18 │     23.20 │  10.67 │  45.98 │       36.15 │   12.05 │         8.30 │             0.68 │   9.99 │
  │ Rodas5P │      0.1214 │      8.24 │     25.93 │  13.09 │  50.47 │       32.48 │   11.08 │         9.03 │             0.75 │   9.99 │
  └─────────┴─────────────┴───────────┴───────────┴────────┴────────┴─────────────┴─────────┴──────────────┴──────────────────┴────────┘
```

With ROS2S, the cost of one radiation subcycle is ~0.5 times the cost of one hydro update.

and the ODE solve only takes about 33% of the total walltime for the DTypeFront problem

However, this is on an H200 GPU, so it would be good to also do this comparison for MI250X.

### Related issues

Not ready yet.
Need a PR to update Microphysics module to add radiation to Rosenbrock. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
