### PR TITLE
Update wave tests: point resistivity error to MHDResistiveDiffusion

### DIFF
--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -538,7 +538,7 @@ auto problem_main() -> int
 		amrex::ParmParse const mhd_pp("mhd");
 		mhd_pp.query("resistivity", eta);
 		if (eta != 0.0) {
-			amrex::Abort("FastWaveConvergence does not support mhd.resistivity != 0; use the AlfvenWaveLinear fixed-resolution test for "
+			amrex::Abort("FastWaveConvergence does not support mhd.resistivity != 0; use MHDResistiveDiffusion for "
 				     "resistivity validation.");
 		}
 	}

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -547,7 +547,7 @@ auto problem_main() -> int
 		amrex::ParmParse const mhd_pp("mhd");
 		mhd_pp.query("resistivity", eta);
 		if (eta != 0.0) {
-			amrex::Abort("SlowWaveConvergence does not support mhd.resistivity != 0; use the AlfvenWaveLinear fixed-resolution test for "
+			amrex::Abort("SlowWaveConvergence does not support mhd.resistivity != 0; use MHDResistiveDiffusion for "
 				     "resistivity validation.");
 		}
 	}


### PR DESCRIPTION
### Description

`FastWaveConvergence` and `SlowWaveConvergence` both reject `mhd.resistivity != 0` with a message pointing users to "the AlfvenWaveLinear fixed-resolution test" for resistivity validation. That pointer is now stale: `MHDResistiveDiffusion` is the dedicated resistivity test (static field, analytic `b_z` decay and Joule-heating checks), and `AlfvenWaveLinear`'s resistive path is currently disabled by default (`Physics_Traits::resistivity_model` is `none`; see #2050).

I considered removing these two checks entirely now that #2050 adds a generic guard for any problem with `resistivity_model = none`, but kept them: their analytic reference solutions have no decay term at all, so simply flipping their trait to `constant` would apply real resistive damping to the simulation while comparing it against a purely ideal reference, silently reintroducing the same class of bug #2050 fixes, in reverse. The problem-specific message is correct to point elsewhere rather than imply a one-line trait flip is sufficient.

This just repoints both messages to `MHDResistiveDiffusion`.

### Related issues

- #2050: related context; that PR documents why `AlfvenWaveLinear` is no longer the right pointer here.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated validation error guidance for unsupported resistivity settings.
  * Error messages now direct users to the appropriate resistive diffusion validation test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->