### PR TITLE
Reattach particles to simulation class after restart refinement

### DIFF
--- a/.github/workflows/checkpoint-restart-refine.yml
+++ b/.github/workflows/checkpoint-restart-refine.yml
@@ -76,7 +76,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       shell: bash
       # Execute the build.  You can specify a specific target with "--target <NAME>"
-      run: cmake --build . --config $BUILD_TYPE --parallel 4 --target HydroBlast3D
+      run: cmake --build . --config $BUILD_TYPE --parallel 4 --target HydroBlast3D BinaryOrbitCIC
 
     - name: Checkpoint/Restart with Refinement Test
       working-directory: ${{github.workspace}}/tests

--- a/inputs/checkpoint_restart_refine_test.sh
+++ b/inputs/checkpoint_restart_refine_test.sh
@@ -255,6 +255,9 @@ fi
 
 mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/BinaryOrbitCIC/BinaryOrbitCIC ../inputs/BinaryOrbitCICAMR_checkpoint_restart.toml \
     restartfile=$particle_checkpoint 'amr.n_cell=64 64 64' amr.blocking_factor=16 amr.max_grid_size=16 regrid_interval=1 \
-    max_timesteps=2 checkpoint_interval=-1 plotfile_interval=-1 suppress_output=1 tiny_profiler.enabled=0 problem.verify_particle_layout=1
+    max_timesteps=2 checkpoint_interval=-1 plotfile_interval=-1 suppress_output=1 tiny_profiler.enabled=0 problem.verify_particle_layout=1 || {
+    echo "❌ PARTICLE LAYOUT CHECK FAILED"
+    exit 1
+}
 
 echo "✅ PARTICLE LAYOUT CHECK PASSED: Restart-refined particle container tracks the regridded AMR hierarchy."

--- a/inputs/checkpoint_restart_refine_test.sh
+++ b/inputs/checkpoint_restart_refine_test.sh
@@ -94,7 +94,8 @@ $SED_INPLACE 's/do_subcycle = 0/do_subcycle = 1/' fine_amr.toml
 
 echo "=== Step 1: Create coarse AMR checkpoint (32^3 base + 1 AMR level) ==="
 # Run coarse AMR simulation to create checkpoints
-mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D coarse_amr.toml stop_time=$CHECKPOINT_TIME
+mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D coarse_amr.toml stop_time=$CHECKPOINT_TIME suppress_output=1 \
+    tiny_profiler.enabled=0
 
 # Save and find last checkpoint
 mkdir -p step1_32cube
@@ -140,7 +141,8 @@ fi
 
 echo ""
 echo "=== Step 2: Run native fine AMR simulation (64^3 base + 1 AMR level) ==="
-mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D fine_amr.toml stop_time=$STOP_TIME
+mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D fine_amr.toml stop_time=$STOP_TIME suppress_output=1 \
+    tiny_profiler.enabled=0
 
 # Save native results  
 mkdir -p step2_native_64cube
@@ -158,7 +160,8 @@ echo "Native fine AMR simulation completed at time t=$native_time"
 
 echo ""
 echo "=== Step 3: Restart with multi-level universal refinement ==="
-mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D fine_amr.toml restartfile=$last_chk stop_time=$STOP_TIME
+mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/HydroBlast3D/HydroBlast3D fine_amr.toml restartfile=$last_chk stop_time=$STOP_TIME suppress_output=1 \
+    tiny_profiler.enabled=0
 
 # Save restart results
 mkdir -p step3_restart_64cube
@@ -234,3 +237,24 @@ echo "3. $([ "$comparison_passed" = true ] && echo "✅" || echo "⚠️ ") Resu
 
 echo ""
 echo "=== Multi-Level Universal Refinement Test Complete ==="
+
+echo ""
+echo "=== Particle Container Restart Refinement Test ==="
+rm -rf particle_step1_32cube 2>/dev/null || true
+
+mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/BinaryOrbitCIC/BinaryOrbitCIC ../inputs/BinaryOrbitAMR.toml \
+    max_timesteps=1 checkpoint_interval=1 plotfile_interval=-1 suppress_output=1 tiny_profiler.enabled=0
+
+mkdir -p particle_step1_32cube
+mv chk* particle_step1_32cube/ 2>/dev/null || true
+particle_checkpoint=$(ls -1d particle_step1_32cube/chk* 2>/dev/null | tail -1)
+if [ -z "$particle_checkpoint" ]; then
+    echo "❌ ERROR: No particle checkpoint files created in particle_step1_32cube/"
+    exit 1
+fi
+
+mpirun --use-hwthread-cpus -n $NPROC $BUILD_DIR/src/problems/BinaryOrbitCIC/BinaryOrbitCIC ../inputs/BinaryOrbitCICAMR_checkpoint_restart.toml \
+    restartfile=$particle_checkpoint 'amr.n_cell=64 64 64' amr.blocking_factor=16 amr.max_grid_size=16 regrid_interval=1 \
+    max_timesteps=2 checkpoint_interval=-1 plotfile_interval=-1 suppress_output=1 tiny_profiler.enabled=0 problem.verify_particle_layout=1
+
+echo "✅ PARTICLE LAYOUT CHECK PASSED: Restart-refined particle container tracks the regridded AMR hierarchy."

