### PR TITLE
Add a radiation flux source term to the user source-term hook

### DIFF
--- a/docs/markdown/flowchart.md
+++ b/docs/markdown/flowchart.md
@@ -70,12 +70,12 @@ partition "AMRSimulation::evolve() — main time loop" {
           end note
           :**IMEX Stage 2** — explicit ForwardEuler + implicit coupling;
           :advanceRadiationForwardEuler(dt · Aex₂₁) → state_tmp1_rad;
-          :SetRadEnergySource() + particle radiation deposition //(3D)//;
+          :SetRadSource() + particle radiation deposition //(3D)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₂₂)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
           :**IMEX Stage 3** — explicit MidpointRK2 + implicit coupling;
           :advanceRadiationMidpointRK2(dt) //(uses state_tmp1 as U^(2))//;
           :Shu-Osher gas combination:\nstate_new_gas ← ½·state_new + ½·state_tmp1;
-          :SetRadEnergySource() + particle radiation deposition //(3D)//;
+          :SetRadSource() + particle radiation deposition //(3D)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₃₃)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
         repeat while (i < nsubSteps?) is (yes)
         -> no;

--- a/docs/markdown/flowchart.md
+++ b/docs/markdown/flowchart.md
@@ -70,12 +70,12 @@ partition "AMRSimulation::evolve() — main time loop" {
           end note
           :**IMEX Stage 2** — explicit ForwardEuler + implicit coupling;
           :advanceRadiationForwardEuler(dt · Aex₂₁) → state_tmp1_rad;
-          :AddRadSource() + particle radiation deposition //(3D)//;
+          :AddRadSource() + particle radiation deposition //(3D)//\n//(both evaluated at t + dt)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₂₂)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
           :**IMEX Stage 3** — explicit MidpointRK2 + implicit coupling;
           :advanceRadiationMidpointRK2(dt) //(uses state_tmp1 as U^(2))//;
           :Shu-Osher gas combination:\nstate_new_gas ← ½·state_new + ½·state_tmp1;
-          :AddRadSource() + particle radiation deposition //(3D)//;
+          :AddRadSource() + particle radiation deposition //(3D)//\n//(both evaluated at t + dt)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₃₃)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
         repeat while (i < nsubSteps?) is (yes)
         -> no;

--- a/docs/markdown/flowchart.md
+++ b/docs/markdown/flowchart.md
@@ -70,12 +70,12 @@ partition "AMRSimulation::evolve() — main time loop" {
           end note
           :**IMEX Stage 2** — explicit ForwardEuler + implicit coupling;
           :advanceRadiationForwardEuler(dt · Aex₂₁) → state_tmp1_rad;
-          :SetRadSource() + particle radiation deposition //(3D)//;
+          :AddRadSource() + particle radiation deposition //(3D)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₂₂)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
           :**IMEX Stage 3** — explicit MidpointRK2 + implicit coupling;
           :advanceRadiationMidpointRK2(dt) //(uses state_tmp1 as U^(2))//;
           :Shu-Osher gas combination:\nstate_new_gas ← ½·state_new + ½·state_tmp1;
-          :SetRadSource() + particle radiation deposition //(3D)//;
+          :AddRadSource() + particle radiation deposition //(3D)//;
           :AddSourceTermsSingleGroup/MultiGroup(dt · Aim₃₃)\n//(implicit Newton–Raphson: matter–radiation coupling)//;
         repeat while (i < nsubSteps?) is (yes)
         -> no;

--- a/inputs/RadStreamingFluxSource.toml
+++ b/inputs/RadStreamingFluxSource.toml
@@ -1,0 +1,27 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+geometry.is_periodic = [0, 1, 1]
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v = 0  # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell = [1000, 8, 8]
+amr.max_level = 0  # number of levels = max_level + 1
+
+do_reflux = 0
+do_subcycle = 0
+suppress_output = 0
+
+# *****************************************************************
+# Problem-specific parameters
+# *****************************************************************
+# Inject the beam with the radFluxSource hook instead of the left boundary
+problem.flux_source = 1

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3169,13 +3169,13 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		// radEnergySource should have the unit of luminosity density, erg s^-1 cm^-3
 		int const nghost = 3; // WendlandC2<N=2>: stencil spans N=2 cells + 1 for possible particle drift
 		amrex::MultiFab radEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
-		// Companion buffer holding the reduced flux f = F / (c E) of the injected radiation, in components
-		// 3 * g + n (group g, direction n); dimensionless, with |f| <= 1. Particles deposit isotropically,
-		// i.e. f = 0.
-		amrex::MultiFab reducedFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
-		// Scratch buffers written by the user hook AddRadSource, then merged into the two buffers above.
-		// Giving the hook its own buffers means a problem simply assigns its own source: it cannot overwrite
+		// Companion buffer holding the radiation flux source, in components 3 * g + n (group g, direction n);
+		// unit: erg cm^-2 s^-2. Particles deposit isotropically, so they contribute nothing to it.
+		amrex::MultiFab radFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
+		// Scratch buffers written by the user hook AddRadSource, then added to the two buffers above. Giving
+		// the hook its own buffers means a problem simply assigns its own source: it cannot overwrite
 		// radiation that particles have already deposited, and need not remember to accumulate onto it.
+		// The hook supplies a reduced flux, which MergeUserRadSource converts to a flux source.
 		amrex::MultiFab userEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
 		amrex::MultiFab userReducedFlux(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
 
@@ -3194,7 +3194,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Implicit source terms for stage 2
 			radEnergySource.setVal(0.0);
-			reducedFluxSource.setVal(0.0);
+			radFluxSource.setVal(0.0);
 			userEnergySource.setVal(0.0);
 			userReducedFlux.setVal(0.0);
 
@@ -3211,12 +3211,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				auto const &prob_hi = geom[lev].ProbHiArray();
 
 				auto const &radEnergySource_arr = radEnergySource.array(iter);
-				auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
+				auto const &radFluxSource_arr = radFluxSource.array(iter);
 				auto const &userEnergySource_arr = userEnergySource.array(iter);
 				auto const &userReducedFlux_arr = userReducedFlux.array(iter);
 				RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 								   time_subcycle + dt_radiation);
-				RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
+				RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, radFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
 									 indexRange);
 
 				// Build face-centered array for MHD-aware radiation coupling
@@ -3231,12 +3231,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 				// Full gas update (gas_update_factor = 1.0)
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange,
 											dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 											tempFloor, p_iteration_counter, p_iteration_failure_counter,
 											cons_fc_arr);
 				} else {
-					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange,
 										       dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 										       tempFloor, p_iteration_counter, p_iteration_failure_counter,
 										       cons_fc_arr);
@@ -3304,7 +3304,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		// Implicit source terms for stage 3
 		radEnergySource.setVal(0.0);
-		reducedFluxSource.setVal(0.0);
+		radFluxSource.setVal(0.0);
 		userEnergySource.setVal(0.0);
 		userReducedFlux.setVal(0.0);
 
@@ -3321,12 +3321,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			auto const &prob_hi = geom[lev].ProbHiArray();
 
 			auto const &radEnergySource_arr = radEnergySource.array(iter);
-			auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
+			auto const &radFluxSource_arr = radFluxSource.array(iter);
 			auto const &userEnergySource_arr = userEnergySource.array(iter);
 			auto const &userReducedFlux_arr = userReducedFlux.array(iter);
 			RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 							   time_subcycle + dt_radiation);
-			RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
+			RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, radFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
 								 indexRange);
 
 			// Build face-centered array for MHD-aware radiation coupling
@@ -3341,11 +3341,11 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Full gas update (gas_update_factor = 1.0)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
 										dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 										tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			} else {
-				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
 									       dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 									       tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3198,8 +3198,11 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			userEnergySource.setVal(0.0);
 			userReducedFlux.setVal(0.0);
 
+			// Both implicit stages of the IMEX PD-ARS tableau have abscissa c = 1 (rows 2 and 3 of Aim each
+			// sum to 1), so every implicit source term is evaluated at the end of the step. Particle
+			// deposition and AddRadSource must therefore use the same time.
 #if AMREX_SPACEDIM == 3
-			particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
+			particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle + dt_radiation);
 #endif
 
 			const amrex::Real dt_stage2_implicit = IMEX_Aim_22 * dt_radiation;
@@ -3306,8 +3309,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		userEnergySource.setVal(0.0);
 		userReducedFlux.setVal(0.0);
 
+		// evaluated at the end of the step, as in stage 2 above
 #if AMREX_SPACEDIM == 3
-		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
+		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle + dt_radiation);
 #endif
 
 		const amrex::Real dt_stage3_implicit = IMEX_Aim_33 * dt_radiation;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3231,15 +3231,13 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 				// Full gas update (gas_update_factor = 1.0)
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange,
-											dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
-											tempFloor, p_iteration_counter, p_iteration_failure_counter,
-											cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsSingleGroup(
+					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				} else {
-					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange,
-										       dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
-										       tempFloor, p_iteration_counter, p_iteration_failure_counter,
-										       cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsMultiGroup(
+					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				}
 			}
 		}
@@ -3326,8 +3324,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			auto const &userReducedFlux_arr = userReducedFlux.array(iter);
 			RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 							   time_subcycle + dt_radiation);
-			RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, radFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
-								 indexRange);
+			RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, radFluxSource_arr, userEnergySource_arr, userReducedFlux_arr, indexRange);
 
 			// Build face-centered array for MHD-aware radiation coupling
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3216,8 +3216,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				auto const &userReducedFlux_arr = userReducedFlux.array(iter);
 				RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 								   time_subcycle + dt_radiation);
