### PR TITLE
[docs] Amrvis -> AMReXplorer visualization tool

### DIFF
--- a/docs/markdown/postprocessing.md
+++ b/docs/markdown/postprocessing.md
@@ -2,18 +2,13 @@
 
 There are several ways to post-process the output of Quokka simulations. AMReX PlotfileTools, yt, and VisIt all allow you to analyze the outputs after they are written to disk.
 
-## Amrvis-container
+## AMReXplorer
 
-[Amrvis-container](https://github.com/AMReX-Codes/Amrvis-container) bundles Amrvis in a Docker/Apptainer image with a browser-based X11 frontend. To browse Quokka plotfiles locally (Docker required), run from the Amrvis-container repo:
+[AMReXplorer](https://github.com/AMReX-Codes/amrexplorer) is a Qt 6 desktop application for interactively exploring 2D and 3D AMReX plotfiles. Follow the [installation instructions](https://github.com/AMReX-Codes/amrexplorer/blob/main/INSTALL.md), then open a Quokka plotfile from the command line:
 
-    ./launch_amrvis_browser.sh /path/to/plotfiles
+    amrexplorer /path/to/plotfile
 
-The target directory is bind-mounted to `/home/vscode/data` in the container. The launcher prints a one-time password; open `http://localhost:8080`, paste the password, and use the `xterm` window to start `amrvis2d` or `amrvis3d` on your `plt*` directories.
-
-> **Tip**
->
-> On SLURM clusters with Apptainer, pull the image once with `apptainer pull amrvis-container.sif docker://ghcr.io/amrex-codes/amrvis-container:main`, then use `./launch_amrvis_browser_hpc.sh /path/to/plotfiles` on a compute node and follow the printed SSH tunnel instructions.
->
+AMReXplorer supports AMR level selection, value probing, line plots, grid and contour overlays, plotfile-sequence animation, and image or video export. See the [AMReXplorer User Guide](https://github.com/AMReX-Codes/amrexplorer/blob/main/docs/user-guide.md) for the complete workflow and controls.
 
 ## AMReX PlotfileTools
 
@@ -70,4 +65,3 @@ Then select ``plotfiles.visit`` in VisIt's Open dialog box.
 > **Warning**
 >
 > There are rendering bugs with unscaled box dimensions. Slices generally work. However, do not expect volume rendering to work when using, e.g. parsec-size boxes with cgs units.
-


### PR DESCRIPTION
### Description
Updates the docs to provide instructions on how to use AMReXplorer instead of Amrvis. Amrvis is deprecated, and replaced by AMReXplorer.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced the Amrvis-container postprocessing workflow with AMReXplorer guidance.
  * Added setup and launch instructions, along with an overview of AMReXplorer features.
  * Preserved existing guidance for other postprocessing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->