### PR TITLE
Abort when max_level is too small on restart

### DIFF
--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -4809,6 +4809,10 @@ template <typename problem_t> auto AMRSimulation<problem_t>::readCheckpointHeade
 
 	// read in finest_level
 	is >> finest_level;
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level <= max_level,
+					 std::format("Checkpoint '{}' contains AMR levels 0-{}, but the restart input configured amr.max_level = {}. "
+						     "Restart with amr.max_level >= {} or use a checkpoint with fewer levels.",
+						     restart_file, finest_level, max_level, finest_level));
 	GotoNextLine(is);
 
 	// read in array of istep
@@ -5067,10 +5071,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 
 	// 1. Read header information
 	auto header_box_arrays = readCheckpointHeader(restart_chkfile);
-	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level <= max_level,
-					 std::format("Checkpoint '{}' contains AMR levels 0-{}, but the restart input configured amr.max_level = {}. "
-						     "Restart with amr.max_level >= {} or use a checkpoint with fewer levels.",
-						     restart_chkfile, finest_level, max_level, finest_level));
 
 	// 3. Detect refinement context
 	auto refinement_context = detectRefinementContext(header_box_arrays[0], geom[0]);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -5067,6 +5067,10 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadCheckpointFile(
 
 	// 1. Read header information
 	auto header_box_arrays = readCheckpointHeader(restart_chkfile);
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level <= max_level,
+					 std::format("Checkpoint '{}' contains AMR levels 0-{}, but the restart input configured amr.max_level = {}. "
+						     "Restart with amr.max_level >= {} or use a checkpoint with fewer levels.",
+						     restart_chkfile, finest_level, max_level, finest_level));
 
 	// 3. Detect refinement context
 	auto refinement_context = detectRefinementContext(header_box_arrays[0], geom[0]);


### PR DESCRIPTION
### Description
When restarting from a checkpoint, we need to check that there are at least N levels allocated for an checkpoint with N levels. We do this by asserting that `amr.max_level` must be greater than or equal to N, where N is the maximum level index in the restart checkpoint.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkpoint restarts by validating that the checkpoint’s finest refinement level does not exceed the simulation’s configured maximum level.
  * If the checkpoint is incompatible, the simulation now stops with a clear, descriptive error explaining how to adjust `amr.max_level` (or use a checkpoint with fewer levels) to proceed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->