-				RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr,
-									 userReducedFlux_arr, indexRange);
+				RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
+									 indexRange);
 
 				// Build face-centered array for MHD-aware radiation coupling
 				std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3220,13 +3220,15 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 				// Full gas update (gas_update_factor = 1.0)
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-					RadSystem<problem_t>::AddSourceTermsSingleGroup(
-					    stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
-					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+											dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
+											tempFloor, p_iteration_counter, p_iteration_failure_counter,
+											cons_fc_arr);
 				} else {
-					RadSystem<problem_t>::AddSourceTermsMultiGroup(
-					    stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
-					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange,
+										       dt_stage2_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
+										       tempFloor, p_iteration_counter, p_iteration_failure_counter,
+										       cons_fc_arr);
 				}
 			}
 		}

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3169,6 +3169,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		// radEnergySource should have the unit of luminosity density, erg s^-1 cm^-3
 		int const nghost = 3; // WendlandC2<N=2>: stencil spans N=2 cells + 1 for possible particle drift
 		amrex::MultiFab radEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
+		// Companion buffer holding the radiation flux source, in components 3 * g + n (group g, direction n);
+		// unit: erg cm^-2 s^-2. Only SetRadSource writes to it (particles deposit isotropically).
+		amrex::MultiFab radFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
 
 		// === Stage 1: trivial U^(1) = U^n; skipped ===
 
@@ -3185,6 +3188,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Implicit source terms for stage 2
 			radEnergySource.setVal(0.0);
+			radFluxSource.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 			particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3199,7 +3203,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				auto const &prob_hi = geom[lev].ProbHiArray();
 
 				auto const &radEnergySource_arr = radEnergySource.array(iter);
-				RadSystem<problem_t>::SetRadEnergySource(radEnergySource_arr, indexRange, dx, prob_lo, prob_hi, time_subcycle + dt_radiation);
+				auto const &radFluxSource_arr = radFluxSource.array(iter);
+				RadSystem<problem_t>::SetRadSource(radEnergySource_arr, radFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+								   time_subcycle + dt_radiation);
 
 				// Build face-centered array for MHD-aware radiation coupling
 				std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;
@@ -3213,13 +3219,13 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 				// Full gas update (gas_update_factor = 1.0)
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-					RadSystem<problem_t>::AddSourceTermsSingleGroup(stateTmp1, radEnergySource_arr, indexRange, dt_stage2_implicit, 1.0,
-											dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor,
-											p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsSingleGroup(
+					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				} else {
-					RadSystem<problem_t>::AddSourceTermsMultiGroup(stateTmp1, radEnergySource_arr, indexRange, dt_stage2_implicit, 1.0,
-										       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor,
-										       p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
+					RadSystem<problem_t>::AddSourceTermsMultiGroup(
+					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				}
 			}
 		}
@@ -3284,6 +3290,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		// Implicit source terms for stage 3
 		radEnergySource.setVal(0.0);
+		radFluxSource.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3298,7 +3305,9 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			auto const &prob_hi = geom[lev].ProbHiArray();
 
 			auto const &radEnergySource_arr = radEnergySource.array(iter);
-			RadSystem<problem_t>::SetRadEnergySource(radEnergySource_arr, indexRange, dx, prob_lo, prob_hi, time_subcycle + dt_radiation);
+			auto const &radFluxSource_arr = radFluxSource.array(iter);
+			RadSystem<problem_t>::SetRadSource(radEnergySource_arr, radFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+							   time_subcycle + dt_radiation);
 
 			// Build face-centered array for MHD-aware radiation coupling
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;
@@ -3312,13 +3321,13 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Full gas update (gas_update_factor = 1.0)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_stage3_implicit, 1.0,
-										dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
-										p_iteration_failure_counter, cons_fc_arr);
+				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
+										dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
+										tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			} else {
-				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, indexRange, dt_stage3_implicit, 1.0,
-									       dustGasInteractionCoeff_, rad_tol, rad_tol_rel, tempFloor, p_iteration_counter,
-									       p_iteration_failure_counter, cons_fc_arr);
+				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
+									       dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
+									       tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			}
 		}
 #ifdef PHOTOCHEMISTRY

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3170,9 +3170,14 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		int const nghost = 3; // WendlandC2<N=2>: stencil spans N=2 cells + 1 for possible particle drift
 		amrex::MultiFab radEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
 		// Companion buffer holding the reduced flux f = F / (c E) of the injected radiation, in components
-		// 3 * g + n (group g, direction n); dimensionless, with |f| <= 1. Only SetRadSource writes to it
-		// (particles deposit isotropically, i.e. f = 0).
+		// 3 * g + n (group g, direction n); dimensionless, with |f| <= 1. Particles deposit isotropically,
+		// i.e. f = 0.
 		amrex::MultiFab reducedFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
+		// Scratch buffers written by the user hook AddRadSource, then merged into the two buffers above.
+		// Giving the hook its own buffers means a problem simply assigns its own source: it cannot overwrite
+		// radiation that particles have already deposited, and need not remember to accumulate onto it.
+		amrex::MultiFab userEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
+		amrex::MultiFab userReducedFlux(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
 
 		// === Stage 1: trivial U^(1) = U^n; skipped ===
 
@@ -3190,6 +3195,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			// Implicit source terms for stage 2
 			radEnergySource.setVal(0.0);
 			reducedFluxSource.setVal(0.0);
+			userEnergySource.setVal(0.0);
+			userReducedFlux.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 			particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3205,8 +3212,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 				auto const &radEnergySource_arr = radEnergySource.array(iter);
 				auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
-				RadSystem<problem_t>::SetRadSource(radEnergySource_arr, reducedFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+				auto const &userEnergySource_arr = userEnergySource.array(iter);
+				auto const &userReducedFlux_arr = userReducedFlux.array(iter);
+				RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 								   time_subcycle + dt_radiation);
+				RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr,
+									 userReducedFlux_arr, indexRange);
 
 				// Build face-centered array for MHD-aware radiation coupling
 				std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;
@@ -3294,6 +3305,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		// Implicit source terms for stage 3
 		radEnergySource.setVal(0.0);
 		reducedFluxSource.setVal(0.0);
+		userEnergySource.setVal(0.0);
+		userReducedFlux.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3309,8 +3322,12 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			auto const &radEnergySource_arr = radEnergySource.array(iter);
 			auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
-			RadSystem<problem_t>::SetRadSource(radEnergySource_arr, reducedFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+			auto const &userEnergySource_arr = userEnergySource.array(iter);
+			auto const &userReducedFlux_arr = userReducedFlux.array(iter);
+			RadSystem<problem_t>::AddRadSource(userEnergySource_arr, userReducedFlux_arr, indexRange, dx, prob_lo, prob_hi,
 							   time_subcycle + dt_radiation);
+			RadSystem<problem_t>::MergeUserRadSource(radEnergySource_arr, reducedFluxSource_arr, userEnergySource_arr, userReducedFlux_arr,
+								 indexRange);
 
 			// Build face-centered array for MHD-aware radiation coupling
 			std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc_arr;

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -3169,9 +3169,10 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 		// radEnergySource should have the unit of luminosity density, erg s^-1 cm^-3
 		int const nghost = 3; // WendlandC2<N=2>: stencil spans N=2 cells + 1 for possible particle drift
 		amrex::MultiFab radEnergySource(grids[lev], dmap[lev], Physics_Traits<problem_t>::nGroups, nghost);
-		// Companion buffer holding the radiation flux source, in components 3 * g + n (group g, direction n);
-		// unit: erg cm^-2 s^-2. Only SetRadSource writes to it (particles deposit isotropically).
-		amrex::MultiFab radFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
+		// Companion buffer holding the reduced flux f = F / (c E) of the injected radiation, in components
+		// 3 * g + n (group g, direction n); dimensionless, with |f| <= 1. Only SetRadSource writes to it
+		// (particles deposit isotropically, i.e. f = 0).
+		amrex::MultiFab reducedFluxSource(grids[lev], dmap[lev], 3 * Physics_Traits<problem_t>::nGroups, nghost);
 
 		// === Stage 1: trivial U^(1) = U^n; skipped ===
 
@@ -3188,7 +3189,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Implicit source terms for stage 2
 			radEnergySource.setVal(0.0);
-			radFluxSource.setVal(0.0);
+			reducedFluxSource.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 			particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3203,8 +3204,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				auto const &prob_hi = geom[lev].ProbHiArray();
 
 				auto const &radEnergySource_arr = radEnergySource.array(iter);
-				auto const &radFluxSource_arr = radFluxSource.array(iter);
-				RadSystem<problem_t>::SetRadSource(radEnergySource_arr, radFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+				auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
+				RadSystem<problem_t>::SetRadSource(radEnergySource_arr, reducedFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
 								   time_subcycle + dt_radiation);
 
 				// Build face-centered array for MHD-aware radiation coupling
@@ -3220,11 +3221,11 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 				// Full gas update (gas_update_factor = 1.0)
 				if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
 					RadSystem<problem_t>::AddSourceTermsSingleGroup(
-					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
 					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				} else {
 					RadSystem<problem_t>::AddSourceTermsMultiGroup(
-					    stateTmp1, radEnergySource_arr, radFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
+					    stateTmp1, radEnergySource_arr, reducedFluxSource_arr, indexRange, dt_stage2_implicit, 1.0, dustGasInteractionCoeff_,
 					    rad_tol, rad_tol_rel, tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 				}
 			}
@@ -3290,7 +3291,7 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 		// Implicit source terms for stage 3
 		radEnergySource.setVal(0.0);
-		radFluxSource.setVal(0.0);
+		reducedFluxSource.setVal(0.0);
 
 #if AMREX_SPACEDIM == 3
 		particleRegister_.depositRadiation(radEnergySource, lev, time_subcycle);
@@ -3305,8 +3306,8 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 			auto const &prob_hi = geom[lev].ProbHiArray();
 
 			auto const &radEnergySource_arr = radEnergySource.array(iter);
-			auto const &radFluxSource_arr = radFluxSource.array(iter);
-			RadSystem<problem_t>::SetRadSource(radEnergySource_arr, radFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
+			auto const &reducedFluxSource_arr = reducedFluxSource.array(iter);
+			RadSystem<problem_t>::SetRadSource(radEnergySource_arr, reducedFluxSource_arr, indexRange, dx, prob_lo, prob_hi,
 							   time_subcycle + dt_radiation);
 
 			// Build face-centered array for MHD-aware radiation coupling
@@ -3321,11 +3322,11 @@ void QuokkaSimulation<problem_t>::subcycleRadiationAtLevel(int lev, amrex::Real 
 
 			// Full gas update (gas_update_factor = 1.0)
 			if constexpr (Physics_Traits<problem_t>::nGroups <= 1) {
-				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
+				RadSystem<problem_t>::AddSourceTermsSingleGroup(stateNew_cc, radEnergySource_arr, reducedFluxSource_arr, indexRange,
 										dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 										tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			} else {
-				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, radFluxSource_arr, indexRange,
+				RadSystem<problem_t>::AddSourceTermsMultiGroup(stateNew_cc, radEnergySource_arr, reducedFluxSource_arr, indexRange,
 									       dt_stage3_implicit, 1.0, dustGasInteractionCoeff_, rad_tol, rad_tol_rel,
 									       tempFloor, p_iteration_counter, p_iteration_failure_counter, cons_fc_arr);
 			}

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -235,9 +235,9 @@ AMREX_GPU_HOST_DEVICE auto wendland_c2(amrex::Real r) -> amrex::Real
 }
 
 template <>
-void RadSystem<DTypeFront>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
+void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
 	amrex::ParmParse const pp("stromgen");
 	amrex::Real Q = 1.0e49_rt;

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -235,7 +235,7 @@ AMREX_GPU_HOST_DEVICE auto wendland_c2(amrex::Real r) -> amrex::Real
 }
 
 template <>
-void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
@@ -287,9 +287,7 @@ void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*radFlux
 		const amrex::Real dk = (AMREX_SPACEDIM >= 3) ? static_cast<amrex::Real>(k - src_k) + 0.5 - frac_z : 0.0;
 		const amrex::Real r2 = AMREX_D_TERM(di * di, +dj * dj, +dk * dk);
 		if (r2 <= cutoff_r2) {
-			radEnergy(i, j, k) = L_star * wendland_c2(std::sqrt(r2) * inv_N) * inv_norm * inv_volume;
-		} else {
-			radEnergy(i, j, k) = 0.0_rt;
+			radEnergy(i, j, k) += L_star * wendland_c2(std::sqrt(r2) * inv_N) * inv_norm * inv_volume;
 		}
 	});
 }

