### PR TITLE
Fix FOFC fallback: include resistive energy flux

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2355,6 +2355,10 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, 1,
 						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_);
+		// FOfluxArrays is the fallback flux substituted in on FOFC-troubled cells (see replaceFluxes() below,
+		// used for both RK stages); without this, those cells retain a resistivity-consistent EMF/induction
+		// update but silently lose the corresponding Joule-heating term in the energy update.
+		MHDSystem<problem_t>::AddResistiveEnergyFlux(FOfluxArrays, state_old_fc_tmp, dx, mhdResistivity_);
 	}
 
 	// Stage 1 of RK2-SSP

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2355,9 +2355,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 		}
 		MHDSystem<problem_t>::ComputeEMF(ec_emf_components_fo, state_old_cc_tmp, FOfaceVel, state_old_fc_tmp, FOfast_mhd_wavespeeds, 1,
 						 emfAveragingScheme_, mhdPlmLimiter_, emfComputingScheme_, dx, mhdResistivity_);
-		// FOfluxArrays is the fallback flux substituted in on FOFC-troubled cells (see replaceFluxes() below,
-		// used for both RK stages); without this, those cells retain a resistivity-consistent EMF/induction
-		// update but silently lose the corresponding Joule-heating term in the energy update.
+		// FOFC fallback cells (see replaceFluxes() below) would otherwise silently drop Joule heating.
 		MHDSystem<problem_t>::AddResistiveEnergyFlux(FOfluxArrays, state_old_fc_tmp, dx, mhdResistivity_);
 	}
 


### PR DESCRIPTION
### Description

`FOfluxArrays` (the first-order fallback flux substituted onto FOFC-troubled cells via `replaceFluxes()`) never received the resistive energy-flux correction. The fallback EMF (`ec_emf_components_fo`) is built with `mhdResistivity_` and stays fully resistivity-consistent through `replaceEMFs()`, but `MHDSystem::AddResistiveEnergyFlux()` was only ever applied to the high-order `fluxArrays`. So on any cell where FOFC fires, the B-field update correctly retains resistive decay while the energy update silently reverts to ideal-MHD, dropping the corresponding Joule heating.

The fix is a single line: apply `AddResistiveEnergyFlux()` to `FOfluxArrays` immediately after `computeFOHydroFluxes()`, using the same `state_old_fc_tmp`/`dx`/`mhdResistivity_` already in scope for the FO EMF computation directly above it. `computeFOHydroFluxes()` runs once per timestep and `FOfluxArrays` is reused for both RK-stage `replaceFluxes()` call sites, so this one addition covers both. `AddResistiveEnergyFlux()` already self-guards internally for isothermal EOS and `resistivity_model == none`, so this is always safe to call unconditionally.

### Validation

`MHDResistiveDiffusion`'s default config gives a byte-identical error norm before and after this change, confirming the fix is a no-op whenever FOFC never fires. To check the case that actually matters, I built a throwaway `MHDBlast` config designed to trigger a handful of FOFC events without fully crashing (resistivity temporarily enabled via a local, uncommitted trait edit; not part of this PR), then compared the internal-energy field step-by-step between builds with and without the fix. The two builds are bit-identical right up until the first FOFC event, at which point a difference appears exactly in the cells FOFC corrected and then spreads outward over subsequent steps the way a local flux correction should, with mixed-sign changes consistent with a redistributive flux term rather than noise. In short: no effect outside FOFC, and inside FOFC the fix does exactly what it's supposed to.

I did not add a committed regression test in this PR. Reliably triggering FOFC in a resistive problem without also triggering a full blowup required narrow CFL-tuning right at the edge of stability during the verification above, which felt like a separate, more deliberate test-design task than this fix itself. Flagging rather than silently omitting it.

### Related issues

Fixes #2074

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetohydrodynamics first-order flux correction so it now includes resistive (Joule-heating) energy contributions when using the FOFC fallback path.
  * Enhanced energy conservation and physical accuracy in cells that rely on first-order flux correction during MHD updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->