### PR TITLE
Extend FieldLoop: expose loop, advection, and AMR region params.

### DIFF
--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -45,6 +45,7 @@ setup.loop_radius = 0.3
 setup.loop_center_x = 0.0
 setup.loop_center_y = 0.0
 setup.advection_angle_deg = 60.0  # measured from the y-axis: vx = sin(angle), vy = cos(angle)
+setup.advection_vz = 1.0  # out-of-plane drift; the loop is z-invariant, so this should not affect the solution
 
 setup.refine_based_on = "Region"  # "Region" or "MagneticEnergy"
 setup.region_lo_x = 0.4

--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -45,13 +45,9 @@ setup.loop_radius = 0.3
 setup.loop_center_x = 0.0
 setup.loop_center_y = 0.0
 setup.advection_vz = 1.0  # out-of-plane drift; the loop is z-invariant, so this should not affect the solution
-# setup.advection_angle_deg is left unset: it defaults to the domain's own diagonal (measured from the
-# y-axis: vx = sin(angle), vy = cos(angle)), so the loop crosses the periodic domain and returns to its
-# starting position. Set explicitly to override with a fixed angle regardless of domain shape.
 
 setup.refine_based_on = "Region"  # "Region" or "MagneticEnergy"
 setup.region_lo_x = 0.4
 setup.region_hi_x = 0.6
 setup.region_lo_y = -0.23125
 setup.region_hi_y = 0.23125
-# setup.region_lo_z / region_hi_z are left unset: they default to the full domain in z

--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -54,3 +54,4 @@ setup.region_lo_x = 0.4
 setup.region_hi_x = 0.6
 setup.region_lo_y = -0.23125
 setup.region_hi_y = 0.23125
+# setup.region_lo_z / region_hi_z are left unset: they default to the full domain in z

--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -44,8 +44,10 @@ mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
 setup.loop_radius = 0.3
 setup.loop_center_x = 0.0
 setup.loop_center_y = 0.0
-setup.advection_angle_deg = 60.0  # measured from the y-axis: vx = sin(angle), vy = cos(angle)
 setup.advection_vz = 1.0  # out-of-plane drift; the loop is z-invariant, so this should not affect the solution
+# setup.advection_angle_deg is left unset: it defaults to the domain's own diagonal (measured from the
+# y-axis: vx = sin(angle), vy = cos(angle)), so the loop crosses the periodic domain and returns to its
+# starting position. Set explicitly to override with a fixed angle regardless of domain shape.
 
 setup.refine_based_on = "Region"  # "Region" or "MagneticEnergy"
 setup.region_lo_x = 0.4

--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -37,3 +37,17 @@ hydro.use_dual_energy = 0
 # MHD parameters
 mhd.emf_reconstruction_order = 5  # xPPM for EMF
 mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
+
+# *****************************************************************
+# Field loop setup
+# *****************************************************************
+setup.loop_radius = 0.3
+setup.loop_center_x = 0.0
+setup.loop_center_y = 0.0
+setup.advection_angle_deg = 60.0  # measured from the y-axis: vx = sin(angle), vy = cos(angle)
+
+setup.refine_based_on = "Region"  # "Region" or "MagneticEnergy"
+setup.region_lo_x = 0.4
+setup.region_hi_x = 0.6
+setup.region_lo_y = -0.23125
+setup.region_hi_y = 0.23125

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -217,12 +217,6 @@ auto problem_main() -> int
 	pp.query("loop_radius", loop_radius);
 	pp.query("loop_center_x", loop_center_x);
 	pp.query("loop_center_y", loop_center_y);
-
-	double advection_angle_deg = 60.0;
-	pp.query("advection_angle_deg", advection_angle_deg);
-	const double advection_angle_rad = advection_angle_deg * M_PI / 180.0;
-	advection_vx = std::sin(advection_angle_rad);
-	advection_vy = std::cos(advection_angle_rad);
 	pp.query("advection_vz", advection_vz);
 
 	RefineOn refine_based_on{};
@@ -253,6 +247,15 @@ auto problem_main() -> int
 	}
 
 	QuokkaSimulation<FieldLoop> sim;