--- a/src/problems/DTypeFront/testDTypeFront.cpp
+++ b/src/problems/DTypeFront/testDTypeFront.cpp
@@ -235,7 +235,7 @@ AMREX_GPU_HOST_DEVICE auto wendland_c2(amrex::Real r) -> amrex::Real
 }
 
 template <>
-void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<DTypeFront>::AddRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
@@ -287,7 +287,9 @@ void RadSystem<DTypeFront>::SetRadSource(array_t &radEnergy, array_t & /*reduced
 		const amrex::Real dk = (AMREX_SPACEDIM >= 3) ? static_cast<amrex::Real>(k - src_k) + 0.5 - frac_z : 0.0;
 		const amrex::Real r2 = AMREX_D_TERM(di * di, +dj * dj, +dk * dk);
 		if (r2 <= cutoff_r2) {
-			radEnergy(i, j, k) += L_star * wendland_c2(std::sqrt(r2) * inv_N) * inv_norm * inv_volume;
+			radEnergy(i, j, k) = L_star * wendland_c2(std::sqrt(r2) * inv_N) * inv_norm * inv_volume;
+		} else {
+			radEnergy(i, j, k) = 0.0_rt;
 		}
 	});
 }

--- a/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
+++ b/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
@@ -79,13 +79,12 @@ template <> struct SimulationData<DTypeFrontVC> {
 };
 
 template <>
-void RadSystem<DTypeFrontVC>::SetRadSource(array_t & /*radEnergy*/, array_t & /*reducedFluxSource*/, const amrex::Box & /*indexRange*/,
+void RadSystem<DTypeFrontVC>::AddRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*dx*/,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
-	// This problem adds no radiation source of its own. The caller has already zeroed the buffers, so
-	// overwriting them here would only discard radiation deposited by particles.
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { radEnergy(i, j, k) = 0.0_rt; });
 }
 
 template <> void QuokkaSimulation<DTypeFrontVC>::preCalculateInitialConditions()

--- a/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
+++ b/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
@@ -79,9 +79,10 @@ template <> struct SimulationData<DTypeFrontVC> {
 };
 
 template <>
-void RadSystem<DTypeFrontVC>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*dx*/,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
+void RadSystem<DTypeFrontVC>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*dx*/,
+					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
+					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { radEnergy(i, j, k) = 0.0_rt; });
 }

--- a/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
+++ b/src/problems/DTypeFrontVC/testDTypeFrontVC.cpp
@@ -79,12 +79,13 @@ template <> struct SimulationData<DTypeFrontVC> {
 };
 
 template <>
-void RadSystem<DTypeFrontVC>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<DTypeFrontVC>::SetRadSource(array_t & /*radEnergy*/, array_t & /*reducedFluxSource*/, const amrex::Box & /*indexRange*/,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*dx*/,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
 {
-	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { radEnergy(i, j, k) = 0.0_rt; });
+	// This problem adds no radiation source of its own. The caller has already zeroed the buffers, so
+	// overwriting them here would only discard radiation deposited by particles.
 }
 
 template <> void QuokkaSimulation<DTypeFrontVC>::preCalculateInitialConditions()

--- a/src/problems/RadStreaming/CMakeLists.txt
+++ b/src/problems/RadStreaming/CMakeLists.txt
@@ -1,1 +1,7 @@
 quokka_add_problem(JOB_NAME RadStreaming)
