### PR TITLE
fix(docs): latex issues in photoionization.md

### DIFF
--- a/docs/markdown/photoionization.md
+++ b/docs/markdown/photoionization.md
@@ -8,33 +8,33 @@ reionization based on a local Eddington tensor" (ATON paper, arXiv:0709.1544)
 ### 1.1 M1 Radiative Transfer for Ionizing Photons
 
 Taking the first two moments of the radiative transfer equation gives conservation laws
-for the ionizing photon number density $N_\gamma$ and flux density $\mathbf{F}_\gamma$:
+for the ionizing photon number density \\(N\_\gamma\\) and flux density \\(\mathbf{F}\_\gamma\\):
 
-$$
+<script type="math/tex; mode=display">
 \frac{\partial N_\gamma}{\partial t} + \nabla \cdot \mathbf{F}_\gamma =
 - n_{\rm H^0} c \sigma_\gamma N_\gamma
 + n_e n_{\rm H^+} (\alpha_A - \alpha_B)
 + \dot{N}^*_\gamma,
-$$
+</script>
 
-$$
+<script type="math/tex; mode=display">
 \frac{\partial \mathbf{F}_\gamma}{\partial t} + c^2 \nabla \cdot \mathsf{P}_\gamma =
 - n_{\rm H^0} c \sigma_\gamma \mathbf{F}_\gamma.
-$$
+</script>
 
 | Symbol | Definition |
 |--------|------------|
-| $N_\gamma$ | Ionizing photon number density (cm^-3) |
-| $\mathbf{F}_\gamma$ | Ionizing photon number flux density (cm^-2 s^-1) |
-| $\mathsf{P}_\gamma$ | Radiation pressure tensor ($= \mathsf{D}\,F_\gamma$, cm^-3) |
-| $n_{\rm H^0}$ | Neutral hydrogen number density |
-| $n_{\rm H^+} = n_e$ | Ionized hydrogen / electron number density |
-| $\sigma_\gamma$ | Frequency-averaged photoionization cross-section |
-| $\alpha_A, \alpha_B$ | Case A / B recombination coefficients (cm^3 s^-1) |
-| $\beta$ | Collisional ionization rate coefficient (cm^3 s^-1) |
-| $\dot{N}^*_\gamma$ | Stellar ionizing photon emission rate (cm^-3 s^-1) |
+| \\(N\_\gamma\\) | Ionizing photon number density (\\(\mathrm{cm}^{-3}\\)) |
+| \\(\mathbf{F}\_\gamma\\) | Ionizing photon number flux density (\\(\mathrm{cm}^{-2}\ \mathrm{s}^{-1}\\)) |
+| \\(\mathsf{P}\_\gamma\\) | Radiation pressure tensor (\\(= \mathsf{D}\,F\_\gamma\\), \\(\mathrm{cm}^{-3}\\)) |
+| \\(n\_{\rm H^0}\\) | Neutral hydrogen number density |
+| \\(n\_{\rm H^+} = n\_e\\) | Ionized hydrogen / electron number density |
+| \\(\sigma\_\gamma\\) | Frequency-averaged photoionization cross-section |
+| \\(\alpha\_A, \alpha\_B\\) | Case A / B recombination coefficients (\\(\mathrm{cm}^{3}\ \mathrm{s}^{-1}\\)) |
+| \\(\beta\\) | Collisional ionization rate coefficient (\\(\mathrm{cm}^{3}\ \mathrm{s}^{-1}\\)) |
+| \\(\dot{N}^*\_\gamma\\) | Stellar ionizing photon emission rate (\\(\mathrm{cm}^{-3}\ \mathrm{s}^{-1}\\)) |
 
-The source term $n_e n_{\rm H^+}(\alpha_A - \alpha_B)$ represents diffuse recombination
+The source term \\(n\_e n\_{\rm H^+}(\alpha\_A - \alpha\_B)\\) represents diffuse recombination
 radiation — photons re-emitted when H recombines directly to the ground state (case A
 minus case B correction).
 