+
+	// default in-plane advection direction: the domain's own diagonal (x-y extent), so the loop
+	// crosses the periodic domain and returns to its starting position; independent of loop_center
+	double advection_angle_deg = std::atan2(sim.geom[0].ProbLength(0), sim.geom[0].ProbLength(1)) * 180.0 / M_PI;
+	pp.query("advection_angle_deg", advection_angle_deg);
+	const double advection_angle_rad = advection_angle_deg * M_PI / 180.0;
+	advection_vx = std::sin(advection_angle_rad);
+	advection_vy = std::cos(advection_angle_rad);
+
 	sim.setInitialConditions();
 	sim.evolve();
 	return 0;

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -82,7 +82,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		const double Eint = P0 / (gamma_gas - 1.0);
 
 		// Az = MAX([A ( loop_radius - r )],0)
-		auto A_z = [=](double x, double y) {
+		auto A_z = [=](double x, double y) -> double {
 			const double dx_c = x - loop_center_x;
 			const double dy_c = y - loop_center_y;
 			const double R = std::sqrt(dx_c * dx_c + dy_c * dy_c);
@@ -116,7 +116,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 		const double yL = prob_lo[1] + (j * dx[1]);
 
 		// Az = MAX([A ( loop_radius - r )],0)
-		auto A_z = [=](double x, double y) {
+		auto A_z = [=](double x, double y) -> double {
 			const double dx_c = x - loop_center_x;
 			const double dy_c = y - loop_center_y;
 			const double R = std::sqrt(dx_c * dx_c + dy_c * dy_c);

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -249,10 +249,10 @@ auto problem_main() -> int
 	advection_vy = std::cos(advection_angle_rad);
 
 	// default the region's z-bounds to the full domain, matching the prior (z-unbounded) behavior
-	if (!pp.query("region_lo_z", region_lo_z)) {
+	if (pp.query("region_lo_z", region_lo_z) == 0) {
 		region_lo_z = sim.geom[0].ProbLo(2);
 	}
-	if (!pp.query("region_hi_z", region_hi_z)) {
+	if (pp.query("region_hi_z", region_hi_z) == 0) {
 		region_hi_z = sim.geom[0].ProbHi(2);
 	}
 	if (region_lo_z >= region_hi_z) {

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "AMReX_Array.H"
 #include "AMReX_Array4.H"
@@ -53,11 +54,13 @@ AMREX_GPU_MANAGED double advection_vy = 0.0; // NOLINT
 // exercises the solver's handling of a flow component the true solution lacks
 AMREX_GPU_MANAGED double advection_vz = 1.0; // NOLINT
 
-// static refinement region: an x-y box spanning the full domain in z
-AMREX_GPU_MANAGED double region_lo_x = 0.4;	 // NOLINT
-AMREX_GPU_MANAGED double region_hi_x = 0.6;	 // NOLINT
-AMREX_GPU_MANAGED double region_lo_y = -0.23125; // NOLINT
-AMREX_GPU_MANAGED double region_hi_y = 0.23125;	 // NOLINT
+// static refinement region: a 3D box, defaulting to the full domain in z unless set
+AMREX_GPU_MANAGED double region_lo_x = 0.4;					 // NOLINT
+AMREX_GPU_MANAGED double region_hi_x = 0.6;					 // NOLINT
+AMREX_GPU_MANAGED double region_lo_y = -0.23125;				 // NOLINT
+AMREX_GPU_MANAGED double region_hi_y = 0.23125;					 // NOLINT
+AMREX_GPU_MANAGED double region_lo_z = -std::numeric_limits<double>::infinity(); // NOLINT
+AMREX_GPU_MANAGED double region_hi_z = std::numeric_limits<double>::infinity();	 // NOLINT
 
 template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
@@ -155,8 +158,9 @@ template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxA
 			amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 				const double x = plo[0] + ((i + 0.5) * dx[0]);
 				const double y = plo[1] + ((j + 0.5) * dx[1]);
+				const double z = plo[2] + ((k + 0.5) * dx[2]);
 
-				if (x >= region_lo_x && x <= region_hi_x && y >= region_lo_y && y <= region_hi_y) {
+				if (x >= region_lo_x && x <= region_hi_x && y >= region_lo_y && y <= region_hi_y && z >= region_lo_z && z <= region_hi_z) {
 					tag(i, j, k) = amrex::TagBox::SET;
 				}
 			});
@@ -233,18 +237,6 @@ auto problem_main() -> int
 	if (region_lo_x >= region_hi_x || region_lo_y >= region_hi_y) {
 		amrex::Abort("setup.region_lo_* must be < setup.region_hi_* in both dimensions.");
 	}
-	if (refine_based_on == RefineOn::Region) {
-		// sanity check: the static refinement region must not overlap the field loop's support,
-		// otherwise the region's own refinement conflates with the loop's magnetic-energy features
-		const double closest_x = std::clamp(loop_center_x, region_lo_x, region_hi_x);
-		const double closest_y = std::clamp(loop_center_y, region_lo_y, region_hi_y);
-		const double dx_c = closest_x - loop_center_x;
-		const double dy_c = closest_y - loop_center_y;
-		const double dist_to_region = std::sqrt(dx_c * dx_c + dy_c * dy_c);
-		if (dist_to_region < loop_radius) {
-			amrex::Abort("the static refinement region overlaps the field loop; move setup.region_* or shrink setup.loop_radius.");
-		}
-	}
 
 	QuokkaSimulation<FieldLoop> sim;
 
@@ -255,6 +247,30 @@ auto problem_main() -> int
 	const double advection_angle_rad = advection_angle_deg * M_PI / 180.0;
 	advection_vx = std::sin(advection_angle_rad);
 	advection_vy = std::cos(advection_angle_rad);
+
+	// default the region's z-bounds to the full domain, matching the prior (z-unbounded) behavior
+	if (!pp.query("region_lo_z", region_lo_z)) {
+		region_lo_z = sim.geom[0].ProbLo(2);
+	}
+	if (!pp.query("region_hi_z", region_hi_z)) {
+		region_hi_z = sim.geom[0].ProbHi(2);
+	}
+	if (region_lo_z >= region_hi_z) {
+		amrex::Abort("setup.region_lo_z must be < setup.region_hi_z.");
+	}
+
+	if (refine_based_on == RefineOn::Region) {
+		// sanity check: the static refinement region must not overlap the field loop's support in the
+		// x-y plane; the loop's structure is z-invariant, so the region's z-bounds don't affect this
+		const double closest_x = std::clamp(loop_center_x, region_lo_x, region_hi_x);
+		const double closest_y = std::clamp(loop_center_y, region_lo_y, region_hi_y);
+		const double dx_c = closest_x - loop_center_x;
+		const double dy_c = closest_y - loop_center_y;
+		const double dist_to_region = std::sqrt(dx_c * dx_c + dy_c * dy_c);
+		if (dist_to_region < loop_radius) {
+			amrex::Abort("the static refinement region overlaps the field loop; move setup.region_* or shrink setup.loop_radius.");
+		}
+	}
 
 	sim.setInitialConditions();
 	sim.evolve();

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -49,6 +49,10 @@ AMREX_GPU_MANAGED double loop_center_y = 0.0; // NOLINT
 AMREX_GPU_MANAGED double advection_vx = 0.0; // NOLINT
 AMREX_GPU_MANAGED double advection_vy = 0.0; // NOLINT
 
+// out-of-plane (z) drift; the loop's structure is invariant along z, so this
+// exercises the solver's handling of a flow component the true solution lacks
+AMREX_GPU_MANAGED double advection_vz = 1.0; // NOLINT
+
 // static refinement region: an x-y box spanning the full domain in z
 AMREX_GPU_MANAGED double region_lo_x = 0.4;	 // NOLINT
 AMREX_GPU_MANAGED double region_hi_x = 0.6;	 // NOLINT
@@ -71,7 +75,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
 		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
 
-		const double Ekin = 0.5 * rho0 * (advection_vx * advection_vx + advection_vy * advection_vy);
+		const double Ekin = 0.5 * rho0 * (advection_vx * advection_vx + advection_vy * advection_vy + advection_vz * advection_vz);
 		const double Eint = P0 / (gamma_gas - 1.0);
 
 		// Az = MAX([A ( loop_radius - r )],0)
@@ -90,7 +94,7 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		state_cc(i, j, k, HydroSystem<FieldLoop>::density_index) = rho0;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::x1Momentum_index) = rho0 * advection_vx;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::x2Momentum_index) = rho0 * advection_vy;
-		state_cc(i, j, k, HydroSystem<FieldLoop>::x3Momentum_index) = 0.0;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x3Momentum_index) = rho0 * advection_vz;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::internalEnergy_index) = Eint;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::energy_index) = Eint + Ekin + Emag;
 	});