+
+# Same executable, run with a beam injected by the radFluxSource hook instead of the boundary
+add_test(
+  NAME RadStreamingFluxSource
+  COMMAND RadStreaming ../inputs/RadStreamingFluxSource.toml ${QuokkaTestParams}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/src/problems/RadStreaming/CMakeLists.txt
+++ b/src/problems/RadStreaming/CMakeLists.txt
@@ -1,6 +1,6 @@
 quokka_add_problem(JOB_NAME RadStreaming)
 
-# Same executable, run with a beam injected by the radFluxSource hook instead of the boundary
+# Same executable, run with a beam injected by the reducedFluxSource hook instead of the boundary
 add_test(
   NAME RadStreamingFluxSource
   COMMAND RadStreaming ../inputs/RadStreamingFluxSource.toml ${QuokkaTestParams}

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -11,12 +11,14 @@
 #include "util/matplotlibcpp.h"
 #endif
 #include "AMReX.H"
+#include "AMReX_ParmParse.H"
 #include "QuokkaSimulation.hpp"
 #include "physics_info.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/BC.hpp"
 #include "util/fextract.hpp"
 #include "util/valarray.hpp"
+#include <algorithm>
 #include <format>
 
 struct StreamingProblem {
@@ -28,6 +30,18 @@ constexpr double c = 1.0;	   // speed of light
 constexpr double chat = 0.2;	   // reduced speed of light
 constexpr double kappa0 = 1.0e-10; // opacity
 constexpr double rho = 1.0;
+
+// Flux-source variant, selected with problem.flux_source = 1 in the input file. Instead of letting the
+// beam enter through the left Dirichlet boundary, it is injected in the interior slab [beam_lo, beam_hi)
+// by SetRadSource, which sets radFluxSource = c * radEnergySource so that the injected radiation is fully
+// beamed (|F| = c E) along +x. In steady state the beam leaving the slab has
+// Erad = beam_S * (beam_hi - beam_lo) / c, so beam_S is chosen to make that equal to 1.
+constexpr double beam_lo = 0.1;
+constexpr double beam_hi = 0.2;
+constexpr double beam_width = beam_hi - beam_lo;
+constexpr double beam_S = c / beam_width; // erg s^-1 cm^-3
+// managed so that setCustomBoundaryConditions can read it on the device
+AMREX_GPU_MANAGED int use_flux_source = 0; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables); set in problem_main()
 
 template <> struct quokka::EOS_Traits<StreamingProblem> {
 	static constexpr double mean_molecular_weight = 1.0;
@@ -60,6 +74,26 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputePlanc
 template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxMeanOpacity(const double /*rho*/, const double /*Tgas*/) -> amrex::Real
 {
 	return kappa0;
+}
+
+template <>
+void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
+{
+	if (use_flux_source == 0) {
+		return; // the default variant injects the beam through the left boundary instead
+	}
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
+		if ((x >= beam_lo) && (x < beam_hi)) {
+			radEnergySource(i, j, k, 0) += beam_S;
+			// setting the flux source to c times the energy source injects fully beamed radiation
+			radFluxSource(i, j, k, 0) += c * beam_S;
+		}
+	});
 }
 
 template <> void QuokkaSimulation<StreamingProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
@@ -103,11 +137,12 @@ AMRSimulation<StreamingProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	// Number of variables (use Physics_Indices which correctly accounts for enabled physics)
 	constexpr int nvar = Physics_Indices<StreamingProblem>::nvarTotal_cc;
 
-	// Prepare left boundary values (streaming inflow)
+	// Prepare left boundary values: streaming inflow, or the ambient state when the beam is instead
+	// injected in the interior by SetRadSource, so that the source is the only radiation input
 	amrex::GpuArray<amrex::Real, nvar> low_bdr_cells{};
 	{
-		const double Erad = 1.0;
-		const double Frad = c * Erad;
+		const double Erad = (use_flux_source != 0) ? initial_Erad : 1.0;
+		const double Frad = (use_flux_source != 0) ? 0.0 : c * Erad;
 		for (int g = 0; g < Physics_Traits<StreamingProblem>::nGroups; ++g) {
 			const double radEnergyFraction = 1.0 / Physics_Traits<StreamingProblem>::nGroups;
 			low_bdr_cells[RadSystem<StreamingProblem>::radEnergy_index + Physics_NumVars::numRadVarsPerGroup * g] = Erad * radEnergyFraction;
@@ -157,6 +192,12 @@ auto problem_main() -> int
 	const double tmax = 1.0;
 	const int max_timesteps = 5000;
 
+	// Select the injection mode: boundary inflow (default) or the radFluxSource hook
+	{
+		amrex::ParmParse const pp("problem");
+		pp.query("flux_source", use_flux_source);
+	}
+
 	// Boundary conditions
 	constexpr int nvars = RadSystem<StreamingProblem>::nvar_;
 	amrex::Vector<amrex::BCRec> BCs_cc(nvars);
@@ -196,7 +237,15 @@ auto problem_main() -> int
 	for (int i = 0; i < nx; ++i) {
 		amrex::Real const x = position[i];
 		xs.at(i) = x;
-		erad_exact.at(i) = (x <= chat * tmax) ? 1.0 : 0.0;
+		if (use_flux_source != 0) {
+			// Radiation injected in [beam_lo, beam_hi) with |F| = c E free-streams in +x at speed
+			// chat, giving a trapezoid: a ramp 0 -> 1 across the source slab, a plateau at 1 out to
+			// beam_lo + chat * t, and a ramp 1 -> 0 down to the front at beam_hi + chat * t.
+			erad_exact.at(i) =
+			    std::clamp(std::min((x - beam_lo) / beam_width, (beam_hi + chat * tmax - x) / beam_width), 0.0, 1.0);
+		} else {
+			erad_exact.at(i) = (x <= chat * tmax) ? 1.0 : 0.0;
+		}
 		double erad_sim = 0.0;
 		for (int g = 0; g < Physics_Traits<StreamingProblem>::nGroups; ++g) {
 			erad_sim += values.at(RadSystem<StreamingProblem>::radEnergy_index + Physics_NumVars::numRadVarsPerGroup * g)[i];
@@ -219,6 +268,28 @@ auto problem_main() -> int
 	}
 	amrex::Print() << "Relative L1 norm = " << rel_err_norm << '\n';
 
+	if (use_flux_source != 0) {
+		// The source-injected radiation must be fully beamed, i.e. the reduced flux F / (c E) must be 1
+		// inside the beam. Check it on the plateau, away from the ramps and the front.
+		double max_dev = 0.;
+		for (int i = 0; i < nx; ++i) {
+			const amrex::Real x = position[i];
+			if ((x < beam_hi) || (x > beam_lo + chat * tmax)) {
+				continue;
+			}
+			const double erad_i = values.at(RadSystem<StreamingProblem>::radEnergy_index)[i];
+			const double frad_i = values.at(RadSystem<StreamingProblem>::x1RadFlux_index)[i];
+			max_dev = std::max(max_dev, std::abs(frad_i / (c * erad_i) - 1.0));
+		}
+		// if the flux source were ignored the injected radiation would be isotropic and this deviation
+		// would be of order unity, so this is a sharp check despite the loose tolerance
+		const double max_dev_tol = 1.0e-4;
+		amrex::Print() << "Max deviation of the reduced flux F / (c E) from 1 = " << max_dev << '\n';
+		if (max_dev > max_dev_tol) {
+			status = 1;
+		}
+	}
+
 #ifdef HAVE_PYTHON
 	// Plot results
 	matplotlibcpp::clf();
@@ -234,7 +305,7 @@ auto problem_main() -> int
 
 	matplotlibcpp::legend();
 	matplotlibcpp::title(std::format("t = {:.4f}", sim.tNew_[0]));
-	matplotlibcpp::save("./radiation_streaming.pdf");
+	matplotlibcpp::save((use_flux_source != 0) ? "./radiation_streaming_flux_source.pdf" : "./radiation_streaming.pdf");
 #endif // HAVE_PYTHON
 
 	// Cleanup and exit

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -241,8 +241,7 @@ auto problem_main() -> int
 			// Radiation injected in [beam_lo, beam_hi) with |F| = c E free-streams in +x at speed
 			// chat, giving a trapezoid: a ramp 0 -> 1 across the source slab, a plateau at 1 out to
 			// beam_lo + chat * t, and a ramp 1 -> 0 down to the front at beam_hi + chat * t.
-			erad_exact.at(i) =
-			    std::clamp(std::min((x - beam_lo) / beam_width, (beam_hi + chat * tmax - x) / beam_width), 0.0, 1.0);
+			erad_exact.at(i) = std::clamp(std::min((x - beam_lo) / beam_width, (beam_hi + chat * tmax - x) / beam_width), 0.0, 1.0);
 		} else {
 			erad_exact.at(i) = (x <= chat * tmax) ? 1.0 : 0.0;
 		}

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -33,7 +33,7 @@ constexpr double rho = 1.0;
 
 // Flux-source variant, selected with problem.flux_source = 1 in the input file. Instead of letting the
 // beam enter through the left Dirichlet boundary, it is injected in the interior slab [beam_lo, beam_hi)
-// by SetRadSource, which sets radFluxSource = c * radEnergySource so that the injected radiation is fully
+// by SetRadSource, which sets the reduced flux to f = (1, 0, 0) so that the injected radiation is fully
 // beamed (|F| = c E) along +x. In steady state the beam leaving the slab has
 // Erad = beam_S * (beam_hi - beam_lo) / c, so beam_S is chosen to make that equal to 1.
 constexpr double beam_lo = 0.1;
@@ -77,7 +77,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 }
 
 template <>
-void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
@@ -90,8 +90,8 @@ void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t
 		const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
 		if ((x >= beam_lo) && (x < beam_hi)) {
 			radEnergySource(i, j, k, 0) += beam_S;
-			// setting the flux source to c times the energy source injects fully beamed radiation
-			radFluxSource(i, j, k, 0) += c * beam_S;
+			// a reduced flux of unit magnitude injects fully beamed (|F| = c E) radiation along +x
+			reducedFluxSource(i, j, k, 0) = 1.0;
 		}
 	});
 }
@@ -192,7 +192,7 @@ auto problem_main() -> int
 	const double tmax = 1.0;
 	const int max_timesteps = 5000;
 
-	// Select the injection mode: boundary inflow (default) or the radFluxSource hook
+	// Select the injection mode: boundary inflow (default) or the reducedFluxSource hook
 	{
 		amrex::ParmParse const pp("problem");
 		pp.query("flux_source", use_flux_source);

--- a/src/problems/RadStreaming/testRadStreaming.cpp
+++ b/src/problems/RadStreaming/testRadStreaming.cpp
@@ -33,7 +33,7 @@ constexpr double rho = 1.0;
 
 // Flux-source variant, selected with problem.flux_source = 1 in the input file. Instead of letting the
 // beam enter through the left Dirichlet boundary, it is injected in the interior slab [beam_lo, beam_hi)
-// by SetRadSource, which sets the reduced flux to f = (1, 0, 0) so that the injected radiation is fully
+// by AddRadSource, which sets the reduced flux to f = (1, 0, 0) so that the injected radiation is fully
 // beamed (|F| = c E) along +x. In steady state the beam leaving the slab has
 // Erad = beam_S * (beam_hi - beam_lo) / c, so beam_S is chosen to make that equal to 1.
 constexpr double beam_lo = 0.1;
@@ -77,7 +77,7 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<StreamingProblem>::ComputeFluxM
 }
 
 template <>
-void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
+void RadSystem<StreamingProblem>::AddRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real /*time*/)
@@ -89,7 +89,7 @@ void RadSystem<StreamingProblem>::SetRadSource(array_t &radEnergySource, array_t
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const amrex::Real x = prob_lo[0] + (i + 0.5) * dx[0];
 		if ((x >= beam_lo) && (x < beam_hi)) {
-			radEnergySource(i, j, k, 0) += beam_S;
+			radEnergySource(i, j, k, 0) = beam_S;
 			// a reduced flux of unit magnitude injects fully beamed (|F| = c E) radiation along +x
 			reducedFluxSource(i, j, k, 0) = 1.0;
 		}
@@ -138,7 +138,7 @@ AMRSimulation<StreamingProblem>::setCustomBoundaryConditions(const amrex::IntVec
 	constexpr int nvar = Physics_Indices<StreamingProblem>::nvarTotal_cc;
 
 	// Prepare left boundary values: streaming inflow, or the ambient state when the beam is instead
-	// injected in the interior by SetRadSource, so that the source is the only radiation input
+	// injected in the interior by AddRadSource, so that the source is the only radiation input
 	amrex::GpuArray<amrex::Real, nvar> low_bdr_cells{};
 	{
 		const double Erad = (use_flux_source != 0) ? initial_Erad : 1.0;

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -122,10 +122,10 @@ const auto initial_Egas = 1e-10 * quokka::EOS<MarshakProblem>::ComputeEintFromTg
 const auto initial_Erad = 1e-10 * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum));      // NOLINT
 
 template <>
-void RadSystem<MarshakProblem>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange,
-						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
-						   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real time)
+void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t & /*radFluxSource*/, amrex::Box const &indexRange,
+					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
+					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real time)
 {
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		amrex::Real const xl = (i + 0.) * dx[0];

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -122,7 +122,7 @@ const auto initial_Egas = 1e-10 * quokka::EOS<MarshakProblem>::ComputeEintFromTg
 const auto initial_Erad = 1e-10 * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum));      // NOLINT
 
 template <>
-void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t & /*reducedFluxSource*/, amrex::Box const &indexRange,
+void RadSystem<MarshakProblem>::AddRadSource(array_t &radEnergySource, array_t & /*reducedFluxSource*/, amrex::Box const &indexRange,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real time)
@@ -144,7 +144,7 @@ void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t &
 		if (time < t0) {
 			src = S * vol_frac;
 		}
-		radEnergySource(i, j, k, 0) += src;
+		radEnergySource(i, j, k, 0) = src;
 	});
 }
 

--- a/src/problems/RadSuOlson/testRadSuOlson.cpp
+++ b/src/problems/RadSuOlson/testRadSuOlson.cpp
@@ -122,7 +122,7 @@ const auto initial_Egas = 1e-10 * quokka::EOS<MarshakProblem>::ComputeEintFromTg
 const auto initial_Erad = 1e-10 * (a_rad * (T_hohlraum * T_hohlraum * T_hohlraum * T_hohlraum));      // NOLINT
 
 template <>
