### PR TITLE
Fix pre-commit script suppressing failing hooks

### DIFF
--- a/scripts/bash/quokka-pre-commit.sh
+++ b/scripts/bash/quokka-pre-commit.sh
@@ -57,10 +57,18 @@ fi
 
 echo "Using: ${PRECOMMIT[*]}"
 
-"${PRECOMMIT[@]}" run --all-files || true
+STATUS=0
+"${PRECOMMIT[@]}" run --all-files || STATUS=$?
 
-# Commit any changes made by pre-commit hooks (e.g. clang-format)
+# Commit any changes made by pre-commit hooks (e.g. clang-format), then rerun
+# the hooks to check for remaining (non-mutating) failures such as invalid
+# YAML or a failed checker.
 if [[ -n $(git status --porcelain) ]]; then
 	git add -A
 	git commit -m "style: apply pre-commit fixes"
+
+	STATUS=0
+	"${PRECOMMIT[@]}" run --all-files || STATUS=$?
 fi
+
+exit "$STATUS"


### PR DESCRIPTION
### Description
`quokka-pre-commit.sh` ran `pre-commit run --all-files || true`, which always discarded the hook results. A failing hook (invalid YAML, merge-conflict markers, etc.) that didn't modify any files would report a clean run, and even when a formatter did fix files, the script committed them without rechecking for other unrelated failures.

**Changed:** capture the first run's exit status. If hooks modified files, commit the fixes and rerun the hooks, exiting with the rerun's status. If nothing was modified, exit with the original status directly.

**Validated:** since there's no shell test harness in this repo, verified the exit-status logic manually with a mocked `pre-commit` command in a scratch git repo, covering all four cases: all hooks pass, formatter fixes files and rerun is clean, non-mutating failure, and formatter fixes files but a residual failure remains. Also ran the real script on this change (clean pass, no residual diff).

### Related issues
Closes #2070

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
