### PR TITLE
Fix AlfvenWaveLinear: restore resistivity_model=constant

### DIFF
--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -43,6 +43,7 @@ template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
 template <> struct Physics_Traits<AlfvenWaveLinear> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr ResistivityModel resistivity_model = ResistivityModel::constant; // eta defaults to 0; no-op unless set
 };
 
 constexpr double sound_speed = 1.0;


### PR DESCRIPTION
### Description

`AlfvenWaveLinear`'s `Physics_Traits` never sets `resistivity_model`, so it defaults to `none` and `mhd.resistivity` is silently ignored (see #2050); this is a regression from the wave-test-consolidation (#1978) that merged the standalone `AlfvenWaveLinear` problem into today's `AlfvenWaveLinearConvergence`. Before that, #1913 validated this exact test's resistive decay against the analytic `gamma = eta*k^2/2` prediction, converging at 2nd order.

This restores `resistivity_model = ResistivityModel::constant`. `mhd.resistivity` defaults to `0.0`, so this is a no-op for every non-resistive run.

### Validation

- Default (non-resistive) `AlfvenWaveLinearConvergence` and `AlfvenWaveLinear` run_sim modes are unaffected: error norm `4.2372669e-10`, identical to before this change.
- Resistive `run_sim` (`mhd.resistivity = 0.01`, `n_cell = [64, 8, 8]`, `stop_time = 1.0`) now applies real Ohmic decay matching the analytic `exp(-gamma) = 0.8208` prediction to near machine precision, confirmed across both `FelkerStone2017`+`LondrilloDelZanna2004` and `Quokka2026`+`Balsara2025`; before this fix, the latter combination showed almost no decay since the resistive term was never applied.
- The original decay-rate-vs-eta convergence figure for this test lives in #1913; this PR restores the same validated configuration rather than re-deriving it.

### Related issues

- #2050: this PR builds on the finding there (`mhd.resistivity` silently ignored when `resistivity_model` is `none`).
- #1913: this PR restores the resistivity_model setting that PR originally added for this problem.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly configures the Alfven Wave Linear convergence test to use the constant resistivity model, ensuring consistent resistivity behavior when enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->