### PR TITLE
Update ROCm to 7.14

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -17,43 +17,41 @@ set -eu -o pipefail
 #   failed files the given number of times.
 echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
 
-# Ref.: https://rocmdocs.amd.com/en/latest/deploy/linux/os-native/install.html
+# Ref.: https://rocm.docs.amd.com/en/latest/install/rocm.html
 sudo mkdir --parents --mode=0755 /etc/apt/keyrings
-wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
-    gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+wget https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg -O - | \
+    gpg --dearmor | sudo tee /etc/apt/keyrings/amdrocm.gpg > /dev/null
 
-# Detect Ubuntu codename and choose a compatible ROCm suite
-# ROCm 7.0 provides packages for Ubuntu 22.04 (jammy). Some runners
-# (e.g., ubuntu-latest on 24.04 noble) are not yet supported by AMD's repo.
-# In such cases, fall back to jammy which is known to work for ROCm 7.0.
+# Detect the Ubuntu release and choose the matching ROCm 7.14 repository.
 if [ -r /etc/os-release ]; then
   . /etc/os-release
 fi
 
 detected_codename="${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}"
-rocm_suite="jammy"
-if [ "${detected_codename}" = "jammy" ]; then
-  rocm_suite="jammy"
-else
-  # Map all other codenames (e.g., noble, focal, etc.) to jammy for ROCm 7.0
-  rocm_suite="jammy"
-fi
+case "${detected_codename}" in
+  jammy)
+    rocm_distribution="ubuntu2204"
+    ;;
+  noble)
+    rocm_distribution="ubuntu2404"
+    ;;
+  *)
+    echo "Unsupported Ubuntu codename for ROCm 7.14: ${detected_codename}" >&2
+    exit 1
+    ;;
+esac
 
-for ver in 7.1; do
-  echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/$ver ${rocm_suite} main" \
-      | sudo tee --append /etc/apt/sources.list.d/rocm.list
-done
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/amdrocm.gpg] https://repo.amd.com/rocm/packages-multi-arch/${rocm_distribution} stable main" \
+  | sudo tee /etc/apt/sources.list.d/rocm.list
 
-echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \
+echo 'export ROCM_PATH=/opt/rocm/core-7.14' | sudo tee /etc/profile.d/rocm.sh
+echo "export PATH=\$ROCM_PATH/lib/llvm/bin:\$ROCM_PATH/bin:\$PATH" \
   | sudo tee -a /etc/profile.d/rocm.sh
-# we should not need to export HIP_PATH=/opt/rocm/hip with those installs
+echo "export LD_LIBRARY_PATH=\$ROCM_PATH/lib:\${LD_LIBRARY_PATH:-}" \
+  | sudo tee -a /etc/profile.d/rocm.sh
 
 sudo apt-get update
 
-# Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#installing-development-packages-for-cross-compilation
-# meta-package: rocm-dkms
-# OpenCL: rocm-opencl
-# other: rocm-dev rocm-utils
 sudo apt-get install -y --no-install-recommends \
     build-essential \
     libc++-dev      \
@@ -62,13 +60,7 @@ sudo apt-get install -y --no-install-recommends \
     libnuma-dev     \
     libopenmpi-dev  \
     openmpi-bin     \
-    rocm-dev7.1.0        \
-    roctracer-dev7.1.0   \
-    rocprofiler-dev7.1.0 \
-    rocrand-dev7.1.0     \
-    hiprand-dev7.1.0     \
-    rocprim-dev7.1.0     \
-    rocsparse-dev7.1.0
+    amdrocm-core-dev7.14-gfx90a
 
 # activate
 #

--- a/.github/workflows/dockerfiles/ROCm-DiskGalaxy/Dockerfile
+++ b/.github/workflows/dockerfiles/ROCm-DiskGalaxy/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=linux/amd64 opensuse/leap:15.6 AS build
 
-ARG ROCM_ZYPP_REPO_VERSION=7.2.0
+ARG ROCM_VERSION=7.14
 ARG ROCM_ZYPP_PACKAGES=
 ARG MPICH_VERSION=4.2.2
 ARG MPICH_URL=https://www.mpich.org/static/downloads/4.2.2/mpich-4.2.2.tar.gz
