### PR TITLE
Update ComputeVolumeIntegral to accept face-centered vars

### DIFF
--- a/src/problems/DiskGalaxy/testDiskGalaxy.cpp
+++ b/src/problems/DiskGalaxy/testDiskGalaxy.cpp
@@ -758,18 +758,19 @@ template <> auto QuokkaSimulation<DiskGalaxy>::ComputeStatistics() -> std::map<s
 	stats["disk_mass_refine_region"] = disk_mass_refine / C::M_solar;
 
 	auto tables = resampledTables_.const_tables();
-	const amrex::Real cold_mass = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		const Real rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
-		const Real x1Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index);
-		const Real x2Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x2Momentum_index);
-		const Real x3Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x3Momentum_index);
-		const Real Egas = state(i, j, k, HydroSystem<DiskGalaxy>::energy_index);
-		// computeVolumeIntegral does not provide face-centred data, so Emag is not available.
-		// The resulting temperature may be slightly overestimated in low-beta regions.
-		const Real Eint = Egas - 0.5 * (x1Mom * x1Mom + x2Mom * x2Mom + x3Mom * x3Mom) / rho;
-		const Real Tgas = quokka::ResampledCooling::ComputeTgasFromEgas(rho, Eint, tables);
-		return (Tgas < 1.0e4) ? rho : 0.0;
-	});
+	const amrex::Real cold_mass =
+	    computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state,
+						       std::array<amrex::Array4<const Real>, AMREX_SPACEDIM> const &state_fc) noexcept {
+		    const Real rho = state(i, j, k, HydroSystem<DiskGalaxy>::density_index);
+		    const Real x1Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x1Momentum_index);
+		    const Real x2Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x2Momentum_index);
+		    const Real x3Mom = state(i, j, k, HydroSystem<DiskGalaxy>::x3Momentum_index);
+		    const Real Egas = state(i, j, k, HydroSystem<DiskGalaxy>::energy_index);
+		    const Real Emag = HydroSystem<DiskGalaxy>::ComputeCellCenteredMagneticEnergy(i, j, k, state_fc);
+		    const Real Eint = quokka::EOS<DiskGalaxy>::ComputeEintFromEgas(rho, x1Mom, x2Mom, x3Mom, Egas, Emag);
+		    const Real Tgas = quokka::ResampledCooling::ComputeTgasFromEgas(rho, Eint, tables);
+		    return (Tgas < 1.0e4) ? rho : 0.0;
+	    });
 	stats["mass_T_lt_1e4"] = cold_mass / C::M_solar;
 
 	if (!std::isnan(flux_sphere_radius_kpc)) {

--- a/src/problems/ShockCloud/testShockCloud.cpp
+++ b/src/problems/ShockCloud/testShockCloud.cpp
@@ -21,6 +21,7 @@
 #include "AMReX_REAL.H"
 #include "AMReX_Reduce.H"
 #include "AMReX_SPACE.H"
+#include <array>
 #include <format>
 
 #include "QuokkaSimulation.hpp"
@@ -499,6 +500,7 @@ template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<s
 	// compute scalar statistics
 	std::map<std::string, amrex::Real> stats;
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(coolingTableType_ == "resampled", "ShockCloud statistics require resampled cooling tables.");
+	using FaceStateArray = std::array<amrex::Array4<const Real>, AMREX_SPACEDIM>;
 
 	// save time
 	const Real t_cc = simulationMetadata_["t_cc"].as<Real>();
@@ -533,36 +535,41 @@ template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<s
 	Real M_cl_12000 = 0.0;
 
 	auto tables = resampledTables_.const_tables();
-	M_cl_1e4 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (T < 1.0e4) ? rho : 0.0;
-		return result;
-	});
-	M_cl_8000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (T < 8000.) ? rho : 0.0;
-		return result;
-	});
-	M_cl_9000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (T < 9000.) ? rho : 0.0;
-		return result;
-	});
-	M_cl_11000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (T < 1.1e4) ? rho : 0.0;
-		return result;
-	});
-	M_cl_12000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (T < 1.2e4) ? rho : 0.0;
-		return result;
-	});
+	M_cl_1e4 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (T < 1.0e4) ? rho : 0.0;
+		    return result;
+	    });
+	M_cl_8000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (T < 8000.) ? rho : 0.0;
+		    return result;
+	    });
+	M_cl_9000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (T < 9000.) ? rho : 0.0;
+		    return result;
+	    });
+	M_cl_11000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (T < 1.1e4) ? rho : 0.0;
+		    return result;
+	    });
+	M_cl_12000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (T < 1.2e4) ? rho : 0.0;
+		    return result;
+	    });
 
 	stats["cloud_mass_1e4"] = M_cl_1e4 / solarmass_in_g;
 	stats["cloud_mass_8000"] = M_cl_8000 / solarmass_in_g;
