### PR TITLE
Consolidate AlfvenWaveCircular: add Richardson convergence sweep

### DIFF
--- a/.github/workflows/mhd-asan.yml
+++ b/.github/workflows/mhd-asan.yml
@@ -102,7 +102,7 @@ jobs:
         ASAN_OPTIONS: detect_leaks=0:print_stats=1:check_initialization_order=1:strict_string_checks=1:detect_stack_use_after_return=1
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
       # Execute all tests with MHD label, excluding the slow cases
-      run: canary run --output-on-failure --workers=1 -k "MHD and not FastWave and not BrioWuShockTube and not MHDQuirk and not HydroWaveConvergence and not FastWaveConvergence and not EntropyWaveConvergence and not AlfvenWaveLinearConvergence" .
+      run: canary run --output-on-failure --workers=1 -k "MHD and not FastWave and not BrioWuShockTube and not MHDQuirk and not HydroWaveConvergence and not FastWaveConvergence and not EntropyWaveConvergence and not AlfvenWaveLinearConvergence and not AlfvenWaveCircularConvergence" .
         
     - name: ccache stats
       if: always()

--- a/docs/markdown/tests/table_of_all_problems.md
+++ b/docs/markdown/tests/table_of_all_problems.md
@@ -13,6 +13,7 @@ This table lists all test problems in the Quokka codebase. The acronyms used are
 | Advection                | 1   | ❌    | ❌  | ❌                | ❌      | ❌                        | ❌             |
 | AdvectionSemiellipse     | 1   | ❌    | ❌  | ❌                | ❌      | ❌                        | ❌             |
 | AlfvenWaveCircular       | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
+| AlfvenWaveCircularConvergence | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
 | AlfvenWaveLinear         | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
 | BinaryOrbitCIC           | 3   | ✅    | ❌  | ❌                | ✅      | CIC                       | ❌             |
 | BrioWuShockTube          | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |

--- a/docs/markdown/tests/table_of_all_problems.md
+++ b/docs/markdown/tests/table_of_all_problems.md
@@ -13,7 +13,6 @@ This table lists all test problems in the Quokka codebase. The acronyms used are
 | Advection                | 1   | ❌    | ❌  | ❌                | ❌      | ❌                        | ❌             |
 | AdvectionSemiellipse     | 1   | ❌    | ❌  | ❌                | ❌      | ❌                        | ❌             |
 | AlfvenWaveCircular       | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
-| AlfvenWaveCircularConvergence | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
 | AlfvenWaveLinear         | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |
 | BinaryOrbitCIC           | 3   | ✅    | ❌  | ❌                | ✅      | CIC                       | ❌             |
 | BrioWuShockTube          | 3   | ✅    | ✅  | ❌                | ❌      | ❌                        | ❌             |

--- a/inputs/AlfvenWaveCircularConvergence.toml
+++ b/inputs/AlfvenWaveCircularConvergence.toml
@@ -3,42 +3,30 @@
 # *****************************************************************
 geometry.prob_lo = [0.0, 0.0, 0.0]
 geometry.prob_hi = [1.0, 1.0, 1.0]
-quokka.bc = ["periodic", "periodic", "periodic"]
+geometry.is_periodic = [1, 1, 1]
 
 # *****************************************************************
 # VERBOSITY
 # *****************************************************************
-amr.v = 1  # verbosity in Amr
+amr.v = 0  # verbosity in Amr
 
 # *****************************************************************
 # Resolution and refinement
 # *****************************************************************
 amr.n_cell = [64, 8, 8]
-amr.max_level = 0
+amr.max_level = 0  # number of levels = max_level + 1
+amr.blocking_factor = 8  # grid size must be divisible by this
 amr.max_grid_size = 128
-amr.blocking_factor_x = 64
-amr.blocking_factor_y = 8
-amr.blocking_factor_z = 8
 
 do_reflux = 0
 do_subcycle = 0
-
 plotfile_interval = -1
-plotfile_prefix = "alfven_wave_circular_plt"
-checkpoint_interval = -1
+
 cfl = 0.3
