### PR TITLE
ci: print problem names before CTest search in quick pipelines

### DIFF
--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -81,11 +81,12 @@ jobs:
       inputs:
         cmakeArgs: '--build . --parallel 16 $(cmakeTargetArgs)'
 
-    - task: CMake@1
+    - script: |
+        echo "Searching for problems matching regex: $(ctestRegex)"
+        ctest -R "$(ctestRegex)" -E "RadMatterCoupling*" -T Test --output-on-failure
       displayName: 'Run CTest (targeted)'
       condition: eq(variables['hasProblems'], 'true')
-      inputs:
-        cmakeArgs: '-E chdir . ctest -R "$(ctestRegex)" -E "RadMatterCoupling*" -T Test --output-on-failure'
+      workingDirectory: build
 
     - task: PublishTestResults@2
       inputs:

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -144,11 +144,12 @@ jobs:
       inputs:
         cmakeArgs: '--build . --parallel 16 $(cmakeTargetArgs)'
 
-    - task: CMake@1
+    - script: |
+        echo "Searching for problems matching regex: $(ctestRegex)"
+        ctest -R "$(ctestRegex)" -E "RadMatterCoupling*" -T Test --output-on-failure
       displayName: 'Run CTest (targeted)'
       condition: eq(variables['hasProblems'], 'true')
-      inputs:
-        cmakeArgs: '-E chdir . ctest -R "$(ctestRegex)" -E "RadMatterCoupling*" -T Test --output-on-failure'
+      workingDirectory: build
 
     - task: PublishTestResults@2
       inputs:


### PR DESCRIPTION
### Description
Print the CTest regex before running tests in quick CI pipelines so it's clear what problems were searched when no tests are found.

The "Run CTest (targeted)" step in both `azure-pipelines-quick.yml` and `azure-pipelines-quick-amdgpu.yml` now echoes the regex pattern before invoking `ctest`. Previously, when ctest printed "No tests were found!!!" there was no immediate indication of what pattern had been searched — the user had to scroll back to an earlier step to find the regex. Now the output reads:

```
Searching for problems matching regex: ^(DiskGalaxy|ShockCloud)($|-)
... ctest output ...
```

The step was converted from a `CMake@1` task to a `script` step so the echo and ctest invocation are colocated in the same log group.

### Related issues
Closes #2017

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