@@ -42,22 +42,22 @@ minus case B correction).
 
 The neutral hydrogen fraction evolves as:
 
-$$
+<script type="math/tex; mode=display">
 \frac{D n_{\rm H^0}}{Dt} = \alpha_A n_e n_{\rm H^+} - \beta n_e n_{\rm H^0} - \Gamma_{\gamma {\rm H}^0} n_{\rm H^0},
-$$
+</script>
 
-with $n_{\rm H^+} = n_e$ (charge conservation), $n_{\rm H^+} + n_{\rm H^0} = n_{\rm H}$
-(nuclei conservation), and the photoionization rate $\Gamma_{\gamma {\rm H}^0} = c \sigma_\gamma N_\gamma$.
+with \\(n\_{\rm H^+} = n\_e\\) (charge conservation), \\(n\_{\rm H^+} + n\_{\rm H^0} = n\_{\rm H}\\)
+(nuclei conservation), and the photoionization rate \\(\Gamma\_{\gamma {\rm H}^0} = c \sigma\_\gamma N\_\gamma\\).
 
 The gas thermal energy evolves as:
 
-$$
+<script type="math/tex; mode=display">
 \rho \frac{D}{Dt}\!\left(\frac{e}{\rho}\right) = \mathcal{H}_{\rm photo} - \mathcal{L},
-$$
+</script>
 
-where $\mathcal{H}_{\rm photo} = n_{\rm H^0} c \sigma_\gamma \epsilon_\gamma N_\gamma$ is
-the photoheating rate and $\epsilon_\gamma = h(\bar{\nu} - \nu_{{\rm H}^0})$ is the mean
-excess photon energy above the ionization threshold (29.65 eV for a $10^5$ K blackbody).
+where \\(\mathcal{H}\_{\rm photo} = n\_{\rm H^0} c \sigma\_\gamma \epsilon\_\gamma N\_\gamma\\) is
+the photoheating rate and \\(\epsilon\_\gamma = h(\bar{\nu} - \nu\_{{\rm H}^0})\\) is the mean
+excess photon energy above the ionization threshold (29.65 eV for a \\(10^5\\) K blackbody).
 For heating and cooling that are not directly due to hydrogen photoionization, we
 reimplement the optically thin prescription of [@Krumholz2007], which proceeds as
 follows. In molecular gas, the approximate cooling and heating functions of [@Koyama2002]
@@ -75,23 +75,23 @@ atom. The **on-the-spot approximation** assumes this photon is re-absorbed local
 within the same resolution element — so recombinations to n = 1 have no net effect on
 the ionization state.
 
-Under OTSA, one replaces $\alpha_A \to \alpha_B$ everywhere and drops the diffuse
+Under OTSA, one replaces \\(\alpha\_A \to \alpha\_B\\) everywhere and drops the diffuse
 recombination source term from the radiation equation:
 
-$$
+<script type="math/tex; mode=display">
 \frac{\partial N_\gamma}{\partial t} + \nabla \cdot \mathbf{F}_\gamma =
 - n_{\rm H^0} c \sigma_\gamma N_\gamma + \dot{N}^*_\gamma,
-$$
+</script>
 
-$$
+<script type="math/tex; mode=display">
 \frac{D n_{\rm H^0}}{Dt} = \alpha_B n_e n_{\rm H^+} - \beta n_e n_{\rm H^0} - \Gamma_{\gamma {\rm H}^0} n_{\rm H^0}.
-$$
+</script>
 
 OTSA is valid when the mean free path of a recombination photon is much smaller than
 the size of the ionized region — a good approximation deep inside large HII regions.
 It breaks down near ionization fronts and in low-density, nearly fully ionized gas.
 
-Quokka currently uses OTSA. The full $(\alpha_A - \alpha_B)$ diffuse source term is
+Quokka currently uses OTSA. The full \\((\alpha\_A - \alpha\_B)\\) diffuse source term is
 planned for a future phase.
 
 ## 2. Numerical Scheme