-void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t & /*radFluxSource*/, amrex::Box const &indexRange,
+void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t & /*reducedFluxSource*/, amrex::Box const &indexRange,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_lo*/,
 					     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const & /*prob_hi*/, amrex::Real time)
@@ -144,7 +144,7 @@ void RadSystem<MarshakProblem>::SetRadSource(array_t &radEnergySource, array_t &
 		if (time < t0) {
 			src = S * vol_frac;
 		}
-		radEnergySource(i, j, k, 0) = src;
+		radEnergySource(i, j, k, 0) += src;
 	});
 }
 

--- a/src/problems/RadhydroShell/testRadhydroShell.cpp
+++ b/src/problems/RadhydroShell/testRadhydroShell.cpp
@@ -78,9 +78,9 @@ constexpr amrex::Real rho_0 = M_shell / ((4. / 3.) * M_PI * r_0 * r_0 * r_0); //
 constexpr amrex::Real c_v = k_B / ((2.2 * m_H) * (gamma_gas - 1.0));
 
 template <>
-void RadSystem<ShellProblem>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-						 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
+void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
 	// point-like radiation source
 

--- a/src/problems/RadhydroShell/testRadhydroShell.cpp
+++ b/src/problems/RadhydroShell/testRadhydroShell.cpp
@@ -78,7 +78,7 @@ constexpr amrex::Real rho_0 = M_shell / ((4. / 3.) * M_PI * r_0 * r_0 * r_0); //
 constexpr amrex::Real c_v = k_B / ((2.2 * m_H) * (gamma_gas - 1.0));
 
 template <>
-void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<ShellProblem>::AddRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
@@ -105,7 +105,7 @@ void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*reduc
 		amrex::Real const z = prob_lo[2] + (k + static_cast<amrex::Real>(0.5)) * dx[2];
 		amrex::Real const r = std::sqrt(std::pow(x - x0, 2) + std::pow(y - y0, 2) + std::pow(z - z0, 2));
 
-		radEnergy(i, j, k) += source_norm * std::exp(-(r * r) / (2.0 * sigma_star * sigma_star));
+		radEnergy(i, j, k) = source_norm * std::exp(-(r * r) / (2.0 * sigma_star * sigma_star));
 	});
 }
 

--- a/src/problems/RadhydroShell/testRadhydroShell.cpp
+++ b/src/problems/RadhydroShell/testRadhydroShell.cpp
@@ -78,7 +78,7 @@ constexpr amrex::Real rho_0 = M_shell / ((4. / 3.) * M_PI * r_0 * r_0 * r_0); //
 constexpr amrex::Real c_v = k_B / ((2.2 * m_H) * (gamma_gas - 1.0));
 
 template <>
