### PR TITLE
Support turning off hydro and radiation while leaving self-gravity on

### DIFF
--- a/docs/markdown/components.md
+++ b/docs/markdown/components.md
@@ -76,6 +76,7 @@ Notes:
 - `Cooling + particles` is exercised by `ParticleSF`, `TallBoxSf`, `RandomBlast`, and `DiskGalaxy` through their input files.
 - `Hydro + dust` is exercised by the dust dynamics problems `DustAdvection*`, `DustDamping*`, `DustSoundwave`, and `DustyShock`.
 - `MHD + dust` is exercised by charged-dust and dust-MHD problems including `DustDampedGyromotion`, `DustDampingMHDZeroB`, `DustHallPedersenDrift`, `DustLorentzShock`, `DustMagnetizedRDI`, `DustyAlfvenWave`, and `DustyOrszagTang`.
+- `Self-gravity + particles` with **no** hyperbolic module is supported: a problem may set `is_hydro_enabled = false` and `is_radiation_enabled = false` while keeping `is_self_gravity_enabled = true`, in which case the timestep is set by the particle CFL condition alone. This is tested by `BinaryOrbitCICGravityOnly`, which reproduces the `BinaryOrbitCIC` orbit without any gas.
 
 
 ## Cell-centred state vector layout
@@ -102,7 +103,7 @@ Defined in `src/physics_info.hpp`. Computes starting indices and total component
 
 **`nvarTotal_cc` calculation:**
 
-- If neither hydro nor radiation is enabled: `nvarTotal_cc = nvarTotal_cc_adv` (= 1, for pure advection).
+- If neither hydro nor radiation is enabled: `nvarTotal_cc = nvarTotal_cc_adv` (= 1). In `AdvectionSimulation` this single component is the advected density; in `QuokkaSimulation` (e.g. a gravity-only problem with particles) nothing evolves it, and it is named `placeholder` in plotfiles and conservation sums.
 - Otherwise: `nvarTotal_cc = numHydroVars + numPassiveScalars + numDustVarsPerGroup * nDustGroups * is_dust_enabled + numRadVarsPerGroup * nGroups * is_radiation_enabled`.
 
 ## Cell-centred component map

--- a/inputs/BinaryOrbitCICGravityOnly.toml
+++ b/inputs/BinaryOrbitCICGravityOnly.toml
@@ -1,0 +1,33 @@
+# *****************************************************************
+# Problem size and geometry
+# *****************************************************************
+geometry.prob_lo = [-2.5e13, -2.5e13, -2.5e13]
+geometry.prob_hi = [2.5e13, 2.5e13, 2.5e13]
+quokka.bc = ["periodic", "periodic", "reflecting"]
+
+# *****************************************************************
+# VERBOSITY
+# *****************************************************************
+amr.v = 1  # verbosity in Amr
+
+# *****************************************************************
+# Resolution and refinement
+# *****************************************************************
+amr.n_cell = [32, 32, 32]
+amr.max_level = 0  # number of levels = max_level + 1
+amr.blocking_factor = 32  # grid size must be divisible by this
+amr.max_grid_size = 32  # at least 128 for GPUs
+amr.n_error_buf = 3  # minimum 3 cell buffer around tagged cells
+amr.grid_eff = 1.0
+
+do_reflux = 1
+do_subcycle = 0
+
+checkpoint_interval = -1
+plotfile_interval = -1
+
+tiny_profiler.enabled = 0
+
+cfl = 0.3
+max_timesteps = 20
+stop_time = 5.0e7  # s

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -487,6 +487,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::defineComponentN
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
 		std::vector<std::string> hydroNames = {"gasDensity", "x-GasMomentum", "y-GasMomentum", "z-GasMomentum", "gasEnergy", "gasInternalEnergy"};
 		componentNames_cc_.insert(componentNames_cc_.end(), hydroNames.begin(), hydroNames.end());
+	} else {
+		// Physics_Indices::nvarTotal_cc still allocates one cell-centred component when there is no
+		// hyperbolic state; name it so that plotfiles and conservation sums stay consistent
+		componentNames_cc_.emplace_back("placeholder");
 	}
 	// add passive scalar variables
 	if constexpr (Physics_Traits<problem_t>::numPassiveScalars > 0) {
@@ -906,9 +910,9 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::computeMaxSignal
 				});
 			}
 		} else {
-			// no physics modules enabled, why are we running?
-			amrex::Abort("At least one of hydro or radiation must be enabled! Cannot "
-				     "compute a time step.");
+			// no hyperbolic physics is enabled (e.g. self-gravity acting on particles only),
+			// so there is no signal speed and the timestep is set by the other physics modules
+			amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { maxSignal(i, j, k) = 0.0; });
 		}
 	}
 
