### PR TITLE
Guard mhd.resistivity: abort when resistivity_model is none

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -624,18 +624,19 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		if constexpr (Physics_Traits<problem_t>::resistivity_model == ResistivityModel::constant) {
 			hpp.query("resistivity", mhdResistivity_);
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mhdResistivity_ >= 0.0, "mhd.resistivity must be >= 0.");
-		} else if constexpr (Physics_Traits<problem_t>::resistivity_model == ResistivityModel::none) {
-			// resistivity_model is a compile-time trait: if it is `none`, mhd.resistivity is never read
-			// (see the `constant` branch above) and the resistive EMF/energy terms never fire, regardless
-			// of what this problem's input file says. Catch a set-but-silently-ignored value here instead
-			// of letting it pass with no effect.
+		} else if constexpr (Physics_Traits<problem_t>::resistivity_model == ResistivityModel::none ||
+				     Physics_Traits<problem_t>::resistivity_model == ResistivityModel::problem_defined) {
+			// mhd.resistivity is only read in the `constant` branch above; every other model falls
+			// through to here.
 			const bool resistivity_key_present = hpp.contains("resistivity");
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!resistivity_key_present, "mhd.resistivity is set in the input file, but this problem's "
-										   "Physics_Traits::resistivity_model is `none`, so resistivity is never "
-										   "applied here. This is a compile-time trait, not a runtime switch: to "
-										   "test resistivity with this problem, set `resistivity_model = "
-										   "ResistivityModel::constant` in its Physics_Traits specialization and "
-										   "rebuild.");
+										   "Physics_Traits::resistivity_model is not `constant`, so this value is "
+										   "ignored (with `none`, no resistivity is applied; with "
+										   "`problem_defined`, resistivity comes from the problem's "
+										   "computeResistivity function instead). This is a compile-time trait, "
+										   "not a runtime switch: to test resistivity with this problem, set "
+										   "`resistivity_model = ResistivityModel::constant` in its Physics_Traits "
+										   "specialization and rebuild.");
 		}
 	}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -624,6 +624,19 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		if constexpr (Physics_Traits<problem_t>::resistivity_model == ResistivityModel::constant) {
 			hpp.query("resistivity", mhdResistivity_);
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(mhdResistivity_ >= 0.0, "mhd.resistivity must be >= 0.");
+		} else if constexpr (Physics_Traits<problem_t>::resistivity_model == ResistivityModel::none) {
+			// resistivity_model is a compile-time trait: if it is `none`, mhd.resistivity is never read
+			// (see the `constant` branch above) and the resistive EMF/energy terms never fire, regardless
+			// of what this problem's input file says. Catch a set-but-silently-ignored value here instead
+			// of letting it pass with no effect.
+			amrex::Real unused_resistivity = 0.0;
+			const bool resistivity_key_present = hpp.query("resistivity", unused_resistivity);
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!resistivity_key_present, "mhd.resistivity is set in the input file, but this problem's "
+										   "Physics_Traits::resistivity_model is `none`, so resistivity is never "
+										   "applied here. This is a compile-time trait, not a runtime switch: to "
+										   "test resistivity with this problem, set `resistivity_model = "
+										   "ResistivityModel::constant` in its Physics_Traits specialization and "
+										   "rebuild.");
 		}
 	}
 

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -629,8 +629,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 			// (see the `constant` branch above) and the resistive EMF/energy terms never fire, regardless
 			// of what this problem's input file says. Catch a set-but-silently-ignored value here instead
 			// of letting it pass with no effect.
-			amrex::Real unused_resistivity = 0.0;
-			const bool resistivity_key_present = hpp.query("resistivity", unused_resistivity);
+			const bool resistivity_key_present = hpp.contains("resistivity");
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!resistivity_key_present, "mhd.resistivity is set in the input file, but this problem's "
 										   "Physics_Traits::resistivity_model is `none`, so resistivity is never "
 										   "applied here. This is a compile-time trait, not a runtime switch: to "


### PR DESCRIPTION
### Description

`mhd.resistivity` is only read from the input file when a problem's `Physics_Traits::resistivity_model` is `constant`; for the default `none`, that read is compiled out entirely, so setting `mhd.resistivity` in the TOML silently has no effect. I found this while comparing `AlfvenWaveLinearConvergence`'s resistive Alfven-wave test across EMF schemes: its `Physics_Traits` never sets `resistivity_model`, so the "decay" it reports is scheme-dependent numerical dissipation, not physical Ohmic decay. Its own error-norm check doesn't catch this either, since the missing decay on the perturbation is swamped by the O(1) background field in the combined norm.

This adds a guard in the shared `readParmParse()` during simulation initialisation in QuokkaSimulation.hpp: if `mhd.resistivity` is present in the input file but `resistivity_model` is `none` in `Physics_Traits`, the simulation aborts with a message pointing at the fix (set `resistivity_model = ResistivityModel::constant` in the problem's `Physics_Traits` and rebuild). Being in the shared path rather than per-problem, this covers every current and future MHD problem, not just the one I found. `FastWaveConvergence`/`SlowWaveConvergence` already have their own problem-specific version of this check; this generalizes it for everything else.

I checked every MHD problem's `Physics_Traits` and every committed `inputs/*.toml`: only `MHDResistiveDiffusion` sets `mhd.resistivity`, and it already declares `resistivity_model = constant`, so this doesn't break anything in the existing test suite.

### Related issues

None.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure resistivity configuration is consistent when resistivity physics is disabled.
  * Prevents unsupported `mhd.resistivity` input from being silently ignored and now raises a clear configuration error.
  * Includes guidance to switch to a supported resistivity model (e.g., constant) when resistivity behavior is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->