@@ -219,6 +223,7 @@ auto problem_main() -> int
 	const double advection_angle_rad = advection_angle_deg * M_PI / 180.0;
 	advection_vx = std::sin(advection_angle_rad);
 	advection_vy = std::cos(advection_angle_rad);
+	pp.query("advection_vz", advection_vz);
 
 	RefineOn refine_based_on{};
 	pp.query("refine_based_on", refine_based_on);

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -8,6 +8,7 @@
 ///   https://www.astro.princeton.edu/~jstone/Athena/tests/field-loop/Field-loop.html
 ///
 
+#include <algorithm>
 #include <cmath>
 
 #include "AMReX_Array.H"
@@ -38,7 +39,21 @@ template <> struct Physics_Traits<FieldLoop> : DefaultPhysicsTraits {
 };
 
 constexpr double A = 1.0e-3;
-constexpr double R_0 = 0.3;
+
+// loop geometry, set from the `setup.*` TOML group in problem_main()
+AMREX_GPU_MANAGED double loop_radius = 0.3;   // NOLINT
+AMREX_GPU_MANAGED double loop_center_x = 0.0; // NOLINT
+AMREX_GPU_MANAGED double loop_center_y = 0.0; // NOLINT
+
+// in-plane advection velocity (unit speed, angle measured from the y-axis)
+AMREX_GPU_MANAGED double advection_vx = 0.0; // NOLINT
+AMREX_GPU_MANAGED double advection_vy = 0.0; // NOLINT
+
+// static refinement region: an x-y box spanning the full domain in z
+AMREX_GPU_MANAGED double region_lo_x = 0.4;	 // NOLINT
+AMREX_GPU_MANAGED double region_hi_x = 0.6;	 // NOLINT
+AMREX_GPU_MANAGED double region_lo_y = -0.23125; // NOLINT
+AMREX_GPU_MANAGED double region_hi_y = 0.23125;	 // NOLINT
 
 template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