@@ -1002,7 +1006,9 @@ void QuokkaSimulation<problem_t>::CheckHydroStates(amrex::MultiFab &mf, std::arr
 						   std::source_location const &location)
 {
 #ifndef NDEBUG
-	checkHydroStates(mf, mf_fc, location.file_name(), static_cast<int>(location.line()));
+	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled) {
+		checkHydroStates(mf, mf_fc, location.file_name(), static_cast<int>(location.line()));
+	}
 #else
 	static_cast<void>(mf);
 	static_cast<void>(mf_fc);
@@ -1557,6 +1563,12 @@ template <typename problem_t> auto QuokkaSimulation<problem_t>::computeErrorNorm
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::computeAfterEvolve(amrex::Vector<amrex::Real> &initSumCons)
 {
+	// there is no gas or radiation energy to report when neither hydro nor radiation is enabled
+	if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+		amrex::ignore_unused(initSumCons);
+		return;
+	}
+
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx0 = geom[0].CellSizeArray();
 	amrex::Real const vol = AMREX_D_TERM(dx0[0], *dx0[1], *dx0[2]);
 
@@ -1653,10 +1665,13 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 	// advance hydro
 	if constexpr (Physics_Traits<problem_t>::is_hydro_enabled) {
 		advanceHydroAtLevelWithRetries(lev, time, dt_lev, fr_as_crse, fr_as_fine, emf_as_crse, emf_as_fine);
-	} else {
+	} else if constexpr (Physics_Traits<problem_t>::is_radiation_enabled) {
 		// copy hydro vars from state_old_cc_ to state_new_cc_
 		// (otherwise radiation update will be wrong!)
 		amrex::MultiFab::Copy(state_new_cc_[lev], state_old_cc_[lev], 0, 0, nvars_, 0);
+	} else {
+		// no hyperbolic state: the cell-centred state holds only the unused placeholder component
+		amrex::MultiFab::Copy(state_new_cc_[lev], state_old_cc_[lev], 0, 0, state_new_cc_[lev].nComp(), 0);
 	}
 
 	// check hydro states after hydro update
@@ -1682,22 +1697,35 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::advanceSingleTim
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::fillPoissonRhsAtLevel(amrex::MultiFab &rhs_mf, const int lev)
 {
-	// add hydro density to Poisson rhs
-	auto const &state = state_new_cc_[lev].const_arrays();
-	auto rhs = rhs_mf.arrays();
-	const Real G = Gconst_;
+	// there is no gas density to add when neither hydro nor radiation is enabled
+	if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+		amrex::ignore_unused(rhs_mf, lev);
+		return;
+	} else {
+		// add hydro density to Poisson rhs
+		auto const &state = state_new_cc_[lev].const_arrays();
+		auto rhs = rhs_mf.arrays();
+		const Real G = Gconst_;
 
-	amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
-		// *add* density to rhs_mf
-		// (N.B. particles **will not work** if you overwrite the density here!)
-		rhs[bx](i, j, k) += 4.0 * M_PI * G * state[bx](i, j, k, HydroSystem<problem_t>::density_index);
-	});
-	amrex::Gpu::streamSynchronizeAll();
+		amrex::ParallelFor(rhs_mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept {
+			// *add* density to rhs_mf
+			// (N.B. particles **will not work** if you overwrite the density here!)
+			rhs[bx](i, j, k) += 4.0 * M_PI * G * state[bx](i, j, k, HydroSystem<problem_t>::density_index);
+		});
+		amrex::Gpu::streamSynchronizeAll();
+	}
 }
 
 template <typename problem_t> void QuokkaSimulation<problem_t>::applyPoissonGravityAtLevel(amrex::MultiFab const &phi_mf, const int lev, const amrex::Real dt)
 {
 #if (AMREX_SPACEDIM == 3)
+	// there is no gas to accelerate when neither hydro nor radiation is enabled
+	// (the cell-centred state does not even hold the hydro variables in that case)
+	if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+		amrex::ignore_unused(phi_mf, lev, dt);
+		return;
+	}
+
 	// apply Poisson gravity operator on level 'lev'
 	auto const &dx = geom[lev].CellSizeArray();
 	auto const &phi = phi_mf.const_arrays();
