### PR TITLE
Update Setonix configuration

### DIFF
--- a/scripts/hpc_profiles/setonix-gpu.profile
+++ b/scripts/hpc_profiles/setonix-gpu.profile
@@ -1,29 +1,66 @@
 #!/bin/bash
 
-source /opt/cray/pe/cpe/25.03/restore_lmod_system_defaults.sh
+source /opt/cray/pe/cpe/26.03/restore_lmod_system_defaults.sh
 
-module load cpe/25.03
+module load cpe/26.03
 module load pawseyenv/2025.08
 
 module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
 
-module load rocm/6.4.1 # MUST use 6.3+ to avoid compiler bugs
-module load cray-mpich
-module load cce/19.0.0
+module load cce/21.0.2
+module load cray-mpich/9.1.0
+
+# singularity
+module load singularity/4.1.0-slurm
 
 # hdf5
-module load hdf5/1.14.5-parallel-api-v112
-
-# adios2 (optional)
-#module load adios2/2.10.2-hdf5
+module load cray-hdf5
 
 # python
-module load cray-python/3.11.7
+module load cray-python/3.12.12
+
+# ROCm 7.14 user-space SDK for the MI250X (gfx90a). The host amdgpu
+# driver is supplied by Setonix; install the wheel environment only once.
+ROCM_VENV="${MYSOFTWARE}/venvs/rocm-7.14"
+
+# Keep pip's large downloads and temporary build files out of $HOME, where
+# Setonix applies a comparatively small quota. Pawsey defines $MYSCRATCH and
+# $MYSOFTWARE for each user/project, so no account-specific paths are needed.
+export PIP_CACHE_DIR="${MYSCRATCH:?MYSCRATCH is not set}/pip-cache"
+export TMPDIR="${MYSCRATCH}/pip-tmp"
+mkdir -p "${PIP_CACHE_DIR}" "${TMPDIR}" "$(dirname "${ROCM_VENV}")"
+
+# Checking only bin/python is insufficient: a failed pip invocation leaves a
+# valid but incomplete virtual environment. Retry until the target SDK exists.
+if [[ ! -x "${ROCM_VENV}/bin/python" ]] ||
+   ! "${ROCM_VENV}/bin/python" -m pip show rocm-sdk-device-gfx90a \
+     >/dev/null 2>&1; then
+  python -m venv "${ROCM_VENV}"
+  "${ROCM_VENV}/bin/python" -m pip install --upgrade pip
+  "${ROCM_VENV}/bin/python" -m pip install \
+    --index-url https://repo.amd.com/rocm/whl-multi-arch/ \
+    "rocm[libraries,devel,device-gfx90a]==7.14.0"
+fi
+source "${ROCM_VENV}/bin/activate"
+
+echo "Initializing ROCm SDK... (may take several minutes on a parallel file system, please be patient)"
+rocm-sdk init
+
+# Expose the wheel-provided ROCm installation to CMake and AMReX. The SDK
+# activation places hipcc on PATH but does not currently publish its CMake
+# package prefix or HIP installation path.
+ROCM_SDK_ROOT="${ROCM_VENV}/lib/python3.12/site-packages/_rocm_sdk_devel"
+export ROCM_PATH="${ROCM_SDK_ROOT}"
+export HIP_PATH="${ROCM_SDK_ROOT}"
+export CMAKE_PREFIX_PATH="${ROCM_SDK_ROOT}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+export LD_LIBRARY_PATH="${ROCM_SDK_ROOT}/lib:${CRAY_LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 # cmake
-module load cmake/3.30.5
+if ! python -c 'import cmake' 2>/dev/null; then
+  python -m pip install cmake
+fi
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
@@ -42,4 +79,3 @@ export CXXFLAGS="-I${MPICH_DIR}/include --gcc-install-dir=/usr/lib64/gcc/x86_64-
 export LDFLAGS="-L${MPICH_DIR}/lib -lmpi \
   ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
   ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}"
-export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH

--- a/scripts/slurm/setonix-1node.submit
+++ b/scripts/slurm/setonix-1node.submit
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #SBATCH -A pawsey0807-gpu
 #SBATCH -J quokka_benchmark
 #SBATCH -o 1node_%x-%j.out
@@ -10,46 +9,55 @@
 ##SBATCH --ntasks-per-node=8
 ##SBATCH --gpus-per-node=8
 
+set -euo pipefail
+
+REPO_ROOT="${SLURM_SUBMIT_DIR:-$(pwd)}"
+cd "${REPO_ROOT}"
+
 # *MUST* load environment modules setup script inside the SLURM script, otherwise job will fail
 . scripts/hpc_profiles/setonix-gpu.profile
 
 # always run with GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
 
