### PR TITLE
installation.md: AMReX_GPU_ARCH should be AMReX_AMD_ARCH

### DIFF
--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -116,7 +116,7 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
          -DCMAKE_CXX_COMPILER=amdclang++ \
          -DCMAKE_C_COMPILER=amdclang \
          -DAMReX_GPU_BACKEND=HIP \
-         -DAMReX_GPU_ARCH=gfx1031 \
+         -DAMReX_AMD_ARCH=gfx1031 \
          -G Ninja
 ```
 

--- a/docs/markdown/installation.md
+++ b/docs/markdown/installation.md
@@ -103,7 +103,7 @@ which should end with output similar to the following:
 
 > *Requires ROCm 6.3.0 or newer. The directory containing the HIP and other related binaries must be added to the `PATH` environment variable after the ROCm installation.*
 
-Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. The typical AMD GPU compilers are `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_GPU_ARCH` option. The GPU architecture can be found using
+Build with `-DAMReX_GPU_BACKEND=HIP`. Your MPI library **must** support GPU-aware MPI for AMD GPUs. The typical AMD GPU compilers are `amdclang++` or `hipcc`. In case your GPU-aware compiler is not being used by default during the build, use the `DCMAKE_CXX_COMPILER` and `DCMAKE_C_COMPILER` options to specify the C++ and C compilers respectively. Additionally, the AMD GPU architecture may have to be specified. This can be done using the `DAMReX_AMD_ARCH` option. The GPU architecture can be found using
 
 ```shell
 rocminfo | grep gfx


### PR DESCRIPTION
I don't see AMReX_GPU_ARCH in the amrex repo history, so I assume this was a typo.

### Description
Fix error
```
CMake Error at extern/amrex/Tools/CMake/AMReXOptions.cmake:239 (message):


  Must specify AMReX_AMD_ARCH if AMReX_GPU_BACKEND=HIP
```
when adapting the example command
```
cmake .. -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_CXX_COMPILER=amdclang++ \
         -DCMAKE_C_COMPILER=amdclang \
         -DAMReX_GPU_BACKEND=HIP \
         -DAMReX_GPU_ARCH=gfx1031 \
         -G Ninja
```

Also changed mention of the variable in the paragraph before the command.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.

PS: https://quokka-astro.github.io/quokka/contributing/ linked in CONTRIBUTING.md 404s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

- Updated AMD GPU build instructions to use the current CMake architecture option.
- Updated both the explanatory text and example build command for specifying AMD GPU architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->