### PR TITLE
Add prune_checkpoints.py: thin checkpoints by time interval

### DIFF
--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -129,9 +129,12 @@ def main():
         print("dry run: nothing deleted (pass --delete to remove the folders marked [-])")
         return
 
+    print()
     for chk_dir, _ in checkpoints:
         if chk_dir not in reasons:
+            print(f"deleting {chk_dir} ...", end=" ", flush=True)
             shutil.rmtree(chk_dir)
+            print("done")
     print(f"deleted {n_delete} checkpoint folder(s)")
 
 

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -8,7 +8,7 @@ Example:
     prune_checkpoints.py . '3*Myr'          # dry run: print what would be kept/deleted
     prune_checkpoints.py . '3*Myr' --delete # actually delete
 
-The simulation time is read from row 4 of <chk*>/Header. Units (yr, kyr, Myr, Gyr)
+The simulation time is read from row 5 of <chk*>/Header. Units (yr, kyr, Myr, Gyr)
 follow src/util/time_units.hpp (Julian year = 365.25 days).
 
 The newest checkpoint and the one pointed to by the last_chk symlink are always kept,
@@ -42,15 +42,22 @@ def parse_time(expr):
 
 
 def read_checkpoint_time(chk_dir):
-    """Return the simulation time (seconds) stored on row 4 of the checkpoint Header."""
+    """Return the simulation time (seconds) of level 0.
+
+    Row 5 of the checkpoint Header is the t_new array, with one entry per level;
+    see AMRSimulation::WriteCheckpointFile in src/simulation.hpp.
+    """
     header = chk_dir / "Header"
     if not header.is_file():
         return None
     lines = header.read_text().splitlines()
-    if len(lines) < 4:
+    if len(lines) < 5:
+        return None
+    fields = lines[4].split()
+    if not fields:
         return None
     try:
-        return float(lines[3].strip())
+        return float(fields[0])
     except ValueError:
         return None
 

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Keep only the checkpoints whose time is closest to multiples of a given interval.
+
+Usage:
+    prune_checkpoints.py <sim_dir> <interval> [--delete]
+
+Example:
+    prune_checkpoints.py . '3*Myr'          # dry run: print what would be kept/deleted
+    prune_checkpoints.py . '3*Myr' --delete # actually delete
+
+The simulation time is read from row 4 of <chk*>/Header. Units (yr, kyr, Myr, Gyr)
+follow src/util/time_units.hpp (Julian year = 365.25 days).
+"""
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+# Time unit conversion factors to CGS seconds; see src/util/time_units.hpp
+UNITS = {
+    "s": 1.0,
+    "yr": 3.15576e7,
+    "kyr": 3.15576e10,
+    "Myr": 3.15576e13,
+    "Gyr": 3.15576e16,
+}
+
+
+def parse_time(expr):
+    """Evaluate a time expression such as '3*Myr' or '2.5*Myr + 500*kyr' into seconds."""
+    try:
+        value = eval(expr, {"__builtins__": {}}, dict(UNITS))  # noqa: S307
+    except Exception as exc:
+        sys.exit(f"error: cannot parse time expression {expr!r}: {exc}")
+    if not isinstance(value, (int, float)) or value <= 0.0:
+        sys.exit(f"error: time expression {expr!r} must evaluate to a positive number")
+    return float(value)
+
+
+def read_checkpoint_time(chk_dir):
+    """Return the simulation time (seconds) stored on row 4 of the checkpoint Header."""
+    header = chk_dir / "Header"
+    if not header.is_file():
+        return None
+    lines = header.read_text().splitlines()
+    if len(lines) < 4:
+        return None
+    try:
+        return float(lines[3].strip())
+    except ValueError:
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("sim_dir", help="simulation directory containing chk* folders")
+    parser.add_argument("interval", help="time interval, e.g. '3*Myr'")
+    parser.add_argument("--delete", action="store_true", help="actually delete instead of dry run")
+    args = parser.parse_args()
+
+    sim_dir = Path(args.sim_dir)
+    if not sim_dir.is_dir():
+        sys.exit(f"error: {sim_dir} is not a directory")
+
+    interval = parse_time(args.interval)
+
+    checkpoints = []
+    for chk_dir in sorted(p for p in sim_dir.glob("chk*") if p.is_dir()):
+        time = read_checkpoint_time(chk_dir)
+        if time is None:
+            print(f"warning: skipping {chk_dir.name} (no readable time in Header)", file=sys.stderr)
+            continue
+        checkpoints.append((chk_dir, time))
+
+    if not checkpoints:
+        sys.exit(f"error: no checkpoints with a readable Header found in {sim_dir}")
+
+    # Group checkpoints by the nearest multiple of the interval; keep the closest one per group.
+    keep = {}
+    for chk_dir, time in checkpoints:
+        index = round(time / interval)
+        best = keep.get(index)
+        if best is None or abs(time - index * interval) < abs(best[1] - index * interval):
+            keep[index] = (chk_dir, time)
+    kept = {chk_dir for chk_dir, _ in keep.values()}
+
+    unit = "Myr"
+    print(f"interval = {args.interval} = {interval / UNITS[unit]:g} {unit}")
+    n_delete = 0
+    for chk_dir, time in checkpoints:
+        if chk_dir in kept:
+            index = round(time / interval)
+            print(f"  {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}  [+] keep   (~ {index} x {args.interval})")
+        else:
+            n_delete += 1
+            print(f"  {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}  [-] delete")
+
+    print(f"\n{len(kept)} to keep, {n_delete} to delete")
+
+    if not args.delete:
+        print("dry run: nothing deleted (pass --delete to remove the folders marked [-])")
+        return
+
+    for chk_dir, _ in checkpoints:
+        if chk_dir not in kept:
+            shutil.rmtree(chk_dir)
+    print(f"deleted {n_delete} checkpoint folder(s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -16,9 +16,13 @@ so that the run stays restartable.
 """
 
 import argparse