@@ -577,36 +584,41 @@ template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<s
 	Real origM_cl_12000 = 0.0;
 
 	auto tables_orig = resampledTables_.const_tables();
-	origM_cl_1e4 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const result = (T < 1.0e4) ? rho_cloud : 0.0;
-		return result;
-	});
-	origM_cl_8000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const result = (T < 8000.) ? rho_cloud : 0.0;
-		return result;
-	});
-	origM_cl_9000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const result = (T < 9000.) ? rho_cloud : 0.0;
-		return result;
-	});
-	origM_cl_11000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const result = (T < 1.1e4) ? rho_cloud : 0.0;
-		return result;
-	});
-	origM_cl_12000 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const result = (T < 1.2e4) ? rho_cloud : 0.0;
-		return result;
-	});
+	origM_cl_1e4 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const result = (T < 1.0e4) ? rho_cloud : 0.0;
+		    return result;
+	    });
+	origM_cl_8000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const result = (T < 8000.) ? rho_cloud : 0.0;
+		    return result;
+	    });
+	origM_cl_9000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const result = (T < 9000.) ? rho_cloud : 0.0;
+		    return result;
+	    });
+	origM_cl_11000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const result = (T < 1.1e4) ? rho_cloud : 0.0;
+		    return result;
+	    });
+	origM_cl_12000 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const T = ComputeCellTempResampled(i, j, k, state, HydroSystem<ShockCloud>::gamma_, tables_orig);
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const result = (T < 1.2e4) ? rho_cloud : 0.0;
+		    return result;
+	    });
 
 	stats["cloud_mass_1e4_original"] = origM_cl_1e4 / solarmass_in_g;
 	stats["cloud_mass_8000_original"] = origM_cl_8000 / solarmass_in_g;
@@ -615,41 +627,45 @@ template <> auto QuokkaSimulation<ShockCloud>::ComputeStatistics() -> std::map<s
 	stats["cloud_mass_12000_original"] = origM_cl_12000 / solarmass_in_g;
 
 	// compute cloud mass according to passive scalar threshold
-	const Real M_cl_scalar_01 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const C = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (C > 0.1) ? rho : 0.0;
-		return result;
-	});
-	const Real M_cl_scalar_01_09 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const C = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index);
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = ((C > 0.1) && (C < 0.9)) ? rho : 0.0;
-		return result;
-	});
+	const Real M_cl_scalar_01 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const C = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (C > 0.1) ? rho : 0.0;
+		    return result;
+	    });
+	const Real M_cl_scalar_01_09 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const C = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = ((C > 0.1) && (C < 0.9)) ? rho : 0.0;
+		    return result;
+	    });
 
 	stats["cloud_mass_scalar_01"] = M_cl_scalar_01 / solarmass_in_g;
 	stats["cloud_mass_scalar_01_09"] = M_cl_scalar_01_09 / solarmass_in_g;
 
 	// compute cloud mass according to cloud fraction threshold
-	const Real M_cl_fraction_01 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const rho_bg = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 2);
-		Real const C_frac = rho_cloud / (rho_cloud + rho_bg);
+	const Real M_cl_fraction_01 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const rho_bg = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 2);
+		    Real const C_frac = rho_cloud / (rho_cloud + rho_bg);
 
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = (C_frac > 0.1) ? rho : 0.0;
-		return result;
-	});
-	const Real M_cl_fraction_01_09 = computeVolumeIntegral([=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state) noexcept {
-		Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
-		Real const rho_bg = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 2);
-		Real const C_frac = rho_cloud / (rho_cloud + rho_bg);
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = (C_frac > 0.1) ? rho : 0.0;
+		    return result;
+	    });
+	const Real M_cl_fraction_01_09 = computeVolumeIntegral(
+	    [=] AMREX_GPU_DEVICE(int i, int j, int k, amrex::Array4<const Real> const &state, FaceStateArray const & /*state_fc*/) noexcept {
+		    Real const rho_cloud = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 1);
+		    Real const rho_bg = state(i, j, k, HydroSystem<ShockCloud>::scalar0_index + 2);
+		    Real const C_frac = rho_cloud / (rho_cloud + rho_bg);
 
-		Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
-		Real const result = ((C_frac > 0.1) && (C_frac < 0.9)) ? rho : 0.0;
-		return result;
-	});
+		    Real const rho = state(i, j, k, HydroSystem<ShockCloud>::density_index);
+		    Real const result = ((C_frac > 0.1) && (C_frac < 0.9)) ? rho : 0.0;
+		    return result;
+	    });
 
 	stats["cloud_mass_fraction_01"] = M_cl_fraction_01 / solarmass_in_g;
 	stats["cloud_mass_fraction_01_09"] = M_cl_fraction_01_09 / solarmass_in_g;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3532,7 +3532,7 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 	const BL_PROFILE("AMRSimulation::computeVolumeIntegral()");
 	using StateArray = amrex::Array4<const amrex::Real>;
 	using FaceArray = std::array<StateArray, AMREX_SPACEDIM>;
