### PR TITLE
Preserve magnetic energy in gas total energy at particle creation

### DIFF
--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -314,11 +314,17 @@ AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int n
 
 	// update cell density to be the threshold density
 	const amrex::Real scale_factor = rho_J / cell_density;
+	// The magnetic energy density is unchanged when a particle forms, so the total energy is reduced only by the
+	// internal and kinetic energy carried away with the mass. Both are proportional to density at fixed
+	// temperature and velocity, so they shrink by (1 - scale_factor). This must be evaluated before the
+	// momentum and internal energy are rescaled below.
+	const amrex::Real removed_kinetic_energy = (1.0 - scale_factor) * 0.5 * cell_density * (vx * vx + vy * vy + vz * vz);
+	const amrex::Real removed_internal_energy = (1.0 - scale_factor) * state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index);
+	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) -= removed_kinetic_energy + removed_internal_energy;
 	state_arr(i, j, k, HydroSystem<problem_t>::density_index) = rho_J;
 	state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
-	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
 	// scale passive scalars to conserve mass fractions
 	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
@@ -713,6 +719,16 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// 	NOT the actual mass of the stochastically created particles, to update the hydro state.)
 					const double factor = (1. - particle_mass / cell_mass);
 
+					// Update the total energy. The magnetic energy density is unchanged when a particle
+					// forms, so the total energy is reduced only by the internal and kinetic energy carried
+					// away with the mass. Both are proportional to density at fixed temperature and velocity,
+					// so they shrink by (1 - factor). This must be evaluated before the density, momentum,
+					// and internal energy are rescaled below.
+					const amrex::Real removed_kinetic_energy = (1. - factor) * 0.5 * cell_density * (vx * vx + vy * vy + vz * vz);
+					const amrex::Real removed_internal_energy =
+					    (1. - factor) * state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index);
+					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) -= removed_kinetic_energy + removed_internal_energy;
+
 					// Update the cell density to reflect mass conversion into stars
 					state_arr(i, j, k, HydroSystem<problem_t>::density_index) *= factor;
 
@@ -723,9 +739,6 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 
 					// Update internal energy to reflect mass change
 					state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
-
-					// Update total energy
-					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
 
 					// Update mass scalars including passive scalars
 					if (nscalars > 0) {


### PR DESCRIPTION
### Description

When a particle forms, mass is removed from the host cell and the remaining gas state is rescaled. The gas total energy was rescaled by the same factor as the density:

```cpp
state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
```

Without magnetic fields this is correct, because $E_\mathrm{tot} = C_V \rho T + p^2 / (2\rho)$ is proportional to $\rho$ at fixed temperature and velocity. With MHD, however, $E_\mathrm{tot} = C_V \rho T + p^2/(2\rho) + B^2/2$, and the magnetic term is not proportional to $\rho$. Quokka holds the magnetic field density fixed when a particle forms, so scaling the whole total energy also destroyed a fraction $(1 - \mathrm{factor})$ of the cell magnetic energy.

The fix subtracts only the internal and kinetic energy that is actually carried away with the mass, leaving the magnetic energy untouched:

```cpp
const amrex::Real removed_kinetic_energy = (1.0 - scale_factor) * 0.5 * cell_density * (vx * vx + vy * vy + vz * vz);
const amrex::Real removed_internal_energy = (1.0 - scale_factor) * state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index);
state_arr(i, j, k, HydroSystem<problem_t>::energy_index) -= removed_kinetic_energy + removed_internal_energy;
```

This requires no face-centered field data, and is exactly equivalent to the old behaviour when $B = 0$. Both affected sites are fixed: `SinkCreationHelpers::initializeSinkLikeParticles` (sink and star particles) and `ParticleCreationTraits<ParticleType::StochasticStellarPop>::ParticleCreator`. In both cases the energy update is evaluated before the density, momentum, and internal energy are rescaled, since it reads the pre-scaling state.

Verified with `ParticleSinkFormation` (3D, MHD enabled with a uniform $B_0 = 10^{-7}$ G background), which creates one sink particle at the first step. Instrumenting the test to print the total gas energy after the formation step gives:

| | total gas energy after step 1 (erg) |
|---|---|
| `development` (buggy) | $3.507672325 \times 10^{45}$ |
| this PR | $3.507705743 \times 10^{45}$ |

The difference, $3.34 \times 10^{40}$ erg, is the magnetic energy that was previously destroyed. The total internal energy is identical in both cases, as expected, since the internal energy update is unchanged. `ParticleSinkFormation` and `ParticleSF` (the `StochasticStellarPop` path, non-MHD) both pass.

### Related issues

Closes #2156 . Thanks to @yaoguangpei for reporting this bug. 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved energy conservation during sink and stochastic stellar-particle creation.
  * Gas kinetic and internal energy are now adjusted explicitly while preserving magnetic energy.
  * Existing density, momentum, internal-energy, and scalar rescaling behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->