### PR TITLE
Fix 2D build: dust headers include conflicting ArrayView definitions

### DIFF
--- a/src/dust/DustSources.hpp
+++ b/src/dust/DustSources.hpp
@@ -11,7 +11,7 @@
 #include "AMReX_SmallMatrix.H"
 #include "hydro/hydro_system.hpp"
 #include "physics_info.hpp"
-#include "util/ArrayView_3d.hpp"
+#include "util/ArrayView.hpp"
 #include <cmath>
 #include <numbers>
 

--- a/src/dust/dust_system.hpp
+++ b/src/dust/dust_system.hpp
@@ -13,7 +13,7 @@
 #include "dust/DustState.hpp"
 #include "dust/dustRiemannSolver.hpp"
 #include "physics_info.hpp"
-#include "util/ArrayView_3d.hpp"
+#include "util/ArrayView.hpp"
 
 template <typename problem_t> class DustSystem
 {


### PR DESCRIPTION
### Description
Both `dust_system.hpp` and `DustSources.hpp` unconditionally included `util/ArrayView_3d.hpp`, bypassing the dimension-aware `ArrayView.hpp` dispatcher. For 2D builds, `hydro_system.hpp` correctly includes `ArrayView.hpp` (which selects `ArrayView_2d.hpp` when `AMREX_SPACEDIM == 2`), but then the dust headers pulled in `ArrayView_3d.hpp`, producing redefinition errors for `FluxDir`, `reorderMultiIndex`, and `Array4View`. Fixed by changing both dust headers to include `util/ArrayView.hpp` instead.

Verified by building and running DustAdvection and DustDamping in 2D (both pass), and DustAdvection in 1D (passes).

### Related issues
Closes #2082

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal array-view dependencies to improve build compatibility.
  * No user-facing functionality or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->