### PR TITLE
Extend MHD tests: expose setup.num_periods instead of stop_time

### DIFF
--- a/inputs/AlfvenWaveCircular.toml
+++ b/inputs/AlfvenWaveCircular.toml
@@ -27,7 +27,6 @@ plotfile_interval = -1
 plotfile_prefix = "alfven_wave_circular_plt"
 checkpoint_interval = -1
 cfl = 0.3
-stop_time = 5.0
 max_timesteps = 8000
 
 hydro.rk_integrator_order = 2
@@ -37,6 +36,7 @@ hydro.use_dual_energy = 0
 setup.run_convergence = false
 setup.run_sim = true
 setup.error_tol = 0.003
+setup.num_periods = 5
 
 mhd.emf_compute_scheme = "Balsara2025"
 mhd.emf_averaging_scheme = "Balsara2025"

--- a/inputs/AlfvenWaveLinear.toml
+++ b/inputs/AlfvenWaveLinear.toml
@@ -27,7 +27,6 @@ plotfile_interval = 1000
 plotfile_prefix = "alfven_wave_linear_plt"
 checkpoint_interval = -1
 cfl = 0.3
-stop_time = 2.0
 max_timesteps = 10000
 
 hydro.rk_integrator_order = 2
@@ -37,6 +36,7 @@ hydro.use_dual_energy = 0
 setup.run_convergence = false
 setup.run_sim = true
 setup.error_tol = 0.005
+setup.num_periods = 2
 setup.num_modes_x = 1
 setup.num_modes_y = 0
 setup.num_modes_z = 0

--- a/inputs/EntropyWave.toml
+++ b/inputs/EntropyWave.toml
@@ -24,7 +24,6 @@ do_tracers = 1
 plotfile_interval = -1
 
 cfl = 0.3
-stop_time = 1.0
 max_timesteps = 10000
 
 hydro.rk_integrator_order = 2
@@ -36,6 +35,7 @@ mhd.emf_reconstruction_order = 3
 setup.run_convergence = false
 setup.run_sim = true
 setup.error_tol = 0.002
+setup.num_periods = 1
 setup.num_modes_x = 1
 setup.num_modes_y = 0
 setup.num_modes_z = 0

--- a/inputs/FastWave.toml
+++ b/inputs/FastWave.toml
@@ -29,7 +29,6 @@ do_subcycle = 0
 plotfile_interval = -1
 checkpoint_interval = -1
 cfl = 0.3
-stop_time = 0.7071068
 max_timesteps = 2000
 
 hydro.rk_integrator_order = 2
@@ -39,6 +38,7 @@ hydro.use_dual_energy = 0
 setup.run_convergence = false
 setup.run_sim = true
 setup.error_tol = 0.002
+setup.num_periods = 1
 setup.num_modes_x = 1
 setup.num_modes_y = 0
 setup.num_modes_z = 0

--- a/inputs/FieldLoop.toml
+++ b/inputs/FieldLoop.toml
@@ -27,7 +27,6 @@ do_subcycle = 0
 plotfile_interval = -1
 checkpoint_interval = -1
 cfl = 0.2
-stop_time = 3.0
 max_timesteps = 3e4
 
 hydro.rk_integrator_order = 2
@@ -41,6 +40,7 @@ mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
 # *****************************************************************
 # Field loop setup
 # *****************************************************************
+setup.num_periods = 1
 setup.loop_radius = 0.3
 setup.loop_center_x = 0.0
 setup.loop_center_y = 0.0

--- a/inputs/MHDBalsaraVortex.toml
+++ b/inputs/MHDBalsaraVortex.toml
@@ -36,4 +36,4 @@ hydro.use_dual_energy = 0
 setup.vortex_Mach = 0.1
 setup.vortex_b_magn = 0.1
 setup.advection = 1
-setup.num_orbits = 3
+setup.num_periods = 3

--- a/inputs/SlowWave.toml
+++ b/inputs/SlowWave.toml
@@ -29,8 +29,6 @@ do_subcycle = 0
 plotfile_interval = -1
 checkpoint_interval = -1
 cfl = 0.3
-# stop_time = 1 slow-wave period at angle=45 deg, c_s = vA = 1, |k| = 2 pi.
-stop_time = 1.8477590650225735
 max_timesteps = 20000
 
 hydro.rk_integrator_order = 2