@@ -2041,6 +2069,12 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::postInitializati
 template <typename problem_t>
 void QuokkaSimulation<problem_t>::ApplyHydroStateFixup(amrex::MultiFab &state_cc, std::array<amrex::MultiFab, AMREX_SPACEDIM> &state_fc, int lev)
 {
+	// there is no hydro state to fix up when neither hydro nor radiation is enabled
+	if constexpr (!(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled)) {
+		amrex::ignore_unused(state_cc, state_fc, lev);
+		return;
+	}
+
 	// Apply the hydro floors after any operator-split state update before the next operator consumes the state.
 	if (this->useDensityFloorParser_) {
 		auto const density_floor_parser = this->densityFloorParserExe_.value();

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -292,6 +292,11 @@ template <typename problem_t> class QuokkaSimulation : public AMRSimulation<prob
 			}
 		}
 		if (enableElectronConduction_) {
+			// conduction.enabled is a runtime option, but conduction operates on the hydro state. Without
+			// hydro or radiation there is no such state (only the unused placeholder component), and
+			// computeTimestepAtLevel() would derive a conduction timestep from it.
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled,
+							 "Electron conduction requires hydro or radiation to be enabled.");
 			// TODO (av): add support for subcycling with conduction
 			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(do_subcycle == 0, "AMR subcycling is not supported with conduction. Set do_subcycle = 0.");
 		}

--- a/src/physics_info.hpp
+++ b/src/physics_info.hpp
@@ -75,6 +75,12 @@ template <typename problem_t> struct Physics_Indices {
 		       Physics_NumVars::numRadVarsPerGroup * Physics_Traits<problem_t>::nGroups *
 			   static_cast<int>(Physics_Traits<problem_t>::is_radiation_enabled);
 	}();
+	// Passive scalars and dust live inside the hydro/radiation block of the state vector, so
+	// nvarTotal_cc silently collapses to nvarTotal_cc_adv (dropping them) if neither module is on.
+	static_assert(Physics_Traits<problem_t>::is_hydro_enabled || Physics_Traits<problem_t>::is_radiation_enabled ||
+			  (Physics_Traits<problem_t>::numPassiveScalars == 0 && !Physics_Traits<problem_t>::is_dust_enabled),
+		      "Passive scalars and dust require hydro or radiation to be enabled.");
+
 	// cell-centered
 	static constexpr int hydroFirstIndex = 0;
 	static constexpr int pscalarFirstIndex = Physics_NumVars::numHydroVars;

