### PR TITLE
clean(EOS) remove EOS:boltzmann_constant

### DIFF
--- a/src/hydro/EOS.hpp
+++ b/src/hydro/EOS.hpp
@@ -34,7 +34,6 @@ template <typename problem_t> struct EOS_Traits {
 	static constexpr double gamma = 5. / 3.;     // default value
 	static constexpr double cs_isothermal = NAN; // only used when gamma = 1
 	static constexpr double mean_molecular_weight = NAN;
-	static constexpr double boltzmann_constant = C::k_B;
 };
 
 template <typename problem_t> class EOS


### PR DESCRIPTION
### Description
`boltzmann_constant` in EOS_Traits is never used in the code. Removing it to avoid confusion. 

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of a thermodynamic constant used in temperature and energy calculations.
  * Calculation behavior now relies on a single shared value, helping keep related results consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->