@@ -44,6 +42,7 @@ mhd.emf_averaging_scheme = "LondrilloDelZanna2004"
 setup.run_convergence = false
 setup.run_sim = true
 setup.error_tol = 0.002
+setup.num_periods = 1
 setup.num_modes_x = 1
 setup.num_modes_y = 0
 setup.num_modes_z = 0

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -331,8 +331,8 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		if (num_periods <= 0.0) {
-			amrex::Abort("setup.num_periods must be > 0.");
+		if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be finite and > 0.");
 		}
 		{
 			double unused_stop_time = 0.0;

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -218,10 +218,17 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::Mu
 	}
 }
 
-auto runWaveTest(int nx, int ny, int nz) -> double
+// one wave period (num_modes and alfven_speed are fixed constants for this problem); shared by
+// runWaveTest() (always exactly one period) and problem_main()'s run_sim path (num_periods * this)
+auto computeWavePeriod() -> double
 {
 	const double wavelength = 1.0 / num_modes;
-	const double max_time = wavelength / alfven_speed;
+	return wavelength / alfven_speed;
+}
+
+auto runWaveTest(int nx, int ny, int nz) -> double
+{
+	const double max_time = computeWavePeriod();
 	const int max_timesteps = std::max(20000, nx * 100);
 
 	// Set grid dimensions using AMReX parameter system
@@ -283,6 +290,13 @@ auto problem_main() -> int
 		pp.query("run_convergence", run_convergence);
 		pp.query("run_sim", run_sim);
 		pp.query("error_tol", error_tol);
+
+		double unused_num_periods = 0.0;
+		if (run_convergence && !run_sim && (pp.query("num_periods", unused_num_periods) != 0)) {
+			amrex::Abort("setup.num_periods has no effect when setup.run_convergence=true and setup.run_sim=false; the "
+				     "convergence sweep always uses a fixed one-period run length. Remove setup.num_periods or set "
+				     "setup.run_sim=true.");
+		}
 	}
 
 	// AlfvenWaveCircularConvergence does not model resistivity; abort early rather than silently
@@ -317,8 +331,17 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		const double wavelength = 1.0 / num_modes;
-		sim.stopTime_ = num_periods * wavelength / alfven_speed;
+		if (num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be > 0.");
+		}
+		{
+			double unused_stop_time = 0.0;
+			if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+				amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+					     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+			}
+		}
+		sim.stopTime_ = num_periods * computeWavePeriod();
 
 		sim.setInitialConditions();
 		sim.evolve();

--- a/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/AlfvenWaveCircularConvergence/testAlfvenWaveCircularConvergence.cpp
@@ -311,6 +311,15 @@ auto problem_main() -> int
 		}
 
 		QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+
+		double num_periods = 1.0;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("num_periods", num_periods);
+		}
+		const double wavelength = 1.0 / num_modes;
+		sim.stopTime_ = num_periods * wavelength / alfven_speed;
+
 		sim.setInitialConditions();
 		sim.evolve();
 

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -567,6 +567,16 @@ auto problem_main() -> int
 		}
 
 		QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
+
+		double num_periods = 1.0;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("num_periods", num_periods);
+		}
+		const double wavelength = 2.0 * M_PI / k_magn;
+		const double cA = alfven_speed * std::abs(std::cos(angle_between_k_b0_rad));
+		sim.stopTime_ = num_periods * wavelength / cA;
+
 		sim.setInitialConditions();
 		sim.evolve();
 

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -399,6 +399,15 @@ void configureResistiveParameters()
 	}
 }
 
+// one wave period for the current k_magn/angle_between_k_b0_rad; shared by runWaveTest() (always exactly
+// one period) and problem_main()'s run_sim path (num_periods * this)
+auto computeWavePeriod() -> double
+{
+	const double wavelength = 2.0 * M_PI / k_magn;
+	const double cA = alfven_speed * std::abs(std::cos(angle_between_k_b0_rad));
+	return wavelength / cA;
+}
+
 auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
@@ -407,7 +416,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	hpp.query("angle_between_k_b0", angle_between_k_b0_deg);
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
-	const double cA = alfven_speed * std::abs(std::cos(angle_between_k_b0_rad));
 	const int max_timesteps = std::max(20000, nx * 100);
 
 	int num_modes_x = 0;
@@ -432,8 +440,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
-	const double wavelength = 2.0 * M_PI / k_magn;
-	const double max_time = wavelength / cA;
+	const double max_time = computeWavePeriod();
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};
 
 	k_rotation_in_xy_rad = std::atan2(k_dir_prf[1], k_dir_prf[0]);
