### PR TITLE
Fix HydroWaveConvergence: broadcast run_sim status across MPI ranks

### DIFF
--- a/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
+++ b/src/problems/HydroWaveConvergence/testHydroWaveConvergence.cpp
@@ -150,7 +150,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 		// ε = || Δ U || = [&sum_k (Δ Uk)2]^{1/2}
 		err_sq += dU_k * dU_k;
 	}
-	const amrex::Real epsilon = std::sqrt(err_sq);
+	amrex::Real epsilon = std::sqrt(err_sq);
+	// fextract only gathers the full comparison to the IO processor; broadcast so every rank agrees
+	amrex::ParallelDescriptor::Bcast(&epsilon, 1, amrex::ParallelDescriptor::IOProcessorNumber());
 
 	return epsilon;
 }
@@ -202,7 +204,9 @@ auto problem_main() -> int
 			}
 			err_sq += dU_k * dU_k;
 		}
-		const amrex::Real epsilon = std::sqrt(err_sq);
+		amrex::Real epsilon = std::sqrt(err_sq);
+		// fextract only gathers the full comparison to the IO processor; broadcast so every rank agrees
+		amrex::ParallelDescriptor::Bcast(&epsilon, 1, amrex::ParallelDescriptor::IOProcessorNumber());
 
 		amrex::Print() << std::format("\nrun_sim error norm = {:.6e}  (tol = {:.6e})\n", static_cast<double>(epsilon), error_tol);
 		if (epsilon > error_tol) {


### PR DESCRIPTION
### Description
I noticed `run_sim`'s pass/fail check computes its error norm independently on every rank and never broadcasts it, unlike `quokka::richardson::run()` (`src/util/richardson.cpp:73`), which already broadcasts its own error from the IO processor for exactly this reason: `fextract()` only gathers the full comparison profile onto rank 0, so non-root ranks can disagree with rank 0 about pass/fail, and `mpirun` reports the whole run as failed if any rank exits nonzero, even when rank 0's own result is within tolerance. I bring `run_sim`'s two error-norm computations (`runWaveTest()` and the duplicate inline block in `problem_main()`) in line with `richardson.cpp`'s existing broadcast pattern.

### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

_(none)_

### Checklist
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency of HydroWave convergence error-norm calculations across parallel MPI runs.
  - Results now remain synchronized across processing ranks, supporting more reliable convergence evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->