### PR TITLE
quick_plot: plot_one() change use of args.weight_field to weight_field

### DIFF
--- a/scripts/python/quick_plot
+++ b/scripts/python/quick_plot
@@ -226,7 +226,7 @@ def plot_one(pltdir, args, suffix_idx=None):
         slc = yt.SlicePlot(ds, view_dir, field, center=center)
     elif kind == "prj":
         slc = yt.ProjectionPlot(ds, view_dir, field,
-                                weight_field=args.weight_field, center=center)
+                                weight_field=weight_field, center=center)
     else:
         raise ValueError(f"kind {kind} not supported")
 


### PR DESCRIPTION
### Description
`plot_one()` disassembles the args object into a bunch of individual variables at the start, then never uses args again. It also has the line `weight_field = args.weight_field`. It then however uses `args.weight_field` later on. I assume this was a typo.

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of projection plot configuration without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->