-void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
@@ -105,7 +105,7 @@ void RadSystem<ShellProblem>::SetRadSource(array_t &radEnergy, array_t & /*radFl
 		amrex::Real const z = prob_lo[2] + (k + static_cast<amrex::Real>(0.5)) * dx[2];
 		amrex::Real const r = std::sqrt(std::pow(x - x0, 2) + std::pow(y - y0, 2) + std::pow(z - z0, 2));
 
-		radEnergy(i, j, k) = source_norm * std::exp(-(r * r) / (2.0 * sigma_star * sigma_star));
+		radEnergy(i, j, k) += source_norm * std::exp(-(r * r) / (2.0 * sigma_star * sigma_star));
 	});
 }
 

--- a/src/problems/StromgrenSphere/testStromgrenSphere.cpp
+++ b/src/problems/StromgrenSphere/testStromgrenSphere.cpp
@@ -61,7 +61,7 @@ template <> struct RadSystem_Traits<StromgrenSphere> {
 };
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
@@ -103,9 +103,7 @@ void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*ra
 		if (r <= r_trunc) {
 			amrex::Real const w_i = std::exp(-(r * r) / (2.0 * sigma_star * sigma_star)) / (std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5));
 			amrex::Real const val = L_star * w_i / sum;
-			radEnergy(i, j, k) = val;
-		} else {
-			radEnergy(i, j, k) = 0.0_rt;
+			radEnergy(i, j, k) += val;
 		}
 	});
 }

--- a/src/problems/StromgrenSphere/testStromgrenSphere.cpp
+++ b/src/problems/StromgrenSphere/testStromgrenSphere.cpp
@@ -61,9 +61,10 @@ template <> struct RadSystem_Traits<StromgrenSphere> {
 };
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-						    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
+void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
 	amrex::ParmParse const pp("stromgen");
 	amrex::Real Q = 1.0e49_rt;

--- a/src/problems/StromgrenSphere/testStromgrenSphere.cpp
+++ b/src/problems/StromgrenSphere/testStromgrenSphere.cpp
@@ -61,7 +61,7 @@ template <> struct RadSystem_Traits<StromgrenSphere> {
 };
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<StromgrenSphere>::AddRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
@@ -103,7 +103,9 @@ void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*re
 		if (r <= r_trunc) {
 			amrex::Real const w_i = std::exp(-(r * r) / (2.0 * sigma_star * sigma_star)) / (std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5));
 			amrex::Real const val = L_star * w_i / sum;
-			radEnergy(i, j, k) += val;
+			radEnergy(i, j, k) = val;
+		} else {
+			radEnergy(i, j, k) = 0.0_rt;
 		}
 	});
 }

--- a/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
+++ b/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
@@ -127,9 +127,10 @@ auto integrate_radius(amrex::Real dt_target, amrex::Real Q, amrex::Real alpha_B,
 } // namespace
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadEnergySource(array_t &radEnergy, const amrex::Box &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-						    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-						    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
+void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
 {
 	amrex::ParmParse const pp("stromgen");
 	amrex::Real Q = 1.0e49_rt;

--- a/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
+++ b/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
@@ -127,7 +127,7 @@ auto integrate_radius(amrex::Real dt_target, amrex::Real Q, amrex::Real alpha_B,
 } // namespace
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*radFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
@@ -169,9 +169,7 @@ void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*ra
 		if (r <= r_trunc) {
 			amrex::Real const w_i = std::exp(-(r * r) / (2.0 * sigma_star * sigma_star)) / (std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5));
 			amrex::Real const val = L_star * w_i / sum;
-			radEnergy(i, j, k) = val;
-		} else {
-			radEnergy(i, j, k) = 0.0_rt;
+			radEnergy(i, j, k) += val;
 		}
 	});
 }

--- a/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
+++ b/src/problems/StromgrenSphereRSLA/testStromgrenSphereRSLA.cpp
@@ -127,7 +127,7 @@ auto integrate_radius(amrex::Real dt_target, amrex::Real Q, amrex::Real alpha_B,
 } // namespace
 
 template <>
-void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
+void RadSystem<StromgrenSphere>::AddRadSource(array_t &radEnergy, array_t & /*reducedFluxSource*/, const amrex::Box &indexRange,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real /*time*/)
@@ -169,7 +169,9 @@ void RadSystem<StromgrenSphere>::SetRadSource(array_t &radEnergy, array_t & /*re
 		if (r <= r_trunc) {
 			amrex::Real const w_i = std::exp(-(r * r) / (2.0 * sigma_star * sigma_star)) / (std::pow(2.0 * M_PI * sigma_star * sigma_star, 1.5));
 			amrex::Real const val = L_star * w_i / sum;
-			radEnergy(i, j, k) += val;
+			radEnergy(i, j, k) = val;
+		} else {
+			radEnergy(i, j, k) = 0.0_rt;
 		}
 	});
 }

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -305,9 +305,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	//! Set the user-defined radiation source terms.
 	//!
 	//! \param radEnergySource luminosity volume density of group g, in component g; unit: erg s^-1 cm^-3.
-	//! \param radFluxSource   flux source of group g along direction n, in component 3 * g + n; unit: erg cm^-2 s^-2.
-	//!			   Setting radFluxSource = c * radEnergySource injects fully beamed (free-streaming) radiation.
-	static void SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+	//! \param reducedFluxSource reduced flux f = F / (c E) of the injected radiation of group g along direction n,
+	//!			   in component 3 * g + n; dimensionless, and physical only if |f| <= 1 (asserted in a debug
+	//!			   build). The deposited flux source is c * f * radEnergySource, so c is always the runtime
+	//!			   speed of light and the injected radiation satisfies F = f c E by construction. f = 0 (the
+	//!			   default) injects isotropic radiation; |f| = 1 injects fully beamed (free-streaming) radiation.
+	static void SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
 
@@ -315,12 +318,12 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 						double gas_update_factor, double Ekin0, amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> const &Src_flux,
 						double Emag = {}) -> FluxUpdateResult<problem_t>;
 
-	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
 					     amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
 					     double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
 
-	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
 					      amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
 					      double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					      std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
@@ -644,12 +647,14 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+void RadSystem<problem_t>::SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
 {
 	// Default implementation: no radiation source is added.
-	// Users should override this method to *add* custom radiation sources to radEnergySource and radFluxSource.
+	// Users should override this method to *add* custom radiation sources to radEnergySource, since particle
+	// radiation has already been deposited there. reducedFluxSource is a ratio rather than an amount, so it
+	// should be assigned, not accumulated; it defaults to zero, i.e. isotropic injection.
 	// This function is intentionally left blank.
 }
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -304,15 +304,26 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 
 	//! Set the user-defined radiation source terms.
 	//!
+	//! Both buffers belong to this hook alone and are zeroed before every call, so assign to them; the
+	//! framework merges the result into any radiation that particles have already deposited.
+	//!
 	//! \param radEnergySource luminosity volume density of group g, in component g; unit: erg s^-1 cm^-3.
 	//! \param reducedFluxSource reduced flux f = F / (c E) of the injected radiation of group g along direction n,
 	//!			   in component 3 * g + n; dimensionless, and physical only if |f| <= 1 (asserted in a debug
 	//!			   build). The deposited flux source is c * f * radEnergySource, so c is always the runtime
 	//!			   speed of light and the injected radiation satisfies F = f c E by construction. f = 0 (the
 	//!			   default) injects isotropic radiation; |f| = 1 injects fully beamed (free-streaming) radiation.
-	static void SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
+	static void AddRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
+
+	//! Merge the source written by AddRadSource into the source that is actually deposited.
+	//!
+	//! Radiation from particles has already been deposited into radEnergySource, so the user source is
+	//! collected in its own buffers and merged here. Particle radiation is isotropic, so only the user
+	//! source carries a flux, and the reduced flux of the merged source is f_user * E_user / E_total.
+	static void MergeUserRadSource(array_t &radEnergySource, array_t &reducedFluxSource, arrayconst_t &userEnergySource, arrayconst_t &userReducedFlux,
+				       amrex::Box const &indexRange);
 
 	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
 						double gas_update_factor, double Ekin0, amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> const &Src_flux,
@@ -647,15 +658,39 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::SetRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
+void RadSystem<problem_t>::AddRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
 {
 	// Default implementation: no radiation source is added.
-	// Users should override this method to *add* custom radiation sources to radEnergySource, since particle
-	// radiation has already been deposited there. reducedFluxSource is a ratio rather than an amount, so it
-	// should be assigned, not accumulated; it defaults to zero, i.e. isotropic injection.
+	// Users should override this method to set their own radiation source. Both buffers belong to this hook
+	// alone and are zeroed before every call, so simply assign to them; the framework merges the result into
+	// the source that particles have already deposited into.
 	// This function is intentionally left blank.
+}
+
+template <typename problem_t>
+void RadSystem<problem_t>::MergeUserRadSource(array_t &radEnergySource, array_t &reducedFluxSource, arrayconst_t &userEnergySource,
+					      arrayconst_t &userReducedFlux, amrex::Box const &indexRange)
+{
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+		for (int g = 0; g < nGroups_; ++g) {
+			const double fx = userReducedFlux(i, j, k, 3 * g + 0);
+			const double fy = userReducedFlux(i, j, k, 3 * g + 1);
+			const double fz = userReducedFlux(i, j, k, 3 * g + 2);
+			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
+
+			const double Euser = userEnergySource(i, j, k, g);
+			const double Etot = radEnergySource(i, j, k, g) + Euser;
+			radEnergySource(i, j, k, g) = Etot;
+
+			// particle radiation is isotropic, so only the user source contributes to the flux
+			const double weight = (Etot > 0.0) ? (Euser / Etot) : 0.0;
+			reducedFluxSource(i, j, k, 3 * g + 0) = weight * fx;
+			reducedFluxSource(i, j, k, 3 * g + 1) = weight * fy;
+			reducedFluxSource(i, j, k, 3 * g + 2) = weight * fz;
+		}
+	});
 }
 
 template <typename problem_t>

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -313,6 +313,7 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	//!			   build). The deposited flux source is c * f * radEnergySource, so c is always the runtime
 	//!			   speed of light and the injected radiation satisfies F = f c E by construction. f = 0 (the
 	//!			   default) injects isotropic radiation; |f| = 1 injects fully beamed (free-streaming) radiation.
+	//!			   Asking for the reduced flux rather than the flux itself makes |F| > c E unrepresentable.
 	static void AddRadSource(array_t &radEnergySource, array_t &reducedFluxSource, amrex::Box const &indexRange,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
 				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
@@ -320,21 +321,21 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	//! Merge the source written by AddRadSource into the source that is actually deposited.
 	//!
 	//! Radiation from particles has already been deposited into radEnergySource, so the user source is
-	//! collected in its own buffers and merged here. Particle radiation is isotropic, so only the user
-	//! source carries a flux, and the reduced flux of the merged source is f_user * E_user / E_total.
-	static void MergeUserRadSource(array_t &radEnergySource, array_t &reducedFluxSource, arrayconst_t &userEnergySource, arrayconst_t &userReducedFlux,
+	//! collected in its own buffers and added here. The user gives a reduced flux, which is converted to
+	//! the flux source c * f * E that the solver consumes; unit: erg cm^-2 s^-2.
+	static void MergeUserRadSource(array_t &radEnergySource, array_t &radFluxSource, arrayconst_t &userEnergySource, arrayconst_t &userReducedFlux,
 				       amrex::Box const &indexRange);
 
 	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
 						double gas_update_factor, double Ekin0, amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> const &Src_flux,
 						double Emag = {}) -> FluxUpdateResult<problem_t>;
 
-	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
+	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
 					     amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
 					     double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
 
-	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
+	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
 					      amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
 					      double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					      std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
@@ -670,25 +671,28 @@ void RadSystem<problem_t>::AddRadSource(array_t &radEnergySource, array_t &reduc
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::MergeUserRadSource(array_t &radEnergySource, array_t &reducedFluxSource, arrayconst_t &userEnergySource,
+void RadSystem<problem_t>::MergeUserRadSource(array_t &radEnergySource, array_t &radFluxSource, arrayconst_t &userEnergySource,
 					      arrayconst_t &userReducedFlux, amrex::Box const &indexRange)
 {
+	const double c = c_light_;
+
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int g = 0; g < nGroups_; ++g) {
+			const double Euser = userEnergySource(i, j, k, g);
 			const double fx = userReducedFlux(i, j, k, 3 * g + 0);
 			const double fy = userReducedFlux(i, j, k, 3 * g + 1);
 			const double fz = userReducedFlux(i, j, k, 3 * g + 2);
-			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
 
-			const double Euser = userEnergySource(i, j, k, g);
-			const double Etot = radEnergySource(i, j, k, g) + Euser;
-			radEnergySource(i, j, k, g) = Etot;
+			// Each contribution must be physical on its own. The set {(E, F) : E >= 0, |F| <= c E} is a
+			// convex cone, so the sum of physical contributions is physical by the triangle inequality:
+			// |F1 + F2| <= |F1| + |F2| <= c (E1 + E2). No flux limiter is needed here.
+			AMREX_ASSERT(Euser >= 0.0);
+			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10);
 
-			// particle radiation is isotropic, so only the user source contributes to the flux
-			const double weight = (Etot > 0.0) ? (Euser / Etot) : 0.0;
-			reducedFluxSource(i, j, k, 3 * g + 0) = weight * fx;
-			reducedFluxSource(i, j, k, 3 * g + 1) = weight * fy;
-			reducedFluxSource(i, j, k, 3 * g + 2) = weight * fz;
+			radEnergySource(i, j, k, g) += Euser;
+			radFluxSource(i, j, k, 3 * g + 0) += c * fx * Euser;
+			radFluxSource(i, j, k, 3 * g + 1) += c * fy * Euser;
+			radFluxSource(i, j, k, 3 * g + 2) += c * fz * Euser;
 		}
 	});
 }

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -671,8 +671,8 @@ void RadSystem<problem_t>::AddRadSource(array_t &radEnergySource, array_t &reduc
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::MergeUserRadSource(array_t &radEnergySource, array_t &radFluxSource, arrayconst_t &userEnergySource,
-					      arrayconst_t &userReducedFlux, amrex::Box const &indexRange)
+void RadSystem<problem_t>::MergeUserRadSource(array_t &radEnergySource, array_t &radFluxSource, arrayconst_t &userEnergySource, arrayconst_t &userReducedFlux,
+					      amrex::Box const &indexRange)
 {
 	const double c = c_light_;
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -302,21 +302,27 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 				  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx, bool use_wavespeed_correction,
 				  std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
 
-	static void SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-				       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi,
-				       amrex::Real time);
+	//! Set the user-defined radiation source terms.
+	//!
+	//! \param radEnergySource luminosity volume density of group g, in component g; unit: erg s^-1 cm^-3.
+	//! \param radFluxSource   flux source of group g along direction n, in component 3 * g + n; unit: erg cm^-2 s^-2.
+	//!			   Setting radFluxSource = c * radEnergySource injects fully beamed (free-streaming) radiation.
+	static void SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+				 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time);
 
 	AMREX_GPU_DEVICE static auto UpdateFlux(int i, int j, int k, arrayconst_t const &consPrev, NewtonIterationResult<problem_t> &energy, double dt,
-						double gas_update_factor, double Ekin0, double Emag = {}) -> FluxUpdateResult<problem_t>;
+						double gas_update_factor, double Ekin0, amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> const &Src_flux,
+						double Emag = {}) -> FluxUpdateResult<problem_t>;
 
-	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt_implicit,
-					     double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor,
-					     int *p_iteration_counter, int *p_iteration_failure_counter,
+	static void AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+					     amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
+					     double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
 
-	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt_implicit,
-					      double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h, double tempFloor,
-					      int *p_iteration_counter, int *p_iteration_failure_counter,
+	static void AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+					      amrex::Real dt_implicit, double gas_update_factor, double dustGasCoeff, double tol_h, double tol_rel_h,
+					      double tempFloor, int *p_iteration_counter, int *p_iteration_failure_counter,
 					      std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc = {});
 
 	static void balanceMatterRadiation(arrayconst_t &consPrev, array_t &consNew, amrex::Box const &indexRange);
@@ -638,12 +644,12 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::Solve3x3matrix(const double C00
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::SetRadEnergySource(array_t &radEnergySource, amrex::Box const &indexRange, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-					      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
+void RadSystem<problem_t>::SetRadSource(array_t &radEnergySource, array_t &radFluxSource, amrex::Box const &indexRange,
+					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_hi, amrex::Real time)
 {
 	// Default implementation: no radiation source is added.
-	// Users should override this method to *add* custom radiation sources to radEnergySource.
+	// Users should override this method to *add* custom radiation sources to radEnergySource and radFluxSource.
 	// This function is intentionally left blank.
 }
 

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -590,9 +590,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource,
-						    amrex::Box const &indexRange, amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
-						    double const tol_h, double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
+void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+						    amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double const tol_h,
+						    double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
 						    int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	static_assert(beta_order_ == 0 || beta_order_ == 1);

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -426,7 +426,8 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::SolveGasRadiationEnergyExchange(
 // Update radiation flux and gas momentum. Returns FluxUpdateResult struct. The function also updates energy.Egas and energy.work.
 template <typename problem_t>
 AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j, int const k, arrayconst_t &consPrev, NewtonIterationResult<problem_t> &energy,
-						       double const dt, double const gas_update_factor, double const Ekin0, double Emag)
+						       double const dt, double const gas_update_factor, double const Ekin0,
+						       amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> const &Src_flux, double Emag)
     -> FluxUpdateResult<problem_t>
 {
 	amrex::GpuArray<amrex::Real, 3> Frad_t0{};
@@ -448,9 +449,11 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 	const double chat = c_hat_;
 
 	for (int g = 0; g < nGroups_; ++g) {
-		Frad_t0[0] = consPrev(i, j, k, x1RadFlux_index + numRadVars_ * g);
-		Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index + numRadVars_ * g);
-		Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index + numRadVars_ * g);
+		// The user-defined flux source is added to the old-time flux, so the implicit absorption below acts on
+		// the freshly injected radiation as well.
+		Frad_t0[0] = consPrev(i, j, k, x1RadFlux_index + numRadVars_ * g) + Src_flux[0][g];
+		Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index + numRadVars_ * g) + Src_flux[1][g];
+		Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index + numRadVars_ * g) + Src_flux[2][g];
 
 		if constexpr ((gamma_ == 1.0) || (beta_order_ == 0)) {
 			for (int n = 0; n < 3; ++n) {
@@ -587,10 +590,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, amrex::Real dt_implicit,
-						    double gas_update_factor_in, double dustGasCoeff, double const tol_h, double const tol_rel_h,
-						    double const tempFloor_local, int *p_iteration_counter, int *p_iteration_failure_counter,
-						    std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
+void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+						    amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double const tol_h,
+						    double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
+						    int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	static_assert(beta_order_ == 0 || beta_order_ == 1);
 
@@ -650,6 +653,18 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 			Src[g] = (RadSystem_NChemBands<problem_t>::value > 0 && g >= nGroups_ - RadSystem_NChemBands<problem_t>::value)
 				     ? dt * radEnergySource(i, j, k, g)
 				     : dt * (chat / c * radEnergySource(i, j, k, g));
+		}
+
+		// load the radiation flux source term, scaled exactly like the energy source above so that a user
+		// setting radFluxSource = c * radEnergySource injects free-streaming (|F| = c E) radiation:
+		// thermal groups are scaled by chat/c, chemical (ionizing) bands are not.
+		amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> Src_flux{};
+		for (int g = 0; g < nGroups_; ++g) {
+			const bool is_chem_band = (RadSystem_NChemBands<problem_t>::value > 0) && (g >= nGroups_ - RadSystem_NChemBands<problem_t>::value);
+			const double flux_scale = is_chem_band ? dt : dt * (chat / c);
+			for (int n = 0; n < 3; ++n) {
+				Src_flux[n][g] = flux_scale * radFluxSource(i, j, k, 3 * g + n);
+			}
 		}
 
 		double Egas0 = NAN;
@@ -775,7 +790,7 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 			// 2. Compute radiation flux update
 
 			// 2.1. Update flux and gas momentum
-			auto updated_flux = UpdateFlux(i, j, k, consPrev, updated_energy, dt, gas_update_factor, Ekin0, Emag);
+			auto updated_flux = UpdateFlux(i, j, k, consPrev, updated_energy, dt, gas_update_factor, Ekin0, Src_flux, Emag);
 
 			// 2.2. Check for convergence of the work term
 			bool work_converged = true;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -590,7 +590,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
 						    amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double const tol_h,
 						    double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
 						    int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
@@ -655,16 +655,18 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 				     : dt * (chat / c * radEnergySource(i, j, k, g));
 		}
 
-		// load the radiation flux source term, scaled exactly like the energy source above so that a user
-		// setting radFluxSource = c * radEnergySource injects free-streaming (|F| = c E) radiation:
-		// thermal groups are scaled by chat/c, chemical (ionizing) bands are not.
+		// load the user-defined reduced flux f = F / (c E) of the injected radiation of each group. The flux
+		// source is c * f * Src, so it inherits the group-dependent scaling of the energy source above and
+		// the injected radiation satisfies F = f c E exactly, with c the runtime speed of light.
 		amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> Src_flux{};
 		for (int g = 0; g < nGroups_; ++g) {
-			const bool is_chem_band = (RadSystem_NChemBands<problem_t>::value > 0) && (g >= nGroups_ - RadSystem_NChemBands<problem_t>::value);
-			const double flux_scale = is_chem_band ? dt : dt * (chat / c);
-			for (int n = 0; n < 3; ++n) {
-				Src_flux[n][g] = flux_scale * radFluxSource(i, j, k, 3 * g + n);
-			}
+			const double fx = reducedFluxSource(i, j, k, 3 * g + 0);
+			const double fy = reducedFluxSource(i, j, k, 3 * g + 1);
+			const double fz = reducedFluxSource(i, j, k, 3 * g + 2);
+			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
+			Src_flux[0][g] = c * fx * Src[g];
+			Src_flux[1][g] = c * fy * Src[g];
+			Src_flux[2][g] = c * fz * Src[g];
 		}
 
 		double Egas0 = NAN;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -590,7 +590,7 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource,
+void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource,
 						    amrex::Box const &indexRange, amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
 						    double const tol_h, double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
 						    int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
@@ -645,28 +645,19 @@ void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst
 		// load radiation energy source term
 		// plus advection source term (for well-balanced/SDC integrators)
 		// Note that radEnergySource should contain the luminosity volume density, L / V; unit: erg s^-1 cm^-3
+		// The radiation flux source is scaled exactly like the energy source; unit: erg cm^-2 s^-2.
 		quokka::valarray<double, nGroups_> Src;
+		amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> Src_flux{};
 		for (int g = 0; g < nGroups_; ++g) {
 			// The last NChemBands groups are ionizing photon groups (no cscale).
 			// All other (thermal) groups require scaling by chat/c (= 1/cscale).
 			// Avoid if constexpr here: NVCC rejects first-captures inside constexpr-if in device lambdas.
-			Src[g] = (RadSystem_NChemBands<problem_t>::value > 0 && g >= nGroups_ - RadSystem_NChemBands<problem_t>::value)
-				     ? dt * radEnergySource(i, j, k, g)
-				     : dt * (chat / c * radEnergySource(i, j, k, g));
-		}
-
-		// load the user-defined reduced flux f = F / (c E) of the injected radiation of each group. The flux
-		// source is c * f * Src, so it inherits the group-dependent scaling of the energy source above and
-		// the injected radiation satisfies F = f c E exactly, with c the runtime speed of light.
-		amrex::GpuArray<quokka::valarray<double, nGroups_>, 3> Src_flux{};
-		for (int g = 0; g < nGroups_; ++g) {
-			const double fx = reducedFluxSource(i, j, k, 3 * g + 0);
-			const double fy = reducedFluxSource(i, j, k, 3 * g + 1);
-			const double fz = reducedFluxSource(i, j, k, 3 * g + 2);
-			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
-			Src_flux[0][g] = c * fx * Src[g];
-			Src_flux[1][g] = c * fy * Src[g];
-			Src_flux[2][g] = c * fz * Src[g];
+			const double src_scale =
+			    (RadSystem_NChemBands<problem_t>::value > 0 && g >= nGroups_ - RadSystem_NChemBands<problem_t>::value) ? dt : dt * (chat / c);
+			Src[g] = src_scale * radEnergySource(i, j, k, g);
+			for (int n = 0; n < 3; ++n) {
+				Src_flux[n][g] = src_scale * radFluxSource(i, j, k, 3 * g + n);
+			}
 		}
 
 		double Egas0 = NAN;

--- a/src/radiation/source_terms_multi_group.hpp
+++ b/src/radiation/source_terms_multi_group.hpp
@@ -590,9 +590,9 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::UpdateFlux(int const i, int const j,
 }
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
-						    amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double const tol_h,
-						    double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
+void RadSystem<problem_t>::AddSourceTermsMultiGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource,
+						    amrex::Box const &indexRange, amrex::Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
+						    double const tol_h, double const tol_rel_h, double const tempFloor_local, int *p_iteration_counter,
 						    int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	static_assert(beta_order_ == 0 || beta_order_ == 1);

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -7,9 +7,9 @@
 #define LARGE 1.0e100
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, amrex::Box const &indexRange, Real dt_implicit,
-						     double gas_update_factor_in, double dustGasCoeff, double tol_h, double /*tol_rel_h*/, double /*tempFloor*/,
-						     int *p_iteration_counter, int *p_iteration_failure_counter,
+void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+						     Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double tol_h, double /*tol_rel_h*/,
+						     double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter,
 						     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
@@ -60,6 +60,17 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		const double Src = RadSystem_Has_ChemBands<problem_t>::value ? radEnergySource(i, j, k, 0) * dt : radEnergySource(i, j, k, 0) * dt / cscale;
 		if constexpr (gamma_ != 1.0) {
 			AMREX_ASSERT(Src >= 0.0);
+		}
+
+		// load the radiation flux source term, scaled exactly like the energy source above so that a user
+		// setting radFluxSource = c * radEnergySource injects free-streaming (|F| = c E) radiation:
+		// a thermal group is scaled by chat/c (= 1/cscale), a chemical (ionizing) band is not. In a
+		// single-group run the only group is a chemical band exactly when ChemBands is defined.
+		const bool is_chem_band = RadSystem_Has_ChemBands<problem_t>::value;
+		const double flux_scale = is_chem_band ? dt : dt / cscale;
+		amrex::GpuArray<amrex::Real, 3> Src_flux{};
+		for (int n = 0; n < 3; ++n) {
+			Src_flux[n] = flux_scale * radFluxSource(i, j, k, n);
 		}
 
 		double Egas0 = NAN;
@@ -390,9 +401,11 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 			amrex::GpuArray<amrex::Real, 3> Frad_t0{};
 			dMomentum = {0., 0., 0.};
 
-			Frad_t0[0] = consPrev(i, j, k, x1RadFlux_index);
-			Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index);
-			Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index);
+			// The user-defined flux source is added to the old-time flux, so the implicit absorption below acts
+			// on the freshly injected radiation as well.
+			Frad_t0[0] = consPrev(i, j, k, x1RadFlux_index) + Src_flux[0];
+			Frad_t0[1] = consPrev(i, j, k, x2RadFlux_index) + Src_flux[1];
+			Frad_t0[2] = consPrev(i, j, k, x3RadFlux_index) + Src_flux[2];
 
 			if constexpr ((gamma_ != 1.0) && (beta_order_ != 0)) {
 				auto erad = Erad_guess;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -7,7 +7,7 @@
 #define LARGE 1.0e100
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
 						     Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double tol_h, double /*tol_rel_h*/,
 						     double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter,
 						     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
@@ -62,15 +62,18 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 			AMREX_ASSERT(Src >= 0.0);
 		}
 
