### PR TITLE
Impose density floor in sink accretion zone

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -806,7 +806,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::rereadRuntimePar
 	readParmParse();
 
 	// Re-read particle parameters
-	quokka::particleParmParse();
+	quokka::particleParmParse(densityFloor_);
 }
 
 template <typename problem_t> auto QuokkaSimulation<problem_t>::computeNumberOfRadiationSubsteps(int lev, amrex::Real dt_lev_hydro) -> int

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -248,7 +248,8 @@ void ComputeAccretionRateInBox(const typename ContainerType::ParIterType &pti, c
 
 // Compute the scale down factor for the accretion rate. We first prevent the gas density from dropping below 75% of its initial value.
 // Then, if the density in the end state is above the Jeans density, we increase the accretion rate so that the density in the end state is
-// equal to the Jeans density.
+// equal to the Jeans density. Finally, we prevent the density in the end state from dropping below the accretion-zone density floor
+// (`sink_accretion_density_floor`, which defaults to the global `density_floor`).
 template <typename problem_t>
 void ComputeScaleDown(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, amrex::MultiFab &scale_down, const amrex::Geometry &geom,
 		      std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc)
@@ -259,6 +260,8 @@ void ComputeScaleDown(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, a
 	const auto &local_scale_down_arr = scale_down.arrays();
 	const auto &dx = geom.CellSizeArray();
 	const double dx_max = std::max({dx[0], dx[1], dx[2]});
+
+	const double density_floor = sink_accretion_density_floor;
 
 	std::remove_reference_t<decltype((*state_fc)[0].const_arrays())> state_fc_x0{};
 	std::remove_reference_t<decltype((*state_fc)[1].const_arrays())> state_fc_x1{};
@@ -310,6 +313,21 @@ void ComputeScaleDown(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, a
 			const double rho_cell = local_state_arr[bx](i, j, k, HydroSystem<problem_t>::density_index);
 			if ((1.0 + accretion_rate_cell) * rho_cell > rho_J) {
 				const double accretion_rate_cell_new = rho_J / rho_cell - 1.0;
+				local_accretion_rate_arr[bx](i, j, k) = accretion_rate_cell_new;
+				local_scale_down_arr[bx](i, j, k) = accretion_rate_cell_new / accretion_rate_cell;
+			}
+			AMREX_ASSERT(local_accretion_rate_arr[bx](i, j, k) <= 0.0);
+			AMREX_ASSERT(local_accretion_rate_arr[bx](i, j, k) > -1.0);
+
+			// Enforce the accretion-zone density floor. This is checked last, against the current (possibly
+			// Jeans-adjusted) accretion rate, so the resulting density never drops below the floor regardless of
+			// what the earlier caps computed. scale_down is still expressed relative to the original
+			// accretion_rate_cell (the pre-cap value used to compute M_dot_cell in ComputeAccretionRateInBox), so
+			// that UpdateParticleMassAndMomentumInBox removes exactly the mass that UpdateHydroState removes from
+			// the cell, i.e. mass is conserved exactly.
+			const double current_rate = local_accretion_rate_arr[bx](i, j, k);
+			if ((1.0 + current_rate) * rho_cell < density_floor) {
+				const double accretion_rate_cell_new = std::min(0.0, density_floor / rho_cell - 1.0);
 				local_accretion_rate_arr[bx](i, j, k) = accretion_rate_cell_new;
 				local_scale_down_arr[bx](i, j, k) = accretion_rate_cell_new / accretion_rate_cell;
 			}

--- a/src/particles/particle_types.hpp
+++ b/src/particles/particle_types.hpp
@@ -540,6 +540,10 @@ inline bool SN_smooth_gas_velocity = true; // NOLINT
 // Sink particle accretion
 inline bool sink_particle_use_uniform_kernel = false; // NOLINT. If true, use uniform accretion kernel in a (7 dx)^3 box
 
+// Density floor enforced in the sink accretion zone. Defaults to the global `density_floor` each time
+// particleParmParse() is called, but can be overridden independently via "particles.sink_accretion_density_floor".
+inline amrex::Real sink_accretion_density_floor = 0.0; // NOLINT
+
 // Verbosity for particle operations
 inline int particle_verbose = 0; // NOLINT print particle logistics
 
@@ -567,12 +571,16 @@ inline amrex::Real SN_p_term_Msunkmps = SN_p_term_Msunkmps_canonical; // NOLINT
 // It tells the linker that all instances of this function across different translation units
 // should be treated as the same function. This is a common pattern for small utility
 // functions defined in header files.
-inline void particleParmParse()
+inline void particleParmParse(amrex::Real global_density_floor = 0.0)
 {
 	// Parse particle parameters
 	const amrex::ParmParse pp("particles");
 	pp.query("disable_SN_feedback", disable_SN_feedback);
 	pp.query("sink_particle_use_uniform_kernel", sink_particle_use_uniform_kernel);
+
+	// Sink accretion-zone density floor; defaults to the global density_floor unless overridden
+	sink_accretion_density_floor = global_density_floor;
+	pp.query("sink_accretion_density_floor", sink_accretion_density_floor);
 
 	// Handle SNScheme enum
 	pp.query("SN_scheme", SN_scheme);

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3579,7 +3579,7 @@ template <typename problem_t> void AMRSimulation<problem_t>::InitPhyParticles(am
 	detail::verify_particle_switch_type<problem_t>();
 
 	// Read particle parameters from input file
-	quokka::particleParmParse();
+	quokka::particleParmParse(densityFloor_);
 
 	// Sink and Star both accrete via the same accretion-rate buffer (see particleMeshInteraction).
 	// Enabling both would double-apply gas removal: computeSinkAccretion accumulates into the shared


### PR DESCRIPTION
### Description
Adds a density floor to the sink particle accretion zone: accretion is capped per-cell so it never depletes a cell below a minimum density, and mass removed from the gas always exactly equals mass added to the particle.

The floor is a new runtime parameter, `particles.sink_accretion_density_floor`, which defaults to the global `density_floor` but can be overridden independently. It's enforced as a third cap in `SinkAccretionUtils::ComputeScaleDown` (`particle_accretion.hpp`), alongside the existing -25%-per-step and Jeans-density caps. The cap's `scale_down` factor is expressed relative to the original, pre-cap accretion rate (same convention as the existing caps), which is what keeps the particle mass gain and the gas mass loss numerically identical.

**Validation**: ran `ParticleAccretion` (3D Bondi-Hoyle test) in Release and Debug. Default behavior is unchanged; with the floor set above the ambient density, accretion was correctly disabled entirely (`Mdot_sim = 0`) with no assertion failures and exact mass conservation.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code. (No new automated test added; validated manually against the existing `ParticleAccretion` test in both Release and Debug across multiple floor values — see Validation above. Happy to add a dedicated regression test if reviewers want one.)
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
