### PR TITLE
Fix Azure template step conditions

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -100,7 +100,8 @@ jobs:
       condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - template: templates/ccache-prepare.yml
-      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
+      parameters:
+        stepCondition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - task: CMake@1
       displayName: 'Configure CMake'
@@ -145,4 +146,5 @@ jobs:
       displayName: Publish CTest temporary logs artifact
 
     - template: templates/ccache-stats.yml
-      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
+      parameters:
+        stepCondition: and(succeededOrFailed(), eq(variables['RunHeavyCI'], 'true'))

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -100,7 +100,8 @@ jobs:
       condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - template: templates/ccache-prepare.yml
-      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
+      parameters:
+        stepCondition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
 
     - script: |
         # Keep the job idle during the restricted window [03:30, 07:00).
@@ -208,4 +209,5 @@ jobs:
       displayName: Publish CTest temporary logs artifact
 
     - template: templates/ccache-stats.yml
-      condition: and(succeeded(), eq(variables['RunHeavyCI'], 'true'))
+      parameters:
+        stepCondition: and(succeededOrFailed(), eq(variables['RunHeavyCI'], 'true'))

--- a/.ci/templates/ccache-prepare.yml
+++ b/.ci/templates/ccache-prepare.yml
@@ -1,4 +1,9 @@
 # Reusable template for preparing and configuring ccache
+parameters:
+- name: stepCondition
+  type: string
+  default: succeeded()
+
 steps:
 - script: |
     mkdir -p "$CCACHE_DIR"
@@ -14,5 +19,6 @@ steps:
       echo "ccache not installed; skipping zero-stats."
     fi
   displayName: Prepare ccache
+  condition: ${{ parameters.stepCondition }}
   env:
     CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache

--- a/.ci/templates/ccache-stats.yml
+++ b/.ci/templates/ccache-stats.yml
@@ -1,4 +1,9 @@
 # Reusable template for reporting ccache statistics
+parameters:
+- name: stepCondition
+  type: string
+  default: succeededOrFailed()
+
 steps:
 - script: |
     if command -v ccache >/dev/null 2>&1; then
@@ -17,6 +22,6 @@ steps:
       echo "ccache not installed; no statistics to report."
     fi
   displayName: Report ccache statistics
-  condition: succeededOrFailed()
+  condition: ${{ parameters.stepCondition }}
   env:
     CCACHE_DIR: $(Agent.HomeDirectory)/cache/ccache


### PR DESCRIPTION
## Description
Fix Azure Pipelines YAML validation errors caused by placing `condition` directly on `- template:` include steps.

This passes conditions into template parameters and applies the condition inside each template step, preserving docs-only no-op behavior for merge queue runs.

## Related issues
N/A
