### PR TITLE
Fix wave convergence tests: remove dead CFL_number override

### DIFF
--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -407,7 +407,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	hpp.query("angle_between_k_b0", angle_between_k_b0_deg);
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
-	const double CFL_number = 0.2;
 	const double cA = alfven_speed * std::abs(std::cos(angle_between_k_b0_rad));
 	const int max_timesteps = std::max(20000, nx * 100);
 
@@ -494,7 +493,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	// Run simulation
 	QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
 
-	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -304,7 +304,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	hpp.query("angle_between_k_b0", angle_between_k_b0_deg);
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
-	const double CFL_number = 0.2;
 	const int max_timesteps = std::max(20000, nx * 100);
 
 	int num_modes_x = 0;
@@ -388,7 +387,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	// Run simulation
 	QuokkaSimulation<EntropyWaveLinear> sim(BCs_cc, BCs_fc);
 
-	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -420,7 +420,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
 
-	const double CFL_number = 0.2;
 	const double a = sound_speed;
 	const double vA = alfven_speed;
 	const double cosθ = std::cos(angle_between_k_b0_rad);
@@ -508,7 +507,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	// Run simulation
 	QuokkaSimulation<FastWaveConvergence> sim(BCs_cc, BCs_fc);
 
-	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -429,7 +429,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
 
-	const double CFL_number = 0.2;
 	const double a = sound_speed;
 	const double vA = alfven_speed;
 	const double cosθ = std::cos(angle_between_k_b0_rad);
@@ -517,7 +516,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	// Run simulation
 	QuokkaSimulation<SlowWaveConvergence> sim(BCs_cc, BCs_fc);
 
-	sim.cflNumber_ = CFL_number;
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
 	sim.setInitialConditions();


### PR DESCRIPTION
### Description

`FastWaveConvergence`, `SlowWaveConvergence`, `AlfvenWaveLinearConvergence`, and `EntropyWaveConvergence` all set `sim.cflNumber_ = CFL_number` (0.2) in `runWaveTest`, but `evolve()` calls `rereadRuntimeParameters()` at its start, which re-reads `cfl` from ParmParse and silently discards that assignment. Every sweep has actually always run at the TOML's `cfl = 0.3`, not 0.2. This removes the dead variable and assignment from all four; behavior is unchanged since the TOML value was already the one taking effect. Found via CodeRabbit review on #2097.

### Related issues

- #2097: where this was originally found; that PR's own copy of the same pattern was fixed directly since it hadn't merged yet.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved wave convergence simulations by consistently using the configured timestep settings instead of test-specific overrides.
  - Corrected fast-wave propagation angle handling by converting angle inputs to the expected measurement format.

- **Tests**
  - Updated Alfvén, entropy, fast-wave, and slow-wave convergence checks to reflect the standardized simulation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->