--- a/src/problems/BinaryOrbitCICGravityOnly/CMakeLists.txt
+++ b/src/problems/BinaryOrbitCICGravityOnly/CMakeLists.txt
@@ -1,0 +1,10 @@
+if (AMReX_SPACEDIM EQUAL 3)
+  	set(JOB_NAME BinaryOrbitCICGravityOnly)
+
+		add_executable(${JOB_NAME} test${JOB_NAME}.cpp ${QuokkaObjSources})
+		if(AMReX_GPU_BACKEND MATCHES "CUDA")
+			setup_target_for_cuda_compilation(${JOB_NAME})
+		endif()
+
+    add_test(NAME ${JOB_NAME} COMMAND ${JOB_NAME} ../inputs/${JOB_NAME}.toml ${QuokkaTestParams} WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+endif()

--- a/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
+++ b/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
@@ -1,0 +1,169 @@
+//==============================================================================
+// TwoMomentRad - a radiation transport library for patch-based AMR codes
+// Copyright 2020 Benjamin Wibking.
+// Released under the MIT license. See LICENSE file included in the GitHub repo.
+//==============================================================================
+/// \file testBinaryOrbitCICGravityOnly.cpp
+/// \brief Defines a test problem for a binary orbit with only self-gravity enabled.
+///
+/// This is a copy of the BinaryOrbitCIC test problem with hydro, MHD and radiation
+/// switched off. The gas in BinaryOrbitCIC is dynamically irrelevant (its total mass
+/// is ~1e-15 of the particle mass), so removing it must not change the orbit: this
+/// test therefore uses the same particles, the same grid and the same tolerance as
+/// BinaryOrbitCIC.
+///
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+
+#include "AMReX.H"
+#include "AMReX_MultiFab.H"
+#include "AMReX_ParallelDescriptor.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Print.H"
+#include "AMReX_REAL.H"
+
+#include "QuokkaSimulation.hpp"
+
+struct BinaryOrbitGravityOnly {
+};
+
+template <> struct Particle_Traits<BinaryOrbitGravityOnly> : DefaultParticleTraits {
+	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;
+};
+
+template <> struct Physics_Traits<BinaryOrbitGravityOnly> : DefaultPhysicsTraits {
+	// hydro, MHD and radiation are all disabled; only self-gravity acts on the particles
+	static constexpr bool is_self_gravity_enabled = true;
+};
+
+template <> struct SimulationData<BinaryOrbitGravityOnly> {
+	std::vector<amrex::ParticleReal> time;
+	std::vector<amrex::ParticleReal> dist;
+};
+
+template <> void QuokkaSimulation<BinaryOrbitGravityOnly>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	// with no hyperbolic state, the cell-centred state holds a single unused placeholder component
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) { state_cc(i, j, k, 0) = 0; });
+}
+
+template <> void QuokkaSimulation<BinaryOrbitGravityOnly>::createInitialCICParticles()
+{
+	// read particles from ASCII file
+	const int nreal_extra = 4; // mass vx vy vz
+	CICParticles->SetVerbose(1);
+	CICParticles->InitFromAsciiFile("../inputs/BinaryOrbit_particles.txt", nreal_extra, nullptr);
+}
+
+template <>
+void QuokkaSimulation<BinaryOrbitGravityOnly>::ComputeDerivedVar(int lev, std::string const &dname, amrex::MultiFab &mf, const int ncomp_cc_in,
+								 amrex::MultiFab const & /*state_cc*/,
+								 amrex::Array<amrex::MultiFab, AMREX_SPACEDIM> const & /*state_fc*/) const
+{
+	// compute derived variables and save in 'mf'
+	if (dname == "gpot") {
+		const int ncomp = ncomp_cc_in;
+		auto const &phi_arr = phi[lev].const_arrays();
+		auto output = mf.arrays();
+		amrex::ParallelFor(mf, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { output[bx](i, j, k, ncomp) = phi_arr[bx](i, j, k); });
+	}
+}
+
+template <> void QuokkaSimulation<BinaryOrbitGravityOnly>::computeAfterTimestep()
+{
+	// every N cycles, save particle statistics at the finest level
+	static int cycle = 1;
+	if (cycle % 10 == 0) {
+		// get the finest level
+		const int finest_level = finestLevel();
+
+		// Get particle data using the physics particle descriptor
+		const auto [real_data, int_data] = particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getParticleDataAtLevel(finest_level);
+
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			if (real_data.size() >= 2) {
+				amrex::Print() << "Computing particle statistics...\n";
+
+				// compute the maximum pairwise separation
+				double dist = 0.0;
+				for (size_t i = 0; i < real_data.size(); ++i) {
+					for (size_t j = i + 1; j < real_data.size(); ++j) {
+						const auto &p1 = real_data[i];
+						const auto &p2 = real_data[j];
+						const double dx = p1[0] - p2[0]; // position x
+						const double dy = p1[1] - p2[1]; // position y
+						const double dz = p1[2] - p2[2]; // position z
+						const double pair_dist = std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+						dist = std::max(dist, pair_dist);
+					}
+				}
+
+				const double dist0 = 6.25e12; // cm
+				const amrex::Real cell_dx0 = this->geom[0].CellSize(0);
+
+				// save statistics
+				userData_.time.push_back(tNew_[finest_level]);
+				userData_.dist.push_back((dist - dist0) / cell_dx0);
+				amrex::Print() << "Maximum particle separation: " << dist << " cm, initial separation is " << dist0 << " cm.\n";
+			}
+		}
+	}
+	++cycle;
+}
+
+auto problem_main() -> int
+{
+	// Problem initialization
+	QuokkaSimulation<BinaryOrbitGravityOnly> sim;
+
+	// initialize
+	sim.setInitialConditions();
+
+	sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->setForceFinestLevel(true);
+
+	// evolve
+	sim.evolve();
+
+	// get the number of particles
+	const int n_particles = sim.particleRegister_.getParticleDescriptor(quokka::ParticleType::CIC)->getNumParticles();
+
+	int status = 0;
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		amrex::Print() << "Number of particles: " << n_particles << "\n";
+
+		if (n_particles != 2) {
+			status += 1;
+			amrex::Print() << "Test failed (number of particles is not 2)\n";
+		}
+
+		double max_deviation = 1.0;
+		if (!sim.userData_.dist.empty()) {
+			auto result = std::max_element(sim.userData_.dist.begin(), sim.userData_.dist.end(),
+						       [](amrex::ParticleReal a, amrex::ParticleReal b) { return std::abs(a) < std::abs(b); });
+			max_deviation = std::abs(*result);
+			amrex::Print() << "max deviation from initial particle separation = " << max_deviation << " cell widths.\n";
+		} else {
+			amrex::Print() << "No particles in userData_.dist.\n";
+		}
+
+		// same tolerance as the hydro-enabled BinaryOrbitCIC test
+		const double max_err_tol = 0.18; // max error tol in cell widths
+		if (max_deviation >= max_err_tol) {
+			status += 1;
+			amrex::Print() << "Test failed (max deviation exceeds " << max_err_tol << " cell widths)\n";
+		}
+
+		if (status > 0) {
+			amrex::Print() << "Test failed\n";
+		} else {
+			amrex::Print() << "Test passed\n";
+		}
+	}
+
+	return status;
+}