-		// load the radiation flux source term, scaled exactly like the energy source above so that a user
-		// setting radFluxSource = c * radEnergySource injects free-streaming (|F| = c E) radiation:
-		// a thermal group is scaled by chat/c (= 1/cscale), a chemical (ionizing) band is not. In a
-		// single-group run the only group is a chemical band exactly when ChemBands is defined.
-		const bool is_chem_band = RadSystem_Has_ChemBands<problem_t>::value;
-		const double flux_scale = is_chem_band ? dt : dt / cscale;
+		// load the user-defined reduced flux f = F / (c E) of the injected radiation. The flux source is
+		// c * f * Src, so it inherits the scaling of the energy source above and the injected radiation
+		// satisfies F = f c E exactly, with c the runtime speed of light.
 		amrex::GpuArray<amrex::Real, 3> Src_flux{};
-		for (int n = 0; n < 3; ++n) {
-			Src_flux[n] = flux_scale * radFluxSource(i, j, k, n);
+		{
+			const double fx = reducedFluxSource(i, j, k, 0);
+			const double fy = reducedFluxSource(i, j, k, 1);
+			const double fz = reducedFluxSource(i, j, k, 2);
+			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
+			Src_flux[0] = c * fx * Src;
+			Src_flux[1] = c * fy * Src;
+			Src_flux[2] = c * fz * Src;
 		}
 
 		double Egas0 = NAN;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -7,7 +7,7 @@
 #define LARGE 1.0e100
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource,
+void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource,
 						     amrex::Box const &indexRange, Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
 						     double tol_h, double /*tol_rel_h*/, double /*tempFloor*/, int *p_iteration_counter,
 						     int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
@@ -57,23 +57,16 @@ void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arraycons
 		// Note that radEnergySource should contain the luminosity volume density, L / V; unit: erg s^-1 cm^-3
 		// Single-group: if ChemBands is defined the only group is an ionizing photon group (no cscale).
 		// For thermal groups, radEnergySource must be scaled by chat/c (= 1/cscale).
-		const double Src = RadSystem_Has_ChemBands<problem_t>::value ? radEnergySource(i, j, k, 0) * dt : radEnergySource(i, j, k, 0) * dt / cscale;
+		const double src_scale = RadSystem_Has_ChemBands<problem_t>::value ? dt : dt / cscale;
+		const double Src = src_scale * radEnergySource(i, j, k, 0);
 		if constexpr (gamma_ != 1.0) {
 			AMREX_ASSERT(Src >= 0.0);
 		}
 
-		// load the user-defined reduced flux f = F / (c E) of the injected radiation. The flux source is
-		// c * f * Src, so it inherits the scaling of the energy source above and the injected radiation
-		// satisfies F = f c E exactly, with c the runtime speed of light.
+		// load the radiation flux source term, scaled exactly like the energy source above; unit: erg cm^-2 s^-2
 		amrex::GpuArray<amrex::Real, 3> Src_flux{};
-		{
-			const double fx = reducedFluxSource(i, j, k, 0);
-			const double fy = reducedFluxSource(i, j, k, 1);
-			const double fz = reducedFluxSource(i, j, k, 2);
-			AMREX_ASSERT(fx * fx + fy * fy + fz * fz <= 1.0 + 1.0e-10); // |f| <= 1 is required for a physical flux
-			Src_flux[0] = c * fx * Src;
-			Src_flux[1] = c * fy * Src;
-			Src_flux[2] = c * fz * Src;
+		for (int n = 0; n < 3; ++n) {
+			Src_flux[n] = src_scale * radFluxSource(i, j, k, n);
 		}
 
 		double Egas0 = NAN;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -7,10 +7,10 @@
 #define LARGE 1.0e100
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource,
-						     amrex::Box const &indexRange, Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
-						     double tol_h, double /*tol_rel_h*/, double /*tempFloor*/, int *p_iteration_counter,
-						     int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
+void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &radFluxSource, amrex::Box const &indexRange,
+						     Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double tol_h, double /*tol_rel_h*/,
+						     double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter,
+						     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
 	array_t &consNew = consVar;

--- a/src/radiation/source_terms_single_group.hpp
+++ b/src/radiation/source_terms_single_group.hpp
@@ -7,10 +7,10 @@
 #define LARGE 1.0e100
 
 template <typename problem_t>
-void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource, amrex::Box const &indexRange,
-						     Real dt_implicit, double gas_update_factor_in, double dustGasCoeff, double tol_h, double /*tol_rel_h*/,
-						     double /*tempFloor*/, int *p_iteration_counter, int *p_iteration_failure_counter,
-						     std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
+void RadSystem<problem_t>::AddSourceTermsSingleGroup(array_t &consVar, arrayconst_t &radEnergySource, arrayconst_t &reducedFluxSource,
+						     amrex::Box const &indexRange, Real dt_implicit, double gas_update_factor_in, double dustGasCoeff,
+						     double tol_h, double /*tol_rel_h*/, double /*tempFloor*/, int *p_iteration_counter,
+						     int *p_iteration_failure_counter, std::array<amrex::Array4<const amrex::Real>, AMREX_SPACEDIM> cons_fc)
 {
 	arrayconst_t &consPrev = consVar; // make read-only
 	array_t &consNew = consVar;


### PR DESCRIPTION
### Description

Renames `RadSystem::SetRadEnergySource` to `AddRadSource` and gives it a second buffer alongside the energy source, so problems can inject directed rather than isotropic radiation.

The hook supplies the reduced flux $f = F / (cE)$ of its source, in components $3 g + n$ for group $g$ and direction $n$. Asking for a reduced flux rather than a flux means the unphysical case $|F| > cE$ cannot be expressed, and that $c$ is applied by the code at its runtime value rather than by the user at write time; $|f| \leq 1$ is asserted in a debug build. $f = 0$ is isotropic injection and $|f| = 1$ is a fully beamed, free-streaming source.

`AddRadSource` writes into scratch buffers of its own, which `MergeUserRadSource` adds to the source that particles have already deposited into, converting the reduced flux once into a flux source $c f E$. A problem therefore just assigns its own source: it cannot overwrite the particle deposition, and need not remember to accumulate onto it. Nothing downstream sees a reduced flux — the solver consumes a flux source in erg cm $^{-2}$ s $^{-2}$, scaled exactly like the energy source. Summing physical contributions needs no flux limiter, because $\{(E, F) : E \geq 0, |F| \leq cE\}$ is a convex cone and hence closed under addition.

Both implicit stages of the IMEX PD-ARS tableau have abscissa $c = 1$, so every implicit source term belongs at the end of the step. `AddRadSource` was already evaluated at $t + \Delta t$, but particle deposition was evaluated at $t$; both now use $t + \Delta t$.

Existing problems keep isotropic injection; their overrides only pick up the new, ignored argument. Split out of #2126.

A new test variant, `RadStreamingFluxSource`, exercises the feature. It reuses the `RadStreaming` binary but injects the beam with `AddRadSource` inside the slab $0.1 \leq x < 0.2$, setting $f = (1, 0, 0)$, instead of through the left Dirichlet boundary; the variant is selected by `problem.flux_source = 1` in the input file. In the free-streaming limit the exact solution is a trapezoid: a ramp $0 \to 1$ across the source slab, a plateau at $1$ out to $x = 0.1 + \hat{c} t$, and a ramp back to $0$ at the front $x = 0.2 + \hat{c} t$. The test checks the $L_1$ error against that solution and, separately, that the reduced flux $F / (cE)$ equals $1$ across the beam.

Measured: $L_1 = 2.1 \times 10^{-3}$ (tolerance $0.05$) and a maximum reduced-flux deviation of $4.4 \times 10^{-6}$ (tolerance $10^{-4}$). Zeroing the reduced flux in the problem hook — which is what a broken or ignored flux source would look like — moves these to $0.99$ and $0.31$, so both checks fail decisively.

`ParticleRadiation`, its two variants and `GravRadParticle3D` still pass after the change to the deposition time, but none of them exercises it: their particles are active for the whole run, so shifting the evaluation time by one substep does not change which particles emit. A targeted test of a particle turning on or off mid-run is still missing.

### Related issues

Stacked with #2126. This branch is cut from #2126 and adds only the `RadStreamingFluxSource` test on top of it, so it is the smaller half and should merge to `development` first. #2126 then consumes the feature: its `DTypeFront1D` problem sets $f = -1$ left of its central source and $f = +1$ right of it, so each half of the source is injected beamed outward. That matters there because an isotropic source injects no net momentum, which leaves that test's outward-momentum budget measuring how quickly the M1 closure can beam an isotropic source (0.78 of the injected momentum, drifting with resolution) instead of what the solver did with it (1.004, flat under an eightfold refinement). Prose documentation for the hook and the scaling of both buffers is added in #2126, in `docs/markdown/radiation_integrator.md`.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Radiation source handling now supports both energy and flux sources.
  - Radiation flux contributions are incorporated during subcycling and implicit updates.
  - Added configurable interior flux-source injection for radiation streaming scenarios.
  - Added validation for radiation profiles and reduced-flux beaming.
- **Refactor**
  - Unified radiation source interfaces across supported simulation problems.
  - Updated radiation flux calculations to account for source contributions.
- **Documentation**
  - Updated the radiation flowchart to reflect the revised source-deposition process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
