### PR TITLE
Fix gas internal energy when MHD is enabled: subtract magnetic energy at all reconstruction sites

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -954,6 +954,24 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 	// print density, velocity magnitude, temperature, adiabatic sound speed
 	amrex::Vector<amrex::Real> cell_values = amrex::get_cell_data(state_new_cc_[lev], index);
 
+	// when MHD is enabled, the cell-centered total energy also contains the magnetic energy, which must be
+	// subtracted to obtain the gas internal energy. The magnetic field is face-centered, so it is read from
+	// state_new_fc_, which shares the DistributionMapping of state_new_cc_ (so the same MPI rank owns both).
+	amrex::Real Emag = 0.;
+	if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			amrex::IntVect index_hi = index;
+			index_hi[idim] += 1;
+			const amrex::Vector<amrex::Real> b_lo = amrex::get_cell_data(state_new_fc_[lev][idim], index);
+			const amrex::Vector<amrex::Real> b_hi = amrex::get_cell_data(state_new_fc_[lev][idim], index_hi);
+			if (!b_lo.empty() && !b_hi.empty()) {
+				const amrex::Real b_cc =
+				    0.5 * (b_lo[Physics_Indices<problem_t>::mhdFirstIndex] + b_hi[Physics_Indices<problem_t>::mhdFirstIndex]);
+				Emag += 0.5 * b_cc * b_cc;
+			}
+		}
+	}
+
 	// cell_values is *only* filled on the MPI rank that holds the box with this cell
 	// (NOTE: for Cray MPICH, standard output is NOT ordered with respect to different ranks.)
 	if (!cell_values.empty()) {
@@ -967,8 +985,7 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::printCellPropert
 		const amrex::Real vx3 = px3 / rho;
 		const amrex::Real vsq = (vx1 * vx1) + (vx2 * vx2) + (vx3 * vx3);
 		const amrex::Real vel_mag = std::sqrt(vsq);
-		const amrex::Real Ekin = 0.5 * rho * vsq;
-		const amrex::Real Eint = Etot - Ekin;
+		const amrex::Real Eint = ::quokka::EOS<problem_t>::ComputeEintFromEgas(rho, px1, px2, px3, Etot, Emag);
 		const amrex::Real P = ::quokka::EOS<problem_t>::ComputePressure(rho, Eint);
 		const amrex::Real cs = ::quokka::EOS<problem_t>::ComputeSoundSpeed(rho, P);
 

--- a/src/particles/particle_accretion.hpp
+++ b/src/particles/particle_accretion.hpp
@@ -506,11 +506,22 @@ void UpdateParticleMassAndMomentum(ContainerType *container, amrex::MultiFab &st
 	}
 }
 
