### PR TITLE
Fix particle container layout after AMR regridding

### DIFF
--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -183,6 +183,9 @@ class PhysicsParticleDescriptorBase
 	// Redistribute particles at level lev and above with ngrow ghost cells
 	virtual void redistribute(int lev, int ngrow) const = 0;
 
+	// Synchronize the particle container with an AMR level after regridding.
+	virtual void setGridLayout(int lev, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm, const amrex::Geometry &geom) const = 0;
+
 	// Write particle data to plot file
 	virtual void writePlotFile(const std::string &plotfilename, const std::string &name) = 0;
 
@@ -679,6 +682,15 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 		}
 	}
 
+	void setGridLayout(int lev, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm, const amrex::Geometry &geom) const override
+	{
+		if (container_ != nullptr) {
+			container_->SetParticleGeometry(lev, geom);
+			container_->SetParticleBoxArray(lev, ba);
+			container_->SetParticleDistributionMap(lev, dm);
+		}
+	}
+
 	// Implementation of particle redistribution with ghost cells
 	void redistribute(int lev, int ngrow) const override
 	{
@@ -1086,6 +1098,15 @@ template <typename problem_t> class PhysicsParticleRegister
 			if (descriptor->getAllowsAccretion()) {
 				descriptor->applySinkAccretion(state, state_accretion_rate, state_fc, geom, lev, time, dt);
 			}
+		}
+	}
+
+	// Synchronize all registered particle containers with an AMR level.
+	void setGridLayout(int lev, const amrex::BoxArray &ba, const amrex::DistributionMapping &dm, const amrex::Geometry &geom) const
+	{
+		const BL_PROFILE("PhysicsParticleRegister::setGridLayout()");
+		for (const auto &[type, descriptor] : particleRegistry_) {
+			descriptor->setGridLayout(lev, ba, dm, geom);
 		}
 	}
 

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2240,8 +2240,13 @@ template <typename problem_t> void AMRSimulation<problem_t>::timeStepWithSubcycl
 				}
 
 #if AMREX_SPACEDIM == 3
-				// redistribute all particles in particleRegister_
-				particleRegister_.redistribute(lev);
+				// Particle containers loaded from a checkpoint may own a snapshot of the
+				// pre-regrid ParGDB. Synchronize every affected AMR level before
+				// redistributing particles onto the new grid layout.
+				for (int k = lev; k <= finest_level; ++k) {
+					particleRegister_.setGridLayout(k, boxArray(k), DistributionMap(k), Geom(k));
+				}
+				particleRegister_.redistribute(lev, 0);
 #endif // AMREX_SPACEDIM == 3
 
 				// do fix-up on all levels that have been re-gridded


### PR DESCRIPTION
### Description
This PR fixes stale particle-grid metadata after AMR regridding. It adds an interface for synchronizing each particle container with the updated `Geometry`, `BoxArray`, and `DistributionMap`, then performs particle redistribution using the new grid layout. This prevents particle iterators from referencing outdated grid indices or MPI ownership after restarting and regridding.
### Related issues
None

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved particle handling after adaptive mesh regridding.
  * Particle data now stays synchronized with updated grid layouts across affected simulation levels.
  * Improved particle redistribution during 3D subcycled time steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->