@@ -112,9 +112,9 @@ in each cell. Quokka replaces the analytic cubic-polynomial solve used in ATON (
 cannot generalize to more complex networks) with a call to **VODE**, a variable-order,
 variable-step stiff ODE integrator.
 
-Under OTSA, VODE integrates the following system over the implicit timestep $\Delta t$:
+Under OTSA, VODE integrates the following system over the implicit timestep \\(\Delta t\\):
 
-$$
+<script type="math/tex; mode=display">
 \begin{aligned}
 \frac{d N_\gamma}{d t} &= - n_{\rm H^0} \hat{c} \sigma_\gamma N_\gamma + \dot{N}, \\[2pt]
 \frac{d F_{\gamma,i}}{d t} &= - n_{\rm H^0} \hat{c} \sigma_\gamma F_{\gamma,i} \quad (i = x, y, z), \\[2pt]
@@ -123,21 +123,21 @@ $$
 \frac{d n_e}{d t} &= -\alpha_B n_e n_{\rm H^+} + \beta n_e n_{\rm H^0} + \hat{c} \sigma_\gamma N_\gamma n_{\rm H^0}, \\[2pt]
 \frac{d e}{d t} &= n_{\rm H^0} \hat{c} \sigma_\gamma \epsilon_\gamma N_\gamma - \text{[cooling terms]}.
 \end{aligned}
-$$
+</script>
 
-where $\hat{c}$ is the reduced speed of light. Only one directional flux component is
+where \\(\hat{c}\\) is the reduced speed of light. Only one directional flux component is
 integrated (normalized to 1.0 before the burn); the other two are scaled proportionally
 after the ODE solve. The state vector has 6 components for a single chemical band:
-$(n_e, n_{\rm H^0}, n_{\rm H^+}, e, N_\gamma, F_\gamma)$.
+\\((n\_e, n\_{\rm H^0}, n\_{\rm H^+}, e, N\_\gamma, F\_\gamma)\\).
 
-Note that $n_{\rm H^+} = n_{\rm H} - n_{\rm H^0}$ and $n_e = n_{\rm H^+}$ by
-construction. Although only one of $n_{\rm H^0}$ or $n_{\rm H^+}$ is an independent
+Note that \\(n\_{\rm H^+} = n\_{\rm H} - n\_{\rm H^0}\\) and \\(n\_e = n\_{\rm H^+}\\) by
+construction. Although only one of \\(n\_{\rm H^0}\\) or \\(n\_{\rm H^+}\\) is an independent
 variable, both are integrated for symmetry.
 
-The flux ODE $dF_\gamma/dt = -n_{\rm H^0} \hat{c} \sigma_\gamma F_\gamma$ is similar
-to the absorption term in $N_\gamma$, but $N_\gamma$ has an additional isotropic source
-term (stellar emission $\dot{N}$). Isotropic sources add photons uniformly in all
-directions — they contribute to $N_\gamma$ but produce no net flux. Flux must be
+The flux ODE \\(dF\_\gamma/dt = -n\_{\rm H^0} \hat{c} \sigma\_\gamma F\_\gamma\\) is similar
+to the absorption term in \\(N\_\gamma\\), but \\(N\_\gamma\\) has an additional isotropic source
+term (stellar emission \\(\dot{N}\\)). Isotropic sources add photons uniformly in all
+directions — they contribute to \\(N\_\gamma\\) but produce no net flux. Flux must be
 integrated to track the attenuation of the directional radiation field across the
 timestep.
 
@@ -148,51 +148,51 @@ timestep.
 Quokka uses VODE (via Microphysics) to integrate the chemistry and internal energy
 source terms. The integrator requires absolute tolerances (`atol`) for each solution
 variable. These are hand-tuned for each problem and specified directly in the input