-template <typename problem_t> void UpdateHydroState(amrex::MultiFab &state, amrex::MultiFab &accretion_rate)
+template <typename problem_t>
+void UpdateHydroState(amrex::MultiFab &state, amrex::MultiFab &accretion_rate, std::array<amrex::MultiFab, AMREX_SPACEDIM> const *state_fc)
 {
 	const BL_PROFILE("SinkAccretionUtils::UpdateHydroState()");
 	const auto &local_accretion_rate_arr = accretion_rate.arrays();
 	const auto &state_arr = state.arrays();
+
+	// the magnetic field is unchanged by accretion, so the magnetic energy must be excluded when the gas
+	// energies are scaled down below (it is identically zero unless MHD is enabled)
+	std::array<amrex::MultiArray4<const amrex::Real>, AMREX_SPACEDIM> state_fc_arrs{};
+	const bool has_state_fc = (state_fc != nullptr);
+	if (has_state_fc) {
+		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+			state_fc_arrs[dir] = (*state_fc)[dir].const_arrays();
+		}
+	}
 
 	amrex::ParallelFor(state, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
 		const double accretion_rate_cell = local_accretion_rate_arr[bx](i, j, k);
@@ -518,12 +529,24 @@ template <typename problem_t> void UpdateHydroState(amrex::MultiFab &state, amre
 		AMREX_ASSERT(accretion_rate_cell > -1.0);
 		const double accretion_down_factor = 1.0 + accretion_rate_cell;
 		AMREX_ASSERT(accretion_down_factor > 0.0);
+
+		std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> fab_fc{};
+		if (has_state_fc) {
+			for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+				fab_fc[dir] = state_fc_arrs[dir][bx];
+			}
+		}
+		const auto *const fab_fc_ptr = has_state_fc ? &fab_fc : nullptr;
+		const double Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc_ptr);
+
 		state_arr[bx](i, j, k, HydroSystem<problem_t>::density_index) *= accretion_down_factor;
 		state_arr[bx](i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= accretion_down_factor;
 		state_arr[bx](i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= accretion_down_factor;
 		state_arr[bx](i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= accretion_down_factor;
 		state_arr[bx](i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= accretion_down_factor;
-		state_arr[bx](i, j, k, HydroSystem<problem_t>::energy_index) *= accretion_down_factor;
+		// scale only the gas part of the total energy, leaving the magnetic energy untouched
+		state_arr[bx](i, j, k, HydroSystem<problem_t>::energy_index) =
+		    (state_arr[bx](i, j, k, HydroSystem<problem_t>::energy_index) - Emag) * accretion_down_factor + Emag;
 
 		// update passive scalars
 		for (int n = 0; n < Physics_Traits<problem_t>::numPassiveScalars; ++n) {
@@ -580,7 +603,7 @@ void applyAccretion(ContainerType *container, amrex::MultiFab &state, amrex::Mul
 	UpdateParticleMassAndMomentum<ContainerType, problem_t>(container, state, scale_down, state_fc, lev, mass_index, time, dt, mdot_index, ang_mom_index);
 
 	// Step 4: Update the hydro state. We do this at last because the original state is needed for updating particles in step 3.
-	UpdateHydroState<problem_t>(state, state_accretion_rate);
+	UpdateHydroState<problem_t>(state, state_accretion_rate, state_fc);
 }
 
 } // namespace SinkAccretionUtils

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -314,11 +314,14 @@ AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int n
 
 	// update cell density to be the threshold density
 	const amrex::Real scale_factor = rho_J / cell_density;
+	// the magnetic field is unchanged by particle creation, so only the gas part of the total energy is scaled
+	// (Emag is identically zero unless MHD is enabled)
+	const amrex::Real Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
 	state_arr(i, j, k, HydroSystem<problem_t>::density_index) = rho_J;
 	state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
-	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
+	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) = (state_arr(i, j, k, HydroSystem<problem_t>::energy_index) - Emag) * scale_factor + Emag;
 	state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
 	// scale passive scalars to conserve mass fractions
 	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
@@ -506,7 +509,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		AMREX_GPU_DEVICE void
 		operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, StateArray const & /*accretion_rate_arr*/, int i, int j,
 			   int k, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const * /*fab_fc*/, amrex::Long base_offset,
+			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, amrex::Long base_offset,
 			   amrex::RandomEngine const &engine) const
 		{
 			if (mass_idx + 3 < ParticleType::NReal) {
@@ -713,6 +716,10 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// 	NOT the actual mass of the stochastically created particles, to update the hydro state.)
 					const double factor = (1. - particle_mass / cell_mass);
 
+					// The magnetic field is unchanged by star formation, so only the gas part of the total
+					// energy is scaled below (Emag is identically zero unless MHD is enabled)
+					const double Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
+
 					// Update the cell density to reflect mass conversion into stars
 					state_arr(i, j, k, HydroSystem<problem_t>::density_index) *= factor;
 
@@ -724,8 +731,9 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// Update internal energy to reflect mass change
 					state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
 
-					// Update total energy
-					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
+					// Update total energy (magnetic energy is left untouched)
+					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) =
+					    (state_arr(i, j, k, HydroSystem<problem_t>::energy_index) - Emag) * factor + Emag;
 
 					// Update mass scalars including passive scalars
 					if (nscalars > 0) {

--- a/src/particles/particle_creation.hpp
+++ b/src/particles/particle_creation.hpp
@@ -314,14 +314,11 @@ AMREX_GPU_DEVICE inline void initializeSinkLikeParticles(PType *particles, int n
 
 	// update cell density to be the threshold density
 	const amrex::Real scale_factor = rho_J / cell_density;
-	// the magnetic field is unchanged by particle creation, so only the gas part of the total energy is scaled
-	// (Emag is identically zero unless MHD is enabled)
-	const amrex::Real Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
 	state_arr(i, j, k, HydroSystem<problem_t>::density_index) = rho_J;
 	state_arr(i, j, k, HydroSystem<problem_t>::x1Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x2Momentum_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::x3Momentum_index) *= scale_factor;
-	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) = (state_arr(i, j, k, HydroSystem<problem_t>::energy_index) - Emag) * scale_factor + Emag;
+	state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= scale_factor;
 	state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= scale_factor;
 	// scale passive scalars to conserve mass fractions
 	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
@@ -509,7 +506,7 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 		AMREX_GPU_DEVICE void
 		operator()(ParticleType *particles, int num_particles, StateArray const &state_arr, StateArray const & /*accretion_rate_arr*/, int i, int j,
 			   int k, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &plo,
-			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const *fab_fc, amrex::Long base_offset,
+			   std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> const * /*fab_fc*/, amrex::Long base_offset,
 			   amrex::RandomEngine const &engine) const
 		{
 			if (mass_idx + 3 < ParticleType::NReal) {
@@ -716,10 +713,6 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// 	NOT the actual mass of the stochastically created particles, to update the hydro state.)
 					const double factor = (1. - particle_mass / cell_mass);
 
-					// The magnetic field is unchanged by star formation, so only the gas part of the total
-					// energy is scaled below (Emag is identically zero unless MHD is enabled)
-					const double Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
-
 					// Update the cell density to reflect mass conversion into stars
 					state_arr(i, j, k, HydroSystem<problem_t>::density_index) *= factor;
 
@@ -731,9 +724,8 @@ template <> struct ParticleCreationTraits<ParticleType::StochasticStellarPop> {
 					// Update internal energy to reflect mass change
 					state_arr(i, j, k, HydroSystem<problem_t>::internalEnergy_index) *= factor;
 
-					// Update total energy (magnetic energy is left untouched)
-					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) =
-					    (state_arr(i, j, k, HydroSystem<problem_t>::energy_index) - Emag) * factor + Emag;
+					// Update total energy
+					state_arr(i, j, k, HydroSystem<problem_t>::energy_index) *= factor;
 
 					// Update mass scalars including passive scalars
 					if (nscalars > 0) {

--- a/src/particles/particle_deposition.hpp
+++ b/src/particles/particle_deposition.hpp
@@ -703,6 +703,10 @@ addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex::
 	const double d_pz = local_buffer(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
 	const double d_e = local_buffer(i, j, k, HydroSystem<problem_t>::energy_index);
 
+	// SN feedback does not change the magnetic field, so the magnetic energy is the same before and after.
+	// It is zero unless MHD is enabled, and must be excluded from the gas internal energy budget below.
+	const double Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
+
 	const double rho_new = rho + d_rho;
 	double px_new = px + d_px;
 	double py_new = py + d_py;
@@ -711,7 +715,8 @@ addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex::
 
 	const double d_e_int_d_rho = e_int / rho;
 	const double e_int_new_tmp = d_e_int_d_rho * rho_new;
-	const double e_int_plus_kinetic = e_int_new_tmp + (0.5 * ((px_new * px_new) + (py_new * py_new) + (pz_new * pz_new)) / rho_new);
+	// total energy (internal + kinetic + magnetic) implied by holding the specific internal energy fixed
+	const double e_int_plus_kinetic = ::quokka::EOS<problem_t>::ComputeEgasFromEint(rho_new, px_new, py_new, pz_new, e_int_new_tmp, Emag);
 
 	const Real uncertainty_tol = static_cast<Real>(5.) * std::numeric_limits<Real>::epsilon();
 
@@ -719,7 +724,7 @@ addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex::
 		e_tot_new = std::max(e_int_plus_kinetic, e_tot_new);
 	} else {
 		// find the lambda such that e_int_plus_kinetic == e_tot_new
-		const double e_kinetic_max = e_tot_new - e_int_new_tmp;
+		const double e_kinetic_max = e_tot_new - e_int_new_tmp - Emag;
 		AMREX_ASSERT(e_kinetic_max >= 0.0);
 
 		// If e_kinetic_max < (0.5 * (px * px + py * py + pz * pz) / rho_new), it means the SN energy (10^51 erg) is not enough to accelerate
@@ -731,7 +736,7 @@ addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex::
 			px_new = rho_new * (px / rho);
 			py_new = rho_new * (py / rho);
 			pz_new = rho_new * (pz / rho);
-			e_tot_new = e_int_new_tmp + (0.5 * ((px_new * px_new) + (py_new * py_new) + (pz_new * pz_new)) / rho_new);
+			e_tot_new = ::quokka::EOS<problem_t>::ComputeEgasFromEint(rho_new, px_new, py_new, pz_new, e_int_new_tmp, Emag);
 		} else {
 
 			// Find analytical solution of the following equation:
@@ -773,7 +778,7 @@ addCompositeBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex::
 		}
 	}
 
-	const double e_int_new = e_tot_new - (0.5 * ((px_new * px_new) + (py_new * py_new) + (pz_new * pz_new)) / rho_new);
+	const double e_int_new = ::quokka::EOS<problem_t>::ComputeEintFromEgas(rho_new, px_new, py_new, pz_new, e_tot_new, Emag);
 	AMREX_ASSERT(e_int_new > 0.0);
 	local_state(i, j, k, HydroSystem<problem_t>::density_index) = rho_new;
 	local_state(i, j, k, HydroSystem<problem_t>::x1Momentum_index) = px_new;
@@ -837,7 +842,9 @@ addThermalOnlyBufferToState(amrex::Array4<amrex::Real> const &local_state, amrex
 	const double py_new = local_state(i, j, k, HydroSystem<problem_t>::x2Momentum_index) + local_buffer(i, j, k, HydroSystem<problem_t>::x2Momentum_index);
 	const double pz_new = local_state(i, j, k, HydroSystem<problem_t>::x3Momentum_index) + local_buffer(i, j, k, HydroSystem<problem_t>::x3Momentum_index);
 	const double e_new = local_state(i, j, k, HydroSystem<problem_t>::energy_index) + local_buffer(i, j, k, HydroSystem<problem_t>::energy_index);
-	const double e_int_new = e_new - (0.5 * ((px_new * px_new) + (py_new * py_new) + (pz_new * pz_new)) / rho_new);
+	// SN feedback does not change the magnetic field; the magnetic energy is zero unless MHD is enabled
+	const double Emag = HydroSystem<problem_t>::ComputeMagneticEnergy(i, j, k, fab_fc);
+	const double e_int_new = ::quokka::EOS<problem_t>::ComputeEintFromEgas(rho_new, px_new, py_new, pz_new, e_new, Emag);
 
 	local_state(i, j, k, HydroSystem<problem_t>::density_index) = rho_new;
 	local_state(i, j, k, HydroSystem<problem_t>::x1Momentum_index) = px_new;


### PR DESCRIPTION
### Description

Under MHD, `energy_index` holds $E_\mathrm{int} + E_\mathrm{kin} + E_\mathrm{mag}$ while `internalEnergy_index` holds $E_\mathrm{int}$ alone. This PR sweeps every call of `EOS::ComputeSoundSpeed` / `ComputePressure` / `ComputeTgasFromEint` / `ComputeEintFromEgas` / `ComputeEgasFromEint`, every hand-written `Etot - Ekin`, and every mutation of `energy_index` in `src/`, and fixes the places that forgot $E_\mathrm{mag}$.

> **Note on #2157.** That PR fixes the same class of bug in `src/particles/particle_creation.hpp` and is in the merge queue but not yet in `development`. My sweep found those two sites independently; I have removed them from this PR so there is no duplicate fix and no conflict. This PR does not touch `particle_creation.hpp` at all.

Everything in `src/hydro/`, `src/radiation/`, `src/cooling/`, `src/conduction/`, `src/dust/`, `src/io/` was already correct and is unchanged. `src/chemistry/Chemistry.hpp` passes `0.0` but is guarded by a `static_assert(!is_mhd_enabled)` directly above it, so it is fine as-is. The remaining bugs were in `QuokkaSimulation.hpp` and two files in `src/particles/`.

**What was broken and is now fixed:**

- `QuokkaSimulation::printCellProperties` used `Eint = Etot - Ekin`, so the pressure and sound speed printed in the CFL diagnostic were too large under MHD. It now reads the face-centered field from `state_new_fc_` and goes through `quokka::EOS::ComputeEintFromEgas`. Diagnostic output only; no effect on the solution.
- `particle_deposition.hpp` `addCompositeBufferToState`: three separate errors. The positivity limiter compared $E_\mathrm{int}+E_\mathrm{kin}$ against a total energy that includes $E_\mathrm{mag}$; `e_kinetic_max` was inflated by $E_\mathrm{mag}$, so SN momentum deposition was under-limited; and the value written to `internalEnergy_index` was $E_\mathrm{int}+E_\mathrm{mag}$. All three now go through `ComputeEgasFromEint` / `ComputeEintFromEgas` with the cell's magnetic energy.
- `particle_deposition.hpp` `addThermalOnlyBufferToState`: the same error in the final internal energy.
- `particle_accretion.hpp` `UpdateHydroState` scaled the entire `energy_index` by the accretion down-factor $f$, scaling $E_\mathrm{mag}$ along with the gas — the same bug #2157 fixes at particle creation, but on the accretion path, which #2157 does not touch. Accreting gas does not change $B$ (and cannot, without violating $\nabla \cdot B = 0$), so the old code left the reconstructed $E_\mathrm{int}$ short by $(1-f)\,E_\mathrm{mag}$: spurious cooling proportional to the accreted mass fraction. `UpdateHydroState` gains a `state_fc` parameter, supplied by its single caller `applyAccretion`.

I used $E_\mathrm{tot}' = f\,(E_\mathrm{tot} - E_\mathrm{mag}) + E_\mathrm{mag}$ here rather than #2157's "subtract the removed internal + kinetic energy" form. Both are correct, but the form used there reads `internalEnergy_index` and so changes the result whenever the auxiliary and conserved internal energies have drifted apart — including for pure-hydro problems. Subtracting $E_\mathrm{mag}$ keeps non-MHD results bit-for-bit identical, which matters more on the accretion path since it runs every step on every cell.

**Found but deliberately not fixed:** `QuokkaSimulation::PreInterpState` / `PostInterpState` convert $E_\mathrm{tot}$ to $(E_\mathrm{tot} - E_\mathrm{kin})/\rho$ before AMR interpolation, which under MHD is $(E_\mathrm{int} + E_\mathrm{mag})/\rho$. The round trip is exact within a cell, but coarse-fine ghost cells get a coarse-interpolated $E_\mathrm{mag}$ that does not match the separately (divergence-preserving) interpolated face-centered $B$. Fixing this requires $B$ on the *coarse temporary* MultiFab built inside `FillPatchWithData`, whose BoxArray and DistributionMapping differ from `state_new_fc_`; that means changing the interp-hook interface in `simulation.hpp`, which is well beyond this PR. Worth a follow-up issue.

**Verified by** building and running with the `3d` preset: `SN` (MHD on, $B_0 = 10^{-7}$ G, `SN_scheme = "SN_thermal_or_thermal_momentum"` — directly exercises the fixed deposition path on a magnetised background), plus `ParticleSinkFormation`, `ParticleAccretion`, `ParticleCreation`, `ParticleSF` and `ParticleDeposition` as regression coverage. All pass. Non-MHD problems are bit-for-bit unaffected because `ComputeMagneticEnergy` returns exactly `0.0` when MHD is disabled. Because `UpdateHydroState` now captures face-centered data inside a device lambda, I also ran a `3d-cuda` compile check on `SN` and `ParticleSinkFormation` (compile and link only; this machine has `nvcc` but no GPU device).

### Related issues
N/A — overlaps with #2157, which covers the `particle_creation.hpp` sites; those are excluded here.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.
