### PR TITLE
eps_ff_eff is now a ramp

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -452,8 +452,8 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			// Create increasing ramp for eps_ff_
 			const amrex::Real Jdx_over_LambdaJ = J * dx[0] / LambdaJ;
 			amrex::Real eps_ff_eff = eps_ff_;
-			if (Jdx_over_LambdaJ > 1.0) {
-				eps_ff_eff = std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ), 1.0);
+			if(Jdx_over_LambdaJ > 1.0) {
+				eps_ff_eff = std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ - 1.), 1.0);
 			}
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);
 			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -453,7 +453,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			const amrex::Real Jdx_over_LambdaJ = J * dx[0] / LambdaJ;
 			amrex::Real eps_ff_eff = eps_ff_;
 			if(Jdx_over_LambdaJ > 1.0) {
-				eps_ff_eff *= std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ), 1.0);
+				eps_ff_eff = std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ), 1.0);
 			}
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);
 			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -452,7 +452,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			// Create increasing ramp for eps_ff_
 			const amrex::Real Jdx_over_LambdaJ = J * dx[0] / LambdaJ;
 			amrex::Real eps_ff_eff = eps_ff_;
-			if(Jdx_over_LambdaJ > 1.0) {
+			if (Jdx_over_LambdaJ > 1.0) {
 				eps_ff_eff = std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ), 1.0);
 			}
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -449,7 +449,10 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			const amrex::Real cs = HydroSystem<problem_t>::ComputeIsothermalSoundSpeed(state_arr, i, j, k, fab_fc);
 			const amrex::Real LambdaJ = cs / std::sqrt(C::Gconst * cell_density);
 			const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * cell_density));
-			const amrex::Real nominal_prob_star_formation = (eps_ff_ / eps_star) * (dt / t_ff);
+			// Create increasing ramp for eps_ff_
+			const amrex::Real dx_over_LambdaJ = dx[0] / LambdaJ;
+			const amrex::Real eps_ff_eff = (dx_over_LambdaJ <= 1/J) ? eps_ff_ : eps_ff_ * std::exp(dx_over_LambdaJ - 1/J);
+			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);
 			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)
 			const amrex::Real actual_prob_star_formation = (LambdaJ < (J_truncate * dx[0])) ? 1.0 : nominal_prob_star_formation;
 			const amrex::Real random_draw = amrex::Random(engine);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -450,8 +450,11 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			const amrex::Real LambdaJ = cs / std::sqrt(C::Gconst * cell_density);
 			const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * cell_density));
 			// Create increasing ramp for eps_ff_
-			const amrex::Real dx_over_LambdaJ = dx[0] / LambdaJ;
-			const amrex::Real eps_ff_eff = (dx_over_LambdaJ <= 1 / J) ? eps_ff_ : eps_ff_ * std::exp(dx_over_LambdaJ - 1 / J);
+			const amrex::Real Jdx_over_LambdaJ = J * dx[0] / LambdaJ;
+			amrex::Real eps_ff_eff = eps_ff_;
+			if(Jdx_over_LambdaJ > 1.0) {
+				eps_ff_eff *= std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ), 1.0);
+			}
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);
 			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)
 			const amrex::Real actual_prob_star_formation = (LambdaJ < (J_truncate * dx[0])) ? 1.0 : nominal_prob_star_formation;

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -452,7 +452,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			// Create increasing ramp for eps_ff_
 			const amrex::Real Jdx_over_LambdaJ = J * dx[0] / LambdaJ;
 			amrex::Real eps_ff_eff = eps_ff_;
-			if(Jdx_over_LambdaJ > 1.0) {
+			if (Jdx_over_LambdaJ > 1.0) {
 				eps_ff_eff = std::min(eps_ff_ * std::exp(Jdx_over_LambdaJ - 1.), 1.0);
 			}
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -451,7 +451,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 			const amrex::Real t_ff = std::sqrt(3.0 * M_PI / (32.0 * C::Gconst * cell_density));
 			// Create increasing ramp for eps_ff_
 			const amrex::Real dx_over_LambdaJ = dx[0] / LambdaJ;
-			const amrex::Real eps_ff_eff = (dx_over_LambdaJ <= 1/J) ? eps_ff_ : eps_ff_ * std::exp(dx_over_LambdaJ - 1/J);
+			const amrex::Real eps_ff_eff = (dx_over_LambdaJ <= 1 / J) ? eps_ff_ : eps_ff_ * std::exp(dx_over_LambdaJ - 1 / J);
 			const amrex::Real nominal_prob_star_formation = (eps_ff_eff / eps_star) * (dt / t_ff);
 			// force P_sf to 1 if we are very far below the Jeans length (as determined by J_truncate)
 			const amrex::Real actual_prob_star_formation = (LambdaJ < (J_truncate * dx[0])) ? 1.0 : nominal_prob_star_formation;


### PR DESCRIPTION
### Description
This PR adds a ramp to `eps_ff` to alleviate creation of high density central region in the M82 simulations. Instead of a constant `eps_ff` for all densities as density increases and `lambda_J` decreases the efficiency of star formation goes as exp(dx/lambdaJ).  


### Related issues
Are there any GitHub issues that are fixed by this pull request? Add a link to them here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ x] I have added a description (see above).
- [ ] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved stochastic stellar particle formation by adapting formation probabilities to local cell size and Jeans length.
  * Cells larger than the Jeans length now receive an exponentially increased effective star-formation efficiency, capped at 100%.
  * This provides more responsive and physically consistent stellar particle creation across varying simulation resolutions while preserving existing behavior in other conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->