--- a/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
+++ b/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
@@ -1,8 +1,3 @@
-//==============================================================================
-// TwoMomentRad - a radiation transport library for patch-based AMR codes
-// Copyright 2020 Benjamin Wibking.
-// Released under the MIT license. See LICENSE file included in the GitHub repo.
-//==============================================================================
 /// \file testBinaryOrbitCICGravityOnly.cpp
 /// \brief Defines a test problem for a binary orbit with only self-gravity enabled.
 ///

--- a/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
+++ b/src/problems/BinaryOrbitCICGravityOnly/testBinaryOrbitCICGravityOnly.cpp
@@ -21,8 +21,7 @@
 
 #include "QuokkaSimulation.hpp"
 
-struct BinaryOrbitGravityOnly {
-};
+struct BinaryOrbitGravityOnly {};
 
 template <> struct Particle_Traits<BinaryOrbitGravityOnly> : DefaultParticleTraits {
 	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1323,7 +1323,13 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	std::vector<dtloc_t *> dts = {&hydro_dt, &conduction_dt, &particle_dt};
 	auto *const dt_min_ptr = *std::min_element(dts.begin(), dts.end(), [](dtloc_t *const p1, dtloc_t *const p2) { return p1->value < p2->value; });
 
-	if (verbose) {
+	// N.B. this must be checked here: computeTimestep() clips dt to 1.1 * dt_[lev], which turns an
+	// unconstrained timestep into a large-but-finite one that no later check can recognise
+	const bool timestep_is_constrained = dt_min_ptr->value < std::numeric_limits<amrex::Real>::max();
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(timestep_is_constrained || constantDt_ > 0.0 || maxDt_ < std::numeric_limits<amrex::Real>::max(),
+					 "No enabled physics module constrains the timestep! Set constant_dt or max_dt in the inputs file.");
+
+	if (verbose && timestep_is_constrained) {
 		// print the physics that limits the timestep
 		if (dt_min_ptr == &hydro_dt) {
 			amrex::Print() << std::format("...[level {}] timestep limited by HYDRO\n", lev);
@@ -1391,9 +1397,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 			dt_0 = constantDt_;
 		}
 	}
-
-	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_0 < std::numeric_limits<amrex::Real>::max(),
-					 "No enabled physics module constrains the timestep! Set constant_dt or max_dt in the inputs file.");
 
 	if (tNew_[0] == 0.0) { // shrink the initial timestep if requested
 		dt_0 *= initShrink_;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1263,9 +1263,14 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	}
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &dx = geom[lev].CellSizeArray();
 	const amrex::Real dx_min = std::min({AMREX_D_DECL(dx[0], dx[1], dx[2])});
-	dtloc_t hydro_dt{.value = cflNumber_ * (dx_min / domain_signal_max), .index = domain_signal_maxloc};
+	// the signal speed is zero when no hyperbolic physics is enabled (e.g. self-gravity acting on
+	// particles only), in which case the hydro timestep does not constrain the simulation
+	dtloc_t hydro_dt{.value = std::numeric_limits<amrex::Real>::max(), .index = domain_signal_maxloc};
+	if (domain_signal_max > 0.0) {
+		hydro_dt.value = cflNumber_ * (dx_min / domain_signal_max);
+	}
 
-	if (verbose) {
+	if (verbose && domain_signal_max > 0.0) {
 		amrex::Print() << std::format("...[level {}] estimated hydro timestep: {:e}\n", lev, hydro_dt.value);
 		amrex::Print() << std::format("...[level {}] \thydro timestep limited at cell {} with signal speed = {:e}\n", lev,
 					      formatIntVect(hydro_dt.index), domain_signal_max);
@@ -1301,6 +1306,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 			amrex::Abort(abort_msg.c_str());
 		}
 		// avoid division by zero by only computing dt if max_particle_speed is not too small
+		// (when no hyperbolic physics is enabled, hydro_dt is unconstrained and the cutoff is zero)
 		if (max_particle_speed.value > 1e-5 * (dx_min / hydro_dt.value)) {
 			particle_dt.value = particleCflNumber_ * (dx_min / max_particle_speed.value);
 		}
@@ -1385,6 +1391,9 @@ template <typename problem_t> void AMRSimulation<problem_t>::computeTimestep()
 			dt_0 = constantDt_;
 		}
 	}