-stop_time = 5.0
-max_timesteps = 8000
 
 hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 5
 hydro.use_dual_energy = 0
 
-setup.run_convergence = false
-setup.run_sim = true
-setup.error_tol = 0.003
-
 mhd.emf_compute_scheme = "Balsara2025"
 mhd.emf_averaging_scheme = "Balsara2025"
-
-

--- a/src/problems/AlfvenWaveCircularConvergence/CMakeLists.txt
+++ b/src/problems/AlfvenWaveCircularConvergence/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(AMReX_SPACEDIM EQUAL 3)
-  set(JOB_NAME AlfvenWaveCircular)
+  set(JOB_NAME AlfvenWaveCircularConvergence)
 
   add_executable(${JOB_NAME} test${JOB_NAME}.cpp ${QuokkaObjSources})
 
@@ -10,6 +10,12 @@ if(AMReX_SPACEDIM EQUAL 3)
   add_test(
     NAME ${JOB_NAME}
     COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}.toml
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  set_tests_properties(AlfvenWaveCircularConvergence PROPERTIES LABELS "MHD")
+
+  add_test(
+    NAME AlfvenWaveCircular
+    COMMAND ${JOB_NAME} ../inputs/AlfvenWaveCircular.toml
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
   set_tests_properties(AlfvenWaveCircular PROPERTIES LABELS "MHD")
 endif()

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -287,6 +287,18 @@ auto problem_main() -> int
 		pp.query("error_tol", error_tol);
 	}
 
+	// AlfvenWaveCircularConvergence does not model resistivity; abort early rather than silently
+	// producing a wrong reference solution if mhd.resistivity is set (applies to both modes).
+	{
+		double eta = 0.0;
+		amrex::ParmParse const mhd_pp("mhd");
+		mhd_pp.query("resistivity", eta);
+		if (eta != 0.0) {
+			amrex::Abort("AlfvenWaveCircularConvergence does not support mhd.resistivity != 0; use AlfvenWaveLinearConvergence "
+				     "for resistivity validation.");
+		}
+	}
+
 	int status = 0;
 
 	if (run_sim) {

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -2,22 +2,28 @@
 // Copyright 2022 Neco Kriel.
 // Released under the MIT license. See LICENSE file included in the GitHub repo.
 //==============================================================================
-/// \file testAlfvenWaveCircular.cpp
-/// \brief Defines a test problem to make sure face-centred quantities are created correctly.
+/// \file testAlfvenWaveCircularConvergence.cpp
+/// \brief Defines a Richardson convergence test for the circularly-polarized Alfven wave, and
+///        makes sure face-centred quantities are created correctly.
 ///
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <format>
 #include <gcem.hpp>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Print.H"
 #include "AMReX_REAL.H"
 
 #include "QuokkaSimulation.hpp"
 #include "grid.hpp"
 #include "physics_info.hpp"
 #include "util/BC.hpp"
+#include "util/richardson.hpp"
 
 struct AlfvenWaveCircular {
 };
@@ -178,6 +184,7 @@ template <>
 void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
+	const amrex::Real time = tNew_[0];
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
 		auto const &stateExact = ref.array(iter);
@@ -187,7 +194,7 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::Multi
 			for (int n = 0; n < ncomp; ++n) {
 				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
 			}
-			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, 0);
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::cc, quokka::direction::na, time);
 		});
 	}
 }
@@ -196,6 +203,7 @@ template <>
 void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
 {
+	const amrex::Real time = tNew_[0];
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
 		auto const &stateExact = ref.array(iter);
@@ -205,25 +213,125 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::Mu
 			for (int n = 0; n < ncomp; ++n) {
 				stateExact(i, j, k, n) = 0.0; // fill unused quantities with zeros
 			}
-			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, 0);
+			computeWaveSolution(i, j, k, stateExact, dx, prob_lo, quokka::centering::fc, dir, time);
 		});
 	}
 }
 
