### PR TITLE
Add O(v/c) work term to the photoionization network

### DIFF
--- a/inputs/DTypeFrontVC.toml
+++ b/inputs/DTypeFrontVC.toml
@@ -1,0 +1,51 @@
+# *****************************************************************
+# Direct photoionization O(v/c) momentum deposition test
+# *****************************************************************
+
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+quokka.bc = ["reflecting", "reflecting", "reflecting"]
+
+amr.v = 0
+amr.n_cell = [16, 16, 16]
+amr.max_level = 0
+amr.blocking_factor = 16
+amr.max_grid_size = 64
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 1
+
+# The problem calls computePhotoChemistry() directly; stop_time is not used.
+stop_time = 0.0
+max_timesteps = 0
+plotfile_interval = -1
+
+photoionization_momentum.primary_species_1 = 1.0e-10
+photoionization_momentum.primary_species_2 = 1.0e2
+photoionization_momentum.primary_species_3 = 1.0e-10
+photoionization_momentum.temperature = 1.0e3
+
+integrator.use_number_densities = 1
+integrator.do_species_clip = 0
+integrator.jacobian = 1
+integrator.renormalize_abundances = 0
+integrator.subtract_internal_energy = 0
+integrator.X_reject_buffer = 1e100
+integrator.ode_max_steps = 50000
+
+network.recombination_switch = 0
+network.energy_switch = 0
+network.collisional_ionization_switch = 0
+network.allow_mixed_cell_cooling = 0
+
+integrator.atol_spec = 1.0e-8
+integrator.atol_enuc = 1.24e8
+integrator.atol_rad_num = 1.0e-8
+integrator.species_failure_tolerance = 1.0e-8
+integrator.radiation_failure_tolerance = 1.0e-8
+
+integrator.rtol_spec = 1.0e-10
+integrator.rtol_rad_num = 1.0e-10
+integrator.rtol_enuc = 1.0e-10
+
+integrator.rosenbrock_tableau = 3

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -68,7 +68,7 @@ template <> struct RadSystem_Traits<DTypeFront> {
 	// beta_order = 0 disables the O(v/c) radiation terms, including the photoionization work term
 	// (photochemistry momentum deposition is gated on beta_order == 1), so this test validates pure
 	// thermal-pressure D-type front expansion against the Spitzer solution without radiation pressure.
-	static constexpr int beta_order = 0;
+	static constexpr int beta_order = 1;
 	static constexpr auto ChemBands() { return ChemBandsHeader_; }
 };
 

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -5,7 +5,6 @@
 //==============================================================================
 /// \file testDTypeFront.cpp
 /// \brief Defines a test problem for the static Stromgren sphere with no temperature dependence.
-/// \note Exercises the photoionization momentum/work-term coupling (radiation force on the gas).
 ///
 
 #include "AMReX.H"
@@ -66,6 +65,9 @@ template <> struct RadSystem_Traits<DTypeFront> {
 	// The 1e-6 prefactor means radiation at T_min becomes numerically negligible after
 	// ~1e6 VODE steps (accumulated local error stays below the physically meaningful level).
 	static constexpr double Erad_floor = C::a_rad * 1.0e-8;
+	// beta_order = 0 disables the O(v/c) radiation terms, including the photoionization work term
+	// (photochemistry momentum deposition is gated on beta_order == 1), so this test validates pure
+	// thermal-pressure D-type front expansion against the Spitzer solution without radiation pressure.
 	static constexpr int beta_order = 0;
 	static constexpr auto ChemBands() { return ChemBandsHeader_; }
 };

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -5,6 +5,7 @@
 //==============================================================================
 /// \file testDTypeFront.cpp
 /// \brief Defines a test problem for the static Stromgren sphere with no temperature dependence.
+/// \note Exercises the photoionization momentum/work-term coupling (radiation force on the gas).
 ///
 
 #include "AMReX.H"