@@ -56,18 +71,15 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
 		const double y = prob_lo[1] + ((j + 0.5) * dx[1]);
 
-		//  Vx=sin(60 degrees) and Vy=cos(60 degrees)
-		const double vx = std::sin(M_PI / 3.0);
-		const double vy = std::cos(M_PI / 3.0);
-		const double vz = 1.0; // this should not affect the solution!
-
-		const double Ekin = 0.5 * rho0 * (vx * vx + vy * vy + vz * vz);
+		const double Ekin = 0.5 * rho0 * (advection_vx * advection_vx + advection_vy * advection_vy);
 		const double Eint = P0 / (gamma_gas - 1.0);
 
-		// Az = MAX([A ( R0 - r )],0)
+		// Az = MAX([A ( loop_radius - r )],0)
 		auto A_z = [=](double x, double y) {
-			const double R = std::sqrt(x * x + y * y);
-			return std::max(A * (R_0 - R), 0.);
+			const double dx_c = x - loop_center_x;
+			const double dy_c = y - loop_center_y;
+			const double R = std::sqrt(dx_c * dx_c + dy_c * dy_c);
+			return std::max(A * (loop_radius - R), 0.);
 		};
 		auto B_x = [=](double xL, double yL) { return (A_z(xL, yL + dx[1]) - A_z(xL, yL)) / dx[1]; };
 		auto B_y = [=](double xL, double yL) { return -(A_z(xL + dx[0], yL) - A_z(xL, yL)) / dx[0]; };