-#if !defined(AMREX_USE_GPU)
+#ifndef AMREX_USE_GPU
 	constexpr bool user_f_accepts_cc_fc = amrex::IsCallable<F const, int, int, int, StateArray const &, FaceArray const &>::value;
 	static_assert(user_f_accepts_cc_fc, "computeVolumeIntegral callback must accept (i, j, k, state_cc, state_fc).");
 #endif

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3532,8 +3532,10 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 	const BL_PROFILE("AMRSimulation::computeVolumeIntegral()");
 	using StateArray = amrex::Array4<const amrex::Real>;
 	using FaceArray = std::array<StateArray, AMREX_SPACEDIM>;
+#if !defined(AMREX_USE_GPU)
 	constexpr bool user_f_accepts_cc_fc = amrex::IsCallable<F const, int, int, int, StateArray const &, FaceArray const &>::value;
 	static_assert(user_f_accepts_cc_fc, "computeVolumeIntegral callback must accept (i, j, k, state_cc, state_fc).");
+#endif
 
 	// allocate temporary multifabs
 	amrex::Vector<amrex::MultiFab> q;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -68,6 +68,7 @@ namespace filesystem = experimental::filesystem;
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 #include "AMReX_SPACE.H"
+#include "AMReX_TypeTraits.H"
 #include "AMReX_Utility.H"
 #include "AMReX_Vector.H"
 #include "AMReX_VisMF.H"
@@ -471,7 +472,7 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 	AMREX_GPU_DEVICE static void setConstantDirichletBCFaceVarHi(amrex::IntVect const &iv, amrex::Array4<amrex::Real> const &consVar_fc,
 								     amrex::GeometryData const &geom, amrex::GpuArray<amrex::Real, ncomp> const &values);
 
-	// compute volume integrals
+	// compute volume integrals. The callback signature is (i, j, k, state_cc, state_fc).
 	template <typename F> auto computeVolumeIntegral(F const &user_f) -> amrex::Real;
 
 	// I/O functions
@@ -3529,6 +3530,10 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 {
 	// compute integral of user_f(i, j, k, state) along the given axis.
 	const BL_PROFILE("AMRSimulation::computeVolumeIntegral()");
+	using StateArray = amrex::Array4<const amrex::Real>;
+	using FaceArray = std::array<StateArray, AMREX_SPACEDIM>;
+	constexpr bool user_f_accepts_cc_fc = amrex::IsCallable<F const, int, int, int, StateArray const &, FaceArray const &>::value;
+	static_assert(user_f_accepts_cc_fc, "computeVolumeIntegral callback must accept (i, j, k, state_cc, state_fc).");
 
 	// allocate temporary multifabs
 	amrex::Vector<amrex::MultiFab> q;
@@ -3542,7 +3547,24 @@ template <typename problem_t> template <typename F> auto AMRSimulation<problem_t
 	for (int lev = 0; lev <= finest_level; ++lev) {
 		auto const &state = state_new_cc_[lev].const_arrays();
 		auto const &result = q[lev].arrays();
-		amrex::ParallelFor(q[lev], [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) { result[bx](i, j, k) = user_f(i, j, k, state[bx]); });
+		if constexpr (Physics_Indices<problem_t>::nvarTotal_fc > 0) {
+			auto const &state_fc_x0 = state_new_fc_[lev][0].const_arrays();
+#if (AMREX_SPACEDIM >= 2)
+			auto const &state_fc_x1 = state_new_fc_[lev][1].const_arrays();
+#endif
+#if (AMREX_SPACEDIM == 3)
+			auto const &state_fc_x2 = state_new_fc_[lev][2].const_arrays();
+#endif
+			amrex::ParallelFor(q[lev], [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+				FaceArray const state_fc{AMREX_D_DECL(state_fc_x0[bx], state_fc_x1[bx], state_fc_x2[bx])};
+				result[bx](i, j, k) = user_f(i, j, k, state[bx], state_fc);
+			});
+		} else {
+			amrex::ParallelFor(q[lev], [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) {
+				FaceArray const state_fc{};
+				result[bx](i, j, k) = user_f(i, j, k, state[bx], state_fc);
+			});
+		}
 	}
 	amrex::Gpu::streamSynchronize();
 


### PR DESCRIPTION
### Description
Updates `ComputeVolumeIntegral` to pass face-centered vars to the user-provided lambda function, so that users can correctly compute the internal energy from conserved vars in MHD problems.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/2006.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
