### PR TITLE
Revert changes to *quick.yml in PR 2035

### DIFF
--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
     - checkout: self
       submodules: recursive
+      fetchDepth: 0
 
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"
@@ -40,7 +41,7 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        git fetch origin "$TARGET_BRANCH"
         MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
         CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')

--- a/.ci/azure-pipelines-quick-amdgpu.yml
+++ b/.ci/azure-pipelines-quick-amdgpu.yml
@@ -40,8 +40,9 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch origin "$TARGET_BRANCH"
-        CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
     - checkout: self
       submodules: recursive
+      fetchDepth: 0
 
     - script: |
         mkdir -p "$(Agent.HomeDirectory)/cache/ccache"
@@ -40,7 +41,7 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        git fetch origin "$TARGET_BRANCH"
         MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
         CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')

--- a/.ci/azure-pipelines-quick.yml
+++ b/.ci/azure-pipelines-quick.yml
@@ -40,8 +40,9 @@ jobs:
     - script: |
         TARGET_BRANCH=$(echo "$(System.PullRequest.TargetBranch)" | sed 's|refs/heads/||')
         [ -z "$TARGET_BRANCH" ] && TARGET_BRANCH="development"
-        git fetch origin "$TARGET_BRANCH"
-        CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
+        git fetch --deepen=100 origin "$TARGET_BRANCH"
+        MERGE_BASE=$(git merge-base FETCH_HEAD HEAD)
+        CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
         PROBLEMS=$(echo "$CHANGED" | grep '^src/problems/' | awk -F'/' '{print $3}' | sort -u | grep -v '^$')
         if [ -z "$PROBLEMS" ]; then
           echo "##[section]No src/problems/ files changed in this PR."


### PR DESCRIPTION
### Description
Revert changes to *quick.yml  in #2035 . It was a mistake: `CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)` would always return empty, apparently. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ ] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the quick CI pipeline to fetch full git history for more reliable change detection.
  * Improved pull request changed-file detection by comparing against a computed merge base rather than the previous diff range.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->