@@ -76,9 +88,9 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGrid(quokka:
 		const double Emag = 0.5 * (bx * bx + by * by);
 
 		state_cc(i, j, k, HydroSystem<FieldLoop>::density_index) = rho0;
-		state_cc(i, j, k, HydroSystem<FieldLoop>::x1Momentum_index) = rho0 * vx;
-		state_cc(i, j, k, HydroSystem<FieldLoop>::x2Momentum_index) = rho0 * vy;
-		state_cc(i, j, k, HydroSystem<FieldLoop>::x3Momentum_index) = rho0 * vz;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x1Momentum_index) = rho0 * advection_vx;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x2Momentum_index) = rho0 * advection_vy;
+		state_cc(i, j, k, HydroSystem<FieldLoop>::x3Momentum_index) = 0.0;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::internalEnergy_index) = Eint;
 		state_cc(i, j, k, HydroSystem<FieldLoop>::energy_index) = Eint + Ekin + Emag;
 	});
@@ -96,10 +108,12 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 		const double xL = prob_lo[0] + (i * dx[0]);
 		const double yL = prob_lo[1] + (j * dx[1]);
 
-		// Az = MAX([A ( R0 - r )],0)
+		// Az = MAX([A ( loop_radius - r )],0)
 		auto A_z = [=](double x, double y) {
-			const double R = std::sqrt(x * x + y * y);
-			return std::max(A * (R_0 - R), 0.);
+			const double dx_c = x - loop_center_x;
+			const double dy_c = y - loop_center_y;
+			const double R = std::sqrt(dx_c * dx_c + dy_c * dy_c);
+			return std::max(A * (loop_radius - R), 0.);
 		};
 		auto B_x = [=](double xL, double yL) { return (A_z(xL, yL + dx[1]) - A_z(xL, yL)) / dx[1]; };
 		auto B_y = [=](double xL, double yL) { return -(A_z(xL + dx[0], yL) - A_z(xL, yL)) / dx[0]; };