--- a/src/problems/DTypeFrontVC/CMakeLists.txt
+++ b/src/problems/DTypeFrontVC/CMakeLists.txt
@@ -1,0 +1,102 @@
+if(AMReX_SPACEDIM GREATER_EQUAL 2)
+  set(microphysics_network_name "photoionization") # this will override
+                                                   # network_name to
+                                                   # photoionization for this
+                                                   # directory only
+  setup_target_for_microphysics_compilation(${microphysics_network_name}
+                                            "${CMAKE_CURRENT_BINARY_DIR}/"
+                                            "Rosenbrock")
+
+  # use the BEFORE keyword so that these files get priority in compilation for
+  # targets in this directory this is critical to ensure the correct Microphysics
+  # files are linked to photoionization target
+  include_directories(
+    BEFORE ${photoionization_dirs} "${CMAKE_CURRENT_BINARY_DIR}/"
+    "includes/extern_parameters.H" "includes/network_properties.H")
+
+  set(JOB_NAME DTypeFrontVC)
+
+  # Number of species
+  set(NSPEC 3)
+  set(NEXTRASPEC 0)
+
+  # Species enums
+  set(SPECIES_ENUM
+  "e = 0,
+  H,
+  Hp"
+  )
+
+  # Atomic masses (in atomic mass units)
+  set(AION
+  "5.4858e-4,
+  1.0,
+  1.0"
+  )
+  set(AION_INV
+  "1822.89,
+  1.0,
+  1.0"
+  )
+
+  # Charges
+  set(ZION
+  "1.0,
+  1.0,
+  1.0"
+  )
+
+  # constexpr switch bodies
+  set(AION_CONSTEXPR
+  "case e:  a = 1.0; break;
+  case H:  a = 1.0; break;
+  case Hp: a = 1.0; break;"
+  )
+
+  set(ZION_CONSTEXPR
+  "case e:  z = 1.0; break;
+  case H:  z = 1.0; break;
+  case Hp: z = 1.0; break;"
+  )
+
+  # Species names
+  set(SHORT_SPEC_NAMES
+  "\"e\",
+  \"H\",
+  \"H+\""
+  )
+
+  set(SPEC_NAMES
+  "\"Electron\",
+  \"Hydrogen\",
+  \"Hydrogen_Ion\""
+  )
+
+  # No extra network properties
+  set(PROPERTIES "")
+
+  # Set photoionisation properties
+  set(NUM_CHEM_BANDS 1)
+  set(CHEM_BANDS "3.29e15, 1.50e16") # Hz
+
+  # Configure the header
+  configure_file(
+      ${CMAKE_SOURCE_DIR}/src/networks/network_header.template
+      ${CMAKE_CURRENT_BINARY_DIR}/network_properties.H
+      @ONLY
+  )
+
+
+  add_executable(
+    ${JOB_NAME} testDTypeFrontVC.cpp "${QuokkaSourcesNoEOS}"
+                ../../radiation/photochemistry.cpp ${photoionization_sources})
+
+  # this will add #define CHEMISTRY
+  target_compile_definitions(${JOB_NAME} PUBLIC PHOTOCHEMISTRY)
+
+  if(AMReX_GPU_BACKEND MATCHES "CUDA")
+    setup_target_for_cuda_compilation(${JOB_NAME})
+  endif(AMReX_GPU_BACKEND MATCHES "CUDA")
+
+  add_test(NAME DTypeFrontVC COMMAND ${JOB_NAME} ../inputs/DTypeFrontVC.toml ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
+++ b/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
@@ -241,7 +241,7 @@ auto problem_main() -> int
 	set_uniform_radiation_beam(sim.state_new_cc_[0], initial_rad_energy, initial_flux_x);
 	const EnergyCheck energy_before = compute_energy_check(sim.state_new_cc_[0], sim.geom[0].CellSizeArray());
 
-	std::array<amrex::MultiFab const *, AMREX_SPACEDIM> fc_ptrs{};
+	std::array<amrex::MultiFab const *, AMREX_SPACEDIM> const fc_ptrs{};
 	static_cast<void>(quokka::photochemistry::computePhotoChemistry<DTypeFrontVC>(sim.state_new_cc_[0], fc_ptrs, burn_dt, 1,
 										      std::numeric_limits<amrex::Real>::max(), 0.0_rt));
 

--- a/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
+++ b/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
@@ -1,0 +1,295 @@
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file testDTypeFrontVC.cpp
+/// \brief Direct photoionization O(v/c) momentum-coupling test.
+///
+
+#include "AMReX.H"
+#include "AMReX_Array.H"
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_REAL.H"
+#include "AMReX_Reduce.H"
+#include "QuokkaSimulation.hpp"
+#include "fundamental_constants.H"
+#include "physics_info.hpp"
+#include "radiation/photochemistry.hpp"
+#include "radiation/radiation_system.hpp"
+#include <array>
+#include <cmath>
+#include <limits>
+
+#include "actual_eos_data.H"
+#include "burn_type.H"
+#include "eos.H"
+#include "extern_parameters.H"
+#include "network.H"
+
+struct DTypeFrontVC {
+};
+
+namespace
+{
+constexpr double c_hat = C::c_light / 1000.0;
+constexpr amrex::Real initial_photon_number_density = 10.0_rt;
+constexpr amrex::Real burn_dt = 1.0e8_rt;
+
+struct MomentumCheck {
+	amrex::Real gas_px{};
+	amrex::Real gas_py{};
+	amrex::Real gas_pz{};
+	amrex::Real expected_px{};
+};
+
+struct EnergyCheck {
+	amrex::Real gas_energy{};
+	amrex::Real gas_internal_energy{};
+	amrex::Real gas_kinetic_energy{};
+};
+} // namespace
+
+template <> struct quokka::EOS_Traits<DTypeFrontVC> {
+	static constexpr double mean_molecular_weight = 1.0;
+	static constexpr double gamma = 5. / 3.;
+};
+
+template <> struct Physics_Traits<DTypeFrontVC> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int numMassScalars = NumSpec;
+	static constexpr int numPassiveScalars = numMassScalars;
+	static constexpr bool is_radiation_enabled = true;
+};
+
+template <> struct RadSystem_Traits<DTypeFrontVC> {
+	static constexpr double c_hat_over_c = c_hat / C::c_light;
+	static constexpr double Erad_floor = C::a_rad * 1.0e-8;
+	static constexpr int beta_order = 1;
+	static constexpr auto ChemBands() { return ChemBandsHeader_; }
+};
+
+template <> struct SimulationData<DTypeFrontVC> {
+	amrex::Real small_temp{};
+	amrex::Real small_dens{};
+	amrex::Real temperature{};
+	amrex::Real primary_species_1{};
+	amrex::Real primary_species_2{};
+	amrex::Real primary_species_3{};
+};
+
+template <>
+void RadSystem<DTypeFrontVC>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*dx*/,
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
+						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
+{
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { radEnergy(i, j, k) = 0.0_rt; });
+}
+
+template <> void QuokkaSimulation<DTypeFrontVC>::preCalculateInitialConditions()
+{
+	init_extern_parameters();
+
+	amrex::ParmParse const pp("photoionization_momentum");
+	userData_.small_temp = 1.0e-2;
+	userData_.small_dens = 1.0e-60;
+	userData_.temperature = 1.0e3;
+	userData_.primary_species_1 = 1.0e-10;
+	userData_.primary_species_2 = 1.0e2;
+	userData_.primary_species_3 = 1.0e-10;
+	pp.query("small_temp", userData_.small_temp);
+	pp.query("small_dens", userData_.small_dens);
+	pp.query("temperature", userData_.temperature);
+	pp.query("primary_species_1", userData_.primary_species_1);
+	pp.query("primary_species_2", userData_.primary_species_2);
+	pp.query("primary_species_3", userData_.primary_species_3);
+
+	eos_init(userData_.small_temp, userData_.small_dens);
+	network_init();
+}
+
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<DTypeFrontVC>::ComputePlanckOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
+{
+	return 0.0_rt;
+}
+
+template <> AMREX_GPU_HOST_DEVICE auto RadSystem<DTypeFrontVC>::ComputeFluxMeanOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
+{
+	return 0.0_rt;
+}
+
+template <> void QuokkaSimulation<DTypeFrontVC>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	burn_t state;
+	std::array<Real, NumSpec> numdens = {userData_.primary_species_1, userData_.primary_species_2, userData_.primary_species_3};
+	state.T = userData_.temperature;
+
+	Real rhotot = 0.0_rt;
+	for (int n = 0; n < NumSpec; ++n) {
+		state.xn[n] = numdens[n];
+		rhotot += state.xn[n] * spmasses[n];
+	}
+	state.rho = rhotot;
+	eos(eos_input_rt, state);
+	const auto Egas0 = state.e * rhotot;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int g = 0; g < Physics_Traits<DTypeFrontVC>::nGroups; ++g) {
+			state_cc(i, j, k, RadSystem<DTypeFrontVC>::radEnergy_index + Physics_NumVars::numRadVarsPerGroup * g) = 1.0e-99_rt;
+			state_cc(i, j, k, RadSystem<DTypeFrontVC>::x1RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) = 0.0_rt;
+			state_cc(i, j, k, RadSystem<DTypeFrontVC>::x2RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) = 0.0_rt;
+			state_cc(i, j, k, RadSystem<DTypeFrontVC>::x3RadFlux_index + Physics_NumVars::numRadVarsPerGroup * g) = 0.0_rt;
+		}
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::gasEnergy_index) = Egas0;
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::gasDensity_index) = rhotot;
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::gasInternalEnergy_index) = Egas0;
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::x1GasMomentum_index) = 0.0_rt;
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::x2GasMomentum_index) = 0.0_rt;
+		state_cc(i, j, k, RadSystem<DTypeFrontVC>::x3GasMomentum_index) = 0.0_rt;
+		for (int nn = 0; nn < NumSpec; ++nn) {
+			state_cc(i, j, k, HydroSystem<DTypeFrontVC>::scalar0_index + nn) = state.xn[nn] * spmasses[nn];
+		}
+	});
+}
+
+template <> void QuokkaSimulation<DTypeFrontVC>::computeAfterTimestep() {}
+
+namespace
+{
+void set_uniform_radiation_beam(amrex::MultiFab &state_mf, amrex::Real const initial_rad_energy, amrex::Real const initial_flux_x)
+{
+	for (amrex::MFIter iter(state_mf); iter.isValid(); ++iter) {
+		const amrex::Box &indexRange = iter.validbox();
+		auto const &state = state_mf.array(iter);
+		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+			state(i, j, k, RadSystem<DTypeFrontVC>::radEnergy_index) = initial_rad_energy;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x1RadFlux_index) = initial_flux_x;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x2RadFlux_index) = 0.0_rt;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x3RadFlux_index) = 0.0_rt;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x1GasMomentum_index) = 0.0_rt;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x2GasMomentum_index) = 0.0_rt;
+			state(i, j, k, RadSystem<DTypeFrontVC>::x3GasMomentum_index) = 0.0_rt;
+		});
+	}
+}
+
+auto compute_momentum_check(amrex::MultiFab const &state_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::Real const initial_flux_x)
+    -> MomentumCheck
+{
+	amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+	amrex::ReduceData<amrex::Real, amrex::Real, amrex::Real, amrex::Real> reduce_data(reduce_op);
+	auto const state = state_mf.const_arrays();
+	const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+	const amrex::Real inv_c2 = 1.0_rt / (C::c_light * C::c_light);
+
+	reduce_op.eval(state_mf, amrex::IntVect(0), reduce_data,
+		       [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept -> amrex::GpuTuple<amrex::Real, amrex::Real, amrex::Real, amrex::Real> {
+			       const amrex::Real gas_px = cell_volume * state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x1GasMomentum_index);
+			       const amrex::Real gas_py = cell_volume * state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x2GasMomentum_index);
+			       const amrex::Real gas_pz = cell_volume * state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x3GasMomentum_index);
+			       const amrex::Real flux_x_after = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x1RadFlux_index);
+			       const amrex::Real expected_px = cell_volume * (initial_flux_x - flux_x_after) * inv_c2;
+			       return {gas_px, gas_py, gas_pz, expected_px};
+		       });
+
+	auto [gas_px, gas_py, gas_pz, expected_px] = reduce_data.value();
+	amrex::ParallelAllReduce::Sum(gas_px, amrex::ParallelContext::CommunicatorSub());
+	amrex::ParallelAllReduce::Sum(gas_py, amrex::ParallelContext::CommunicatorSub());
+	amrex::ParallelAllReduce::Sum(gas_pz, amrex::ParallelContext::CommunicatorSub());
+	amrex::ParallelAllReduce::Sum(expected_px, amrex::ParallelContext::CommunicatorSub());
+	return {.gas_px = gas_px, .gas_py = gas_py, .gas_pz = gas_pz, .expected_px = expected_px};
+}
+
+auto compute_energy_check(amrex::MultiFab const &state_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx) -> EnergyCheck
+{
+	amrex::ReduceOps<amrex::ReduceOpSum, amrex::ReduceOpSum, amrex::ReduceOpSum> reduce_op;
+	amrex::ReduceData<amrex::Real, amrex::Real, amrex::Real> reduce_data(reduce_op);
+	auto const state = state_mf.const_arrays();
+	const amrex::Real cell_volume = AMREX_D_TERM(dx[0], *dx[1], *dx[2]);
+
+	reduce_op.eval(state_mf, amrex::IntVect(0), reduce_data,
+		       [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept -> amrex::GpuTuple<amrex::Real, amrex::Real, amrex::Real> {
+			       const amrex::Real rho = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::gasDensity_index);
+			       const amrex::Real px = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x1GasMomentum_index);
+			       const amrex::Real py = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x2GasMomentum_index);
+			       const amrex::Real pz = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::x3GasMomentum_index);
+			       const amrex::Real kinetic = (px * px + py * py + pz * pz) / (2.0_rt * rho);
+			       const amrex::Real gas_energy = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::gasEnergy_index);
+			       const amrex::Real gas_internal_energy = state[box_no](i, j, k, RadSystem<DTypeFrontVC>::gasInternalEnergy_index);
+			       return {cell_volume * gas_energy, cell_volume * gas_internal_energy, cell_volume * kinetic};
+		       });
+
+	auto [gas_energy, gas_internal_energy, gas_kinetic_energy] = reduce_data.value();
+	amrex::ParallelAllReduce::Sum(gas_energy, amrex::ParallelContext::CommunicatorSub());
+	amrex::ParallelAllReduce::Sum(gas_internal_energy, amrex::ParallelContext::CommunicatorSub());
+	amrex::ParallelAllReduce::Sum(gas_kinetic_energy, amrex::ParallelContext::CommunicatorSub());
+	return {.gas_energy = gas_energy, .gas_internal_energy = gas_internal_energy, .gas_kinetic_energy = gas_kinetic_energy};
+}
+} // namespace
+
+auto problem_main() -> int
+{
+	QuokkaSimulation<DTypeFrontVC> sim;
+	sim.setInitialConditions();
+
+	const amrex::Real photon_energy = RadSystem<DTypeFrontVC>::GetChemBandQuanta(0);
+	const amrex::Real initial_rad_energy = initial_photon_number_density * photon_energy;
+	const amrex::Real initial_flux_x = C::c_light * initial_rad_energy;
+	set_uniform_radiation_beam(sim.state_new_cc_[0], initial_rad_energy, initial_flux_x);
+	const EnergyCheck energy_before = compute_energy_check(sim.state_new_cc_[0], sim.geom[0].CellSizeArray());
+
+	std::array<amrex::MultiFab const *, AMREX_SPACEDIM> fc_ptrs{};
+	static_cast<void>(quokka::photochemistry::computePhotoChemistry<DTypeFrontVC>(sim.state_new_cc_[0], fc_ptrs, burn_dt, 1,
+										      std::numeric_limits<amrex::Real>::max(), 0.0_rt));
+
+	const MomentumCheck check = compute_momentum_check(sim.state_new_cc_[0], sim.geom[0].CellSizeArray(), initial_flux_x);
+	const EnergyCheck energy_after = compute_energy_check(sim.state_new_cc_[0], sim.geom[0].CellSizeArray());
+
+	int status = 0;
+	const amrex::Real rel_err = std::abs(check.gas_px - check.expected_px) / check.expected_px;
+	const amrex::Real transverse_momentum = std::sqrt(check.gas_py * check.gas_py + check.gas_pz * check.gas_pz);
+	const amrex::Real transverse_rel = transverse_momentum / check.expected_px;
+	const amrex::Real internal_rel = std::abs(energy_after.gas_internal_energy - energy_before.gas_internal_energy) / energy_before.gas_internal_energy;
+	const amrex::Real total_energy_delta = energy_after.gas_energy - energy_before.gas_energy;
+	const amrex::Real kinetic_abs = std::abs(total_energy_delta - energy_after.gas_kinetic_energy);
+	const amrex::Real kinetic_rel = std::abs(total_energy_delta - energy_after.gas_kinetic_energy) / energy_after.gas_kinetic_energy;
+
+	amrex::Print() << "Gas x-momentum: " << check.gas_px << '\n';
+	amrex::Print() << "Expected x-momentum from absorbed flux: " << check.expected_px << '\n';
+	amrex::Print() << "Relative x-momentum error: " << rel_err << '\n';
+	amrex::Print() << "Relative transverse momentum: " << transverse_rel << '\n';
+	amrex::Print() << "Relative internal-energy change from O(v/c) work term: " << internal_rel << '\n';
+	amrex::Print() << "Total gas-energy change: " << total_energy_delta << '\n';
+	amrex::Print() << "Gas kinetic energy after momentum deposition: " << energy_after.gas_kinetic_energy << '\n';
+	amrex::Print() << "Absolute total-energy/kinetic-energy error: " << kinetic_abs << '\n';
+	amrex::Print() << "Relative total-energy/kinetic-energy error: " << kinetic_rel << '\n';
+
+	if (!(check.expected_px > 0.0_rt)) {
+		amrex::Print() << "Test FAILED: no chem-band flux was absorbed.\n";
+		status = 1;
+	}
+	if (rel_err > 1.0e-12_rt) {
+		amrex::Print() << "Test FAILED: gas momentum does not match absorbed photon momentum.\n";
+		status = 1;
+	}
+	if (transverse_rel > 1.0e-14_rt) {
+		amrex::Print() << "Test FAILED: transverse momentum was deposited by a purely x-directed beam.\n";
+		status = 1;
+	}
+	if (internal_rel > 1.0e-12_rt) {
+		amrex::Print() << "Test FAILED: O(v/c) momentum work changed gas internal energy.\n";
+		status = 1;
+	}
+	if (kinetic_abs > 1.0e-12_rt * energy_after.gas_energy) {
+		amrex::Print() << "Test FAILED: absorbed momentum did not increase total gas energy by the kinetic-energy gain.\n";
+		status = 1;
+	}
+	if (status == 0) {
+		amrex::Print() << "Test passed: photoionization O(v/c) momentum deposition changes kinetic energy only.\n";
+	}
+
+	return status;
+}

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -5,6 +5,7 @@
 //==============================================================================
 /// \file testOneZonePhotoionization.cpp
 /// \brief Defines a test problem for photoionization.
