### PR TITLE
Enable resistivity support in the CurrentSheet test problem

### DIFF
--- a/src/problems/CurrentSheet/testCurrentSheet.cpp
+++ b/src/problems/CurrentSheet/testCurrentSheet.cpp
@@ -32,6 +32,7 @@ template <> struct quokka::EOS_Traits<CurrentSheet> {
 template <> struct Physics_Traits<CurrentSheet> : DefaultPhysicsTraits {
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
+	static constexpr ResistivityModel resistivity_model = ResistivityModel::constant; // eta defaults to 0; no-op unless set
 };
 
 // constants


### PR DESCRIPTION
### Description

`CurrentSheet`'s `Physics_Traits` never sets `resistivity_model`, so it defaults to `none`. Since #2050, setting `mhd.resistivity` on a problem in that state hard-aborts at startup with a message telling you to set `resistivity_model = ResistivityModel::constant` in its `Physics_Traits` specialization; this PR is doing so and making it standard.

This is needed to exercise a resistive `CurrentSheet` setup used to validate the Joule-heating implementation for an upcoming paper. Since the trait is a compile-time switch with no cost or behavioural effect unless `mhd.resistivity` is explicitly set, it's enabled generally here rather than gated to that one use case, matching how other MHD test problems (e.g. `AlfvenWaveLinear`) already expose it.

`mhd.resistivity` defaults to `0.0`, so this is a no-op for every existing `CurrentSheet` config.

### Related issues

N/A

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the Contributing Guide.
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; existing default behaviour is preserved bit-for-bit.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`.