@@ -119,12 +133,11 @@ template <> void QuokkaSimulation<FieldLoop>::setInitialConditionsOnGridFaceVars
 template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
 {
 	RefineOn refine_based_on{};
-	amrex::ParmParse const pp("field_loop");
+	amrex::ParmParse const pp("setup");
 	pp.query("refine_based_on", refine_based_on);
 
 	auto const &dx = geom[lev].CellSizeArray();
 	auto const &plo = geom[lev].ProbLoArray();
-	auto const &phi = geom[lev].ProbHiArray();
 
 	for (amrex::MFIter mfi(state_new_cc_[lev]); mfi.isValid(); ++mfi) {
 		const amrex::Box &box = mfi.validbox();
@@ -134,12 +147,12 @@ template <> void QuokkaSimulation<FieldLoop>::refineGrid(int lev, amrex::TagBoxA
 		const auto &Bz_fc = state_new_fc_[lev][2].const_array(mfi);
 
 		if (refine_based_on == RefineOn::Region) {
-			// static mesh refinement
+			// static mesh refinement within a fixed physical region
 			amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-				const double x_frac = ((i + 0.5) * dx[0]) / (phi[0] - plo[0]);
-				const double y_frac = ((j + 0.5) * dx[1]) / (phi[1] - plo[1]);
+				const double x = plo[0] + ((i + 0.5) * dx[0]);
+				const double y = plo[1] + ((j + 0.5) * dx[1]);
 
-				if (x_frac >= 0.7 && x_frac <= 0.8 && y_frac >= 0.3 && y_frac <= 0.7) {
+				if (x >= region_lo_x && x <= region_hi_x && y >= region_lo_y && y <= region_hi_y) {
 					tag(i, j, k) = amrex::TagBox::SET;
 				}
 			});
@@ -195,6 +208,45 @@ void QuokkaSimulation<FieldLoop>::ComputeDerivedVar(int lev, std::string const &
 
 auto problem_main() -> int
 {
+	amrex::ParmParse const pp("setup");
+
+	pp.query("loop_radius", loop_radius);
+	pp.query("loop_center_x", loop_center_x);
+	pp.query("loop_center_y", loop_center_y);
+
+	double advection_angle_deg = 60.0;
+	pp.query("advection_angle_deg", advection_angle_deg);
+	const double advection_angle_rad = advection_angle_deg * M_PI / 180.0;
+	advection_vx = std::sin(advection_angle_rad);
+	advection_vy = std::cos(advection_angle_rad);
+
+	RefineOn refine_based_on{};
+	pp.query("refine_based_on", refine_based_on);
+
+	pp.query("region_lo_x", region_lo_x);
+	pp.query("region_hi_x", region_hi_x);
+	pp.query("region_lo_y", region_lo_y);
+	pp.query("region_hi_y", region_hi_y);
+
+	if (loop_radius <= 0.0) {
+		amrex::Abort("setup.loop_radius must be > 0.");
+	}
+	if (region_lo_x >= region_hi_x || region_lo_y >= region_hi_y) {
+		amrex::Abort("setup.region_lo_* must be < setup.region_hi_* in both dimensions.");
+	}
+	if (refine_based_on == RefineOn::Region) {
+		// sanity check: the static refinement region must not overlap the field loop's support,
+		// otherwise the region's own refinement conflates with the loop's magnetic-energy features
+		const double closest_x = std::clamp(loop_center_x, region_lo_x, region_hi_x);
+		const double closest_y = std::clamp(loop_center_y, region_lo_y, region_hi_y);
+		const double dx_c = closest_x - loop_center_x;
+		const double dy_c = closest_y - loop_center_y;
+		const double dist_to_region = std::sqrt(dx_c * dx_c + dy_c * dy_c);
+		if (dist_to_region < loop_radius) {
+			amrex::Abort("the static refinement region overlaps the field loop; move setup.region_* or shrink setup.loop_radius.");
+		}
+	}
+
 	QuokkaSimulation<FieldLoop> sim;
 	sim.setInitialConditions();
 	sim.evolve();


### PR DESCRIPTION
### Description

The `FieldLoop` hardcodes many parameters: the loop's radius, position, and advection direction, and the static-refinement region, as compile-time constants. So, changing any of them means editing the source and rebuilding. The refine-mode switch also lived under a bespoke `field_loop.*` ParmParse group instead of the (now standard) `setup.*` convention that other MHD tests use (e.g. `MHDBalsaraVortex`).

This adds `setup.loop_radius`, `setup.loop_center_x/y`, `setup.advection_angle_deg`, `setup.advection_vz`, and `setup.region_lo/hi_x/y/z`, and renames `field_loop.refine_based_on` to `setup.refine_based_on` for consistency. Domain shape and AMR level count needed no new parameters: `geometry.prob_lo/hi` and `amr.max_level` are already free-standing AMReX ParmParse keys.

`problem_main()` gains three sanity checks: `loop_radius > 0`, `region_lo_* < region_hi_*` in all three dimensions, and, when `refine_based_on == Region`, that the AMR region doesn't overlap with the loop's initial position.

Every new parameter defaults to the test's original hardcoded value, so default behaviour is unchanged.

### Validation

Confirmed the default `inputs/FieldLoop.toml` reproduces identical exit behaviour before and after this change, at reduced resolution.

Exercised every new parameter together: domain `[-1.5,1.5]×[-1,1]×[-0.5,0.5]` (3:2:1 aspect ratio), `loop_radius=0.5`, advection direction ratio `(3,2,1)` (not aligned to any coordinate plane), a 3D-bounded refinement region placed off the loop's forward path, one AMR level, `96×64×32` cells, `mhd.emf_compute_scheme=Quokka2026` with `emf_averaging_scheme=Balsara2025`, both reconstruction orders at PPM-EP, run for one full domain-diagonal crossing (`t/T = 1`).

<img width="5061" height="2295" alt="field-loop-div-b" src="https://github.com/user-attachments/assets/dbf4a374-73be-4017-a27b-b32f62b50e85" />

### Related issues

N/A.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above): n/a, see Related issues.
- [x] I have read the Contributing Guide.
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; existing default behaviour is preserved bit-for-bit (see Validation).
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fully configurable field-loop setup via TOML (loop geometry, advection velocity, and static refinement region bounds).
  * Enabled runtime parameterization of the loop’s position and motion direction.
  * Switched refinement-on-region to use the configured physical bounds.
  * Added configuration validation for invalid ranges and incompatible geometry.
* **Bug Fixes**
  * Updated field initialization and refinement logic to consistently derive magnetic quantities and initial momenta from the configured loop center, radius, and advection parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