+/// \note Zero-flux regression for the photoionization momentum/work-term coupling.
 ///
 
 #include "AMReX.H"

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -5,7 +5,6 @@
 //==============================================================================
 /// \file testOneZonePhotoionization.cpp
 /// \brief Defines a test problem for photoionization.
-/// \note Zero-flux regression for the photoionization momentum/work-term coupling.
 ///
 
 #include "AMReX.H"

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -138,23 +138,81 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			for (int nn = 0; nn < NumSpec; ++nn) {
 				state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) = photochemstate.xn[nn] * spmasses[nn];
 			}
+			// Attenuate the photon field and accumulate the momentum transferred to the gas.
+			// Absorbed ionizing photons deposit their momentum in the gas: dp = -(F_new - F_old) / (c * chat),
+			// matching the RSLA-consistent radiation-force convention used by the M1 source terms.
+			const Real inv_c_chat = 1.0_rt / (C::c_light * photochemstate.c_hat);
+			Real dMomX = 0.0_rt;
+			Real dMomY = 0.0_rt;
+			Real dMomZ = 0.0_rt;
+			amrex::GpuArray<Real, NumChemBands> dMomMag{};
+			Real dMomMagSum = 0.0_rt;
 			for (int nn = 0; nn < NumChemBands; ++nn) {
-				state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
-				    photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
-				state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
-				    photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] *
-				    state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn);
-				state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
-				    photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] *
-				    state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn);
-				state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
-				    photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn] *
-				    state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn);
+				const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+				const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+				const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+				const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+
+				state(i, j, k, eIdx) = photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
+
+				// flux_factor = F_new / F_old (photon flux attenuation from the burn)
+				const Real flux_factor = photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn];
+				const Real FxOld = state(i, j, k, fxIdx);
+				const Real FyOld = state(i, j, k, fyIdx);
+				const Real FzOld = state(i, j, k, fzIdx);
+
+				const Real dpx = (1.0_rt - flux_factor) * FxOld * inv_c_chat;
+				const Real dpy = (1.0_rt - flux_factor) * FyOld * inv_c_chat;
+				const Real dpz = (1.0_rt - flux_factor) * FzOld * inv_c_chat;
+				dMomX += dpx;
+				dMomY += dpy;
+				dMomZ += dpz;
+				dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
+				dMomMagSum += dMomMag[nn];
+
+				state(i, j, k, fxIdx) = flux_factor * FxOld;
+				state(i, j, k, fyIdx) = flux_factor * FyOld;
+				state(i, j, k, fzIdx) = flux_factor * FzOld;
 			}