@@ -513,6 +520,13 @@ auto problem_main() -> int
 		pp.query("run_convergence", run_convergence);
 		pp.query("run_sim", run_sim);
 		pp.query("error_tol", error_tol);
+
+		double unused_num_periods = 0.0;
+		if (run_convergence && !run_sim && (pp.query("num_periods", unused_num_periods) != 0)) {
+			amrex::Abort("setup.num_periods has no effect when setup.run_convergence=true and setup.run_sim=false; the "
+				     "convergence sweep always uses a fixed one-period run length. Remove setup.num_periods or set "
+				     "setup.run_sim=true.");
+		}
 	}
 
 	int status = 0;
@@ -573,9 +587,17 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		const double wavelength = 2.0 * M_PI / k_magn;
-		const double cA = alfven_speed * std::abs(std::cos(angle_between_k_b0_rad));
-		sim.stopTime_ = num_periods * wavelength / cA;
+		if (num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be > 0.");
+		}
+		{
+			double unused_stop_time = 0.0;
+			if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+				amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+					     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+			}
+		}
+		sim.stopTime_ = num_periods * computeWavePeriod();
 
 		sim.setInitialConditions();
 		sim.evolve();

--- a/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/AlfvenWaveLinearConvergence/testAlfvenWaveLinearConvergence.cpp
@@ -587,8 +587,8 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		if (num_periods <= 0.0) {
-			amrex::Abort("setup.num_periods must be > 0.");
+		if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be finite and > 0.");
 		}
 		{
 			double unused_stop_time = 0.0;

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -459,6 +459,15 @@ auto problem_main() -> int
 		}
 
 		QuokkaSimulation<EntropyWaveLinear> sim(BCs_cc, BCs_fc);
+
+		double num_periods = 1.0;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("num_periods", num_periods);
+		}
+		const double wavelength = 2.0 * M_PI / k_magn;
+		sim.stopTime_ = num_periods * wavelength / adv_speed;
+
 		sim.setInitialConditions();
 		sim.evolve();
 

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -296,6 +296,14 @@ void QuokkaSimulation<EntropyWaveLinear>::computeReferenceSolution_fc(amrex::Mul
 	}
 }
 
+// one wave period for the current k_magn; shared by runWaveTest() (always exactly one period) and
+// problem_main()'s run_sim path (num_periods * this)
+auto computeWavePeriod() -> double
+{
+	const double wavelength = 2.0 * M_PI / k_magn;
+	return wavelength / adv_speed;
+}
+
 auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
@@ -328,8 +336,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
-	const double wavelength = 2.0 * M_PI / k_magn;
-	const double max_time = wavelength / adv_speed;
+	const double max_time = computeWavePeriod();
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};
 
 	k_rotation_in_xy_rad = std::atan2(k_dir_prf[1], k_dir_prf[0]);
@@ -407,6 +414,13 @@ auto problem_main() -> int
 		pp.query("run_convergence", run_convergence);
 		pp.query("run_sim", run_sim);
 		pp.query("error_tol", error_tol);
+
+		double unused_num_periods = 0.0;
+		if (run_convergence && !run_sim && (pp.query("num_periods", unused_num_periods) != 0)) {
+			amrex::Abort("setup.num_periods has no effect when setup.run_convergence=true and setup.run_sim=false; the "
+				     "convergence sweep always uses a fixed one-period run length. Remove setup.num_periods or set "
+				     "setup.run_sim=true.");
+		}
 	}
 
 	int status = 0;
@@ -465,8 +479,17 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		const double wavelength = 2.0 * M_PI / k_magn;
-		sim.stopTime_ = num_periods * wavelength / adv_speed;
+		if (num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be > 0.");
+		}
+		{
+			double unused_stop_time = 0.0;
+			if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+				amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+					     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+			}
+		}
+		sim.stopTime_ = num_periods * computeWavePeriod();
 
 		sim.setInitialConditions();
 		sim.evolve();

