### PR TITLE
Enable Azure merge-queue checks

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -3,9 +3,41 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-# Disable automatic CI trigger on push/merge to development branch.
-# Pipeline can still be triggered manually via `/azp run` or on PR validation.
-trigger: none
+# Run on merge queue branches so GitHub merge queue sees Azure checks.
+trigger:
+  branches:
+    include:
+    - gh-readonly-queue/development/*
+  paths:
+    include:
+    - src/**
+    - tests/**
+    - inputs/**
+    - CMakeLists.txt
+    - .ci/azure-pipelines-amdgpu.yml
+    - extern/cooling/*.h5
+    - extern/amrex
+    - extern/amrex/**
+    - extern/Microphysics
+    - extern/Microphysics/**
+    - extern/fmt
+    - extern/fmt/**
+    - extern/yaml-cpp
+    - extern/yaml-cpp/**
+    - extern/openPMD-api
+    - extern/openPMD-api/**
+    - extern/AMReX-Hydro
+    - extern/AMReX-Hydro/**
+    - extern/turbulence
+    - extern/turbulence/**
+    - .gitmodules
+    exclude:
+    - docs/**
+    - paper/**
+    - scripts/**
+    - '*.md'
+    - '*.rst'
+    - '*.txt'
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -8,36 +8,6 @@ trigger:
   branches:
     include:
     - gh-readonly-queue/development/*
-  paths:
-    include:
-    - src/**
-    - tests/**
-    - inputs/**
-    - CMakeLists.txt
-    - .ci/azure-pipelines-amdgpu.yml
-    - extern/cooling/*.h5
-    - extern/amrex
-    - extern/amrex/**
-    - extern/Microphysics
-    - extern/Microphysics/**
-    - extern/fmt
-    - extern/fmt/**
-    - extern/yaml-cpp
-    - extern/yaml-cpp/**
-    - extern/openPMD-api
-    - extern/openPMD-api/**
-    - extern/AMReX-Hydro
-    - extern/AMReX-Hydro/**
-    - extern/turbulence
-    - extern/turbulence/**
-    - .gitmodules
-    exclude:
-    - docs/**
-    - paper/**
-    - scripts/**
-    - '*.md'
-    - '*.rst'
-    - '*.txt'
 
 pr:
   autoCancel: true
@@ -81,10 +51,42 @@ jobs:
     pool: amdgpu
     timeoutInMinutes: 150
     steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - script: |
+        set -euo pipefail
+
+        git fetch origin development --depth=1
+        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+
+        run_heavy="false"
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          case "$f" in
+            src/*|tests/*|inputs/*|CMakeLists.txt|.ci/azure-pipelines-amdgpu.yml|extern/cooling/*.h5|extern/amrex|extern/amrex/*|extern/Microphysics|extern/Microphysics/*|extern/fmt|extern/fmt/*|extern/yaml-cpp|extern/yaml-cpp/*|extern/openPMD-api|extern/openPMD-api/*|extern/AMReX-Hydro|extern/AMReX-Hydro/*|extern/turbulence|extern/turbulence/*|.gitmodules)
+              run_heavy="true"
+              break
+              ;;
+          esac
+        done <<< "$changed_files"
+
+        echo "RunHeavyCI=${run_heavy}"
+        echo "##vso[task.setvariable variable=RunHeavyCI]${run_heavy}"
+      displayName: Detect CI-relevant changes
+
+    - script: |
+        if [ "$(RunHeavyCI)" != "true" ]; then
+          echo "No CI-relevant files changed; skipping HIP build/test."
+        fi
+      displayName: Announce docs-only no-op
+      condition: and(succeeded(), ne(variables['RunHeavyCI'], 'true'))
+
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"
         echo "Using shared local disk cache at $(Agent.HomeDirectory)/cache/ccache"
       displayName: Prepare shared ccache directory
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
@@ -95,11 +97,14 @@ jobs:
           echo "##vso[task.setvariable variable=cmakeLauncherArgs]"
         fi
       displayName: Detect ccache
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - template: templates/ccache-prepare.yml
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - task: CMake@1
       displayName: 'Configure CMake'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
@@ -109,6 +114,7 @@ jobs:
     
     - task: CMake@1
       displayName: 'Build Quokka'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
@@ -118,6 +124,7 @@ jobs:
     
     - task: CMake@1
       displayName: 'Run CTest'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       inputs:
         cmakeArgs: '-E chdir . ctest -E "RadMatterCoupling*" -T Test --output-on-failure'
     
@@ -126,7 +133,8 @@ jobs:
         testResultsFormat: cTest
         testResultsFiles: build/Testing/*/Test.xml
         testRunTitle: $(Agent.JobName)
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), eq(variables['RunHeavyCI'], 'true'))
       displayName: Publish test results
 
     - template: templates/ccache-stats.yml
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -3,9 +3,41 @@
 # Add steps that build, run tests, deploy, and more:
 # https://aka.ms/yaml
 
