### PR TITLE
Fix Microphysics url mistake in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,8 +3,8 @@
 	url = https://github.com/AMReX-Codes/amrex.git
 [submodule "extern/Microphysics"]
 	path = extern/Microphysics
-	url = https://github.com/AMReX-Astro/Microphysics.git
-	branch = development
+	url = https://github.com/chongchonghe/Microphysics-fork.git
+	branch = photochemistry
 [submodule "extern/yaml-cpp"]
 	path = extern/yaml-cpp
 	url = https://github.com/jbeder/yaml-cpp.git


### PR DESCRIPTION
### Description
The `.gitmodules` is still pointing to the old url: `url = https://github.com/AMReX-Astro/Microphysics.git` . This PR updates it to `https://github.com/chongchonghe/Microphysics-fork.git` 

### Related issues
Recently we see Microphysics submodule is still tracking the old url, and we have to manually set-url. With this change, all the user need to do is to run:
```
git pull
git submodule sync --recursive
git submodule update --init --recursive
```
This will pull the url from .gitmodules to .git/modules/Microphysics.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