+
 			// Quokka uses rho*eint
 			const Real dEint = (photochemstate.e * photochemstate.rho) - Eint;
 			state(i, j, k, RadSystem<problem_t>::gasInternalEnergy_index) += dEint * energy_update_factor;
-			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor;
+
+			// Update the gas momentum by conservation with the absorbed photons.
+			const Real xmom_new = xmom + dMomX;
+			const Real ymom_new = ymom + dMomY;
+			const Real zmom_new = zmom + dMomZ;
+			state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index) = xmom_new;
+			state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index) = ymom_new;
+			state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index) = zmom_new;
+
+			// Reconstruct the gas total energy from the updated internal energy and the updated kinetic energy.
+			// dEkin is the work done on the gas by the radiation force (magnetic energy is unchanged by the kick).
+			const Real dEkin =
+			    (xmom_new * xmom_new + ymom_new * ymom_new + zmom_new * zmom_new - (xmom * xmom + ymom * ymom + zmom * zmom)) / (2.0_rt * rho);
+			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor + dEkin;
+
+			// Strict energy conservation: remove the work-term energy (c / chat) * dEkin from the chem-band photon field,
+			// split across bands in proportion to each band's momentum contribution. Clamp so n_gamma stays >= small_x.
+			// Rescale each band's flux by the same factor its energy density changes so the reduced flux |F| / (c E) is
+			// preserved (keeps the M1 closure constraint F / c <= E from being violated by the energy debit).
+			if (dMomMagSum > 0.0_rt) {
+				const Real E_debit = (C::c_light / photochemstate.c_hat) * dEkin;
+				for (int nn = 0; nn < NumChemBands; ++nn) {
+					const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+					const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+					const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+					const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+					const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
+					const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
+					state(i, j, k, eIdx) = E_new;
+					const Real flux_rescale = E_new / E_old;
+					state(i, j, k, fxIdx) *= flux_rescale;
+					state(i, j, k, fyIdx) *= flux_rescale;
+					state(i, j, k, fzIdx) *= flux_rescale;
+				}
+			}
 		});
 
 #ifdef AMREX_USE_HIP

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -158,9 +158,9 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			// here unconditionally (cheap) and only applied when do_vc_work is true -- computing it outside the
 			// `if constexpr (do_vc_work)` block avoids NVCC's "cannot first-capture in constexpr-if" restriction.
 			const Real inv_c2 = 1.0_rt / (C::c_light * C::c_light);
-			[[maybe_unused]] Real dMomX = 0.0_rt;
-			[[maybe_unused]] Real dMomY = 0.0_rt;
-			[[maybe_unused]] Real dMomZ = 0.0_rt;
+			Real dMomX = 0.0_rt;
+			Real dMomY = 0.0_rt;
+			Real dMomZ = 0.0_rt;
 			// per-band momentum-kick magnitudes, used only to split the optional work-term energy debit across bands
 			[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
 			[[maybe_unused]] Real dMomMagSum = 0.0_rt;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -154,26 +154,43 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			for (int nn = 0; nn < NumSpec; ++nn) {
 				state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) = photochemstate.xn[nn] * spmasses[nn];
 			}
-			// Cache the pre-burn chem-band radiation flux (energy units) so the O(v/c) work term can use the
-			// VODE-attenuated flux difference -(F_after - F_before) to deposit the absorbed photon momentum to
-			// the gas. Only needed when the work term is active.
-			[[maybe_unused]] amrex::GpuArray<amrex::GpuArray<Real, 3>, NumChemBands> frad_before{};
-			if constexpr (do_vc_work) {
-				for (int nn = 0; nn < NumChemBands; ++nn) {
-					frad_before[nn][0] = state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn);
-					frad_before[nn][1] = state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn);
-					frad_before[nn][2] = state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn);
-				}
-			}
-
-			// Update the chem-band photon number density and attenuate the flux by the burn's rn[1] factor.
+			// Update the chem-band photon number density, attenuate the flux by the burn's rn[1] factor, and
+			// accumulate the momentum the gas absorbs from the O(v/c) work term: dP = -(F_after - F_before) / c^2,
+			// summed over chem bands. The absorbed photon momentum is tied to the physical photon flux F = c E; the
+			// reduced speed of light only changes the absorption rate used by the chemistry solve. dMom is computed
+			// here unconditionally (cheap) and only applied when do_vc_work is true -- computing it outside the
+			// `if constexpr (do_vc_work)` block avoids NVCC's "cannot first-capture in constexpr-if" restriction.
+			const Real inv_c2 = 1.0_rt / (C::c_light * C::c_light);
+			[[maybe_unused]] Real dMomX = 0.0_rt;
+			[[maybe_unused]] Real dMomY = 0.0_rt;
+			[[maybe_unused]] Real dMomZ = 0.0_rt;
+			// per-band momentum-kick magnitudes, used only to split the optional work-term energy debit across bands
+			[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
+			[[maybe_unused]] Real dMomMagSum = 0.0_rt;
 			for (int nn = 0; nn < NumChemBands; ++nn) {
+				const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+				const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+				const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
 				const Real flux_factor = photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn];
 				state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
 				    photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
-				state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
-				state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
-				state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
+				const Real FxOld = state(i, j, k, fxIdx);
+				const Real FyOld = state(i, j, k, fyIdx);
+				const Real FzOld = state(i, j, k, fzIdx);
+				// dp = (F_before - F_after) / c^2 = (1 - flux_factor) * F_before / c^2
+				const Real dpx = (1.0_rt - flux_factor) * FxOld * inv_c2;
+				const Real dpy = (1.0_rt - flux_factor) * FyOld * inv_c2;
+				const Real dpz = (1.0_rt - flux_factor) * FzOld * inv_c2;
+				dMomX += dpx;
+				dMomY += dpy;
+				dMomZ += dpz;
+				if constexpr (debit_work_term_from_radiation) {
+					dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
+					dMomMagSum += dMomMag[nn];
+				}
+				state(i, j, k, fxIdx) = flux_factor * FxOld;
+				state(i, j, k, fyIdx) = flux_factor * FyOld;
+				state(i, j, k, fzIdx) = flux_factor * FzOld;
 			}
 
 			// Quokka uses rho*eint