-# use correct NIC-to-GPU binding
+# Cray MPICH 9.1's small-message HSA path performs CPU non-temporal loads
+# from GPU mappings and segfaults on Setonix. Force all positive-size GPU
+# messages onto the HSA IPC path instead.
+export GTL_HSA_VSMSG_CUTOFF_SIZE=0
+
+# All GPUs remain visible for IPC, so select the NIC from each rank's CPU NUMA placement.
 export MPICH_OFI_NIC_POLICY=NUMA
 
 # OpenMP threads (pure MPI => 1)
 # QUOKKA does not use OpenMP, but it's good practice on Setonix to avoid accidental thread oversubscription
 export OMP_NUM_THREADS=1
 
-## run
-EXE="build/src/problems/HydroBlast3D/test_hydro3d_blast"
+# Run the 3D HIP build produced by `quokka config/build -d 3d-hip`.
+QUOKKA_PRESET="${QUOKKA_PRESET:-3d-hip}"
+EXE="build/${QUOKKA_PRESET}/src/problems/HydroBlast3D/HydroBlast3D"
 INPUTS="inputs/benchmark_unigrid_512.toml"
 
-# Wrapper that sets ROCR_VISIBLE_DEVICES per task
-# Create it in the working directory
-cat > selectGPU_X.sh << 'EOF'
-#!/bin/bash
-# Set the visible GPU for this task to its local task ID on the node
-export ROCR_VISIBLE_DEVICES="$SLURM_LOCALID"
-exec "$@"
-EOF
-chmod 755 ./selectGPU_X.sh
+if [[ ! -x "${EXE}" ]]; then
+	echo "Error: executable not found: ${EXE}" >&2
+	echo "Build it with: ./scripts/bash/quokka build -d ${QUOKKA_PRESET} HydroBlast3D" >&2
+	exit 1
+fi
 
-# Generate optimal CPU binding list for 8 tasks on the GPUs allocated to this job
-CPU_BIND=$(generate_CPU_BIND.sh map_cpu)
+# Keep every allocated GPU visible to every rank for Cray GTL IPC, while
+# placing local rank N on the CPU chiplet nearest GCD N (AMReX's assignment).
+CPU_BIND="$(generate_CPU_BIND.sh map_cpu)"
 echo -e "\n# CPU_BIND=${CPU_BIND}"
 
-echo -e "\n# Run: 8 MPI tasks, manual GPU + CPU binding"
+echo -e "\n# Run: 8 MPI tasks, IPC-safe GPU + CPU binding"
 # Notes:
 # -N 1, -n 8: 8 ranks on this node
 # -c 8: reserve one full chiplet per rank (actual threads controlled by OMP_NUM_THREADS)
 # --gres=gpu:8: expose 8 GPUs per node to this step
-# --cpu-bind=${CPU_BIND}: bind each rank to the chiplet matching its GPU
-# No --gpus-per-task, no --gpu-bind (manual binding avoids ROCm IPC attach error)
-srun -N 1 -n 8 -c 8 --gres=gpu:8 --cpu-bind=${CPU_BIND} ./selectGPU_X.sh ${EXE} ${INPUTS}
+# --gpu-bind=none: avoid per-task device cgroups that prevent peer-GPU IPC
+# --cpu-bind=${CPU_BIND}: preserve the optimal rank-to-chiplet-to-GCD mapping
+srun -N 1 -n 8 -c 8 --gres=gpu:8 --gpu-bind=none --cpu-bind="verbose,${CPU_BIND}" \
+	"${EXE}" "${INPUTS}"
 
 echo -e "\n# sacct summary"
-sacct -j ${SLURM_JOBID} -o jobid%20,Start%20,elapsed%20
+sacct -j "${SLURM_JOB_ID}" -o jobid%20,Start%20,elapsed%20
 echo -e "\n# Done"


### PR DESCRIPTION
### Description
Updates Setonix to use the latest ROCm 10.0.0. Adds a workaround for a strange GPU-aware MPI issue to the SLURM example job script.

Tested on Setonix (21 September 2026).

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the Setonix GPU environment with newer compiler, MPI, Python, Singularity, HDF5, ROCm, and CMake tooling.
  - Added persistent ROCm SDK and virtual-environment configuration with scratch-based caching.
  - Added support for selecting a configurable `3d-hip` executable preset.

- **Bug Fixes**
  - Improved GPU job launching and inter-process communication.
  - Added executable validation and clearer CPU/GPU binding behavior.
  - Improved submission reliability with stricter validation and directory handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->