+
+	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(dt_0 < std::numeric_limits<amrex::Real>::max(),
+					 "No enabled physics module constrains the timestep! Set constant_dt or max_dt in the inputs file.");
 
 	if (tNew_[0] == 0.0) { // shrink the initial timestep if requested
 		dt_0 *= initShrink_;


### PR DESCRIPTION
### Description

Quokka could not run a problem with hydro and radiation both disabled: `computeMaxSignalLocal` aborted with *"At least one of hydro or radiation must be enabled! Cannot compute a time step."* Several other code paths also indexed hydro components of the cell-centred state, which holds only a single placeholder component when there is no hyperbolic system (`Physics_Indices::nvarTotal_cc == 1`).

This PR makes self-gravity usable on its own and adds a test for it.

Core changes:
- The timestep no longer requires a hyperbolic system. `computeMaxSignalLocal` returns a zero signal speed instead of aborting, and `computeTimestepAtLevel` leaves the hydro timestep unconstrained in that case so the particle CFL sets `dt`. If no enabled physics module constrains the timestep at all and neither `constant_dt` nor `max_dt` is set, `computeTimestepAtLevel` aborts with a clear message; the check lives there because `computeTimestep` later clips `dt` to `1.1 * dt_[lev]`, which would turn an unconstrained timestep into a large-but-finite one that no later check could recognise. The `timestep limited by ...` attribution is suppressed when nothing constrains `dt`, so an unconstrained step is never misreported as hydro-limited.
- Guarded the paths that index into hydro state components when there is no hydro state: `fillPoissonRhsAtLevel`, `applyPoissonGravityAtLevel`, `ApplyHydroStateFixup`, `CheckHydroStates` and `computeAfterEvolve`.
- `advanceSingleTimestepAtLevel` no longer copies six components out of a one-component state.
- `defineComponentNames` names the placeholder component, so plotfiles and conservation sums stay consistent.
- Added a `static_assert` requiring hydro or radiation when passive scalars or dust are enabled. Those components live inside the hydro/radiation block, so without either module `nvarTotal_cc` silently collapses to `nvarTotal_cc_adv` and drops them. This was reachable only in theory before; this PR makes the configuration real.

New test `BinaryOrbitCICGravityOnly`: the `BinaryOrbitCIC` binary orbit with hydro, MHD and radiation switched off, using the same particles, the same grid and the same 0.18 cell-width tolerance.

### Verification

Run at the same fixed timestep, `BinaryOrbitCIC` and `BinaryOrbitCICGravityOnly` report identical particle separations (6.179871901e12 cm and 6.164338886e12 cm at cycles 10 and 20) and an identical max deviation of 0.05482311283 cell widths, confirming that the gas in the original test is dynamically irrelevant. The new problem also runs clean under a Debug build with AMReX bounds checking.

The guard against an unconstrained timestep was checked directly with a zero-velocity particle IC: it aborts with `No enabled physics module constrains the timestep!`, and runs normally once `max_dt` or `constant_dt` is supplied.

Regression tests, all passing locally on CPU: the full `BinaryOrbitCIC*` suite (including the split, AMR and refactor-restart variants), `GravRadParticle3D` (radiation + gravity + particles with hydro disabled), `ParticleDeposition*`, `HydroShocktube`, `RadMarshak` (radiation-only) and `RadhydroShock`.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for self-gravity simulations with particles when hydrodynamics and radiation are disabled.
  * Added a binary-orbit gravity-only simulation configuration and validation test.
  * Added safer timestep handling for simulations without hyperbolic physics.

* **Bug Fixes**
  * Invalid physics combinations, including passive scalars, dust, or electron conduction without hydro or radiation, now fail early.
  * Gravity-only simulations no longer perform irrelevant hydro operations or encounter zero-speed timestep errors.

* **Documentation**
  * Clarified compatibility and state-component behavior for gravity-only simulations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->