@@ -181,35 +198,12 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			state(i, j, k, RadSystem<problem_t>::gasInternalEnergy_index) += dEint * energy_update_factor;
 			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor;
 
-			// O(v/c) radiation-pressure work term: deposit the photon momentum absorbed during the burn to the
-			// gas. dP = -(F_after - F_before) / c^2, summed over chem bands. The absorbed photon momentum is tied
-			// to the physical photon flux F = c E; the reduced speed of light only changes the absorption rate
-			// used by the chemistry solve. This changes the kinetic energy of the updated momentum only; the
-			// auxiliary internal energy is unaffected.
-			if constexpr (do_vc_work) {
-				const Real inv_c2 = 1.0_rt / (C::c_light * C::c_light);
-				Real dMomX = 0.0_rt;
-				Real dMomY = 0.0_rt;
-				Real dMomZ = 0.0_rt;
-				// per-band momentum-kick magnitudes, used only to split the optional work-term energy debit across bands
-				[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
-				[[maybe_unused]] Real dMomMagSum = 0.0_rt;
-				for (int nn = 0; nn < NumChemBands; ++nn) {
-					const Real dpx =
-					    (frad_before[nn][0] - state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
-					const Real dpy =
-					    (frad_before[nn][1] - state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
-					const Real dpz =
-					    (frad_before[nn][2] - state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
-					dMomX += dpx;
-					dMomY += dpy;
-					dMomZ += dpz;
-					if constexpr (debit_work_term_from_radiation) {
-						dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
-						dMomMagSum += dMomMag[nn];
-					}
-				}
-
+			// O(v/c) radiation-pressure work term: apply the absorbed photon momentum (dMom, computed above) to the
+			// gas. This changes the kinetic energy of the updated momentum only; the auxiliary internal energy is
+			// unaffected. Gated on beta_order==1 && hydro (do_vc_work), so beta_order==0 problems are untouched.
+			// Use a runtime `if` on the constexpr flag (the dead branch is optimized away): NVCC rejects extended
+			// __device__ lambdas that first-capture a variable inside an `if constexpr` block.
+			if (do_vc_work) {
 				const Real xmom_new = xmom + dMomX;
 				const Real ymom_new = ymom + dMomY;
 				const Real zmom_new = zmom + dMomZ;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -21,6 +21,15 @@
 
 namespace quokka::photochemistry
 {
+// If true, the work-term kinetic energy the gas gains from the absorbed-photon momentum kick is debited
+// from the chem-band photon field (photon energy density reduced by (c / chat) * dEkin, and each band's
+// flux rescaled by the same factor to preserve the M1 closure |F| <= c E), strictly conserving the
+// gas+radiation energy. If false (default), the photon field is left unchanged after the burn: the gas
+// still gains the kinetic energy, but it is not removed from the radiation, so the ionizing photon number
+// density is conserved at the cost of gas+radiation energy conservation. Conserving the ionizing photon
+// budget is the more important property for correct ionization-front propagation, so it is the default.
+static constexpr bool debit_work_term_from_radiation = false;
+
 AMREX_GPU_DEVICE void photochem_burner(burn_t &photochemstate, Real dt);
 
 template <typename problem_t>
@@ -145,8 +154,9 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			Real dMomX = 0.0_rt;
 			Real dMomY = 0.0_rt;
 			Real dMomZ = 0.0_rt;
-			amrex::GpuArray<Real, NumChemBands> dMomMag{};
-			Real dMomMagSum = 0.0_rt;
+			// per-band momentum-kick magnitudes, used only to split the work-term energy debit across bands
+			[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
+			[[maybe_unused]] Real dMomMagSum = 0.0_rt;
 			for (int nn = 0; nn < NumChemBands; ++nn) {
 				const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
 				const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
@@ -167,8 +177,10 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 				dMomX += dpx;
 				dMomY += dpy;
 				dMomZ += dpz;
-				dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
-				dMomMagSum += dMomMag[nn];
+				if constexpr (debit_work_term_from_radiation) {
+					dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
+					dMomMagSum += dMomMag[nn];
+				}
 
 				state(i, j, k, fxIdx) = flux_factor * FxOld;
 				state(i, j, k, fyIdx) = flux_factor * FyOld;
@@ -193,24 +205,28 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			    (xmom_new * xmom_new + ymom_new * ymom_new + zmom_new * zmom_new - (xmom * xmom + ymom * ymom + zmom * zmom)) / (2.0_rt * rho);
 			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor + dEkin;
 
-			// Strict energy conservation: remove the work-term energy (c / chat) * dEkin from the chem-band photon field,
-			// split across bands in proportion to each band's momentum contribution. Clamp so n_gamma stays >= small_x.
-			// Rescale each band's flux by the same factor its energy density changes so the reduced flux |F| / (c E) is
+			// Optionally enforce strict gas+radiation energy conservation: remove the work-term energy (c / chat) * dEkin
+			// from the chem-band photon field, split across bands in proportion to each band's momentum contribution, and
+			// rescale each band's flux by the same factor its energy density changes so the reduced flux |F| / (c E) is
 			// preserved (keeps the M1 closure constraint F / c <= E from being violated by the energy debit).
-			if (dMomMagSum > 0.0_rt) {
-				const Real E_debit = (C::c_light / photochemstate.c_hat) * dEkin;
-				for (int nn = 0; nn < NumChemBands; ++nn) {
-					const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-					const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-					const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-					const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-					const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
-					const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
-					state(i, j, k, eIdx) = E_new;
-					const Real flux_rescale = E_new / E_old;
-					state(i, j, k, fxIdx) *= flux_rescale;
-					state(i, j, k, fyIdx) *= flux_rescale;
-					state(i, j, k, fzIdx) *= flux_rescale;
+			// Disabled by default: conserving the ionizing photon number density is more important than energy conservation
+			// for correct ionization-front propagation (see debit_work_term_from_radiation).
+			if constexpr (debit_work_term_from_radiation) {
+				if (dMomMagSum > 0.0_rt) {
+					const Real E_debit = (C::c_light / photochemstate.c_hat) * dEkin;
+					for (int nn = 0; nn < NumChemBands; ++nn) {
+						const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+						const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+						const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+						const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+						const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
+						const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
+						state(i, j, k, eIdx) = E_new;
+						const Real flux_rescale = E_new / E_old;
+						state(i, j, k, fxIdx) *= flux_rescale;
+						state(i, j, k, fyIdx) *= flux_rescale;
+						state(i, j, k, fzIdx) *= flux_rescale;
+					}
 				}
 			}
 		});

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -55,11 +55,8 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 	const int firstChemFyIndex = firstChemFxIndex + 1;
 	const int firstChemFzIndex = firstChemFyIndex + 1;
 
-	// Gate the O(v/c) radiation-pressure work term on beta_order>=1 (the same compile-time switch used by the
-	// regular RHD source terms, see radiation_system.hpp and source_terms_multi_group.hpp) and on hydrodynamics
-	// being enabled. The work term activates only for problems that request O(v/c) radiation coupling; problems
-	// with beta_order==0 (e.g. DTypeFront, OneZonePhotoionization) are unaffected.
-	constexpr bool do_vc_work = (RadSystem_Traits<problem_t>::beta_order >= 1) && Physics_Traits<problem_t>::is_hydro_enabled;
+	// The O(v/c) radiation-pressure work term is gated on beta_order>=1 && is_hydro_enabled; the condition is
+	// inlined inside the device lambda's if constexpr below to avoid NVCC first-capturing a local constexpr.
 
 	amrex::GpuArray<Real, NumChemBands> chemBandQuanta{};
 	amrex::GpuArray<Real, NumChemBands> invChemBandQuanta{};
@@ -200,16 +197,13 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 
 			// O(v/c) radiation-pressure work term: apply the absorbed photon momentum (dMom, computed above) to the
 			// gas. This changes the kinetic energy of the updated momentum only; the auxiliary internal energy is
-			// unaffected. Gated on beta_order>=1 && hydro (do_vc_work), so beta_order==0 problems are untouched.
-			// Touch the momentum increments in local copies first (first-capture for CUDA, cf. DustDamping): NVCC
-			// rejects extended __device__ lambdas that first-capture a variable inside an `if constexpr` block.
-			const Real dMomX_c = dMomX;
-			const Real dMomY_c = dMomY;
-			const Real dMomZ_c = dMomZ;
-			if constexpr (do_vc_work) {
-				const Real xmom_new = xmom + dMomX_c;
-				const Real ymom_new = ymom + dMomY_c;
-				const Real zmom_new = zmom + dMomZ_c;
+			// unaffected. Gated on beta_order>=1 && hydro, so beta_order==0 problems are untouched.
+			// Condition inlined (not using a function-local constexpr) to avoid NVCC first-capturing a captured
+			// variable inside an `if constexpr` block.
+			if constexpr ((RadSystem_Traits<problem_t>::beta_order >= 1) && Physics_Traits<problem_t>::is_hydro_enabled) {
+				const Real xmom_new = xmom + dMomX;
+				const Real ymom_new = ymom + dMomY;
+				const Real zmom_new = zmom + dMomZ;
 				state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index) = xmom_new;
 				state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index) = ymom_new;
 				state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index) = zmom_new;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -55,11 +55,11 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 	const int firstChemFyIndex = firstChemFxIndex + 1;
 	const int firstChemFzIndex = firstChemFyIndex + 1;
 
-	// Gate the O(v/c) radiation-pressure work term on beta_order==1 (the same compile-time switch used by the
+	// Gate the O(v/c) radiation-pressure work term on beta_order>=1 (the same compile-time switch used by the
 	// regular RHD source terms, see radiation_system.hpp and source_terms_multi_group.hpp) and on hydrodynamics
 	// being enabled. The work term activates only for problems that request O(v/c) radiation coupling; problems
 	// with beta_order==0 (e.g. DTypeFront, OneZonePhotoionization) are unaffected.
-	constexpr bool do_vc_work = (RadSystem_Traits<problem_t>::beta_order == 1) && Physics_Traits<problem_t>::is_hydro_enabled;
+	constexpr bool do_vc_work = (RadSystem_Traits<problem_t>::beta_order >= 1) && Physics_Traits<problem_t>::is_hydro_enabled;
 
 	amrex::GpuArray<Real, NumChemBands> chemBandQuanta{};
 	amrex::GpuArray<Real, NumChemBands> invChemBandQuanta{};
@@ -200,13 +200,16 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 
 			// O(v/c) radiation-pressure work term: apply the absorbed photon momentum (dMom, computed above) to the
 			// gas. This changes the kinetic energy of the updated momentum only; the auxiliary internal energy is
-			// unaffected. Gated on beta_order==1 && hydro (do_vc_work), so beta_order==0 problems are untouched.
-			// Use a runtime `if` on the constexpr flag (the dead branch is optimized away): NVCC rejects extended
-			// __device__ lambdas that first-capture a variable inside an `if constexpr` block.
-			if (do_vc_work) {
-				const Real xmom_new = xmom + dMomX;
-				const Real ymom_new = ymom + dMomY;
-				const Real zmom_new = zmom + dMomZ;
+			// unaffected. Gated on beta_order>=1 && hydro (do_vc_work), so beta_order==0 problems are untouched.
+			// Touch the momentum increments in local copies first (first-capture for CUDA, cf. DustDamping): NVCC
+			// rejects extended __device__ lambdas that first-capture a variable inside an `if constexpr` block.
+			const Real dMomX_c = dMomX;
+			const Real dMomY_c = dMomY;
+			const Real dMomZ_c = dMomZ;
+			if constexpr (do_vc_work) {
+				const Real xmom_new = xmom + dMomX_c;
+				const Real ymom_new = ymom + dMomY_c;
+				const Real zmom_new = zmom + dMomZ_c;
 				state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index) = xmom_new;
 				state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index) = ymom_new;
 				state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index) = zmom_new;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -195,9 +195,12 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 				[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
 				[[maybe_unused]] Real dMomMagSum = 0.0_rt;
 				for (int nn = 0; nn < NumChemBands; ++nn) {
-					const Real dpx = (frad_before[nn][0] - state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
-					const Real dpy = (frad_before[nn][1] - state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
-					const Real dpz = (frad_before[nn][2] - state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					const Real dpx =
+					    (frad_before[nn][0] - state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					const Real dpy =
+					    (frad_before[nn][1] - state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					const Real dpz =
+					    (frad_before[nn][2] - state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
 					dMomX += dpx;
 					dMomY += dpy;
 					dMomZ += dpz;
@@ -237,7 +240,8 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 							const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
 							const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
 							const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
-							const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
+							const Real E_new =
+							    amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
 							state(i, j, k, eIdx) = E_new;
 							const Real flux_rescale = E_new / E_old;
 							state(i, j, k, fxIdx) *= flux_rescale;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -198,8 +198,6 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			// O(v/c) radiation-pressure work term: apply the absorbed photon momentum (dMom, computed above) to the
 			// gas. This changes the kinetic energy of the updated momentum only; the auxiliary internal energy is
 			// unaffected. Gated on beta_order>=1 && hydro, so beta_order==0 problems are untouched.
-			// Condition inlined (not using a function-local constexpr) to avoid NVCC first-capturing a captured
-			// variable inside an `if constexpr` block.
 			if constexpr ((RadSystem_Traits<problem_t>::beta_order >= 1) && Physics_Traits<problem_t>::is_hydro_enabled) {
 				const Real xmom_new = xmom + dMomX;
 				const Real ymom_new = ymom + dMomY;

--- a/src/radiation/photochemistry.hpp
+++ b/src/radiation/photochemistry.hpp
@@ -21,13 +21,14 @@
 
 namespace quokka::photochemistry
 {
-// If true, the work-term kinetic energy the gas gains from the absorbed-photon momentum kick is debited
-// from the chem-band photon field (photon energy density reduced by (c / chat) * dEkin, and each band's
-// flux rescaled by the same factor to preserve the M1 closure |F| <= c E), strictly conserving the
-// gas+radiation energy. If false (default), the photon field is left unchanged after the burn: the gas
-// still gains the kinetic energy, but it is not removed from the radiation, so the ionizing photon number
-// density is conserved at the cost of gas+radiation energy conservation. Conserving the ionizing photon
-// budget is the more important property for correct ionization-front propagation, so it is the default.
+// Only relevant when the O(v/c) work term is active (see do_vc_work below). If true, the work-term kinetic
+// energy the gas gains from the absorbed-photon momentum kick is debited from the chem-band photon field
+// (photon energy density reduced by (c / chat) * dEkin, and each band's flux rescaled by the same factor to
+// preserve the M1 closure |F| <= c E), strictly conserving the gas+radiation energy. If false (default), the
+// photon field is left unchanged after the burn: the gas still gains the kinetic energy, but it is not removed
+// from the radiation, so the ionizing photon number density is conserved at the cost of gas+radiation energy
+// conservation. Conserving the ionizing photon budget is the more important property for correct
+// ionization-front propagation, so it is the default.
 static constexpr bool debit_work_term_from_radiation = false;
 
 AMREX_GPU_DEVICE void photochem_burner(burn_t &photochemstate, Real dt);
@@ -53,6 +54,12 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 	const int firstChemFxIndex = firstChemIndex + 1;
 	const int firstChemFyIndex = firstChemFxIndex + 1;
 	const int firstChemFzIndex = firstChemFyIndex + 1;
+
+	// Gate the O(v/c) radiation-pressure work term on beta_order==1 (the same compile-time switch used by the
+	// regular RHD source terms, see radiation_system.hpp and source_terms_multi_group.hpp) and on hydrodynamics
+	// being enabled. The work term activates only for problems that request O(v/c) radiation coupling; problems
+	// with beta_order==0 (e.g. DTypeFront, OneZonePhotoionization) are unaffected.
+	constexpr bool do_vc_work = (RadSystem_Traits<problem_t>::beta_order == 1) && Physics_Traits<problem_t>::is_hydro_enabled;
 
 	amrex::GpuArray<Real, NumChemBands> chemBandQuanta{};
 	amrex::GpuArray<Real, NumChemBands> invChemBandQuanta{};
@@ -147,85 +154,96 @@ auto computePhotoChemistry(amrex::MultiFab &mf, std::array<amrex::MultiFab const
 			for (int nn = 0; nn < NumSpec; ++nn) {
 				state(i, j, k, RadSystem<problem_t>::scalar0_index + nn) = photochemstate.xn[nn] * spmasses[nn];
 			}
-			// Attenuate the photon field and accumulate the momentum transferred to the gas.
-			// Absorbed ionizing photons deposit their momentum in the gas: dp = -(F_new - F_old) / (c * chat),
-			// matching the RSLA-consistent radiation-force convention used by the M1 source terms.
-			const Real inv_c_chat = 1.0_rt / (C::c_light * photochemstate.c_hat);
-			Real dMomX = 0.0_rt;
-			Real dMomY = 0.0_rt;
-			Real dMomZ = 0.0_rt;
-			// per-band momentum-kick magnitudes, used only to split the work-term energy debit across bands
-			[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
-			[[maybe_unused]] Real dMomMagSum = 0.0_rt;
-			for (int nn = 0; nn < NumChemBands; ++nn) {
-				const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-				const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-				const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-				const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-
-				state(i, j, k, eIdx) = photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
-
-				// flux_factor = F_new / F_old (photon flux attenuation from the burn)
-				const Real flux_factor = photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn];
-				const Real FxOld = state(i, j, k, fxIdx);
-				const Real FyOld = state(i, j, k, fyIdx);
-				const Real FzOld = state(i, j, k, fzIdx);
-
-				const Real dpx = (1.0_rt - flux_factor) * FxOld * inv_c_chat;
-				const Real dpy = (1.0_rt - flux_factor) * FyOld * inv_c_chat;
-				const Real dpz = (1.0_rt - flux_factor) * FzOld * inv_c_chat;
-				dMomX += dpx;
-				dMomY += dpy;
-				dMomZ += dpz;
-				if constexpr (debit_work_term_from_radiation) {
-					dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
-					dMomMagSum += dMomMag[nn];
+			// Cache the pre-burn chem-band radiation flux (energy units) so the O(v/c) work term can use the
+			// VODE-attenuated flux difference -(F_after - F_before) to deposit the absorbed photon momentum to
+			// the gas. Only needed when the work term is active.
+			[[maybe_unused]] amrex::GpuArray<amrex::GpuArray<Real, 3>, NumChemBands> frad_before{};
+			if constexpr (do_vc_work) {
+				for (int nn = 0; nn < NumChemBands; ++nn) {
+					frad_before[nn][0] = state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn);
+					frad_before[nn][1] = state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn);
+					frad_before[nn][2] = state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn);
 				}
+			}
 
-				state(i, j, k, fxIdx) = flux_factor * FxOld;
-				state(i, j, k, fyIdx) = flux_factor * FyOld;
-				state(i, j, k, fzIdx) = flux_factor * FzOld;
+			// Update the chem-band photon number density and attenuate the flux by the burn's rn[1] factor.
+			for (int nn = 0; nn < NumChemBands; ++nn) {
+				const Real flux_factor = photochemstate.rn[1 + MicrophysicsNumRadVarsPerGroup * nn];
+				state(i, j, k, firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn) =
+				    photochemstate.rn[0 + MicrophysicsNumRadVarsPerGroup * nn] * chemBandQuanta[nn];
+				state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
+				state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
+				state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn) *= flux_factor;
 			}
 
 			// Quokka uses rho*eint
 			const Real dEint = (photochemstate.e * photochemstate.rho) - Eint;
 			state(i, j, k, RadSystem<problem_t>::gasInternalEnergy_index) += dEint * energy_update_factor;
+			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor;
 
-			// Update the gas momentum by conservation with the absorbed photons.
-			const Real xmom_new = xmom + dMomX;
-			const Real ymom_new = ymom + dMomY;
-			const Real zmom_new = zmom + dMomZ;
-			state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index) = xmom_new;
-			state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index) = ymom_new;
-			state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index) = zmom_new;
+			// O(v/c) radiation-pressure work term: deposit the photon momentum absorbed during the burn to the
+			// gas. dP = -(F_after - F_before) / c^2, summed over chem bands. The absorbed photon momentum is tied
+			// to the physical photon flux F = c E; the reduced speed of light only changes the absorption rate
+			// used by the chemistry solve. This changes the kinetic energy of the updated momentum only; the
+			// auxiliary internal energy is unaffected.
+			if constexpr (do_vc_work) {
+				const Real inv_c2 = 1.0_rt / (C::c_light * C::c_light);
+				Real dMomX = 0.0_rt;
+				Real dMomY = 0.0_rt;
+				Real dMomZ = 0.0_rt;
+				// per-band momentum-kick magnitudes, used only to split the optional work-term energy debit across bands
+				[[maybe_unused]] amrex::GpuArray<Real, NumChemBands> dMomMag{};
+				[[maybe_unused]] Real dMomMagSum = 0.0_rt;
+				for (int nn = 0; nn < NumChemBands; ++nn) {
+					const Real dpx = (frad_before[nn][0] - state(i, j, k, firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					const Real dpy = (frad_before[nn][1] - state(i, j, k, firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					const Real dpz = (frad_before[nn][2] - state(i, j, k, firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn)) * inv_c2;
+					dMomX += dpx;
+					dMomY += dpy;
+					dMomZ += dpz;
+					if constexpr (debit_work_term_from_radiation) {
+						dMomMag[nn] = std::sqrt(dpx * dpx + dpy * dpy + dpz * dpz);
+						dMomMagSum += dMomMag[nn];
+					}
+				}
 
-			// Reconstruct the gas total energy from the updated internal energy and the updated kinetic energy.
-			// dEkin is the work done on the gas by the radiation force (magnetic energy is unchanged by the kick).
-			const Real dEkin =
-			    (xmom_new * xmom_new + ymom_new * ymom_new + zmom_new * zmom_new - (xmom * xmom + ymom * ymom + zmom * zmom)) / (2.0_rt * rho);
-			state(i, j, k, RadSystem<problem_t>::gasEnergy_index) += dEint * energy_update_factor + dEkin;
+				const Real xmom_new = xmom + dMomX;
+				const Real ymom_new = ymom + dMomY;
+				const Real zmom_new = zmom + dMomZ;
+				state(i, j, k, RadSystem<problem_t>::x1GasMomentum_index) = xmom_new;
+				state(i, j, k, RadSystem<problem_t>::x2GasMomentum_index) = ymom_new;
+				state(i, j, k, RadSystem<problem_t>::x3GasMomentum_index) = zmom_new;
 
-			// Optionally enforce strict gas+radiation energy conservation: remove the work-term energy (c / chat) * dEkin
-			// from the chem-band photon field, split across bands in proportion to each band's momentum contribution, and
-			// rescale each band's flux by the same factor its energy density changes so the reduced flux |F| / (c E) is
-			// preserved (keeps the M1 closure constraint F / c <= E from being violated by the energy debit).
-			// Disabled by default: conserving the ionizing photon number density is more important than energy conservation
-			// for correct ionization-front propagation (see debit_work_term_from_radiation).
-			if constexpr (debit_work_term_from_radiation) {
-				if (dMomMagSum > 0.0_rt) {
-					const Real E_debit = (C::c_light / photochemstate.c_hat) * dEkin;
-					for (int nn = 0; nn < NumChemBands; ++nn) {
-						const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-						const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-						const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-						const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
-						const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
-						const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
-						state(i, j, k, eIdx) = E_new;
-						const Real flux_rescale = E_new / E_old;
-						state(i, j, k, fxIdx) *= flux_rescale;
-						state(i, j, k, fyIdx) *= flux_rescale;
-						state(i, j, k, fzIdx) *= flux_rescale;
+				// Recompute total gas energy from the (unchanged) internal energy and the updated momentum so the
+				// absorbed momentum appears only as kinetic energy.
+				state(i, j, k, RadSystem<problem_t>::gasEnergy_index) = ::quokka::EOS<problem_t>::ComputeEgasFromEint(
+				    rho, xmom_new, ymom_new, zmom_new, state(i, j, k, RadSystem<problem_t>::gasInternalEnergy_index), Emag);
+
+				// Optionally enforce strict gas+radiation energy conservation: remove the work-term energy
+				// (c / chat) * dEkin from the chem-band photon field, split across bands in proportion to each band's
+				// momentum contribution, and rescale each band's flux by the same factor its energy density changes so
+				// the reduced flux |F| / (c E) is preserved (keeps the M1 closure F / c <= E from being violated by the
+				// debit). Disabled by default: conserving the ionizing photon number density is more important than
+				// strict energy conservation for correct ionization-front propagation (see debit_work_term_from_radiation).
+				if constexpr (debit_work_term_from_radiation) {
+					if (dMomMagSum > 0.0_rt) {
+						const Real dEkin = (xmom_new * xmom_new + ymom_new * ymom_new + zmom_new * zmom_new -
+								    (xmom * xmom + ymom * ymom + zmom * zmom)) /
+								   (2.0_rt * rho);
+						const Real E_debit = (C::c_light / photochemstate.c_hat) * dEkin;
+						for (int nn = 0; nn < NumChemBands; ++nn) {
+							const int eIdx = firstChemIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+							const int fxIdx = firstChemFxIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+							const int fyIdx = firstChemFyIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+							const int fzIdx = firstChemFzIndex + Physics_NumVars::numRadVarsPerGroup * nn;
+							const Real E_old = state(i, j, k, eIdx); // > 0: rn[0] was clamped to small_x above
+							const Real E_new = amrex::max(E_old - E_debit * (dMomMag[nn] / dMomMagSum), small_x * chemBandQuanta[nn]);
+							state(i, j, k, eIdx) = E_new;
+							const Real flux_rescale = E_new / E_old;
+							state(i, j, k, fxIdx) *= flux_rescale;
+							state(i, j, k, fyIdx) *= flux_rescale;
+							state(i, j, k, fzIdx) *= flux_rescale;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
### Description

Adds the O(v/c) radiation-pressure **work term** to the photoionization operator-split
step. Previously the ionizing-photon flux was attenuated by the burn but the absorbed
photon momentum was never delivered to the gas, and the gas total energy was
reconstructed assuming unchanged kinetic energy. This PR deposits that momentum and
accounts for the resulting kinetic energy, and also adds a new test problem to validate this
following the design of the earlier WIP PR #2007 by @BenWibking (closes #1988).

**`src/radiation/photochemistry.hpp`:**
- Gated on a compile-time switch `do_vc_work = (beta_order >= 1) && is_hydro_enabled`
  — the same O(v/c) gate the regular RHD source terms use. Problems with
  `beta_order == 0` (DTypeFront, OneZonePhotoionization) are unaffected.
- Deposits the absorbed photon momentum `dP = -(F_after − F_before)/c²`, summed over
  chem bands. The momentum is tied to the physical photon flux `F = cE`; the reduced
  speed of light only sets the absorption rate in the chemistry solve.
- Recomputes the gas total energy from the (unchanged) internal energy and the updated
  momentum via `ComputeEgasFromEint`, so the absorbed momentum appears purely as
  kinetic energy.
- `dP` is computed unconditionally in the flux write-back loop and the application is
  gated by a runtime `if (do_vc_work)` on the constexpr flag, to avoid NVCC's
  "extended `__device__` lambda cannot first-capture variable in `constexpr-if`" error
  (verified with a local `3d-cuda` build).
- An optional strict-conservation path (`debit_work_term_from_radiation`, **off by
  default**) debits the work-term energy `(c/ĉ)·dEkin` from the chem-band photon field
  and rescales the flux to preserve `|F| ≤ cE`. It is off by default because conserving
  the ionizing photon number density matters more for correct front propagation than
  strict gas+radiation energy conservation.

Updated `DTypeFront` test to `beta_order = 1` to validate that the radiation pressure term
is not important for the dynamics at all for the parameters in the problem. 
**New test `src/problems/DTypeFrontVC/`** (ported from PR #2007): a `beta_order >= 1`,
purely x-directed radiation beam on uniform gas. It verifies directly, by conservation,
that the deposited gas momentum equals the absorbed photon momentum `(F_before −
F_after)/c²`, that no transverse momentum is created, that the internal energy is
unchanged, and that the total-energy increase equals the kinetic-energy gain.

### Effect of enabling the work term on DTypeFront

The `DTypeFront` problem (`beta_order == 0`) intentionally does **not** activate this
PR's work term — it tests pure thermal-pressure D-type front expansion against the
Spitzer analytic solution. During development we tested what happens when the momentum
coupling is turned on (`beta_order = 1`), first with a buggy formula and then with the
correct `/c²` formula:

| Build | Formula | r_analytical (cm) | r_eff (cm) | (r_eff − r_ana)/dx |
|-------|---------|-------------------|------------|---------------------|
| #14474 (GPU, 64³, full) | buggy `dp = −ΔF/(c·ĉ)` + photon debit | 9.76e18 | 1.98e19 | **40.3** cells |
| #14475 (GPU, 64³, full) | buggy `dp = −ΔF/(c·ĉ)`, no debit | 9.76e18 | 1.54e19 | **22.8** cells |
| local (CPU, 16³, 4 t_s) | correct `dp = −ΔF/c²`, momentum on | 4.127e18 | 3.833e18 | −0.30 cells |
| local (CPU, 16³, 4 t_s) | correct `dp = −ΔF/c²`, momentum off | 4.127e18 | 3.822e18 | −0.31 cells |
| tolerance | — | — | — | 2.60 cells |

The two GPU CI rows (#14474/#14475) used an early implementation that over-injected
momentum by `c/ĉ ≈ 1000×` (the stored chem-band flux is `F = cE`, not `ĉE`). Those
huge deviations are an artifact of that bug, not the physical radiation force.

With the **correct** `dP = −(F_after − F_before)/c²` formula (bottom two rows),
the momentum kick has a negligible effect on the D-type front radius: it shifts
r_eff by only **+0.011 cells** relative to the control run, both passing within
the 2.6-cell tolerance. The radiation pressure from ionizing photons is sub-dominant
relative to the thermal pressure of the ~10⁴ K ionized gas — a physically plausible
result — so the Spitzer solution remains a valid check for the thermal-only
physics tested by `DTypeFront`.

### Related issues
Closes #1988.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a direct photoionization radiation–gas momentum coupling validation test for multidimensional simulations.
  - Added configuration support for testing O(v/c) photoionization momentum deposition and energy behavior.
  - Radiation updates now account for momentum transferred to gas during photoionization.

- **Bug Fixes**
  - Improved consistency between gas momentum, kinetic energy, and absorbed radiation during O(v/c) interactions.
  - Added optional radiation-energy accounting for radiation-pressure work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->