--- a/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
+++ b/src/problems/BinaryOrbitCIC/testBinaryOrbitCIC.cpp
@@ -32,8 +32,9 @@
 struct BinaryOrbit {
 };
 
-static bool do_split_particles = false; // NOLINT
-static int split_factor = 8;		// NOLINT
+static bool do_split_particles = false;	    // NOLINT
+static int split_factor = 8;		    // NOLINT
+static bool verify_particle_layout = false; // NOLINT
 
 template <> struct quokka::EOS_Traits<BinaryOrbit> {
 	static constexpr double gamma = 1.0;	       // isothermal
@@ -107,6 +108,15 @@ void QuokkaSimulation<BinaryOrbit>::ComputeDerivedVar(int lev, std::string const
 
 template <> void QuokkaSimulation<BinaryOrbit>::computeAfterTimestep()
 {
+	if (verify_particle_layout) {
+		bool layout_matches = CICParticles->GetParGDB() == GetParGDB();
+		for (int lev = 0; lev <= finestLevel(); ++lev) {
+			layout_matches = layout_matches && CICParticles->ParticleBoxArray(lev).CellEqual(boxArray(lev)) &&
+					 CICParticles->ParticleDistributionMap(lev) == DistributionMap(lev);
+		}
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(layout_matches, "Particle container does not track the AMR hierarchy after restart refinement");
+	}
+
 	// every N cycles, save particle statistics at the finest level
 	static int cycle = 1;
 	if (cycle % 10 == 0) {
@@ -155,6 +165,7 @@ auto problem_main() -> int
 	amrex::ParmParse const pp("problem");
 	pp.query("do_split_particles", do_split_particles);
 	pp.query("split_factor", split_factor);
+	pp.query("verify_particle_layout", verify_particle_layout);
 
 	// Problem initialization
 	QuokkaSimulation<BinaryOrbit> sim;
@@ -179,7 +190,6 @@ auto problem_main() -> int
 	const auto &real_data = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleDataAtLevel(0).first;
 
 	int status = 0;
-
 	// check max abs particle distance
 	double max_deviation = 0.0;
 	if (amrex::ParallelDescriptor::IOProcessor()) {

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -5218,6 +5218,7 @@ void AMRSimulation<problem_t>::restartParticleContainerWithRefinement(std::uniqu
 			particles->SetParticleBoxArray(lev, current_ba[lev]);
 			particles->SetParticleDistributionMap(lev, current_dm[lev]);
 		}
+		particles->Define(this->GetParGDB());
 
 		// Redistribute particles to refined grid
 		particles->Redistribute();


### PR DESCRIPTION
### Description

#### Problem

Universal restart refinement temporarily assigns geometry and grid layouts from the checkpoint file to physics particle containers. This detaches an `AmrParticleContainer` from the actual `AmrCore` `ParGDB` used for the simulation. Due to this, after a later AMR regrid, the particle container's `BoxArray` and `DistributionMapping` are no longer in sync with the actual AMR grids used by the AMRSimulation/AMRCore class.

This issue only affected users if they restarted a simulation with universal refinement, and then ran then simulation with AMR regridding enabled. This would then cause a crash due to invalid memory accesses.

#### Solution

- Reattach the particle containers to `AmrCore::GetParGDB()` before redistributing particles at the end of the restart procedure
- Extended `BinaryOrbitCIC` to verify this resolves the original bug as part of the existing CheckpointRestartRefine action.
- Confirmed the new test fails on `development` at the first post-restart regrid before applying the fix.
- Full `inputs/checkpoint_restart_refine_test.sh` with four MPI ranks: existing hydro comparison passed, `fcompare` passed, and the new particle layout check passed with 16 particles.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for restarting particle containers while refining the AMR hierarchy.
  * Added optional verification to confirm particle layouts remain consistent with the refined hierarchy.
  * Extended automated coverage for particle checkpoint and restart-refinement workflows.

* **Bug Fixes**
  * Improved particle container setup during refined restarts to preserve compatibility with the current AMR layout.

* **Tests**
  * Added validation for successful particle checkpoint creation and refined restart behavior.
  * Reduced unnecessary runtime output and profiling during AMR test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->