-auto problem_main() -> int
+auto runWaveTest(int nx, int ny, int nz) -> double
 {
+	const double CFL_number = 0.2;
+	const double wavelength = 1.0 / num_modes;
+	const double max_time = wavelength / alfven_speed;
+	const int max_timesteps = std::max(20000, nx * 100);
 
-	QuokkaSimulation<AlfvenWaveCircular> sim;
+	// Set grid dimensions using AMReX parameter system
+	amrex::ParmParse pp("amr");
+	amrex::Vector<int> const ncells = {nx, ny, nz};
 
+	if (!pp.contains("blocking_factor")) {
+		pp.add("blocking_factor", 8);
+	}
+
+	if (!pp.contains("max_grid_size")) {
+		pp.add("max_grid_size", 128);
+	}
+
+	pp.add("max_level", 0);
+	pp.addarr("n_cell", ncells);
+
+	// Set domain bounds using AMReX parameter system
+	amrex::ParmParse pp_geom("geometry");
+	amrex::Vector<double> const prob_lo = {0.0, 0.0, 0.0};
+	amrex::Vector<double> const prob_hi = {1.0, 1.0, 1.0};
+	amrex::Vector<int> const is_periodic = {1, 1, 1};
+	pp_geom.addarr("prob_lo", prob_lo);
+	pp_geom.addarr("prob_hi", prob_hi);
+	pp_geom.addarr("is_periodic", is_periodic);
+
+	// Setup boundary conditions
+	auto BCs_cc = quokka::BC<AlfvenWaveCircular>(quokka::BCType::int_dir);
+
+	const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
+	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir);
+			BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+		}
+	}
+
+	// Run simulation
+	QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+
+	sim.cflNumber_ = CFL_number;
+	sim.stopTime_ = max_time;
+	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();
+
+	// Main time loop
 	sim.evolve();
 