--- a/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
+++ b/src/problems/EntropyWaveConvergence/testEntropyWaveConvergence.cpp
@@ -479,8 +479,8 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		if (num_periods <= 0.0) {
-			amrex::Abort("setup.num_periods must be > 0.");
+		if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be finite and > 0.");
 		}
 		{
 			double unused_stop_time = 0.0;

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -611,8 +611,8 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		if (num_periods <= 0.0) {
-			amrex::Abort("setup.num_periods must be > 0.");
+		if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be finite and > 0.");
 		}
 		{
 			double unused_stop_time = 0.0;

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -591,6 +591,19 @@ auto problem_main() -> int
 		}
 
 		QuokkaSimulation<FastWaveConvergence> sim(BCs_cc, BCs_fc);
+
+		double num_periods = 1.0;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("num_periods", num_periods);
+		}
+		const double wavelength = 2.0 * M_PI / k_magn;
+		const double a = sound_speed;
+		const double vA = alfven_speed;
+		const double cosθ = std::cos(angle_between_k_b0_rad);
+		const double cf = std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
+		sim.stopTime_ = num_periods * wavelength / cf;
+
 		sim.setInitialConditions();
 		sim.evolve();
 

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -411,6 +411,18 @@ void QuokkaSimulation<FastWaveConvergence>::computeReferenceSolution_fc(amrex::M
 	}
 }
 
+// one wave period for the current k_magn/angle_between_k_b0_rad; shared by runWaveTest() (always exactly
+// one period) and problem_main()'s run_sim path (num_periods * this)
+auto computeWavePeriod() -> double
+{
+	const double wavelength = 2.0 * M_PI / k_magn;
+	const double a = sound_speed;
+	const double vA = alfven_speed;
+	const double cos_theta = std::cos(angle_between_k_b0_rad);
+	const double cf = std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
+	return wavelength / cf;
+}
+
 auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
@@ -420,10 +432,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
 
-	const double a = sound_speed;
-	const double vA = alfven_speed;
-	const double cosθ = std::cos(angle_between_k_b0_rad);
-	const double cf = std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
 	const int max_timesteps = std::max(20000, nx * 100);
 
 	int num_modes_x = 0;
@@ -448,8 +456,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
-	const double wavelength = 2.0 * M_PI / k_magn;
-	const double max_time = wavelength / cf;
+	const double max_time = computeWavePeriod();
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};
 
 	k_rotation_in_xy_rad = std::atan2(k_dir_prf[1], k_dir_prf[0]);
@@ -527,6 +534,13 @@ auto problem_main() -> int
 		pp.query("run_convergence", run_convergence);
 		pp.query("run_sim", run_sim);
 		pp.query("error_tol", error_tol);
+
+		double unused_num_periods = 0.0;
+		if (run_convergence && !run_sim && (pp.query("num_periods", unused_num_periods) != 0)) {
+			amrex::Abort("setup.num_periods has no effect when setup.run_convergence=true and setup.run_sim=false; the "
+				     "convergence sweep always uses a fixed one-period run length. Remove setup.num_periods or set "
+				     "setup.run_sim=true.");
+		}
 	}
 
 	// FastWaveConvergence does not model resistivity; abort early rather than silently
@@ -597,13 +611,17 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		const double wavelength = 2.0 * M_PI / k_magn;
-		const double a = sound_speed;
-		const double vA = alfven_speed;
-		const double cos_theta = std::cos(angle_between_k_b0_rad);
-		const double cf =
-		    std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
-		sim.stopTime_ = num_periods * wavelength / cf;
+		if (num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be > 0.");
+		}
+		{
+			double unused_stop_time = 0.0;
+			if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+				amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+					     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+			}
+		}
+		sim.stopTime_ = num_periods * computeWavePeriod();
 
 		sim.setInitialConditions();
 		sim.evolve();

--- a/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
+++ b/src/problems/FastWaveConvergence/testFastWaveConvergence.cpp
@@ -600,8 +600,9 @@ auto problem_main() -> int
 		const double wavelength = 2.0 * M_PI / k_magn;
 		const double a = sound_speed;
 		const double vA = alfven_speed;
