### PR TITLE
Extend MHDQuirk: expose run params via TOML

### DIFF
--- a/inputs/MHDQuirk.toml
+++ b/inputs/MHDQuirk.toml
@@ -22,18 +22,5 @@ do_reflux = 0
 do_subcycle = 0
 
 plotfile_interval = -1
-checkpoint_interval = -1
-cfl = 0.4
-stop_time = 0.4
-max_timesteps = 2000
 
-hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 2  # PLM
-
-setup.dl = 3.692
-setup.ul = -0.625
-setup.pl = 26.85
-setup.dr = 1.0
-setup.ur = -5.0
-setup.pr = 0.6
-setup.xshock = 0.4

--- a/inputs/MHDQuirk.toml
+++ b/inputs/MHDQuirk.toml
@@ -27,4 +27,13 @@ cfl = 0.4
 stop_time = 0.4
 max_timesteps = 2000
 
+hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 2  # PLM
+
+setup.dl = 3.692
+setup.ul = -0.625
+setup.pl = 26.85
+setup.dr = 1.0
+setup.ur = -5.0
+setup.pr = 0.6
+setup.xshock = 0.4

--- a/inputs/MHDQuirk.toml
+++ b/inputs/MHDQuirk.toml
@@ -23,4 +23,4 @@ do_subcycle = 0
 
 plotfile_interval = -1
 
-hydro.reconstruction_order = 2  # PLM
+hydro.reconstruction_order = 2

--- a/inputs/MHDQuirk.toml
+++ b/inputs/MHDQuirk.toml
@@ -20,3 +20,11 @@ amr.max_grid_size = 128  # must be 128 for this problem
 
 do_reflux = 0
 do_subcycle = 0
+
+plotfile_interval = -1
+checkpoint_interval = -1
+cfl = 0.4
+stop_time = 0.4
+max_timesteps = 2000
+
+hydro.reconstruction_order = 2  # PLM

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -52,13 +52,13 @@ template <> struct Physics_Traits<MHDQuirk> : DefaultPhysicsTraits {
 	static constexpr bool is_mhd_enabled = true;
 };
 
-AMREX_GPU_MANAGED Real dl = 3.692;    // NOLINT
-AMREX_GPU_MANAGED Real ul = -0.625;   // NOLINT
-AMREX_GPU_MANAGED Real pl = 26.85;    // NOLINT
-AMREX_GPU_MANAGED Real dr = 1.0;      // NOLINT
-AMREX_GPU_MANAGED Real ur = -5.0;     // NOLINT
-AMREX_GPU_MANAGED Real pr = 0.6;      // NOLINT
-AMREX_GPU_MANAGED Real xshock = 0.4;  // NOLINT
+AMREX_GPU_MANAGED Real dl = 3.692;   // NOLINT
+AMREX_GPU_MANAGED Real ul = -0.625;  // NOLINT
+AMREX_GPU_MANAGED Real pl = 26.85;   // NOLINT
+AMREX_GPU_MANAGED Real dr = 1.0;     // NOLINT
+AMREX_GPU_MANAGED Real ur = -5.0;    // NOLINT
+AMREX_GPU_MANAGED Real pr = 0.6;     // NOLINT
+AMREX_GPU_MANAGED Real xshock = 0.4; // NOLINT
 constexpr int ishock_g = 0;
 
 template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -52,13 +52,12 @@ template <> struct Physics_Traits<MHDQuirk> : DefaultPhysicsTraits {
 	static constexpr bool is_mhd_enabled = true;
 };
 
-AMREX_GPU_MANAGED Real dl = 3.692;   // NOLINT
-AMREX_GPU_MANAGED Real ul = -0.625;  // NOLINT
-AMREX_GPU_MANAGED Real pl = 26.85;   // NOLINT
-AMREX_GPU_MANAGED Real dr = 1.0;     // NOLINT
-AMREX_GPU_MANAGED Real ur = -5.0;    // NOLINT
-AMREX_GPU_MANAGED Real pr = 0.6;     // NOLINT
-AMREX_GPU_MANAGED Real xshock = 0.4; // NOLINT
+constexpr Real dl = 3.692;
+constexpr Real ul = -0.625;
+constexpr Real pl = 26.85;
+constexpr Real dr = 1.0;
+constexpr Real ur = -5.0;
+constexpr Real pr = 0.6;
 constexpr int ishock_g = 0;
 
 template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
@@ -84,6 +83,7 @@ template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGrid(quokka::
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
+	Real const xshock = 0.4;
 	int ishock = 0;
 	for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + static_cast<Real>(0.5))) < xshock; ++ishock) {
 	}
