### PR TITLE
Fix wave tests: rename dead mhd.reconstruction_order key

### DIFF
--- a/inputs/AlfvenWaveLinearConvergence.toml
+++ b/inputs/AlfvenWaveLinearConvergence.toml
@@ -30,7 +30,7 @@ hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 3
 hydro.use_dual_energy = 0
 
-mhd.reconstruction_order = 3
+mhd.emf_reconstruction_order = 3
 
 setup.num_modes_x = 1
 setup.num_modes_y = 0

--- a/inputs/AlfvenWaveLinearConvergence.toml
+++ b/inputs/AlfvenWaveLinearConvergence.toml
@@ -27,10 +27,10 @@ cfl = 0.3
 
 
 hydro.rk_integrator_order = 2
-hydro.reconstruction_order = 3
+hydro.reconstruction_order = 5
 hydro.use_dual_energy = 0
 
-mhd.emf_reconstruction_order = 3
+mhd.emf_reconstruction_order = 5
 
 setup.num_modes_x = 1
 setup.num_modes_y = 0

--- a/inputs/EntropyWave.toml
+++ b/inputs/EntropyWave.toml
@@ -31,7 +31,7 @@ hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 3
 hydro.use_dual_energy = 0
 
-mhd.reconstruction_order = 3
+mhd.emf_reconstruction_order = 3
 
 setup.run_convergence = false
 setup.run_sim = true

--- a/inputs/EntropyWaveConvergence.toml
+++ b/inputs/EntropyWaveConvergence.toml
@@ -34,4 +34,4 @@ setup.num_modes_y = 0
 setup.num_modes_z = 0
 setup.angle_between_k_b0 = 0
 
-mhd.reconstruction_order = 3
+mhd.emf_reconstruction_order = 3

--- a/inputs/FastWaveConvergence.toml
+++ b/inputs/FastWaveConvergence.toml
@@ -35,6 +35,6 @@ setup.num_modes_y = 0
 setup.num_modes_z = 0
 setup.angle_between_k_b0 = 90
 
-mhd.reconstruction_order = 3
+mhd.emf_reconstruction_order = 3
 mhd.emf_compute_scheme = "FelkerStone2017"
 mhd.emf_averaging_scheme = "LondrilloDelZanna2004"

--- a/inputs/SlowWave.toml
+++ b/inputs/SlowWave.toml
@@ -37,7 +37,7 @@ hydro.rk_integrator_order = 2
 hydro.reconstruction_order = 5
 hydro.use_dual_energy = 0
 
-mhd.reconstruction_order = 5
+mhd.emf_reconstruction_order = 5
 mhd.emf_compute_scheme = "Balsara2025"
 mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
 

--- a/inputs/SlowWaveConvergence.toml
+++ b/inputs/SlowWaveConvergence.toml
@@ -35,4 +35,4 @@ setup.num_modes_y = 0
 setup.num_modes_z = 0
 setup.angle_between_k_b0 = 45
 
-mhd.reconstruction_order = 5
+mhd.emf_reconstruction_order = 5


### PR DESCRIPTION
### Description

`mhd.reconstruction_order` is set in `AlfvenWaveLinearConvergence.toml`, `EntropyWave.toml`, `EntropyWaveConvergence.toml`, `FastWaveConvergence.toml`, `SlowWave.toml`, and `SlowWaveConvergence.toml`, but no such key is used anywhere; the correct key is `mhd.emf_reconstruction_order`. This PR fixes this assignment.

Fixing the key in `AlfvenWaveLinearConvergence.toml` also meant `hydro.reconstruction_order` and `mhd.emf_reconstruction_order` no longer matched, so I set both to `5` (ppm_ep): this was the value that the EMF reconstruction was already using quietly by default,.

### Validation

Ran each affected file's binary with the corrected key: all six exit 0 with error norms well within tolerance, and the "Unused ParmParse Variables" warning for this key no longer appears in any of them (it did before the fix). For `AlfvenWaveLinearConvergence` specifically: confirmed the ppm/ppm combo fails (rate 1.48 at 16->32, matching CI), and the ppm_ep/ppm_ep combo passes cleanly (rates 2.10/2.03/2.01, overall 2.05, error norms ~10x smaller across the board).

### Related issues

- #2097: where I first hit this.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.