### PR TITLE
[Testing] Fix Azure GPU change-detection: plain fetch so the merge-base resolves

### DIFF
--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -59,9 +59,8 @@ jobs:
 
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
-        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
-        changed_files="$(git diff --name-only "$MERGE_BASE" HEAD)"
+        git fetch origin "$TARGET_BRANCH"
+        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
 
         run_heavy="false"
         while IFS= read -r f; do

--- a/.ci/azure-pipelines-amdgpu.yml
+++ b/.ci/azure-pipelines-amdgpu.yml
@@ -57,8 +57,11 @@ jobs:
     - script: |
         set -euo pipefail
 
-        git fetch origin development --depth=1
-        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+        TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
+        [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        changed_files="$(git diff --name-only "$MERGE_BASE" HEAD)"
 
         run_heavy="false"
         while IFS= read -r f; do

--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -40,9 +40,8 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
-        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
-        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+        git fetch origin "$TARGET_BRANCH"
+        CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -40,9 +40,8 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
-        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
-        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+        git fetch origin "$TARGET_BRANCH"
+        CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -59,9 +59,8 @@ jobs:
 
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
-        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
-        changed_files="$(git diff --name-only "$MERGE_BASE" HEAD)"
+        git fetch origin "$TARGET_BRANCH"
+        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
 
         run_heavy="false"
         while IFS= read -r f; do

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -57,8 +57,11 @@ jobs:
     - script: |
         set -euo pipefail
 
-        git fetch origin development --depth=1
-        changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
+        TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
+        [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        changed_files="$(git diff --name-only "$MERGE_BASE" HEAD)"
 
         run_heavy="false"
         while IFS= read -r f; do


### PR DESCRIPTION
### Description

The Azure GPU pipelines begin with a "Detect CI-relevant changes" step that decides whether to run the expensive GPU build. In the two heavy pipelines (`.ci/azure-pipelines.yml`, `.ci/azure-pipelines-amdgpu.yml`) it previously did:

```bash
git fetch origin development --depth=1
changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
```

Here the three-dot `FETCH_HEAD...HEAD` diff is taken from the merge-base of `development`'s tip and the PR branch. But `--depth=1` fetches only `development`'s tip commit with no ancestry, so as soon as `development` advances past the commit that a PR branch last branched from or merged, that merge-base falls outside the shallow boundary and git aborts:

```
fatal: FETCH_HEAD...HEAD: no merge base
```

The check then exits (code 128) before any build runs, failing the GPU check on essentially any PR whose branch isn't sitting exactly on `development`'s tip when the agent runs the fetch. Re-merging `development` only masks it until `development` next moves.

Since these jobs already `checkout` with `fetchDepth: 0` the clone is non-shallow, so any `--depth`/`--deepen` only re-introduces a shallow graft. All four pipelines now use a plain fetch of the target branch and the standard three-dot diff:

```bash
TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
[ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
git fetch origin "$TARGET_BRANCH"
changed_files="$(git diff --name-only FETCH_HEAD...HEAD)"
```

A plain fetch completes the target branch with full ancestry and no graft, so the merge-base is always reachable however far the branch is behind. The `-quick` pipelines previously used `--deepen=100`, which carried the same latent weakness past 100 commits; they now use the same plain-fetch form. Using the PR's actual target branch also keeps it correct for non-`development` targets.

### Validation

I reproduced the failure and the fix in throwaway clones, using the exact commits that failed (a branch whose merge-base was 2 commits behind `development`'s tip), with `development` fetched from GitHub so the shallow semantics are real. The old `--depth=1` form aborts with `no merge base` (exit 128); the plain-fetch form writes no `.git/shallow`, resolves the merge-base, and returns the branch's own changed files unchanged.

### Related issues

- #2031: this PR is a prerequisite for that PR's Azure GPU checks going green (its GitHub CUDA/HIP builds already pass; only the AZP change-detection step fails). It unblocks any active PR hitting the same failure, not just #2031.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code. *(N/A: CI-infrastructure change, no new physics.)*
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI change detection so pull requests are compared against the correct target branch instead of always using the default branch.
  * Build and test selection now relies on a more direct diff of the PR branch against the fetched base branch, helping CI run the right checks more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->