### PR TITLE
Lower one zone photoionization test tolerance

### DIFF
--- a/inputs/OneZonePhotoionization.toml
+++ b/inputs/OneZonePhotoionization.toml
@@ -36,17 +36,17 @@ photoionization.temperature = 1e3
 
 # Validation test against Julia reference at 1e-6 L1 error tolerance.
 # Use very tight tolerances (effectively pure relative) to match the reference.
-integrator.atol_spec                     = 1e-14
-integrator.atol_enuc                     = 1e-14
-integrator.atol_rad_num                  = 1e-14
-integrator.species_failure_tolerance     = 1e-14    # cm^-3; matches atol_spec — VODE internal step guard
+integrator.atol_spec                     = 1e-5
+integrator.atol_enuc                     = 1e+3
+integrator.atol_rad_num                  = 1e-5
+integrator.species_failure_tolerance     = 1e-5    # cm^-3; matches atol_spec — VODE internal step guard
 integrator.radiation_failure_tolerance   = 0.05     # cm^-3; N_gamma guard, must exceed atol_rad_num
 
-integrator.rtol_spec     = 1e-14
-integrator.rtol_rad_num  = 1e-14
-integrator.rtol_enuc     = 1e-14
+integrator.rtol_spec     = 1e-7
+integrator.rtol_rad_num  = 1e-7
+integrator.rtol_enuc     = 1e-7
 
-integrator.rosenbrock_tableau = 0
+integrator.rosenbrock_tableau = 3
 
 network.energy_switch = 0
 network.collisional_ionization_switch = 0

--- a/inputs/OneZonePhotoionization.toml
+++ b/inputs/OneZonePhotoionization.toml
@@ -46,7 +46,7 @@ integrator.rtol_spec     = 1e-14
 integrator.rtol_rad_num  = 1e-14
 integrator.rtol_enuc     = 1e-14
 
-integrator.rosenbrock_tableau = 3
+integrator.rosenbrock_tableau = 0
 
 network.energy_switch = 0
 network.collisional_ionization_switch = 0

--- a/inputs/OneZonePhotoionizationWithEnergy.toml
+++ b/inputs/OneZonePhotoionizationWithEnergy.toml
@@ -36,17 +36,17 @@ photoionization.temperature = 1e3
 
 # Validation test against Julia reference at 1e-6 L1 error tolerance.
 # Use very tight tolerances (effectively pure relative) to match the reference.
-integrator.atol_spec                     = 1e-14
-integrator.atol_enuc                     = 1e-14
-integrator.atol_rad_num                  = 1e-14
-integrator.species_failure_tolerance     = 1e-14    # cm^-3; matches atol_spec — VODE internal step guard
+integrator.atol_spec                     = 1e-3
+integrator.atol_enuc                     = 1e+3
+integrator.atol_rad_num                  = 1e-3
+integrator.species_failure_tolerance     = 1e-3    # cm^-3; matches atol_spec — VODE internal step guard
 integrator.radiation_failure_tolerance   = 0.05     # cm^-3; N_gamma guard, must exceed atol_rad_num
 
-integrator.rtol_spec     = 1e-14
-integrator.rtol_rad_num  = 1e-14
-integrator.rtol_enuc     = 1e-14
+integrator.rtol_spec     = 1e-7
+integrator.rtol_rad_num  = 1e-7
+integrator.rtol_enuc     = 1e-7
 
-integrator.rosenbrock_tableau = 0
+integrator.rosenbrock_tableau = 3
 
 network.energy_switch = 1
 network.KI_heating_switch = 0

--- a/inputs/OneZonePhotoionizationWithEnergy.toml
+++ b/inputs/OneZonePhotoionizationWithEnergy.toml
@@ -46,7 +46,7 @@ integrator.rtol_spec     = 1e-14
 integrator.rtol_rad_num  = 1e-14
 integrator.rtol_enuc     = 1e-14
 
-integrator.rosenbrock_tableau = 3
+integrator.rosenbrock_tableau = 0
 
 network.energy_switch = 1
 network.KI_heating_switch = 0

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -4,7 +4,7 @@
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
 /// \file testOneZonePhotoionization.cpp
-/// \brief Defines a test problem for one-zone photoionization.
+/// \brief Defines a test problem for photoionization.
 ///
 
 #include "AMReX.H"

--- a/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
+++ b/src/problems/OneZonePhotoionization/testOneZonePhotoionization.cpp
@@ -4,7 +4,7 @@
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
 /// \file testOneZonePhotoionization.cpp
-/// \brief Defines a test problem for photoionization.
+/// \brief Defines a test problem for one-zone photoionization.
 ///
 
 #include "AMReX.H"


### PR DESCRIPTION
### Description
This PR lowers the tolerances for the one zone photoionization tests, otherwise they are very slow on GPUs.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated photochemistry integration settings for the standard and energy-enabled one-zone configurations.
  * Relaxed absolute and relative numerical tolerances to support more practical simulation runs.
  * Retained the existing radiation failure threshold while adjusting species, radiation, and energy-related tolerance values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->