@@ -247,15 +247,6 @@ AMRSimulation<MHDQuirk>::setCustomBoundaryConditions(const amrex::IntVect &iv, a
 
 auto problem_main() -> int
 {
-	amrex::ParmParse const hpp("setup");
-	hpp.query("dl", dl);
-	hpp.query("ul", ul);
-	hpp.query("pl", pl);
-	hpp.query("dr", dr);
-	hpp.query("ur", ur);
-	hpp.query("pr", pr);
-	hpp.query("xshock", xshock);
-
 	// Boundary conditions: ext_dir in x, periodic in y and z
 	auto BCs_cc = quokka::BC<MHDQuirk>(quokka::BCType::ext_dir,  // x: outflow
 					   quokka::BCType::int_dir,  // y: periodic
@@ -272,6 +263,10 @@ auto problem_main() -> int
 
 	// Problem initialization
 	QuokkaSimulation<MHDQuirk> sim(BCs_cc, BCs_fc);
+
+	sim.stopTime_ = 0.4;
+	sim.cflNumber_ = 0.4;
+	sim.maxTimesteps_ = 2000;
 
 	// initialize
 	sim.setInitialConditions();

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -52,12 +52,13 @@ template <> struct Physics_Traits<MHDQuirk> : DefaultPhysicsTraits {
 	static constexpr bool is_mhd_enabled = true;
 };
 
-constexpr Real dl = 3.692;
-constexpr Real ul = -0.625;
-constexpr Real pl = 26.85;
-constexpr Real dr = 1.0;
-constexpr Real ur = -5.0;
-constexpr Real pr = 0.6;
+AMREX_GPU_MANAGED Real dl = 3.692;    // NOLINT
+AMREX_GPU_MANAGED Real ul = -0.625;   // NOLINT
+AMREX_GPU_MANAGED Real pl = 26.85;    // NOLINT
+AMREX_GPU_MANAGED Real dr = 1.0;      // NOLINT
+AMREX_GPU_MANAGED Real ur = -5.0;     // NOLINT
+AMREX_GPU_MANAGED Real pr = 0.6;      // NOLINT
+AMREX_GPU_MANAGED Real xshock = 0.4;  // NOLINT
 constexpr int ishock_g = 0;
 
 template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
@@ -83,7 +84,6 @@ template <> void QuokkaSimulation<MHDQuirk>::setInitialConditionsOnGrid(quokka::
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 
-	Real const xshock = 0.4;
 	int ishock = 0;
 	for (ishock = 0; (prob_lo[0] + dx[0] * (ishock + static_cast<Real>(0.5))) < xshock; ++ishock) {
 	}
@@ -247,6 +247,15 @@ AMRSimulation<MHDQuirk>::setCustomBoundaryConditions(const amrex::IntVect &iv, a
 
 auto problem_main() -> int
 {
+	amrex::ParmParse const hpp("setup");
+	hpp.query("dl", dl);
+	hpp.query("ul", ul);
+	hpp.query("pl", pl);
+	hpp.query("dr", dr);
+	hpp.query("ur", ur);
+	hpp.query("pr", pr);
+	hpp.query("xshock", xshock);
+
 	// Boundary conditions: ext_dir in x, periodic in y and z
 	auto BCs_cc = quokka::BC<MHDQuirk>(quokka::BCType::ext_dir,  // x: outflow
 					   quokka::BCType::int_dir,  // y: periodic

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -264,12 +264,6 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<MHDQuirk> sim(BCs_cc, BCs_fc);
 
-	sim.reconstructionOrder_ = 2; // PLM
-	sim.stopTime_ = 0.4;
-	sim.cflNumber_ = 0.4;
-	sim.maxTimesteps_ = 2000;
-	sim.plotfileInterval_ = -1;
-
 	// initialize
 	sim.setInitialConditions();
 


### PR DESCRIPTION
### Description

This PR links up two parameters for `MHDQuirk`: `reconstructionOrder_` and `plotfileInterval_` in `problem_main()` 
, to the TOML file; the TOML values were being silently ignored. I need this to run the Quirk problem with the paper's recommended scheme (PPM-EP) instead of the CI-pinned PLM default, and to get plotfile output at all (`plotfileInterval_` was hardcoded to `-1`, so no plotfiles were ever written).



### Related issues

N/A.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above) — n/a, see Related issues.
- [x] I have read the Contributing Guide.
- [ ] I have added tests for any new physics that this PR adds to the code — n/a, no new physics; existing test behaviour is preserved (see Validation).
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Updated the MHD Quirk configuration to disable plot output (`plotfile_interval = -1`) and set the hydro reconstruction order to `2`.
* **Bug Fixes**
  * Adjusted the MHD Quirk test runner to rely on configured defaults by removing explicit in-code overrides for reconstruction order and plot interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->