-file (see SS 3.2). The `SetAtolFromPhysics` machinery (PR #1980) will derive tolerances
+file (see § 3.2). The `SetAtolFromPhysics` machinery (PR #1980) will derive tolerances
 from physical scales automatically in a future PR.
 
 ### 3.2 Input parameters
 
 | Parameter                               | Description                                                       |
 | --------------------------------------- | ----------------------------------------------------------------- |
-| `integrator.atol_spec`                  | Absolute tolerance for chemical species (cm^-3)                   |
-| `integrator.atol_enuc`                  | Absolute tolerance for gas internal energy (erg g^-1)             |
-| `integrator.atol_rad_num`               | Absolute tolerance for photon number density (cm^-3)              |
+| `integrator.atol_spec`                  | Absolute tolerance for chemical species (\\(\mathrm{cm}^{-3}\\))                   |
+| `integrator.atol_enuc`                  | Absolute tolerance for gas internal energy (\\(\mathrm{erg}\ \mathrm{g}^{-1}\\))             |
+| `integrator.atol_rad_num`               | Absolute tolerance for photon number density (\\(\mathrm{cm}^{-3}\\))              |
 | `integrator.rtol_spec`                  | Relative tolerance for chemical species                           |
 | `integrator.rtol_enuc`                  | Relative tolerance for gas internal energy                        |
 | `integrator.rtol_rad_num`               | Relative tolerance for photon number density                      |
-| `integrator.species_failure_tolerance`  | VODE internal substep rejection threshold for negative species (cm^-3, see SS 3.7) |
-| `integrator.radiation_failure_tolerance`| VODE internal substep rejection threshold for negative photon density (cm^-3, see SS 3.5) |
+| `integrator.species_failure_tolerance`  | VODE internal substep rejection threshold for negative species (\\(\mathrm{cm}^{-3}\\), see § 3.7) |
+| `integrator.radiation_failure_tolerance`| VODE internal substep rejection threshold for negative photon density (\\(\mathrm{cm}^{-3}\\), see § 3.5) |
 
 ### 3.3 Why flux is excluded from convergence
 
-The radiation flux $F_\gamma$ (normalized to 1.0 before the ODE) is integrated alongside the
+The radiation flux \\(F\_\gamma\\) (normalized to 1.0 before the ODE) is integrated alongside the
 other variables, but does not participate in any VODE convergence or error checks.
 
-**Why flux is in the ODE.** The flux ODE is $dF/dt = -(\hat{c}\sigma)\,n_{\rm H^0} F$.
-This is similar to the absorption term in $N_\gamma$, but $N_\gamma$ also has an
-isotropic source term (stellar emission in OTSA, or $n_e n_{\rm H^+}(\alpha_A - \alpha_B)$
+**Why flux is in the ODE.** The flux ODE is \\(dF/dt = -(\hat{c}\sigma)\,n\_{\rm H^0} F\\).
+This is similar to the absorption term in \\(N\_\gamma\\), but \\(N\_\gamma\\) also has an
+isotropic source term (stellar emission in OTSA, or \\(n\_e n\_{\rm H^+}(\alpha\_A - \alpha\_B)\\)
 recombination radiation in case A). Since isotropic sources contribute photons uniformly
 in all directions, they add to the photon number density but produce no net flux. Flux
 must be integrated separately to track the attenuation of the directional radiation field.
 
 **Why flux is excluded from convergence.** Flux is a passive scalar — its RHS depends
-on $n_{\rm H^0}$ but flux does *not* appear in any other equation (species, energy, or
-$N_\gamma$). Convergence should be driven by the physically consequential quantities, not
+on \\(n\_{\rm H^0}\\) but flux does *not* appear in any other equation (species, energy, or
+\\(N\_\gamma\\)). Convergence should be driven by the physically consequential quantities, not
 by a diagnostic variable. In dark cells where flux goes to 0, demanding 1% accuracy on a
 near-zero value wastes VODE steps with no physical benefit.
 
-Excluding flux from convergence gave a **3.8x speedup** in photochemistry on CPU and a
-**2.2x speedup** on GPU for the DTypeFront test.
+Excluding flux from convergence gave a **3.8× speedup** in photochemistry on CPU and a
+**2.2× speedup** on GPU for the DTypeFront test.
 
 ### 3.4 Physical constants
 
 | Symbol  | Value                                   | Description                                                      |
 | ------- | --------------------------------------- | ---------------------------------------------------------------- |
-| `a_rad` | `7.5657e-15 erg cm^-3 K^-4`             | Radiation constant (from `fundamental_constants.H`)              |
-| `k_B`   | `1.380649e-16 erg K^-1`                 | Boltzmann constant                                               |
-| `m_p`   | `1.67262192e-24 g`                      | Proton mass                                                      |
-| `c_v`   | `3/2 x k_B / m_p ~ 1.24e8 erg g^-1 K^-1` | Specific heat of monatomic hydrogen gas                           |
+| `a_rad` | \\(7.5657 \times 10^{-15}\ \mathrm{erg}\ \mathrm{cm}^{-3}\ \mathrm{K}^{-4}\\) | Radiation constant (from `fundamental_constants.H`)              |
+| `k_B`   | \\(1.380649 \times 10^{-16}\ \mathrm{erg}\ \mathrm{K}^{-1}\\)                 | Boltzmann constant                                               |
+| `m_p`   | \\(1.67262192 \times 10^{-24}\ \mathrm{g}\\)                      | Proton mass                                                      |
+| `c_v`   | \\(\frac{3}{2} k\_B / m\_p \sim 1.24 \times 10^{8}\ \mathrm{erg}\ \mathrm{g}^{-1}\ \mathrm{K}^{-1}\\) | Specific heat of monatomic hydrogen gas                           |
 
 ### 3.5 radiation_failure_tolerance
 
@@ -202,26 +202,26 @@ VODE uses this threshold in two places:
    `radiation_failure_tolerance`, VODE rejects the substep and retries with a smaller
    timestep. This is the primary use.
 2. **Final state:** after interpolating to the output time, if the photon number density
-   is more negative than $1.5 \times$ `radiation_failure_tolerance`, the burn is
+   is more negative than \\(1.5 \times\\) `radiation_failure_tolerance`, the burn is
    declared failed. The 1.5× factor (via `vode_final_state_radiation_failure_tolerance_factor`
    in `vode_type.H`) accounts for VODE's non-monotonic interpolation, preventing false
    failures from interpolation noise.
 
 Set `radiation_failure_tolerance` equal to `atol_rad_num` (the photon negligibility
-floor). The $1.5\times$ final-state factor absorbs BDF interpolation overshoot without
+floor). The \\(1.5\times\\) final-state factor absorbs BDF interpolation overshoot without
 manual inflation.
 
 Physically, the amount of spurious ionization that can be produced by a negative photon
-overshoot is at most $\texttt{radiation\_failure\_tolerance} / n_{\rm H}$. Whether this
+overshoot is at most `radiation_failure_tolerance` / \\(n\_{\rm H}\\). Whether this
 matters depends on two regimes:
 
-1. **Bright cells** ($N_\gamma \gtrsim n_{\rm H}$): the cell is fully ionized. A few
+1. **Bright cells** (\\(N\_\gamma \gtrsim n\_{\rm H}\\)): the cell is fully ionized. A few
    percent error in photon count does not change the outcome.
-2. **Dark cells** ($N_\gamma \ll n_{\rm H}$): the ratio is negligible as long as
-   $\texttt{radiation\_failure\_tolerance} \ll n_{\rm H}$.
+2. **Dark cells** (\\(N\_\gamma \ll n\_{\rm H}\\)): the ratio is negligible as long as
+   `radiation_failure_tolerance` \\(\ll n\_{\rm H}\\).
 
 For low-density environments such as the CGM or IGM, where the ionized gas density can
-be $\sim 10^{-4}$–$10^{-3}$ cm$^{-3}$, the default value of this parameter may compete
+be \\(\sim 10^{-4}\\)–\\(10^{-3}\ \mathrm{cm}^{-3}\\), the default value of this parameter may compete
 with the physical ionization equilibrium — override it in the input file.
 
 ### 3.6 Erad_floor
@@ -230,18 +230,18 @@ with the physical ionization equilibrium — override it in the input file.
 the M1 hyperbolic solver floor — it prevents the radiation moment solver from
 encountering zero energy density. It is **independent** of the VODE tolerances.
 
-Define the equivalent floor temperature $T_{\rm floor}$ by $E_{\rm rad, floor} \equiv a_{\rm rad} T_{\rm floor}^4$.
-The photon number density at the floor is $N_{\gamma,{\rm floor}} = E_{\rm rad, floor} / E_{\rm photon}$.
+Define the equivalent floor temperature \\(T\_{\rm floor}\\) by \\(E\_{\rm rad, floor} \equiv a\_{\rm rad} T\_{\rm floor}^4\\).
+The photon number density at the floor is \\(N\_{\gamma,{\rm floor}} = E\_{\rm rad, floor} / E\_{\rm photon}\\).
 
-Dark cells (where $E_{\rm rad} \approx E_{\rm rad, floor}$) converge in one VODE step when
-$\texttt{atol\_rad\_num} \gg N_{\gamma,{\rm floor}}$. A ratio of $\geq 10^4$ is sufficient:
+Dark cells (where \\(E\_{\rm rad} \approx E\_{\rm rad, floor}\\)) converge in one VODE step when
+\\(\texttt{atol\_rad\_num} \gg N\_{\gamma,{\rm floor}}\\). A ratio of \\(\geq 10^4\\) is sufficient:
 
-$$
+<script type="math/tex; mode=display">
 \frac{\texttt{atol\_rad\_num}}{N_{\gamma,{\rm floor}}} \geq 10^4.
-$$
+</script>
 
-For typical `Erad_floor` values corresponding to $T_{\rm floor} = 0.01$–$1$ K, an
-`atol_rad_num` on the order of $10^{-6}$–$10^{-2}$ cm^-3 satisfies this constraint.
+For typical `Erad_floor` values corresponding to \\(T\_{\rm floor} = 0.01\\)–\\(1\\) K, an
+`atol_rad_num` on the order of \\(10^{-6}\\)–\\(10^{-2}\ \mathrm{cm}^{-3}\\) satisfies this constraint.
 
 ### 3.7 species_failure_tolerance
 
@@ -251,13 +251,13 @@ VODE uses this threshold in two places:
    than `species_failure_tolerance`, VODE rejects the substep and retries with a smaller
    timestep.
 2. **Final state (secondary):** after interpolating to the output time, if a species is
-   more negative than $1.5 \times$ `species_failure_tolerance`, the burn is declared
+   more negative than \\(1.5 \times\\) `species_failure_tolerance`, the burn is declared
    failed. The 1.5× factor (via `vode_final_state_species_failure_tolerance_factor` in
    `vode_type.H`) accounts for VODE's non-monotonic interpolation, preventing false
    failures from interpolation noise.
 
 Set `integrator.species_failure_tolerance` equal to `atol_spec` (the species
-negligibility floor). The $1.5\times$ final-state factor absorbs BDF interpolation
+negligibility floor). The \\(1.5\times\\) final-state factor absorbs BDF interpolation
 overshoot without manual inflation.
 
 ## 4. Compatibility
@@ -276,7 +276,7 @@ including:
 - collisional ionization and excitation cooling.
 
 The photoionization module computes the same processes from first principles using
-the M1 radiation field and the hydrogen chemistry network (SS 1). Enabling both
+the M1 radiation field and the hydrogen chemistry network (§ 1). Enabling both
 simultaneously would double-count every one of these rates, producing physically
 incorrect temperatures and ionization fractions.
 


### PR DESCRIPTION
### Description
The photoionization page uses markdown style latex [see this page](https://quokka-astro.github.io/quokka/photoionization.html), but our mdBook-based documentation requires [a different syntax](https://rust-lang.github.io/mdBook/format/mathjax.html) . This PR updates the .md file to use the correct syntax. 

### Related issues
None. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
