### PR TITLE
Fix MHD temperature floor in EnforceLimits

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -1946,13 +1946,13 @@ void QuokkaSimulation<problem_t>::ApplyHydroStateFixup(amrex::MultiFab &state_cc
 									  amrex::Real base_density_floor) -> amrex::Real {
 			return density_floor_parser(x, y, z, base_density_floor);
 		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_cc, geom[lev], density_floor_func);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_cc, state_fc, geom[lev], density_floor_func);
 	} else {
 		auto const density_floor_func = [this] AMREX_GPU_HOST_DEVICE(amrex::Real x, amrex::Real y, amrex::Real z,
 									     amrex::Real base_density_floor) -> amrex::Real {
 			return densityFloor(x, y, z, base_density_floor);
 		};
-		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_cc, geom[lev], density_floor_func);
+		HydroSystem<problem_t>::EnforceLimits(densityFloor_, dustDensityFloor_, tempFloor_, state_cc, state_fc, geom[lev], density_floor_func);
 	}
 
 	if (useDualEnergy_ == 1) {

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1106,7 +1106,7 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 
 			// Enforce temperature floor (for total energy)
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> state_fc{};
-			if (Physics_Traits<problem_t>::is_mhd_enabled) {
+			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				state_fc[0] = state_fc_x0[bx];
 #if AMREX_SPACEDIM >= 2
 				state_fc[1] = state_fc_x1[bx];
@@ -1116,9 +1116,9 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 #endif
 			}
 			amrex::Real const Emag = ComputeMagneticEnergy(i, j, k, &state_fc);
+			amrex::Real const Eint = ComputeInternalEnergy(state[bx],i, j, k, &state_fc);
 			amrex::GpuArray<Real, nmscalars_> const massScalars = RadSystem<problem_t>::ComputeMassScalars(state[bx], i, j, k);
-			amrex::Real const Etot = state[bx](i, j, k, energy_index);
-			amrex::Real const primTemp = ::quokka::EOS<problem_t>::ComputeTgasFromEint(rho_new, (Etot - Ekin - Emag), massScalars);
+			amrex::Real const primTemp = ::quokka::EOS<problem_t>::ComputeTgasFromEint(rho_new, Eint, massScalars);
 
 			if (primTemp < tempFloor) {
 				amrex::Real const prim_eint = ::quokka::EOS<problem_t>::ComputeEintFromTgas(rho_new, tempFloor, massScalars);

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1105,16 +1105,18 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 			amrex::Real const Ekin = 0.5 * rho_new * (vx1 * vx1 + vx2 * vx2 + vx3 * vx3);
 
 			// Enforce temperature floor (for total energy)
-			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> state_fc{};
-			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
-				state_fc[0] = state_fc_x0[bx];
-#if AMREX_SPACEDIM >= 2
-				state_fc[1] = state_fc_x1[bx];
-#endif
-#if AMREX_SPACEDIM == 3
-				state_fc[2] = state_fc_x2[bx];
-#endif
+			// First-capture face-centered arrays before any constexpr-if context for CUDA.
+			std::remove_cv_t<std::remove_reference_t<decltype(state_fc_x0[bx])>> state_fc_x0_ref{};
+			if (Physics_Traits<problem_t>::is_mhd_enabled) {
+				state_fc_x0_ref = state_fc_x0[bx];
+				state_fc_x1_ref = state_fc_x1[bx];
+				state_fc_x2_ref = state_fc_x2[bx];
 			}
+			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> state_fc{};
+			state_fc[0] = state_fc_x0_ref;
+			state_fc[1] = state_fc_x1_ref;
+			state_fc[2] = state_fc_x2_ref;
+
 			amrex::Real const Emag = ComputeMagneticEnergy(i, j, k, &state_fc);
 			amrex::Real const Eint = ComputeInternalEnergy(state[bx],i, j, k, &state_fc);
 			amrex::GpuArray<Real, nmscalars_> const massScalars = RadSystem<problem_t>::ComputeMassScalars(state[bx], i, j, k);

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1116,7 +1116,7 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 #endif
 			}
 			amrex::Real const Emag = ComputeMagneticEnergy(i, j, k, &state_fc);
-			amrex::Real const Eint = ComputeInternalEnergy(state[bx],i, j, k, &state_fc);
+			amrex::Real const Eint = ComputeInternalEnergy(state[bx], i, j, k, &state_fc);
 			amrex::GpuArray<Real, nmscalars_> const massScalars = RadSystem<problem_t>::ComputeMassScalars(state[bx], i, j, k);
 			amrex::Real const primTemp = ::quokka::EOS<problem_t>::ComputeTgasFromEint(rho_new, Eint, massScalars);
 

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1107,15 +1107,29 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 			// Enforce temperature floor (for total energy)
 			// First-capture face-centered arrays before any constexpr-if context for CUDA.
 			std::remove_cv_t<std::remove_reference_t<decltype(state_fc_x0[bx])>> state_fc_x0_ref{};
+#if AMREX_SPACEDIM >= 2
+			std::remove_cv_t<std::remove_reference_t<decltype(state_fc_x1[bx])>> state_fc_x1_ref{};
+#endif
+#if AMREX_SPACEDIM == 3
+			std::remove_cv_t<std::remove_reference_t<decltype(state_fc_x2[bx])>> state_fc_x2_ref{};
+#endif
 			if (Physics_Traits<problem_t>::is_mhd_enabled) {
 				state_fc_x0_ref = state_fc_x0[bx];
+#if AMREX_SPACEDIM >= 2
 				state_fc_x1_ref = state_fc_x1[bx];
+#endif
+#if AMREX_SPACEDIM == 3
 				state_fc_x2_ref = state_fc_x2[bx];
+#endif
 			}
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> state_fc{};
 			state_fc[0] = state_fc_x0_ref;
+#if AMREX_SPACEDIM >= 2
 			state_fc[1] = state_fc_x1_ref;
+#endif
+#if AMREX_SPACEDIM == 3
 			state_fc[2] = state_fc_x2_ref;
+#endif
 
 			amrex::Real const Emag = ComputeMagneticEnergy(i, j, k, &state_fc);
 			amrex::Real const Eint = ComputeInternalEnergy(state[bx], i, j, k, &state_fc);

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -11,6 +11,7 @@
 
 // c++ headers
 #include <algorithm>
+#include <array>
 #include <cmath>
 
 // library headers
@@ -165,7 +166,8 @@ template <typename problem_t> class HydroSystem : public HyperbolicSystem<proble
 
 	template <typename DensityFloorFunc>
 	static void EnforceLimits(amrex::Real densityFloor, amrex::Real dustDensityFloor, amrex::Real tempFloor, amrex::MultiFab &state_mf,
-				  amrex::Geometry const &geom, DensityFloorFunc const &density_floor_func);
+				  std::array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc_mf, amrex::Geometry const &geom,
+				  DensityFloorFunc const &density_floor_func);
 
 	static void AddInternalEnergyPdV(amrex::MultiFab &rhs_mf, amrex::MultiFab const &consVar_mf,
 					 std::array<amrex::MultiFab, AMREX_SPACEDIM> const &cons_fc_mf, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx,
@@ -1013,9 +1015,17 @@ void HydroSystem<problem_t>::FlattenShocks(amrex::MultiFab const &q_mf, amrex::M
 template <typename problem_t>
 template <typename DensityFloorFunc>
 void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex::Real const dustDensityFloor, amrex::Real const tempFloor,
-					   amrex::MultiFab &state_mf, amrex::Geometry const &geom, DensityFloorFunc const &density_floor_func)
+					   amrex::MultiFab &state_mf, std::array<amrex::MultiFab, AMREX_SPACEDIM> const &state_fc_mf,
+					   amrex::Geometry const &geom, DensityFloorFunc const &density_floor_func)
 {
 	auto state = state_mf.arrays();
+	auto const &state_fc_x0 = state_fc_mf[0].const_arrays();
+#if AMREX_SPACEDIM >= 2
+	auto const &state_fc_x1 = state_fc_mf[1].const_arrays();
+#endif
+#if AMREX_SPACEDIM == 3
+	auto const &state_fc_x2 = state_fc_mf[2].const_arrays();
+#endif
 	auto const prob_lo = geom.ProbLoArray();
 	auto const dx = geom.CellSizeArray();
 
@@ -1095,13 +1105,24 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 			amrex::Real const Ekin = 0.5 * rho_new * (vx1 * vx1 + vx2 * vx2 + vx3 * vx3);
 
 			// Enforce temperature floor (for total energy)
+			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> state_fc{};
+			if (Physics_Traits<problem_t>::is_mhd_enabled) {
+				state_fc[0] = state_fc_x0[bx];
+#if AMREX_SPACEDIM >= 2
+				state_fc[1] = state_fc_x1[bx];
+#endif
+#if AMREX_SPACEDIM == 3
+				state_fc[2] = state_fc_x2[bx];
+#endif
+			}
+			amrex::Real const Emag = ComputeMagneticEnergy(i, j, k, &state_fc);
 			amrex::GpuArray<Real, nmscalars_> const massScalars = RadSystem<problem_t>::ComputeMassScalars(state[bx], i, j, k);
 			amrex::Real const Etot = state[bx](i, j, k, energy_index);
-			amrex::Real const primTemp = ::quokka::EOS<problem_t>::ComputeTgasFromEint(rho_new, (Etot - Ekin), massScalars);
+			amrex::Real const primTemp = ::quokka::EOS<problem_t>::ComputeTgasFromEint(rho_new, (Etot - Ekin - Emag), massScalars);
 
 			if (primTemp < tempFloor) {
 				amrex::Real const prim_eint = ::quokka::EOS<problem_t>::ComputeEintFromTgas(rho_new, tempFloor, massScalars);
-				state[bx](i, j, k, energy_index) = Ekin + prim_eint;
+				state[bx](i, j, k, energy_index) = Ekin + Emag + prim_eint;
 			}
 
 			// Enforce temperature floor (for auxiliary internal energy)

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -151,43 +151,45 @@ void checkEnforceLimitsPreservesMagneticEnergy()
 {
 	amrex::Print() << "Checking MHD temperature floor magnetic-energy accounting...\n";
 
+	// create domain
 	amrex::Box const domain(amrex::IntVect(AMREX_D_DECL(0, 0, 0)), amrex::IntVect(AMREX_D_DECL(0, 0, 0)));
 	amrex::BoxArray ba(domain);
 	amrex::DistributionMapping const dm(ba);
+	amrex::RealBox const real_box({AMREX_D_DECL(0.0, 0.0, 0.0)}, {AMREX_D_DECL(1.0, 1.0, 1.0)});
+	amrex::Vector<int> is_periodic(AMREX_SPACEDIM, 0);
+	amrex::Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
 
+	// create state_cc
 	amrex::MultiFab state_cc(ba, dm, Physics_Indices<FCQuantities>::nvarTotal_cc, 0);
+	state_cc.setVal(0.0);
+
+	// create state_fc
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> state_fc;
 	for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
 		state_fc[dir].define(amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir)), dm, Physics_Indices<FCQuantities>::nvarPerDim_fc, 0);