-# Disable automatic CI trigger on push/merge to development branch.
-# Pipeline can still be triggered manually via `/azp run` or on PR validation.
-trigger: none
+# Run on merge queue branches so GitHub merge queue sees Azure checks.
+trigger:
+  branches:
+    include:
+    - gh-readonly-queue/development/*
+  paths:
+    include:
+    - src/**
+    - tests/**
+    - inputs/**
+    - CMakeLists.txt
+    - .ci/azure-pipelines.yml
+    - extern/cooling/*.h5
+    - extern/amrex
+    - extern/amrex/**
+    - extern/Microphysics
+    - extern/Microphysics/**
+    - extern/fmt
+    - extern/fmt/**
+    - extern/yaml-cpp
+    - extern/yaml-cpp/**
+    - extern/openPMD-api
+    - extern/openPMD-api/**
+    - extern/AMReX-Hydro
+    - extern/AMReX-Hydro/**
+    - extern/turbulence
+    - extern/turbulence/**
+    - .gitmodules
+    exclude:
+    - docs/**
+    - paper/**
+    - scripts/**
+    - '*.md'
+    - '*.rst'
+    - '*.txt'
 
 pr:
   autoCancel: true

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -8,36 +8,6 @@ trigger:
   branches:
     include:
     - gh-readonly-queue/development/*
-  paths:
-    include:
-    - src/**
-    - tests/**
-    - inputs/**
-    - CMakeLists.txt
-    - .ci/azure-pipelines.yml
-    - extern/cooling/*.h5
-    - extern/amrex
-    - extern/amrex/**
-    - extern/Microphysics
-    - extern/Microphysics/**
-    - extern/fmt
-    - extern/fmt/**
-    - extern/yaml-cpp
-    - extern/yaml-cpp/**
-    - extern/openPMD-api
-    - extern/openPMD-api/**
-    - extern/AMReX-Hydro
-    - extern/AMReX-Hydro/**
-    - extern/turbulence
-    - extern/turbulence/**
-    - .gitmodules
-    exclude:
-    - docs/**
-    - paper/**
-    - scripts/**
-    - '*.md'
-    - '*.rst'
-    - '*.txt'
 
 pr:
   autoCancel: true
@@ -81,10 +51,42 @@ jobs:
     pool: avatar
     timeoutInMinutes: 360
     steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - script: |
+        set -euo pipefail
+
+        git fetch origin development --depth=1
+        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+
+        run_heavy="false"
+        while IFS= read -r f; do
+          [ -z "$f" ] && continue
+          case "$f" in
+            src/*|tests/*|inputs/*|CMakeLists.txt|.ci/azure-pipelines.yml|extern/cooling/*.h5|extern/amrex|extern/amrex/*|extern/Microphysics|extern/Microphysics/*|extern/fmt|extern/fmt/*|extern/yaml-cpp|extern/yaml-cpp/*|extern/openPMD-api|extern/openPMD-api/*|extern/AMReX-Hydro|extern/AMReX-Hydro/*|extern/turbulence|extern/turbulence/*|.gitmodules)
+              run_heavy="true"
+              break
+              ;;
+          esac
+        done <<< "$changed_files"
+
+        echo "RunHeavyCI=${run_heavy}"
+        echo "##vso[task.setvariable variable=RunHeavyCI]${run_heavy}"
+      displayName: Detect CI-relevant changes
+
+    - script: |
+        if [ "$(RunHeavyCI)" != "true" ]; then
+          echo "No CI-relevant files changed; skipping CUDA build/test."
+        fi
+      displayName: Announce docs-only no-op
+      condition: and(succeeded(), ne(variables['RunHeavyCI'], 'true'))
+
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"
         echo "Using shared local disk cache at $(Agent.HomeDirectory)/cache/ccache"
       displayName: Prepare shared ccache directory
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - script: |
         if command -v ccache >/dev/null 2>&1; then
@@ -95,8 +97,10 @@ jobs:
           echo "##vso[task.setvariable variable=cmakeLauncherArgs]"
         fi
       displayName: Detect ccache
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - template: templates/ccache-prepare.yml
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - script: |
         # Keep the job idle during the restricted window [03:30, 07:00).
@@ -159,9 +163,11 @@ jobs:
           waited=$((waited + gpu_check_interval))
         done
       displayName: 'Wait for allowed time and free GPU'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - task: CMake@1
       displayName: 'Configure CMake'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
@@ -171,6 +177,7 @@ jobs:
     
     - task: CMake@1
       displayName: 'Build Quokka'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       env:
         CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache
         CCACHE_BASEDIR: $(Build.SourcesDirectory)
@@ -180,6 +187,7 @@ jobs:
     
     - task: CMake@1
       displayName: 'Run CTest'
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
       inputs:
         cmakeArgs: '-E chdir . ctest -E "RadMatterCoupling*" -T Test --output-on-failure'
     
@@ -188,7 +196,8 @@ jobs:
         testResultsFormat: cTest
         testResultsFiles: build/Testing/*/Test.xml
         testRunTitle: $(Agent.JobName)
-      condition: succeededOrFailed()
+      condition: and(succeededOrFailed(), eq(variables['RunHeavyCI'], 'true'))
       displayName: Publish test results
 
     - template: templates/ccache-stats.yml
+      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))


### PR DESCRIPTION
### Description
Enable Azure CUDA and AMDGPU pipelines to trigger on merge queue branches so merge queue entries receive Azure check results.

This updates `.ci/azure-pipelines.yml` and `.ci/azure-pipelines-amdgpu.yml` by replacing `trigger: none` with queue-branch triggers for `gh-readonly-queue/development/*`, while preserving each pipeline's existing path filters. The change keeps PR validation behavior intact and adds merge-queue coverage for the same scoped paths.

### Related issues
Depends on #2010 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