-		const double cosθ = std::cos(angle_between_k_b0_rad);
-		const double cf = std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
+		const double cos_theta = std::cos(angle_between_k_b0_rad);
+		const double cf =
+		    std::sqrt(0.5 * (a * a + vA * vA + std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
 		sim.stopTime_ = num_periods * wavelength / cf;
 
 		sim.setInitialConditions();

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -254,8 +254,8 @@ auto problem_main() -> int
 	// a normalised run-duration unit, not a guarantee that the loop retraces itself.
 	double num_periods = 1.0;
 	pp.query("num_periods", num_periods);
-	if (num_periods <= 0.0) {
-		amrex::Abort("setup.num_periods must be > 0.");
+	if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+		amrex::Abort("setup.num_periods must be finite and > 0.");
 	}
 	{
 		double unused_stop_time = 0.0;

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -249,9 +249,21 @@ auto problem_main() -> int
 	advection_vy = std::cos(advection_angle_rad);
 
 	// advection speed in the x1-x2 plane is 1 by construction (sin^2 + cos^2 = 1); one period is one
-	// full crossing of the domain diagonal
+	// domain-diagonal length of travel. This exactly returns the loop to its starting position only at
+	// the default advection_angle_deg (chosen so vx/vy = Lx/Ly); at any other angle, num_periods is just
+	// a normalised run-duration unit, not a guarantee that the loop retraces itself.
 	double num_periods = 1.0;
 	pp.query("num_periods", num_periods);
+	if (num_periods <= 0.0) {
+		amrex::Abort("setup.num_periods must be > 0.");
+	}
+	{
+		double unused_stop_time = 0.0;
+		if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+			amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+				     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+		}
+	}
 	const double domain_diagonal = std::hypot(sim.geom[0].ProbLength(0), sim.geom[0].ProbLength(1));
 	sim.stopTime_ = num_periods * domain_diagonal;
 

--- a/src/problems/FieldLoop/testFieldLoop.cpp
+++ b/src/problems/FieldLoop/testFieldLoop.cpp
@@ -248,6 +248,13 @@ auto problem_main() -> int
 	advection_vx = std::sin(advection_angle_rad);
 	advection_vy = std::cos(advection_angle_rad);
 
+	// advection speed in the x1-x2 plane is 1 by construction (sin^2 + cos^2 = 1); one period is one
+	// full crossing of the domain diagonal
+	double num_periods = 1.0;
+	pp.query("num_periods", num_periods);
+	const double domain_diagonal = std::hypot(sim.geom[0].ProbLength(0), sim.geom[0].ProbLength(1));
+	sim.stopTime_ = num_periods * domain_diagonal;
+
 	// default the region's z-bounds to the full domain, matching the prior (z-unbounded) behavior
 	if (pp.query("region_lo_z", region_lo_z) == 0) {
 		region_lo_z = sim.geom[0].ProbLo(2);

--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -228,8 +228,8 @@ auto problem_main() -> int
 	if (vortex_radius <= 0.0) {
 		amrex::Abort("vortex_radius must be > 0.");
 	}
-	if (num_periods <= 0.0) {
-		amrex::Abort("setup.num_periods must be > 0.");
+	if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+		amrex::Abort("setup.num_periods must be finite and > 0.");
 	}
 	{
 		double unused_stop_time = 0.0;

--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -218,7 +218,7 @@ auto problem_main() -> int
 	amrex::ParmParse const hpp("setup");
 
 	int advection_int = 0;
-	int num_periods = 1;
+	double num_periods = 1.0;
 	hpp.query("vortex_Mach", vortex_Mach);
 	hpp.query("vortex_b_magn", vortex_b_magn);
 	hpp.query("advection", advection_int);
@@ -227,6 +227,16 @@ auto problem_main() -> int
 	const bool is_advection_enabled = (advection_int != 0);
 	if (vortex_radius <= 0.0) {
 		amrex::Abort("vortex_radius must be > 0.");
+	}
+	if (num_periods <= 0.0) {
+		amrex::Abort("setup.num_periods must be > 0.");
+	}
+	{
+		double unused_stop_time = 0.0;
+		if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+			amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+				     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+		}
 	}
 
 	auto BCs_cc = quokka::BC<MHDBalsaraVortex>(quokka::BCType::int_dir);
@@ -253,11 +263,11 @@ auto problem_main() -> int
 		}
 		const double advection_distance = std::sqrt(length_x1 * length_x1 + length_x2 * length_x2);
 		const double advection_duration = advection_distance / vortex_u_magn;
-		stop_time = static_cast<double>(num_periods) * advection_duration;
+		stop_time = num_periods * advection_duration;
 	} else {
 		vortex_drift_x1 = vortex_drift_x2 = 0.0;
 		const double orbital_duration = 2.0 * std::numbers::pi / vortex_u_magn;
-		stop_time = static_cast<double>(num_periods) * orbital_duration;
+		stop_time = num_periods * orbital_duration;
 	}
 
 	sim.stopTime_ = stop_time;

--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -218,11 +218,11 @@ auto problem_main() -> int
 	amrex::ParmParse const hpp("setup");
 
 	int advection_int = 0;
-	int num_orbits = 1;
+	int num_periods = 1;
 	hpp.query("vortex_Mach", vortex_Mach);
 	hpp.query("vortex_b_magn", vortex_b_magn);
 	hpp.query("advection", advection_int);
-	hpp.query("num_orbits", num_orbits);
+	hpp.query("num_periods", num_periods);
 	const double vortex_u_magn = vortex_Mach * sound_speed;
 	const bool is_advection_enabled = (advection_int != 0);
 	if (vortex_radius <= 0.0) {
@@ -253,11 +253,11 @@ auto problem_main() -> int
 		}
 		const double advection_distance = std::sqrt(length_x1 * length_x1 + length_x2 * length_x2);
 		const double advection_duration = advection_distance / vortex_u_magn;
-		stop_time = static_cast<double>(num_orbits) * advection_duration;
+		stop_time = static_cast<double>(num_periods) * advection_duration;
 	} else {
 		vortex_drift_x1 = vortex_drift_x2 = 0.0;
 		const double orbital_duration = 2.0 * std::numbers::pi / vortex_u_magn;
-		stop_time = static_cast<double>(num_orbits) * orbital_duration;
+		stop_time = static_cast<double>(num_periods) * orbital_duration;
 	}
 
 	sim.stopTime_ = stop_time;

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -600,6 +600,19 @@ auto problem_main() -> int
 		}
 
 		QuokkaSimulation<SlowWaveConvergence> sim(BCs_cc, BCs_fc);