-	// Compute test success condition
+	return sim.computeErrorNorm();
+}
+
+auto problem_main() -> int
+{
+	bool run_convergence = true;
+	bool run_sim = false;
+	double error_tol = 0.003;
+	{
+		amrex::ParmParse const pp("setup");
+		pp.query("run_convergence", run_convergence);
+		pp.query("run_sim", run_sim);
+		pp.query("error_tol", error_tol);
+	}
+
 	int status = 0;
-	const double error_tol = 0.003;
-	amrex::Real const error_norm = sim.computeErrorNorm();
-	if (error_norm > error_tol) {
-		status = 1;
+
+	if (run_sim) {
+		auto BCs_cc = quokka::BC<AlfvenWaveCircular>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
+		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
+		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
+			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+				BCs_fc[icomp].setLo(idim, amrex::BCType::int_dir);
+				BCs_fc[icomp].setHi(idim, amrex::BCType::int_dir);
+			}
+		}
+
+		QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+		sim.setInitialConditions();
+		sim.evolve();
+
+		const double error_norm = sim.computeErrorNorm();
+		amrex::Print() << std::format("\nrun_sim error norm = {:.6e}  (tol = {:.6e})\n", error_norm, error_tol);
+		if (error_norm > error_tol) {
+			status = 1;
+		}
+	}
+
+	if (run_convergence) {
+		quokka::richardson::applyQuietDefaults();
+
+		quokka::richardson::Parameters params{};
+		params.machine_precision_target = 2.0e-10;
+		params.nx_initial = 16;
+		params.nx_max = 128;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("nx_start", params.nx_initial);
+			pp.query("nx_max", params.nx_max);
+			pp.query("machine_precision_target", params.machine_precision_target);
+		}
+		params.expected_rate = 2.0;
+		params.tolerance = 0.3;
+		params.test_name = "Alfven Wave Circular";
+		params.csv_filename = "alfven_wave_circular_convergence.csv";
+
+		if (quokka::richardson::run(params, [](int nx, int ny, int nz) { return runWaveTest(nx, ny, nz); }) != 0) {
+			status = 1;
+		}
 	}
 
 	return status;

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -220,7 +220,6 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::Mu
 
 auto runWaveTest(int nx, int ny, int nz) -> double
 {
-	const double CFL_number = 0.2;
 	const double wavelength = 1.0 / num_modes;
 	const double max_time = wavelength / alfven_speed;
 	const int max_timesteps = std::max(20000, nx * 100);
@@ -264,7 +263,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	// Run simulation
 	QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
 
-	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();


### PR DESCRIPTION
### Description

This PR updates `AlfvenWaveCircular` so that it is consistent with #1978's consolidation of MHD wave convergence and correctness test problems. Since `AlfvenWaveCircular` was only ever a correctness test, and had no sister convergence test, it wasn't integrated into the same structure. Since adding the ability to test convergence is trivial, since the test already has an analytic solution, I do so here.

This PR renames `AlfvenWaveCircular` to `AlfvenWaveCircularConvergence`, adds a `runWaveTest(nx, ny, nz)` sweep driven by `quokka::richardson::run`, and gates the two paths behind `setup.run_convergence` (default `true`) / `setup.run_sim` (default `false`). The original `AlfvenWaveCircular` CTest is re-registered against the same binary with `setup.run_sim=true`, so its coverage and tolerance (`error_tol=0.003`) are unchanged.

Unlike the linear-wave family, I kept this test's fixed x1-propagation / circular-polarization construction rather than generalizing it to the arbitrary-rotation that `AlfvenWaveLinearConvergence` uses. The circular test's whole purpose is exercising the face-centered curl construction along a single fixed axis; there's no `num_modes_y/z` or `angle_between_k_b0` knob to expose here, so `refine_n_dims` stays fixed at 1 (unlike its Convergence siblings, which expose it).

While in there, I also fixed a latent bug: `computeReferenceSolution`/`computeReferenceSolution_fc` hardcoded `time=0` instead of using `tNew_[0]`, which only worked because the existing TOML happens to stop at an exact integer multiple of the wave period (5 periods). It now uses the actual simulation time, like every sibling Convergence test does, so it's correct for any stop time, not just exact-period multiples.

I also added the same `mhd.resistivity != 0` guard that `FastWaveConvergence`/`SlowWaveConvergence` carry: this problem's analytic reference has no decay term, so the generic guard from #2050 isn't enough on its own; silencing it by setting `resistivity_model = constant` would apply real resistive damping to the simulation while comparing against a purely ideal reference, the same bug in reverse. Kept the earlier, problem-specific abort pointing to `AlfvenWaveLinearConvergence`, matching the reasoning in #2051.

Finally, I excluded `AlfvenWaveCircularConvergence` from the ASAN workflow, same as its sibling `AlfvenWaveLinearConvergence`: same default Richardson sweep (nx 16 to 128), same cost profile, and the sibling is already excluded there specifically for being too slow under the instrumented, single-worker ASAN build.

### Validation

Ran both CTest paths locally:
- `AlfvenWaveCircular` (`run_sim`, fixed resolution 64x8x8): error norm `1.5e-9` against tolerance `3e-3`.
- `AlfvenWaveCircularConvergence` (`run_convergence`, capped `setup.nx_max=64` for a quick local check): confirmed 2nd order convergence.
- Confirmed the new resistivity guard aborts with the expected message when `mhd.resistivity` is set nonzero.

### Known issues

- Haven't run the full default sweep (`nx_max=128`) locally, or the ASAN/GPU tiers; those run in CI once this is opened.
- No rate-vs-resolution plot attached, only the console table above; happy to add one if useful for review.

### Related issues

- #1916: this PR extends the proposal there to `AlfvenWaveCircular`, the one wave test its consolidation table didn't cover.
- #1978: implements the same dual-mode pattern this PR follows.
- #2050, #2051: prior art and reasoning for the `mhd.resistivity` guard kept here.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable Alfvén wave circular simulations and Richardson convergence testing.
  - Added support for selecting standard simulation or convergence runs with configurable error tolerances.
  - Added detailed convergence-test configuration, including grid resolution, AMR, periodicity, and numerical-solver settings.

- **Tests**
  - Registered the Alfvén wave circular simulation and convergence tests under MHD validation.
  - Updated automated test selection to run the appropriate test configurations.
  - Improved reference-solution timing and convergence error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->