### PR TITLE
Fix unnormalized small-x Planck integral

### DIFF
--- a/src/radiation/planck_integral.hpp
+++ b/src/radiation/planck_integral.hpp
@@ -242,7 +242,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto integrate_planck_from_0_to_x(const
 	const Real logx = std::log10(x);
 	Real y = NAN;
 	if (logx < LOG_X_MIN) {
-		// Taylor series of the Planck integral for small x: x^3/3 - x^4/8 + x^5/60, normalized by gInf to match interpolate_planck_integral()
+		// Taylor series of the Planck integral for small x: x^3/3 - x^4/8 + x^5/60 - x^7/5040 + x^9/272160, normalized by gInf to
+		// match interpolate_planck_integral(). Truncating at 5th order drops a negative 7th-order term, so this approximation is always positive.
 		y = (x * x * x / 3.0 - x * x * x * x / 8.0 + x * x * x * x * x / 60.0) / gInf;
 		// Y_INTERP_MIN is the minimum value returned from interpolate_planck_integral. To ensure y is monotonic with respect to x:
 		// AMREX_ASSERT(y <= Y_INTERP_MIN);

--- a/src/radiation/planck_integral.hpp
+++ b/src/radiation/planck_integral.hpp
@@ -242,8 +242,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto integrate_planck_from_0_to_x(const
 	const Real logx = std::log10(x);
 	Real y = NAN;
 	if (logx < LOG_X_MIN) {
-		// y = x * x * x / 3.0;    // 1st order
-		y = ((-4 + x) * x + 8 * std::log((2 + x) / 2)) / gInf; // 2nd order, normalized by gInf to match interpolate_planck_integral()
+		// Taylor series of the Planck integral for small x: x^3/3 - x^4/8 + x^5/60, normalized by gInf to match interpolate_planck_integral()
+		y = (x * x * x / 3.0 - x * x * x * x / 8.0 + x * x * x * x * x / 60.0) / gInf;
 		// Y_INTERP_MIN is the minimum value returned from interpolate_planck_integral. To ensure y is monotonic with respect to x:
 		// AMREX_ASSERT(y <= Y_INTERP_MIN);
 		if (y > Y_INTERP_MIN) {

--- a/src/radiation/planck_integral.hpp
+++ b/src/radiation/planck_integral.hpp
@@ -243,7 +243,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto integrate_planck_from_0_to_x(const
 	Real y = NAN;
 	if (logx < LOG_X_MIN) {
 		// y = x * x * x / 3.0;    // 1st order
-		y = (-4 + x) * x + 8 * std::log((2 + x) / 2); // 2nd order
+		y = ((-4 + x) * x + 8 * std::log((2 + x) / 2)) / gInf; // 2nd order, normalized by gInf to match interpolate_planck_integral()
 		// Y_INTERP_MIN is the minimum value returned from interpolate_planck_integral. To ensure y is monotonic with respect to x:
 		// AMREX_ASSERT(y <= Y_INTERP_MIN);
 		if (y > Y_INTERP_MIN) {


### PR DESCRIPTION
### Description
`integrate_planck_from_0_to_x()` (`src/radiation/planck_integral.hpp`) is meant to return the Planck integral fraction, normalized by `gInf = π^4/15`. Its small-x branch (`x < 1e-3`) had two problems:

1. **Missing normalization:** it returned the raw unnormalized series — about `gInf ≈ 6.49x` too large — which fed incorrect group weights into small multigroup RHD group boundaries.
2. **Incorrect series:** the closed form `(-4 + x)·x + 8·ln((2 + x)/2)` is only accurate through 4th order. Its Taylor expansion is `x³/3 − x⁴/8 + x⁵/20 − …`, but the true integral of `t³/(eᵗ−1)` expands to `x³/3 − x⁴/8 + x⁵/60 − …` (the x⁵ coefficient is 1/60, not 1/20).

Fix: replace the small-x branch with the correct 5th-order Taylor series `(x³/3 − x⁴/8 + x⁵/60) / gInf`, normalized by `gInf` to match the interpolation-table branch. For `x < 1e-3` the x⁵ term is negligible, so numerical results are unchanged, but the expression is now mathematically correct to 5th order.

### Related issues
Closes #2069

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code. (N/A — bug fix, no new physics; validated with the existing multigroup `RadTube` test, see Validation below.)
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.

### Validation
Built and ran the multigroup RHD `RadTube` test (2 groups) under the `1d` preset:
```
Relative L1 norm = 6.827103469e-05
RadTube SUCCESS
```
(tolerance `rel_err_tol = 0.003` in `testRadTube.cpp`)

Regression check with a related, unmodified multigroup test, `RadhydroPulseMGconst` (`1d` preset):
```
Relative L1 error norm = 0.004194961044
RadhydroPulseMGconst SUCCESS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Planck integral accuracy for very small input values by updating the small‑x approximation.
  * Enhanced alignment between approximation results and interpolated computations.
  * Kept the existing monotonicity behavior and validation checks unchanged to maintain expected output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->