### PR TITLE
Fix computeErrorNorm: remove unstable reference-norm reconstruction

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -332,7 +332,7 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 	void computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction dir);
 	auto computeErrorNorm(bool use_rel_err = true) -> amrex::Real;
-	auto computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>;
+	auto computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real, amrex::Real>>;
 	void WriteSingleLevelPlotfileSimplified(const std::string &plotfile_prefix, const amrex::MultiFab &mf, const amrex::Vector<std::string> &compNames,
 						int lev, int interval) override;
 
@@ -1293,13 +1293,14 @@ AMREX_GPU_HOST_DEVICE auto QuokkaSimulation<problem_t>::densityFloor(amrex::Real
 	return base_density_floor;
 }
 
-template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real>>
+template <typename problem_t>
+auto QuokkaSimulation<problem_t>::computeComponentErrors() -> std::vector<std::tuple<std::string, amrex::Real, amrex::Real, amrex::Real>>
 {
-	// returns a vector of tuples: (component name, absolute error, relative error)
-	// absolute error is normalized by number of cells
+	// returns a vector of tuples: (component name, absolute error, relative error, reference norm)
+	// absolute error and reference norm are normalized by number of cells
 	// relative error is NAN if reference norm is zero
 
-	std::vector<std::tuple<std::string, amrex::Real, amrex::Real>> comp_errors{};
+	std::vector<std::tuple<std::string, amrex::Real, amrex::Real, amrex::Real>> comp_errors{};
 
 	// Compute cell-centered errors
 	const int ncomp = state_new_cc_[0].nComp();
@@ -1336,7 +1337,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			rel_err = abs_err / ref_norm;
 		}
 
-		comp_errors.emplace_back(componentNames_cc_[icomp], abs_err, rel_err);
+		comp_errors.emplace_back(componentNames_cc_[icomp], abs_err, rel_err, ref_norm);
 	}
 
 	// Compute face-centered errors (if MHD is enabled)
@@ -1380,7 +1381,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 					rel_err = abs_err / ref_norm;
 				}
 
-				comp_errors.emplace_back(componentNames_fc_[idim][icomp_fc], abs_err, rel_err);
+				comp_errors.emplace_back(componentNames_fc_[idim][icomp_fc], abs_err, rel_err, ref_norm);
 			}
 		}
 	}
@@ -1391,7 +1392,7 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeComponent
 			       << "Relative Error" << "\n";
 		amrex::Print() << std::string(70, '-') << "\n";
 	}
-	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+	for (const auto &[name, abs_err, rel_err, ref_norm] : comp_errors) {
 		if (this->suppress_output == 0) {
 			amrex::Print() << std::setw(25) << std::left << name << std::setw(20) << std::right << std::scientific << std::setprecision(4)
 				       << abs_err;
@@ -1426,17 +1427,17 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 	amrex::Real sum_sq_err = 0.0;
 	amrex::Real sum_sq_ref = 0.0;
 
-	for (const auto &[name, abs_err, rel_err] : comp_errors) {
+	for (const auto &[name, abs_err, rel_err, ref_norm] : comp_errors) {
 		// Convert normalized errors back to L1 norms
-		amrex::Real L1_err = abs_err * n_cells;
+		amrex::Real const L1_err = abs_err * n_cells;
 		sum_sq_err += L1_err * L1_err;
 
-		// Reconstruct reference L1 norm
-		if (!std::isnan(rel_err) && rel_err != 0.0) {
-			amrex::Real L1_ref = (abs_err / rel_err) * n_cells;
-			sum_sq_ref += L1_ref * L1_ref;
-		}
-		// If rel_err is NaN or zero, reference was zero, contributes 0 to sum_sq_ref
+		// Reference L1 norm, carried directly from computeComponentErrors() rather than
+		// reconstructed via abs_err / rel_err: that division is unstable whenever a component's
+		// true error rounds to exactly zero, which silently drops the component's (potentially
+		// large) reference norm from the sum instead of correctly contributing zero error against it.
+		amrex::Real const L1_ref = ref_norm * n_cells;
+		sum_sq_ref += L1_ref * L1_ref;
 	}
 
 	const amrex::Real err_norm = std::sqrt(sum_sq_err);


### PR DESCRIPTION
### Description

In order to get an estimate for the rate at which regression test problems converge, `computeErrorNorm()` combines every evolved field component's error into one "Relative RMS L1 error norm" by summing `L1_err_i^2` and `L1_ref_i^2` across components. This reference-norm was being reconstructed from `abs_err_i / rel_err_i`, instead of simply using the reference norm that `computeComponentErrors()` was already computing internally, so it had to guarded by `if (rel_err_i != 0.0)`. Algebraically this reconstruction is exact whenever `abs_err_i != 0`, but whenever a component's absolute error rounds to bit-exact `0.0` at a given resolution, `rel_err_i` is also exactly `0.0`, and so the guard fails, and that component's entire reference norm is silently dropped from the denominator instead of correctly contributing zero error against a nonzero reference. The denominator shrinks abnormally at that one resolution, spiking the reported relative error there, unrelated to solver accuracy.

I found this while working on #2097, where extending `AlfvenWaveCircularConvergence` to a full Richardson sweep was showing that the reported error jumped by roughly five orders of magnitude at nx=128->256, looking like a catastrophic convergence failure, though every other resolution converged cleanly at second order; the estimate at that one point was simply wrong, not the underlying solution. See the updated estimate of convergence below. This PR fixes it by having `computeComponentErrors()` return the reference norm directly, so `computeErrorNorm()` no longer needs to reconstruct it.

### Validation

The figure below compares `AlfvenWaveCircularConvergence` (`ppm_ep`, `q26-b25`, nx=16-2048) before and after the fix: the spurious jump at nx=256 is gone, and the sweep now converges cleanly at second order across the full range. I also reran the same comparison across the full EMF-scheme x interpolation-order matrix for this and the other three `*Convergence` wave tests; old and new agree everywhere except this one case, since the bug only triggers when a component's error happens to round to exact zero.

<img width="2161" height="2217" alt="wave-convergence" src="https://github.com/user-attachments/assets/0a481d18-09d7-4643-9ac8-6b04cb580b25" />

### Related issues

- #2097: where this was found, while extending `AlfvenWaveCircular` to a Richardson sweep.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

Note: this touches `QuokkaSimulation.hpp` (shared, outside `src/problems`), so per the CI-tier rule this needs `/azp run` (full suite), not just `/azp run quick`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved global error norm calculations by using stored reference norms directly.
  * Preserved accurate component-level error reporting, including cell-centered and face-centered data.
  * Prevented calculation issues when relative errors are zero or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->