+import re
 import shutil
 import sys
 from pathlib import Path
+
+# Checkpoint folders are named chk followed by the step number, e.g. chk0000010.
+CHK_PATTERN = re.compile(r"chk\d+")
 
 # Time unit conversion factors to CGS seconds; see src/util/time_units.hpp
 UNITS = {
@@ -76,7 +80,7 @@ def main():
     interval = parse_time(args.interval)
 
     checkpoints = []
-    for chk_dir in sorted(p for p in sim_dir.glob("chk*") if p.is_dir()):
+    for chk_dir in sorted(p for p in sim_dir.glob("chk*") if p.is_dir() and CHK_PATTERN.fullmatch(p.name)):
         time = read_checkpoint_time(chk_dir)
         if time is None:
             print(f"warning: skipping {chk_dir.name} (no readable time in Header)", file=sys.stderr)

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -10,6 +10,9 @@ Example:
 
 The simulation time is read from row 4 of <chk*>/Header. Units (yr, kyr, Myr, Gyr)
 follow src/util/time_units.hpp (Julian year = 365.25 days).
+
+The newest checkpoint and the one pointed to by the last_chk symlink are always kept,
+so that the run stays restartable.
 """
 
 import argparse
@@ -83,27 +86,36 @@ def main():
         best = keep.get(index)
         if best is None or abs(time - index * interval) < abs(best[1] - index * interval):
             keep[index] = (chk_dir, time)
-    kept = {chk_dir for chk_dir, _ in keep.values()}
+    reasons = {chk_dir: f"~ {index} x {args.interval}" for index, (chk_dir, _) in keep.items()}
+
+    # Always protect the newest checkpoint and whatever the last_chk symlink points to.
+    newest = max(checkpoints, key=lambda item: item[1])[0]
+    reasons[newest] = f"{reasons[newest]}, newest" if newest in reasons else "newest"
+    last_chk = sim_dir / "last_chk"
+    if last_chk.is_symlink():
+        target = last_chk.resolve()
+        for chk_dir, _ in checkpoints:
+            if chk_dir.resolve() == target:
+                reasons[chk_dir] = f"{reasons[chk_dir]}, last_chk" if chk_dir in reasons else "last_chk"
 
     unit = "Myr"
     print(f"interval = {args.interval} = {interval / UNITS[unit]:g} {unit}")
     n_delete = 0
     for chk_dir, time in checkpoints:
-        if chk_dir in kept:
-            index = round(time / interval)
-            print(f"  {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}  [+] keep   (~ {index} x {args.interval})")
+        if chk_dir in reasons:
+            print(f"  {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}  [+] keep   ({reasons[chk_dir]})")
         else:
             n_delete += 1
             print(f"  {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}  [-] delete")
 
-    print(f"\n{len(kept)} to keep, {n_delete} to delete")
+    print(f"\n{len(reasons)} to keep, {n_delete} to delete")
 
     if not args.delete:
         print("dry run: nothing deleted (pass --delete to remove the folders marked [-])")
         return
 
     for chk_dir, _ in checkpoints:
-        if chk_dir not in kept:
+        if chk_dir not in reasons:
             shutil.rmtree(chk_dir)
     print(f"deleted {n_delete} checkpoint folder(s)")
 

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Keep only the checkpoints whose time is closest to multiples of a given interval.
+"""Prune checkpoint folders, either by time interval or by hand.
 
 Usage:
     prune_checkpoints.py <sim_dir> <interval> [--delete]
+    prune_checkpoints.py <sim_dir> --manual
 
 Example:
     prune_checkpoints.py . '3*Myr'          # dry run: print what would be kept/deleted
     prune_checkpoints.py . '3*Myr' --delete # actually delete
+    prune_checkpoints.py . --manual         # pick the checkpoints to keep interactively
 
 The simulation time is read from row 5 of <chk*>/Header. Units (yr, kyr, Myr, Gyr)
 follow src/util/time_units.hpp (Julian year = 365.25 days).
@@ -16,6 +18,7 @@ so that the run stays restartable.
 """
 
 import argparse
+import curses
 import re
 import shutil
 import sys
@@ -69,19 +72,8 @@ def read_checkpoint_time(chk_dir):
         return None
 
 
-def main():
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("sim_dir", help="simulation directory containing chk* folders")
-    parser.add_argument("interval", help="time interval, e.g. '3*Myr'")
-    parser.add_argument("--delete", action="store_true", help="actually delete instead of dry run")
-    args = parser.parse_args()
-
-    sim_dir = Path(args.sim_dir)
-    if not sim_dir.is_dir():
-        sys.exit(f"error: {sim_dir} is not a directory")
-
-    interval = parse_time(args.interval)
-
+def collect_checkpoints(sim_dir):
+    """Return [(path, time)] for every chk<digits> folder with a readable Header, sorted by name."""
     checkpoints = []
     for chk_dir in sorted(p for p in sim_dir.glob("chk*") if p.is_dir() and CHK_PATTERN.fullmatch(p.name)):
         time = read_checkpoint_time(chk_dir)
@@ -89,32 +81,134 @@ def main():
             print(f"warning: skipping {chk_dir.name} (no readable time in Header)", file=sys.stderr)
             continue
         checkpoints.append((chk_dir, time))
+    return checkpoints
 
-    if not checkpoints:
-        sys.exit(f"error: no checkpoints with a readable Header found in {sim_dir}")
 
-    # Group checkpoints by the nearest multiple of the interval; keep the closest one per group.
+def add_reason(reasons, chk_dir, text):
+    """Record why chk_dir is kept, appending to any reason already recorded."""
+    reasons[chk_dir] = f"{reasons[chk_dir]}, {text}" if chk_dir in reasons else text
+
+
+def protected_checkpoints(sim_dir, checkpoints):
+    """Return {path: reason} for checkpoints that must never be deleted."""
+    reasons = {}
+    add_reason(reasons, max(checkpoints, key=lambda item: item[1])[0], "newest")
+    last_chk = sim_dir / "last_chk"
+    if last_chk.is_symlink():
+        target = last_chk.resolve()
+        for chk_dir, _ in checkpoints:
+            if chk_dir.resolve() == target:
+                add_reason(reasons, chk_dir, "last_chk")
+    return reasons
+
+
+def select_by_interval(checkpoints, interval, expr):
+    """Return {path: reason} for the checkpoint closest to each multiple of the interval."""
     keep = {}
     for chk_dir, time in checkpoints:
         index = round(time / interval)
         best = keep.get(index)
         if best is None or abs(time - index * interval) < abs(best[1] - index * interval):
             keep[index] = (chk_dir, time)
-    reasons = {chk_dir: f"~ {index} x {args.interval}" for index, (chk_dir, _) in keep.items()}
+    return {chk_dir: f"~ {index} x {expr}" for index, (chk_dir, _) in keep.items()}
 
-    # Always protect the newest checkpoint and whatever the last_chk symlink points to.
-    newest = max(checkpoints, key=lambda item: item[1])[0]
-    reasons[newest] = f"{reasons[newest]}, newest" if newest in reasons else "newest"
-    last_chk = sim_dir / "last_chk"
-    if last_chk.is_symlink():
-        target = last_chk.resolve()
-        for chk_dir, _ in checkpoints:
-            if chk_dir.resolve() == target:
-                reasons[chk_dir] = f"{reasons[chk_dir]}, last_chk" if chk_dir in reasons else "last_chk"
 
-    match = UNIT_PATTERN.search(args.interval)
-    unit = match.group(1) if match is not None else "s"
-    print(f"interval = {args.interval} = {interval / UNITS[unit]:g} {unit}")
+def _selector(stdscr, checkpoints, protected, unit):
+    """curses loop for manual mode; returns the set of selected paths, or None if aborted."""
+    curses.curs_set(0)
+    selected = {chk_dir for chk_dir, _ in checkpoints}
+    row = 0
+    top = 0
+    message = ""
+    while True:
+        height, width = stdscr.getmaxyx()
+        view = max(1, height - 4)
+        top = min(top, row)
+        top = max(top, row - view + 1)
+        stdscr.erase()
+        stdscr.addnstr(0, 0, "up/down: move   space: toggle   enter: confirm   q: abort", width - 1)
+        stdscr.addnstr(1, 0, f"[x] keep, [ ] delete -- {len(selected)} of {len(checkpoints)} kept.  {message}", width - 1)
+        for offset in range(min(view, len(checkpoints) - top)):
+            chk_dir, time = checkpoints[top + offset]
+            mark = "x" if chk_dir in selected else " "
+            lock = f"  ({protected[chk_dir]}, locked)" if chk_dir in protected else ""
+            line = f" [{mark}] {chk_dir.name}  {time / UNITS[unit]:12.4f} {unit}{lock}"
+            attr = curses.A_REVERSE if top + offset == row else curses.A_NORMAL
+            stdscr.addnstr(2 + offset, 0, line.ljust(width - 1), width - 1, attr)
+        stdscr.refresh()
+
+        key = stdscr.getch()
+        message = ""
+        if key in (curses.KEY_UP, ord("k")):
+            row = max(0, row - 1)
+        elif key in (curses.KEY_DOWN, ord("j")):
+            row = min(len(checkpoints) - 1, row + 1)
+        elif key == ord(" "):
+            chk_dir = checkpoints[row][0]
+            if chk_dir in protected:
+                message = f"{chk_dir.name} is protected ({protected[chk_dir]})."
+            elif chk_dir in selected:
+                selected.remove(chk_dir)
+            else:
+                selected.add(chk_dir)
+        elif key in (curses.KEY_ENTER, ord("\n"), ord("\r")):
+            return selected
+        elif key == ord("q"):
+            return None
+
+
+def select_manually(checkpoints, protected, unit):
+    """Run the interactive picker; returns {path: reason} for the checkpoints to keep."""
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        sys.exit("error: --manual requires an interactive terminal")
+    selected = curses.wrapper(_selector, checkpoints, protected, unit)
+    if selected is None:
+        sys.exit("aborted: nothing deleted")
+    return {chk_dir: "selected" for chk_dir in selected}
+
+
+def confirm_deletion(n_delete):
+    """Require the user to type an exact phrase before deleting."""
+    phrase = f"delete {n_delete} checkpoint" + ("s" if n_delete != 1 else "")
+    answer = input(f'\ntype "{phrase}" to confirm: ')
+    if answer.strip() != phrase:
+        sys.exit("aborted: nothing deleted")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("sim_dir", help="simulation directory containing chk* folders")
+    parser.add_argument("interval", nargs="?", help="time interval, e.g. '3*Myr'")
+    parser.add_argument("--manual", action="store_true", help="pick the checkpoints to keep interactively")
+    parser.add_argument("--delete", action="store_true", help="actually delete instead of dry run (interval mode only)")
+    args = parser.parse_args()
+
+    if args.manual == (args.interval is not None):
+        parser.error("give either an interval or --manual, not both")
+
+    sim_dir = Path(args.sim_dir)
+    if not sim_dir.is_dir():
+        sys.exit(f"error: {sim_dir} is not a directory")
+
+    checkpoints = collect_checkpoints(sim_dir)
+    if not checkpoints:
+        sys.exit(f"error: no checkpoints with a readable Header found in {sim_dir}")
+
+    protected = protected_checkpoints(sim_dir, checkpoints)
+
+    if args.manual:
+        unit = "Myr"
+        reasons = select_manually(checkpoints, protected, unit)
+    else:
+        interval = parse_time(args.interval)
+        match = UNIT_PATTERN.search(args.interval)
+        unit = match.group(1) if match is not None else "s"
+        reasons = select_by_interval(checkpoints, interval, args.interval)
+        print(f"interval = {args.interval} = {interval / UNITS[unit]:g} {unit}")
+
+    for chk_dir, reason in protected.items():
+        add_reason(reasons, chk_dir, reason)
+
     n_delete = 0
     for chk_dir, time in checkpoints:
         if chk_dir in reasons:
@@ -125,7 +219,13 @@ def main():
 
     print(f"\n{len(reasons)} to keep, {n_delete} to delete")
 
-    if not args.delete:
+    if n_delete == 0:
+        print("nothing to delete")
+        return
+
+    if args.manual:
+        confirm_deletion(n_delete)
+    elif not args.delete:
         print("dry run: nothing deleted (pass --delete to remove the folders marked [-])")
         return
 

--- a/scripts/python/prune_checkpoints.py
+++ b/scripts/python/prune_checkpoints.py
@@ -24,6 +24,9 @@ from pathlib import Path
 # Checkpoint folders are named chk followed by the step number, e.g. chk0000010.
 CHK_PATTERN = re.compile(r"chk\d+")
 
+# First unit name appearing in the interval expression; used as the display unit.
+UNIT_PATTERN = re.compile(r"\b(Gyr|Myr|kyr|yr|s)\b")
+
 # Time unit conversion factors to CGS seconds; see src/util/time_units.hpp
 UNITS = {
     "s": 1.0,
@@ -109,7 +112,8 @@ def main():
             if chk_dir.resolve() == target:
                 reasons[chk_dir] = f"{reasons[chk_dir]}, last_chk" if chk_dir in reasons else "last_chk"
 
-    unit = "Myr"
+    match = UNIT_PATTERN.search(args.interval)
+    unit = match.group(1) if match is not None else "s"
     print(f"interval = {args.interval} = {interval / UNITS[unit]:g} {unit}")
     n_delete = 0
     for chk_dir, time in checkpoints:

--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -1,0 +1,13 @@
+# Third-party packages used by the scripts in this directory.
+# Install with:  pip install -r scripts/python/requirements.txt
+# Scripts not listed here (e.g. prune_checkpoints.py) need only the standard library.
+
+numpy         # create_particles, convert_cooling_table_hdf5, plot_*, quick_plot
+matplotlib    # hydro_wave_convergence_analysis, plot_*, quick_plot
+h5py          # convert_cooling_table_hdf5
+yt            # plot_fcquantities_bfield_lines, quick_plot
+unyt          # quick_plot
+scienceplots  # quick_plot (optional: falls back to the default matplotlib style)
+
+# check_inputs_toml, convert_inputs_to_toml; tomllib is in the standard library from 3.11
+tomli; python_version < "3.11"


### PR DESCRIPTION
### Description
Adds `scripts/python/prune_checkpoints.py`, a utility for thinning the checkpoints left behind by a long run.

```
prune_checkpoints.py . '3*Myr'           # dry run: print the keep/delete plan
prune_checkpoints.py . '3*Myr' --delete  # delete
prune_checkpoints.py . --manual          # pick what to keep interactively
```

In interval mode it keeps the checkpoint closest to each multiple of the given time, e.g. one roughly every 3 Myr. Any expression built from `yr`, `kyr`, `Myr`, `Gyr` works, and times are printed in the unit you used.

Manual mode opens a list of all checkpoints; arrow keys move, space toggles keep/delete, enter confirms. It then requires you to type a confirmation phrase before deleting anything.

The newest checkpoint and the `last_chk` target are always kept, so a pruned run stays restartable. Dry run is the default, deletions are printed as they happen, and only folders named `chk` followed by digits are ever touched.

Also adds `scripts/python/requirements.txt`, which was missing: the third-party packages the existing scripts in that directory import.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool for reviewing and pruning simulation checkpoints by time interval or through an interactive selector.
  * Protects the newest checkpoint and the checkpoint marked as current.
  * Supports dry-run previews and confirmed deletion of unneeded checkpoints.

* **Chores**
  * Added a consolidated list of Python packages required by the available scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->