@@ -16,30 +16,27 @@ RUN set -euo pipefail && \
     if ! zypper repos -E | grep -q devel_languages_perl; then \
       zypper --non-interactive addrepo https://download.opensuse.org/repositories/devel:/languages:/perl/15.6/devel:languages:perl.repo; \
     fi && \
-    roc_repos_version="${ROCM_ZYPP_REPO_VERSION%.*}" && \
-    printf "[ROCm-%s]\nname=ROCm%s\nbaseurl=https://repo.radeon.com/rocm/zyp/%s/main\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.radeon.com/rocm/rocm.gpg.key\n" \
-      "${ROCM_ZYPP_REPO_VERSION}" "${ROCM_ZYPP_REPO_VERSION}" "${roc_repos_version}" > /etc/zypp/repos.d/rocm.repo && \
+    printf "[rocm]\nname=ROCm %s\nbaseurl=https://repo.amd.com/rocm/packages-multi-arch/sles15/x86_64\nenabled=1\ngpgcheck=1\ngpgkey=https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg\npriority=50\n" \
+      "${ROCM_VERSION}" > /etc/zypp/repos.d/rocm.repo && \
     zypper --non-interactive --gpg-auto-import-keys refresh && \
     if [ -n "${ROCM_ZYPP_PACKAGES}" ]; then \
       zypper --non-interactive install --no-recommends ${ROCM_ZYPP_PACKAGES}; \
     else \
       zypper --non-interactive install --no-recommends \
-        rocm-llvm hipcc hip-runtime-amd hip-devel hsa-rocr comgr \
-        rocm-device-libs rocrand-devel hiprand-devel rocprim-devel rocsparse-devel; \
+        "amdrocm-core-devel${ROCM_VERSION}-${AMREX_AMD_ARCH}"; \
     fi && \
     zypper --non-interactive install --no-recommends \
       cmake git gcc13 gcc13-c++ libstdc++6-devel-gcc13 \
       make tar gzip wget patch hdf5-devel python3-devel && \
     ln -sf /usr/lib64/libefa.so.1 /usr/lib64/libefa.so && \
     zypper clean --all && \
-    printf "%s\n" "/opt/rocm/lib" "/opt/rocm/lib64" >> /etc/ld.so.conf.d/rocm.conf && \
+    printf "%s\n" "/opt/rocm/core-${ROCM_VERSION}/lib" >> /etc/ld.so.conf.d/rocm.conf && \
     ldconfig
 
-ENV LD_LIBRARY_PATH="/opt/rocm/lib"
+ENV ROCM_PATH="/opt/rocm/core-${ROCM_VERSION}"
 
-ENV PATH="/opt/rocm/bin:${PATH}" \
-    LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH}" \
-    ROCM_PATH="/opt/rocm" \
+ENV PATH="${ROCM_PATH}/lib/llvm/bin:${ROCM_PATH}/bin:${PATH}" \
+    LD_LIBRARY_PATH="${ROCM_PATH}/lib" \
     AMREX_AMD_ARCH="${AMREX_AMD_ARCH}" \
     CC="amdclang" \
     CXX="amdclang++"
@@ -54,7 +51,7 @@ RUN set -euo pipefail && \
     tar xzf "mpich-${MPICH_VERSION}.tar.gz" && \
     cd "mpich-${MPICH_VERSION}" && \
     patch -p1 < /tmp/mpich.patch && \
-    ./configure --with-device=ch4:ofi --with-hip=/opt/rocm --disable-fortran --prefix="/opt/mpich/${MPICH_VERSION}" && \
+    ./configure --with-device=ch4:ofi --with-hip="${ROCM_PATH}" --disable-fortran --prefix="/opt/mpich/${MPICH_VERSION}" && \
     make -j"$(nproc)" && \
     make install && \
     cd .. && \
@@ -88,6 +85,7 @@ RUN set -euo pipefail && \
 # Runtime stage (reduced image size)
 FROM --platform=linux/amd64 opensuse/leap:15.6
 