+		state_fc[dir].setVal(0.0);
 	}
 
-	state_cc.setVal(0.0);
-	for (auto &face_state : state_fc) {
-		face_state.setVal(0.0);
-	}
-
+	// set initial conditions
 	constexpr amrex::Real rho = 1.0;
 	constexpr amrex::Real temp_cold = 1.0;
 	constexpr amrex::Real temp_floor = 10.0;
 	amrex::Real const Eint_cold = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_cold);
 	amrex::Real const Eint_floor = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_floor);
 	amrex::Real const Emag = 10.0 * Eint_floor;
-	amrex::Real const Bx = std::sqrt(2.0 * Emag);
+	amrex::Real const Bx = std::sqrt(2.0 * Emag); // By, Bz are zero
 
 	state_cc.setVal(rho, HydroSystem<FCQuantities>::density_index, 1, 0);
 	state_cc.setVal(Eint_cold + Emag, HydroSystem<FCQuantities>::energy_index, 1, 0);
 	state_cc.setVal(Eint_cold, HydroSystem<FCQuantities>::internalEnergy_index, 1, 0);
 	state_fc[0].setVal(Bx, Physics_Indices<FCQuantities>::mhdFirstIndex, 1, 0);
 
-	amrex::RealBox const real_box({AMREX_D_DECL(0.0, 0.0, 0.0)}, {AMREX_D_DECL(1.0, 1.0, 1.0)});
-	amrex::Vector<int> is_periodic(AMREX_SPACEDIM, 0);
-	amrex::Geometry geom;
-	geom.define(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
-
-	auto const density_floor_func = [] AMREX_GPU_HOST_DEVICE(amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
-								 amrex::Real base_density_floor) noexcept -> amrex::Real { return base_density_floor; };
-
-	HydroSystem<FCQuantities>::EnforceLimits(0.0, 0.0, temp_floor, state_cc, state_fc, geom, density_floor_func);
+	// Enforce temperature floor:
+	// this should raise the temperature from temp_cold to temp_floor,
+	// while leaving the magnetic energy unchanged
+	HydroSystem<FCQuantities>::EnforceLimits(0.0, 0.0, temp_floor, state_cc, state_fc, geom,
+						 [] AMREX_GPU_DEVICE(amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+								     amrex::Real base_density_floor) noexcept -> amrex::Real { return base_density_floor; });
 	amrex::Gpu::streamSynchronizeAll();
 
 	amrex::Real const expected_Etot = Eint_floor + Emag;

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -9,7 +9,9 @@
 #include "hydro/hydro_system.hpp"
 #include "hydro/mhd_system.hpp"
 #include <algorithm>
+#include <array>
 #include <cassert>
+#include <cmath>
 #include <format>
 #include <limits>
 #include <ostream>
@@ -19,6 +21,11 @@
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
+#include "AMReX_BoxArray.H"
+#include "AMReX_DistributionMapping.H"
+#include "AMReX_Geometry.H"
+#include "AMReX_GpuDevice.H"
+#include "AMReX_MultiFab.H"
 #include "AMReX_MultiFabUtil.H"
 #include "AMReX_Print.H"
 #include "AMReX_REAL.H"
@@ -140,6 +147,61 @@ void setPlotfileParams(std::string const &prefix)
 	pp.add("skip_initial_plotfile", 0);
 }
 