+
+		double num_periods = 1.0;
+		{
+			amrex::ParmParse const pp("setup");
+			pp.query("num_periods", num_periods);
+		}
+		const double wavelength = 2.0 * M_PI / k_magn;
+		const double a = sound_speed;
+		const double vA = alfven_speed;
+		const double cosθ = std::cos(angle_between_k_b0_rad);
+		const double cs = std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
+		sim.stopTime_ = num_periods * wavelength / cs;
+
 		sim.setInitialConditions();
 		sim.evolve();
 

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -420,6 +420,18 @@ void QuokkaSimulation<SlowWaveConvergence>::computeReferenceSolution_fc(amrex::M
 	}
 }
 
+// one wave period for the current k_magn/angle_between_k_b0_rad; shared by runWaveTest() (always exactly
+// one period) and problem_main()'s run_sim path (num_periods * this)
+auto computeWavePeriod() -> double
+{
+	const double wavelength = 2.0 * M_PI / k_magn;
+	const double a = sound_speed;
+	const double vA = alfven_speed;
+	const double cos_theta = std::cos(angle_between_k_b0_rad);
+	const double cs = std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
+	return wavelength / cs;
+}
+
 auto runWaveTest(int nx, int ny, int nz) -> double
 {
 	// Read problem parameters
@@ -429,10 +441,6 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	constexpr double deg2rad = M_PI / 180.0;
 	angle_between_k_b0_rad = deg2rad * angle_between_k_b0_deg;
 
-	const double a = sound_speed;
-	const double vA = alfven_speed;
-	const double cosθ = std::cos(angle_between_k_b0_rad);
-	const double cs = std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
 	const int max_timesteps = std::max(20000, nx * 100);
 
 	int num_modes_x = 0;
@@ -457,8 +465,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	const std::array<amrex::Real, 3> k_vec_prf = {2.0 * M_PI * static_cast<amrex::Real>(num_modes_x), 2.0 * M_PI * static_cast<amrex::Real>(num_modes_y),
 						      2.0 * M_PI * static_cast<amrex::Real>(num_modes_z)};
 	k_magn = computeMagnitude(k_vec_prf);
-	const double wavelength = 2.0 * M_PI / k_magn;
-	const double max_time = wavelength / cs;
+	const double max_time = computeWavePeriod();
 	k_dir_prf = {k_vec_prf[0] / k_magn, k_vec_prf[1] / k_magn, k_vec_prf[2] / k_magn};
 
 	k_rotation_in_xy_rad = std::atan2(k_dir_prf[1], k_dir_prf[0]);
@@ -536,6 +543,13 @@ auto problem_main() -> int
 		pp.query("run_convergence", run_convergence);
 		pp.query("run_sim", run_sim);
 		pp.query("error_tol", error_tol);
+
+		double unused_num_periods = 0.0;
+		if (run_convergence && !run_sim && (pp.query("num_periods", unused_num_periods) != 0)) {
+			amrex::Abort("setup.num_periods has no effect when setup.run_convergence=true and setup.run_sim=false; the "
+				     "convergence sweep always uses a fixed one-period run length. Remove setup.num_periods or set "
+				     "setup.run_sim=true.");
+		}
 	}
 
 	// SlowWaveConvergence does not model resistivity; abort early rather than silently