+ARG ROCM_VERSION=7.14
 ARG MPICH_VERSION=4.2.2
 
 COPY --from=build /opt/rocm /opt/rocm
@@ -98,9 +96,11 @@ RUN set -euo pipefail && \
     zypper --non-interactive refresh && \
     zypper --non-interactive install --no-recommends libhdf5 libpciaccess0 libnuma1 libdrm2 libdrm_amdgpu1 && \
     zypper clean --all && \
-    printf "%s\n" "/opt/rocm/lib" "/opt/rocm/lib64" >> /etc/ld.so.conf.d/rocm.conf && \
-    rm -rf /opt/rocm/bin /opt/rocm/include /opt/rocm/share /opt/rocm/lib/cmake \
-           /opt/rocm/llvm/bin /opt/rocm/llvm/include /opt/rocm/llvm/share /opt/rocm/llvm/lib/cmake && \
+    printf "%s\n" "/opt/rocm/core-${ROCM_VERSION}/lib" >> /etc/ld.so.conf.d/rocm.conf && \
+    rm -rf "/opt/rocm/core-${ROCM_VERSION}/bin" "/opt/rocm/core-${ROCM_VERSION}/include" \
+           "/opt/rocm/core-${ROCM_VERSION}/share" "/opt/rocm/core-${ROCM_VERSION}/lib/cmake" \
+           "/opt/rocm/core-${ROCM_VERSION}/lib/llvm/bin" "/opt/rocm/core-${ROCM_VERSION}/lib/llvm/include" \
+           "/opt/rocm/core-${ROCM_VERSION}/lib/llvm/share" "/opt/rocm/core-${ROCM_VERSION}/lib/llvm/lib/cmake" && \
     find /opt/rocm -type f -name "*.a" -delete && \
     find /opt/rocm -type f -name "*.o" -delete && \
     find /opt/mpich -type f -name "*.a" -delete && \
@@ -117,11 +117,11 @@ COPY --from=build /tmp/quokka-src/extern/agora_data/ /opt/quokka/share/quokka/ex
 RUN chmod 0755 /opt/quokka/bin/DiskGalaxy && \
     chown -R leap /opt/quokka
 
-ENV LD_LIBRARY_PATH="/opt/rocm/lib"
+ENV ROCM_PATH="/opt/rocm/core-${ROCM_VERSION}"
 
 ENV MPICH_VERSION="${MPICH_VERSION}" \
     PATH="/opt/quokka/bin:/opt/mpich/${MPICH_VERSION}/bin:${PATH}" \
-    LD_LIBRARY_PATH="/opt/mpich/${MPICH_VERSION}/lib:/opt/rocm/lib:${LD_LIBRARY_PATH}"
+    LD_LIBRARY_PATH="/opt/mpich/${MPICH_VERSION}/lib:${ROCM_PATH}/lib"
 
 USER leap
 WORKDIR /home/leap

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -24,7 +24,7 @@ jobs:
       workflow_file: '.github/workflows/hip.yml'
 
   tests-hip:
-    name: HIP ROCm C++20
+    name: HIP ROCm 7.14 C++20
     runs-on: ubuntu-latest
     needs: check_changes
     if: needs.check_changes.outputs.has_non_docs_changes == 'true'
@@ -66,7 +66,7 @@ jobs:
         cmake -S . -B build                               \
             -DCMAKE_VERBOSE_MAKEFILE=ON                   \
             -DAMReX_GPU_BACKEND=HIP                       \
-            -DAMReX_AMD_ARCH=gfx908                       \
+            -DAMReX_AMD_ARCH=gfx90a                       \
             -DAMReX_ROCTX=ON                              \
             -DCMAKE_C_COMPILER=$(which clang)             \
             -DCMAKE_CXX_COMPILER=$(which clang++)         \


### PR DESCRIPTION
### Description
Updates the AMD compiler/runtime to ROCm 7.14.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded the AMD ROCm environment to version 7.14 across development and container workflows.
  * Added support for Ubuntu 22.04 and 24.04 repository configurations, with clear errors for unsupported versions.
  * Updated GPU targeting from `gfx908` to `gfx90a`.
  * Refreshed runtime paths and library configuration for the new ROCm layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->