+void checkEnforceLimitsPreservesMagneticEnergy()
+{
+	amrex::Print() << "Checking MHD temperature floor magnetic-energy accounting...\n";
+
+	amrex::Box const domain(amrex::IntVect(AMREX_D_DECL(0, 0, 0)), amrex::IntVect(AMREX_D_DECL(0, 0, 0)));
+	amrex::BoxArray ba(domain);
+	amrex::DistributionMapping const dm(ba);
+
+	amrex::MultiFab state_cc(ba, dm, Physics_Indices<FCQuantities>::nvarTotal_cc, 0);
+	std::array<amrex::MultiFab, AMREX_SPACEDIM> state_fc;
+	for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+		state_fc[dir].define(amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir)), dm, Physics_Indices<FCQuantities>::nvarPerDim_fc, 0);
+	}
+
+	state_cc.setVal(0.0);
+	for (auto &face_state : state_fc) {
+		face_state.setVal(0.0);
+	}
+
+	constexpr amrex::Real rho = 1.0;
+	constexpr amrex::Real temp_cold = 1.0;
+	constexpr amrex::Real temp_floor = 10.0;
+	amrex::Real const Eint_cold = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_cold);
+	amrex::Real const Eint_floor = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_floor);
+	amrex::Real const Emag = 10.0 * Eint_floor;
+	amrex::Real const Bx = std::sqrt(2.0 * Emag);
+
+	state_cc.setVal(rho, HydroSystem<FCQuantities>::density_index, 1, 0);
+	state_cc.setVal(Eint_cold + Emag, HydroSystem<FCQuantities>::energy_index, 1, 0);
+	state_cc.setVal(Eint_cold, HydroSystem<FCQuantities>::internalEnergy_index, 1, 0);
+	state_fc[0].setVal(Bx, Physics_Indices<FCQuantities>::mhdFirstIndex, 1, 0);
+
+	amrex::RealBox const real_box({AMREX_D_DECL(0.0, 0.0, 0.0)}, {AMREX_D_DECL(1.0, 1.0, 1.0)});
+	amrex::Vector<int> is_periodic(AMREX_SPACEDIM, 0);
+	amrex::Geometry geom;
+	geom.define(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
+
+	auto const density_floor_func = [] AMREX_GPU_HOST_DEVICE(amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+								 amrex::Real base_density_floor) noexcept -> amrex::Real { return base_density_floor; };
+
+	HydroSystem<FCQuantities>::EnforceLimits(0.0, 0.0, temp_floor, state_cc, state_fc, geom, density_floor_func);
+	amrex::Gpu::streamSynchronizeAll();
+
+	amrex::Real const expected_Etot = Eint_floor + Emag;
+	amrex::Real const actual_Etot = state_cc.min(HydroSystem<FCQuantities>::energy_index);
+	amrex::Real const Etot_rel_error = std::abs(actual_Etot - expected_Etot) / std::max(std::abs(expected_Etot), 1.0);
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Etot_rel_error <= 1000.0 * std::numeric_limits<amrex::Real>::epsilon(),
+					 std::format("MHD temperature floor total energy mismatch: got {}, expected {}", actual_Etot, expected_Etot));
+
+	amrex::Real const actual_aux_eint = state_cc.min(HydroSystem<FCQuantities>::internalEnergy_index);
+	amrex::Real const aux_rel_error = std::abs(actual_aux_eint - Eint_floor) / std::max(std::abs(Eint_floor), 1.0);
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(aux_rel_error <= 1000.0 * std::numeric_limits<amrex::Real>::epsilon(),
+					 std::format("MHD auxiliary internal energy floor mismatch: got {}, expected {}", actual_aux_eint, Eint_floor));
+}
+
 void checkDivFreeRestart(QuokkaSimulation<FCQuantities> const &sim)
 {
 	auto const &state_fc = sim.getNewMF_fc();
@@ -181,6 +243,7 @@ auto problem_main() -> int
 	setAmrNCell(coarse_ncells);
 	setPlotfileParams("fcq_pre");
 	QuokkaSimulation<FCQuantities> sim_write;
+	checkEnforceLimitsPreservesMagneticEnergy();
 	sim_write.setInitialConditions();
 	amrex::Print() << "\n";
 

--- a/src/problems/FCQuantities/testFCQuantities.cpp
+++ b/src/problems/FCQuantities/testFCQuantities.cpp
@@ -153,11 +153,11 @@ void checkEnforceLimitsPreservesMagneticEnergy()
 
 	// create domain
 	amrex::Box const domain(amrex::IntVect(AMREX_D_DECL(0, 0, 0)), amrex::IntVect(AMREX_D_DECL(0, 0, 0)));
-	amrex::BoxArray ba(domain);
+	amrex::BoxArray const ba(domain);
 	amrex::DistributionMapping const dm(ba);
 	amrex::RealBox const real_box({AMREX_D_DECL(0.0, 0.0, 0.0)}, {AMREX_D_DECL(1.0, 1.0, 1.0)});
 	amrex::Vector<int> is_periodic(AMREX_SPACEDIM, 0);
-	amrex::Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
+	amrex::Geometry const geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
 
 	// create state_cc
 	amrex::MultiFab state_cc(ba, dm, Physics_Indices<FCQuantities>::nvarTotal_cc, 0);


### PR DESCRIPTION
## Summary

Fixes #1971.

`HydroSystem::EnforceLimits` now receives the face-centered MHD state, subtracts magnetic energy when computing the gas temperature for the total-energy floor, and preserves that magnetic energy when raising total energy to the temperature floor.

## Root Cause

For MHD states, total gas energy stores `Ekin + Eint + Emag`, but the temperature floor previously passed `Etot - Ekin` to the EOS. That treated magnetic energy as thermal energy, which could mask cold cells. If the floor did trigger, the replacement total energy was `Ekin + Eint_floor`, which discarded `Emag`.

## Validation

- `scripts/bash/quokka build -d 3d FCQuantities`
- `scripts/bash/quokka run -d 3d --filter '^FCQuantities$'`
- `scripts/bash/quokka build -d 3d HydroBlast3D`
- `clang-format --dry-run -Werror src/hydro/hydro_system.hpp src/QuokkaSimulation.hpp src/problems/FCQuantities/testFCQuantities.cpp`
- `git diff --check`
- `./scripts/bash/quokka-pre-commit.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temperature floor enforcement so magnetic energy is now preserved when limiting low-temperature states.
  * Limited states are now adjusted using both cell-centered and face-centered data, making energy corrections more accurate and consistent.
  * Added coverage for this behavior to verify total energy and internal energy are updated correctly while magnetic energy stays unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->