@@ -606,13 +620,17 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		const double wavelength = 2.0 * M_PI / k_magn;
-		const double a = sound_speed;
-		const double vA = alfven_speed;
-		const double cos_theta = std::cos(angle_between_k_b0_rad);
-		const double cs =
-		    std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
-		sim.stopTime_ = num_periods * wavelength / cs;
+		if (num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be > 0.");
+		}
+		{
+			double unused_stop_time = 0.0;
+			if (amrex::ParmParse const pp_root; pp_root.query("stop_time", unused_stop_time) != 0) {
+				amrex::Abort("stop_time is set explicitly, which will override setup.num_periods (see "
+					     "AMRSimulation::rereadRuntimeParameters()). Remove stop_time and use setup.num_periods instead.");
+			}
+		}
+		sim.stopTime_ = num_periods * computeWavePeriod();
 
 		sim.setInitialConditions();
 		sim.evolve();

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -609,8 +609,9 @@ auto problem_main() -> int
 		const double wavelength = 2.0 * M_PI / k_magn;
 		const double a = sound_speed;
 		const double vA = alfven_speed;
-		const double cosθ = std::cos(angle_between_k_b0_rad);
-		const double cs = std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cosθ * cosθ)));
+		const double cos_theta = std::cos(angle_between_k_b0_rad);
+		const double cs =
+		    std::sqrt(0.5 * (a * a + vA * vA - std::sqrt((a * a + vA * vA) * (a * a + vA * vA) - 4.0 * a * a * vA * vA * cos_theta * cos_theta)));
 		sim.stopTime_ = num_periods * wavelength / cs;
 
 		sim.setInitialConditions();

--- a/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
+++ b/src/problems/SlowWaveConvergence/testSlowWaveConvergence.cpp
@@ -620,8 +620,8 @@ auto problem_main() -> int
 			amrex::ParmParse const pp("setup");
 			pp.query("num_periods", num_periods);
 		}
-		if (num_periods <= 0.0) {
-			amrex::Abort("setup.num_periods must be > 0.");
+		if (!std::isfinite(num_periods) || num_periods <= 0.0) {
+			amrex::Abort("setup.num_periods must be finite and > 0.");
 		}
 		{
 			double unused_stop_time = 0.0;


### PR DESCRIPTION
### Description
This PR replaces the hardcoded `stop_time` in `AlfvenWaveLinear`, `AlfvenWaveCircular`, `FastWave`, `SlowWave`, `EntropyWave`, and `FieldLoop` with a `setup.num_periods` parameter, computed from each test's own wave period (or crossing time, for `FieldLoop`) at runtime. Each TOML previously hardcoded a raw `stop_time` that was really some number of periods worked out by hand (`SlowWave.toml` even carried a comment saying so). `MHDBalsaraVortex` already computed `stop_time` this way, just under a different name (`setup.num_orbits`); renamed to `setup.num_periods` here for consistency with the rest.

For the first five wave tests and `MHDBalsaraVortex`, the new default reproduces the prior `stop_time` exactly: no behaviour change, pure convenience exposure/naming. `FieldLoop` is the one exception: its old `stop_time = 3.0` corresponded to a non-round ~1.30 domain crossings, so rather than preserve that number, the default is normalised to `num_periods = 1` (i.e. the loop now runs for exactly one full crossing). This is a deliberate, small behaviour change for `FieldLoop` only.

### Related issues
N/A.

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above): n/a, see Related issues.
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; behaviour is preserved exactly for 6 of 7 problems (see Description for the one exception, `FieldLoop`).
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulation duration can now be configured by specifying the desired number of physical periods.
  * Wave and field-loop simulations calculate stop times automatically from their characteristic periods or domain size.
  * Balsara vortex runs support fractional period counts for more flexible durations.

* **Bug Fixes**
  * Invalid or nonpositive period values are rejected.
  * Conflicting fixed stop-time settings now produce clear configuration errors.
  * Convergence tests retain their intended fixed-duration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->