### PR TITLE
Rename MHD problem structs: add MHD prefix to C++ type names

### DIFF
--- a/src/problems/MHDAlfvenWaveCircularConvergence/testMHDAlfvenWaveCircularConvergence.cpp
+++ b/src/problems/MHDAlfvenWaveCircularConvergence/testMHDAlfvenWaveCircularConvergence.cpp
@@ -25,14 +25,14 @@
 #include "util/BC.hpp"
 #include "util/richardson.hpp"
 
-struct AlfvenWaveCircular {};
+struct MHDAlfvenWaveCircular {};
 
-template <> struct quokka::EOS_Traits<AlfvenWaveCircular> {
+template <> struct quokka::EOS_Traits<MHDAlfvenWaveCircular> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<AlfvenWaveCircular> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDAlfvenWaveCircular> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
@@ -40,7 +40,7 @@ template <> struct Physics_Traits<AlfvenWaveCircular> : DefaultPhysicsTraits {
 
 // constants
 constexpr double sound_speed = 1.0;
-constexpr double gamma_gas = quokka::EOS_Traits<AlfvenWaveCircular>::gamma;
+constexpr double gamma_gas = quokka::EOS_Traits<MHDAlfvenWaveCircular>::gamma;
 
 // we have set up the problem so that the direction of wave propagation, vec(k), is aligned with the x1-direction, and the background magnetic field sits in the
 // x1-x2 plane
@@ -105,12 +105,12 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 		const double Eint = pressure / (gamma_gas - 1);
 		const double Etot = Ekin + Emag + Eint;
 
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::density_index) = density;
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x1Momentum_index) = x1vel * density;
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x2Momentum_index) = x2vel * density;
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::x3Momentum_index) = x3vel * density;
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::energy_index) = Etot;
-		state(i, j, k, HydroSystem<AlfvenWaveCircular>::internalEnergy_index) = Eint;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::density_index) = density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::x1Momentum_index) = x1vel * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::x2Momentum_index) = x2vel * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::x3Momentum_index) = x3vel * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveCircular>::internalEnergy_index) = Eint;
 	} else if (cen == quokka::centering::fc) {
 		const double x1mag = (computeMagneticVectorPotential_z(x1_L, x2_L + dx[1], x3_L + dx[2] / 2.0, time) -
 				      computeMagneticVectorPotential_z(x1_L, x2_L, x3_L + dx[2] / 2.0, time)) /
@@ -131,16 +131,16 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 				      computeMagneticVectorPotential_x(x1_L + dx[0] / 2.0, x2_L, x3_L, time)) /
 					 dx[1];
 		if (dir == quokka::direction::x) {
-			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x1mag;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveCircular>::bfield_index) = x1mag;
 		} else if (dir == quokka::direction::y) {
-			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x2mag;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveCircular>::bfield_index) = x2mag;
 		} else if (dir == quokka::direction::z) {
-			state(i, j, k, MHDSystem<AlfvenWaveCircular>::bfield_index) = x3mag;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveCircular>::bfield_index) = x3mag;
 		}
 	}
 }
 
-template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDAlfvenWaveCircular>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -150,7 +150,7 @@ template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGri
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_cc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDAlfvenWaveCircular>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		for (int n = 0; n < ncomp_cc; ++n) {
@@ -160,7 +160,7 @@ template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGri
 	});
 }
 
-template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDAlfvenWaveCircular>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -170,7 +170,7 @@ template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGri
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_fc = Physics_Indices<AlfvenWaveCircular>::nvarPerDim_fc;
+	const int ncomp_fc = Physics_Indices<MHDAlfvenWaveCircular>::nvarPerDim_fc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		for (int n = 0; n < ncomp_fc; ++n) {
@@ -181,8 +181,8 @@ template <> void QuokkaSimulation<AlfvenWaveCircular>::setInitialConditionsOnGri
 }
 
 template <>
-void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								    amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+void QuokkaSimulation<MHDAlfvenWaveCircular>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	const amrex::Real time = tNew_[0];
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
@@ -200,8 +200,9 @@ void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution(amrex::Multi
 }
 
 template <>
-void QuokkaSimulation<AlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								       amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+void QuokkaSimulation<MHDAlfvenWaveCircular>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+									  quokka::direction const dir)
 {
 	const amrex::Real time = tNew_[0];
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
@@ -256,9 +257,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	pp_geom.addarr("is_periodic", is_periodic);
 
 	// Setup boundary conditions
-	auto BCs_cc = quokka::BC<AlfvenWaveCircular>(quokka::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MHDAlfvenWaveCircular>(quokka::BCType::int_dir);
 
-	const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
+	const int nvars_fc = Physics_Indices<MHDAlfvenWaveCircular>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -268,7 +269,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	}
 
 	// Run simulation
-	QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+	QuokkaSimulation<MHDAlfvenWaveCircular> sim(BCs_cc, BCs_fc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
@@ -314,8 +315,8 @@ auto problem_main() -> int
 	int status = 0;
 
 	if (run_sim) {
-		auto BCs_cc = quokka::BC<AlfvenWaveCircular>(quokka::BCType::int_dir);
-		const int nvars_fc = Physics_Indices<AlfvenWaveCircular>::nvarTotal_fc;
+		auto BCs_cc = quokka::BC<MHDAlfvenWaveCircular>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<MHDAlfvenWaveCircular>::nvarTotal_fc;
 		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -324,7 +325,7 @@ auto problem_main() -> int
 			}
 		}
 
-		QuokkaSimulation<AlfvenWaveCircular> sim(BCs_cc, BCs_fc);
+		QuokkaSimulation<MHDAlfvenWaveCircular> sim(BCs_cc, BCs_fc);
 
 		double num_periods = 1.0;
 		{

--- a/src/problems/MHDAlfvenWaveLinearConvergence/testMHDAlfvenWaveLinearConvergence.cpp
+++ b/src/problems/MHDAlfvenWaveLinearConvergence/testMHDAlfvenWaveLinearConvergence.cpp
@@ -32,14 +32,14 @@
 #include "util/matplotlibcpp.h"
 #endif
 
-struct AlfvenWaveLinear {};
+struct MHDAlfvenWaveLinear {};
 
-template <> struct quokka::EOS_Traits<AlfvenWaveLinear> {
+template <> struct quokka::EOS_Traits<MHDAlfvenWaveLinear> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<AlfvenWaveLinear> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDAlfvenWaveLinear> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
@@ -47,7 +47,7 @@ template <> struct Physics_Traits<AlfvenWaveLinear> : DefaultPhysicsTraits {
 };
 
 constexpr double sound_speed = 1.0;
-constexpr double gamma_gas = quokka::EOS_Traits<AlfvenWaveLinear>::gamma;
+constexpr double gamma_gas = quokka::EOS_Traits<MHDAlfvenWaveLinear>::gamma;
 constexpr double bg_density = 1.0;
 constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
 constexpr double b0_magn = 1.0;
@@ -266,12 +266,12 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double Eint = pressure / (gamma_gas - 1);
 		const double Etot = Ekin + Emag + Eint;
 
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::density_index) = density;
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x1Momentum_index) = v_x1_prf * density;
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x2Momentum_index) = v_x2_prf * density;
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::x3Momentum_index) = v_x3_prf * density;
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::energy_index) = Etot;
-		state(i, j, k, HydroSystem<AlfvenWaveLinear>::internalEnergy_index) = Eint;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::density_index) = density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::x1Momentum_index) = v_x1_prf * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::x2Momentum_index) = v_x2_prf * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::x3Momentum_index) = v_x3_prf * density;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<MHDAlfvenWaveLinear>::internalEnergy_index) = Eint;
 	} else if (cen == quokka::centering::fc) {
 		// compute b-field using the magnetic vector potential to preserve div(b) = 0 topology
 		const double b_x1 =
@@ -287,16 +287,16 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L + dx[1], x3_prf_L, time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) / dx[1];
 
 		if (dir == quokka::direction::x) {
-			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = b_x1;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveLinear>::bfield_index) = b_x1;
 		} else if (dir == quokka::direction::y) {
-			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = b_x2;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveLinear>::bfield_index) = b_x2;
 		} else if (dir == quokka::direction::z) {
-			state(i, j, k, MHDSystem<AlfvenWaveLinear>::bfield_index) = b_x3;
+			state(i, j, k, MHDSystem<MHDAlfvenWaveLinear>::bfield_index) = b_x3;
 		}
 	}
 }
 
-template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDAlfvenWaveLinear>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -305,7 +305,7 @@ template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGrid(
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_cc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDAlfvenWaveLinear>::nvarTotal_cc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0; // fill unused quantities with zeros
@@ -314,7 +314,7 @@ template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGrid(
 	});
 }
 
-template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDAlfvenWaveLinear>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -324,7 +324,7 @@ template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGridF
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_fc = Physics_Indices<AlfvenWaveLinear>::nvarPerDim_fc;
+	const int ncomp_fc = Physics_Indices<MHDAlfvenWaveLinear>::nvarPerDim_fc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_fc; ++n) {
@@ -335,8 +335,8 @@ template <> void QuokkaSimulation<AlfvenWaveLinear>::setInitialConditionsOnGridF
 }
 
 template <>
-void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+void QuokkaSimulation<MHDAlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -354,8 +354,9 @@ void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution(amrex::MultiFa
 }
 
 template <>
-void QuokkaSimulation<AlfvenWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+void QuokkaSimulation<MHDAlfvenWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+									quokka::direction const dir)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -486,9 +487,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	pp_geom.addarr("is_periodic", is_periodic);
 
 	// Setup boundary conditions
-	auto BCs_cc = quokka::BC<AlfvenWaveLinear>(quokka::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MHDAlfvenWaveLinear>(quokka::BCType::int_dir);
 
-	const int nvars_fc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_fc;
+	const int nvars_fc = Physics_Indices<MHDAlfvenWaveLinear>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -498,7 +499,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	}
 
 	// Run simulation
-	QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
+	QuokkaSimulation<MHDAlfvenWaveLinear> sim(BCs_cc, BCs_fc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
@@ -570,8 +571,8 @@ auto problem_main() -> int
 			normalizeVector(outofplane_dir_prf);
 		}
 
-		auto BCs_cc = quokka::BC<AlfvenWaveLinear>(quokka::BCType::int_dir);
-		const int nvars_fc = Physics_Indices<AlfvenWaveLinear>::nvarTotal_fc;
+		auto BCs_cc = quokka::BC<MHDAlfvenWaveLinear>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<MHDAlfvenWaveLinear>::nvarTotal_fc;
 		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -580,7 +581,7 @@ auto problem_main() -> int
 			}
 		}
 
-		QuokkaSimulation<AlfvenWaveLinear> sim(BCs_cc, BCs_fc);
+		QuokkaSimulation<MHDAlfvenWaveLinear> sim(BCs_cc, BCs_fc);
 
 		double num_periods = 1.0;
 		{

--- a/src/problems/MHDBrioWuShockTube/testMHDBrioWuShockTube.cpp
+++ b/src/problems/MHDBrioWuShockTube/testMHDBrioWuShockTube.cpp
@@ -28,14 +28,14 @@
 #include "util/BC.hpp"
 #include "util/fextract.hpp"
 
-struct MHDShocktubeProblem {};
+struct MHDBrioWuShockTube {};
 
-template <> struct quokka::EOS_Traits<MHDShocktubeProblem> {
+template <> struct quokka::EOS_Traits<MHDBrioWuShockTube> {
 	static constexpr double gamma = 2.0;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<MHDShocktubeProblem> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDBrioWuShockTube> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
@@ -53,14 +53,14 @@ constexpr amrex::Real By_L = 1.0;
 constexpr amrex::Real By_R = -1.0;
 constexpr amrex::Real Bz = 0.0; // constant
 
-template <> void QuokkaSimulation<MHDShocktubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDBrioWuShockTube>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 
-	const int ncomp_cc = Physics_Indices<MHDShocktubeProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDBrioWuShockTube>::nvarTotal_cc;
 
 	// magnetic field at center of cell
 	const double x1mag = 0.75; // constant
@@ -68,7 +68,7 @@ template <> void QuokkaSimulation<MHDShocktubeProblem>::setInitialConditionsOnGr
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
-		const auto gamma = quokka::EOS_Traits<MHDShocktubeProblem>::gamma;
+		const auto gamma = quokka::EOS_Traits<MHDBrioWuShockTube>::gamma;
 		double rho = NAN;
 		double P = NAN;
 		double x2mag = NAN;
@@ -93,16 +93,16 @@ template <> void QuokkaSimulation<MHDShocktubeProblem>::setInitialConditionsOnGr
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::density_index) = rho;
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::x1Momentum_index) = vx * rho;
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::x2Momentum_index) = vy * rho;
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::x3Momentum_index) = vz * rho;
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::energy_index) = P / (gamma - 1.) + 0.5 * rho * (vx * vx) + Emag;
-		state_cc(i, j, k, HydroSystem<MHDShocktubeProblem>::internalEnergy_index) = P / (gamma - 1.);
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::density_index) = rho;
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::x1Momentum_index) = vx * rho;
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::x2Momentum_index) = vy * rho;
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::x3Momentum_index) = vz * rho;
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::energy_index) = P / (gamma - 1.) + 0.5 * rho * (vx * vx) + Emag;
+		state_cc(i, j, k, HydroSystem<MHDBrioWuShockTube>::internalEnergy_index) = P / (gamma - 1.);
 	});
 }
 
-template <> void QuokkaSimulation<MHDShocktubeProblem>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDBrioWuShockTube>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -123,24 +123,24 @@ template <> void QuokkaSimulation<MHDShocktubeProblem>::setInitialConditionsOnGr
 		}
 
 		if (dir == quokka::direction::x) {
-			state_fc(i, j, k, Physics_Indices<MHDShocktubeProblem>::mhdFirstIndex) = x1mag;
+			state_fc(i, j, k, Physics_Indices<MHDBrioWuShockTube>::mhdFirstIndex) = x1mag;
 		} else if (dir == quokka::direction::y) {
-			state_fc(i, j, k, Physics_Indices<MHDShocktubeProblem>::mhdFirstIndex) = x2mag;
+			state_fc(i, j, k, Physics_Indices<MHDBrioWuShockTube>::mhdFirstIndex) = x2mag;
 		} else if (dir == quokka::direction::z) {
-			state_fc(i, j, k, Physics_Indices<MHDShocktubeProblem>::mhdFirstIndex) = x3mag;
+			state_fc(i, j, k, Physics_Indices<MHDBrioWuShockTube>::mhdFirstIndex) = x3mag;
 		}
 	});
 }
 
 template <>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/,
-								int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
-								const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
+AMRSimulation<MHDBrioWuShockTube>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/,
+							       int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
+							       const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
 {
 	// Number of variables (use Physics_Indices which correctly accounts for enabled physics)
-	constexpr int nvar = Physics_Indices<MHDShocktubeProblem>::nvarTotal_cc;
-	const auto gamma = quokka::EOS_Traits<MHDShocktubeProblem>::gamma;
+	constexpr int nvar = Physics_Indices<MHDBrioWuShockTube>::nvarTotal_cc;
+	const auto gamma = quokka::EOS_Traits<MHDBrioWuShockTube>::gamma;
 
 	const double Emag_L = 0.5 * (Bx * Bx + By_L * By_L + Bz * Bz);
 	const double Emag_R = 0.5 * (Bx * Bx + By_R * By_R + Bz * Bz);
@@ -150,12 +150,12 @@ AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditions(const amrex::Int
 	// Initialize all to 0 first
 
 	// Set specific values
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::gasEnergy_index] = P_L / (gamma - 1.) + Emag_L;
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::gasInternalEnergy_index] = P_L / (gamma - 1.);
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::gasDensity_index] = rho_L;
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::x1GasMomentum_index] = 0.;
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::x2GasMomentum_index] = 0.;
-	low_bdr_cells[RadSystem<MHDShocktubeProblem>::x3GasMomentum_index] = 0.;
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasEnergy_index] = P_L / (gamma - 1.) + Emag_L;
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasInternalEnergy_index] = P_L / (gamma - 1.);
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasDensity_index] = rho_L;
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::x1GasMomentum_index] = 0.;
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::x2GasMomentum_index] = 0.;
+	low_bdr_cells[RadSystem<MHDBrioWuShockTube>::x3GasMomentum_index] = 0.;
 
 	// Prepare right boundary values (right state)
 	amrex::GpuArray<amrex::Real, nvar> high_bdr_cells{};
@@ -164,12 +164,12 @@ AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditions(const amrex::Int
 		high_bdr_cells[n] = 0;
 	}
 	// Set specific values
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::gasEnergy_index] = P_R / (gamma - 1.) + Emag_R;
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::gasInternalEnergy_index] = P_R / (gamma - 1.);
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::gasDensity_index] = rho_R;
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::x1GasMomentum_index] = 0.;
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::x2GasMomentum_index] = 0.;
-	high_bdr_cells[RadSystem<MHDShocktubeProblem>::x3GasMomentum_index] = 0.;
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasEnergy_index] = P_R / (gamma - 1.) + Emag_R;
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasInternalEnergy_index] = P_R / (gamma - 1.);
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::gasDensity_index] = rho_R;
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::x1GasMomentum_index] = 0.;
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::x2GasMomentum_index] = 0.;
+	high_bdr_cells[RadSystem<MHDBrioWuShockTube>::x3GasMomentum_index] = 0.;
 
 	// Apply boundary conditions using helper functions (direction 0 = x-axis)
 	setConstantDirichletBCLo<0>(iv, consVar, geom, low_bdr_cells);
@@ -179,9 +179,9 @@ AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditions(const amrex::Int
 template <>
 template <quokka::direction dir>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar_fc, int /*dcomp*/,
-								       int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
-								       const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
+AMRSimulation<MHDBrioWuShockTube>::setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar_fc, int /*dcomp*/,
+								      int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
+								      const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
 {
 	// Prepare boundary values for each face direction: {x-face, y-face, z-face}
 	// For low boundary (left side)
@@ -196,7 +196,7 @@ AMRSimulation<MHDShocktubeProblem>::setCustomBoundaryConditionsFaceVar(const amr
 	setConstantDirichletBCFaceVarHi<0, dir, 3>(iv, consVar_fc, geom, high_bdr_values);
 }
 
-template <> void QuokkaSimulation<MHDShocktubeProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
+template <> void QuokkaSimulation<MHDBrioWuShockTube>::refineGrid(int lev, amrex::TagBoxArray &tags, Real /*time*/, int /*ngrow*/)
 {
 	// tag cells for refinement
 
@@ -224,7 +224,7 @@ template <> void QuokkaSimulation<MHDShocktubeProblem>::refineGrid(int lev, amre
 
 auto problem_main() -> int
 {
-	QuokkaSimulation<MHDShocktubeProblem> sim;
+	QuokkaSimulation<MHDBrioWuShockTube> sim;
 
 	// Main time loop
 	sim.setInitialConditions();

--- a/src/problems/MHDEntropyWaveConvergence/testMHDEntropyWaveConvergence.cpp
+++ b/src/problems/MHDEntropyWaveConvergence/testMHDEntropyWaveConvergence.cpp
@@ -34,14 +34,14 @@
 #include "util/matplotlibcpp.h"
 #endif
 
-struct EntropyWaveLinear {};
+struct MHDEntropyWaveLinear {};
 
-template <> struct quokka::EOS_Traits<EntropyWaveLinear> {
+template <> struct quokka::EOS_Traits<MHDEntropyWaveLinear> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<EntropyWaveLinear> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDEntropyWaveLinear> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
@@ -49,7 +49,7 @@ template <> struct Physics_Traits<EntropyWaveLinear> : DefaultPhysicsTraits {
 
 // Background and perturbation parameters
 constexpr double adv_speed = 1.0; // advection speed of the entropy wave (in MRF along k)
-constexpr double gamma_gas = quokka::EOS_Traits<EntropyWaveLinear>::gamma;
+constexpr double gamma_gas = quokka::EOS_Traits<MHDEntropyWaveLinear>::gamma;
 constexpr double bg_density = 1.0;
 constexpr double delta_rho_magn = 1e-6; // small density perturbation amplitude
 constexpr double sound_speed = 1.0;
@@ -192,12 +192,12 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double Eint = pressure / (gamma_gas - 1.0);
 		const double Etot = Ekin + Emag + Eint;
 
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::density_index) = density;
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::x1Momentum_index) = v_x1_prf * density;
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::x2Momentum_index) = v_x2_prf * density;
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::x3Momentum_index) = v_x3_prf * density;
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::energy_index) = Etot;
-		state(i, j, k, HydroSystem<EntropyWaveLinear>::internalEnergy_index) = Eint;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::density_index) = density;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::x1Momentum_index) = v_x1_prf * density;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::x2Momentum_index) = v_x2_prf * density;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::x3Momentum_index) = v_x3_prf * density;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<MHDEntropyWaveLinear>::internalEnergy_index) = Eint;
 	} else if (cen == quokka::centering::fc) {
 		// compute b-field using the magnetic vector potential (background only) to preserve div(b)=0
 		const double b_x1 =
@@ -213,16 +213,16 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L + dx[1], x3_prf_L, time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) / dx[1];
 
 		if (dir == quokka::direction::x) {
-			state(i, j, k, MHDSystem<EntropyWaveLinear>::bfield_index) = b_x1;
+			state(i, j, k, MHDSystem<MHDEntropyWaveLinear>::bfield_index) = b_x1;
 		} else if (dir == quokka::direction::y) {
-			state(i, j, k, MHDSystem<EntropyWaveLinear>::bfield_index) = b_x2;
+			state(i, j, k, MHDSystem<MHDEntropyWaveLinear>::bfield_index) = b_x2;
 		} else if (dir == quokka::direction::z) {
-			state(i, j, k, MHDSystem<EntropyWaveLinear>::bfield_index) = b_x3;
+			state(i, j, k, MHDSystem<MHDEntropyWaveLinear>::bfield_index) = b_x3;
 		}
 	}
 }
 
-template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDEntropyWaveLinear>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -231,7 +231,7 @@ template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGrid
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_cc = Physics_Indices<EntropyWaveLinear>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDEntropyWaveLinear>::nvarTotal_cc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0; // fill unused quantities with zeros
@@ -240,7 +240,7 @@ template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGrid
 	});
 }
 
-template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDEntropyWaveLinear>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
@@ -250,7 +250,7 @@ template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGrid
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_fc = Physics_Indices<EntropyWaveLinear>::nvarPerDim_fc;
+	const int ncomp_fc = Physics_Indices<MHDEntropyWaveLinear>::nvarPerDim_fc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_fc; ++n) {
@@ -261,8 +261,8 @@ template <> void QuokkaSimulation<EntropyWaveLinear>::setInitialConditionsOnGrid
 }
 
 template <>
-void QuokkaSimulation<EntropyWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+void QuokkaSimulation<MHDEntropyWaveLinear>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+								      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -279,8 +279,9 @@ void QuokkaSimulation<EntropyWaveLinear>::computeReferenceSolution(amrex::MultiF
 }
 
 template <>
-void QuokkaSimulation<EntropyWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo, quokka::direction const dir)
+void QuokkaSimulation<MHDEntropyWaveLinear>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									 amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+									 quokka::direction const dir)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -380,9 +381,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	pp_geom.addarr("is_periodic", is_periodic);
 
 	// Setup boundary conditions
-	auto BCs_cc = quokka::BC<EntropyWaveLinear>(quokka::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MHDEntropyWaveLinear>(quokka::BCType::int_dir);
 
-	const int nvars_fc = Physics_Indices<EntropyWaveLinear>::nvarTotal_fc;
+	const int nvars_fc = Physics_Indices<MHDEntropyWaveLinear>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -392,7 +393,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	}
 
 	// Run simulation
-	QuokkaSimulation<EntropyWaveLinear> sim(BCs_cc, BCs_fc);
+	QuokkaSimulation<MHDEntropyWaveLinear> sim(BCs_cc, BCs_fc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
@@ -462,8 +463,8 @@ auto problem_main() -> int
 			normalizeVector(outofplane_dir_prf);
 		}
 
-		auto BCs_cc = quokka::BC<EntropyWaveLinear>(quokka::BCType::int_dir);
-		const int nvars_fc = Physics_Indices<EntropyWaveLinear>::nvarTotal_fc;
+		auto BCs_cc = quokka::BC<MHDEntropyWaveLinear>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<MHDEntropyWaveLinear>::nvarTotal_fc;
 		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -472,7 +473,7 @@ auto problem_main() -> int
 			}
 		}
 
-		QuokkaSimulation<EntropyWaveLinear> sim(BCs_cc, BCs_fc);
+		QuokkaSimulation<MHDEntropyWaveLinear> sim(BCs_cc, BCs_fc);
 
 		double num_periods = 1.0;
 		{

--- a/src/problems/MHDFCQuantities/testMHDFCQuantities.cpp
+++ b/src/problems/MHDFCQuantities/testMHDFCQuantities.cpp
@@ -35,24 +35,24 @@
 #include "physics_info.hpp"
 #include "util/BC.hpp"
 
-struct FCQuantities {};
+struct MHDFCQuantities {};
 
-template <> struct quokka::EOS_Traits<FCQuantities> {
+template <> struct quokka::EOS_Traits<MHDFCQuantities> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FCQuantities> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDFCQuantities> : DefaultPhysicsTraits {
 	// cell-centred
 	static constexpr bool is_hydro_enabled = true;
 	// face-centred
 	static constexpr bool is_mhd_enabled = true;
 };
 
-constexpr double rho0 = 1.0;					     // background density
-constexpr double P0 = 1.0 / quokka::EOS_Traits<FCQuantities>::gamma; // background pressure
-constexpr double v0 = 0.;					     // background velocity
-constexpr double amp = 1.0e-6;					     // perturbation amplitude
+constexpr double rho0 = 1.0;						// background density
+constexpr double P0 = 1.0 / quokka::EOS_Traits<MHDFCQuantities>::gamma; // background pressure
+constexpr double v0 = 0.;						// background velocity
+constexpr double amp = 1.0e-6;						// perturbation amplitude
 
 AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &state, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
 					  amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
@@ -62,7 +62,7 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	const amrex::Real A = amp;
 
 	const quokka::valarray<double, 3> R = {1.0, -1.0, 1.5}; // right eigenvector of sound wave
-	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<FCQuantities>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
+	const quokka::valarray<double, 3> U_0 = {rho0, rho0 * v0, P0 / (quokka::EOS_Traits<MHDFCQuantities>::gamma - 1.0) + 0.5 * rho0 * std::pow(v0, 2)};
 	const quokka::valarray<double, 3> dU = (A * R / (2.0 * M_PI * dx[0])) * (std::cos(2.0 * M_PI * x_L) - std::cos(2.0 * M_PI * x_R));
 
 	double const rho = U_0[0] + dU[0];
@@ -70,15 +70,15 @@ AMREX_GPU_DEVICE void computeWaveSolution(int i, int j, int k, amrex::Array4<amr
 	double const Etot = U_0[2] + dU[2];
 	double const Eint = Etot - 0.5 * (xmom * xmom) / rho;
 
-	state(i, j, k, HydroSystem<FCQuantities>::density_index) = rho;
-	state(i, j, k, HydroSystem<FCQuantities>::x1Momentum_index) = xmom;
-	state(i, j, k, HydroSystem<FCQuantities>::x2Momentum_index) = 0;
-	state(i, j, k, HydroSystem<FCQuantities>::x3Momentum_index) = 0;
-	state(i, j, k, HydroSystem<FCQuantities>::energy_index) = Etot;
-	state(i, j, k, HydroSystem<FCQuantities>::internalEnergy_index) = Eint;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::density_index) = rho;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::x1Momentum_index) = xmom;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::x2Momentum_index) = 0;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::x3Momentum_index) = 0;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::energy_index) = Etot;
+	state(i, j, k, HydroSystem<MHDFCQuantities>::internalEnergy_index) = Eint;
 }
 
-template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDFCQuantities>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx = grid_elem.dx_;
@@ -86,7 +86,7 @@ template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quok
 	const amrex::Array4<double> &state = grid_elem.array_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 
-	const int ncomp_cc = Physics_Indices<FCQuantities>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDFCQuantities>::nvarTotal_cc;
 	// loop over the grid and set the initial condition
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		for (int n = 0; n < ncomp_cc; ++n) {
@@ -96,7 +96,7 @@ template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGrid(quok
 	});
 }
 
-template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDFCQuantities>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	// extract grid information
 	const amrex::Array4<double> &state = grid_elem.array_;
@@ -116,7 +116,7 @@ template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceV
 			amrex::Real const y_lo = prob_lo[1] + static_cast<amrex::Real>(j) * dx[1];
 			amrex::Real const y_hi = prob_lo[1] + static_cast<amrex::Real>(j + 1) * dx[1];
 			amrex::Real const z = prob_lo[2] + static_cast<amrex::Real>(k) * dx[2];
-			state(i, j, k, MHDSystem<FCQuantities>::bfield_index) = (psi(x, y_hi, z) - psi(x, y_lo, z)) / dx[1];
+			state(i, j, k, MHDSystem<MHDFCQuantities>::bfield_index) = (psi(x, y_hi, z) - psi(x, y_lo, z)) / dx[1];
 		});
 	} else if (dir == quokka::direction::y) {
 		amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
@@ -124,11 +124,11 @@ template <> void QuokkaSimulation<FCQuantities>::setInitialConditionsOnGridFaceV
 			amrex::Real const x_hi = prob_lo[0] + static_cast<amrex::Real>(i + 1) * dx[0];
 			amrex::Real const y = prob_lo[1] + static_cast<amrex::Real>(j) * dx[1];
 			amrex::Real const z = prob_lo[2] + static_cast<amrex::Real>(k) * dx[2];
-			state(i, j, k, MHDSystem<FCQuantities>::bfield_index) = -(psi(x_hi, y, z) - psi(x_lo, y, z)) / dx[0];
+			state(i, j, k, MHDSystem<MHDFCQuantities>::bfield_index) = -(psi(x_hi, y, z) - psi(x_lo, y, z)) / dx[0];
 		});
 	} else if (dir == quokka::direction::z) {
 		amrex::ParallelFor(indexRange,
-				   [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { state(i, j, k, MHDSystem<FCQuantities>::bfield_index) = 0.0; });
+				   [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept { state(i, j, k, MHDSystem<MHDFCQuantities>::bfield_index) = 0.0; });
 	}
 }
 
@@ -159,13 +159,13 @@ void checkEnforceLimitsPreservesMagneticEnergy()
 	amrex::Geometry const geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic.data());
 
 	// create state_cc
-	amrex::MultiFab state_cc(ba, dm, Physics_Indices<FCQuantities>::nvarTotal_cc, 0);
+	amrex::MultiFab state_cc(ba, dm, Physics_Indices<MHDFCQuantities>::nvarTotal_cc, 0);
 	state_cc.setVal(0.0);
 
 	// create state_fc
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> state_fc;
 	for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-		state_fc[dir].define(amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir)), dm, Physics_Indices<FCQuantities>::nvarPerDim_fc, 0);
+		state_fc[dir].define(amrex::convert(ba, amrex::IntVect::TheDimensionVector(dir)), dm, Physics_Indices<MHDFCQuantities>::nvarPerDim_fc, 0);
 		state_fc[dir].setVal(0.0);
 	}
 
@@ -173,37 +173,37 @@ void checkEnforceLimitsPreservesMagneticEnergy()
 	constexpr amrex::Real rho = 1.0;
 	constexpr amrex::Real temp_cold = 1.0;
 	constexpr amrex::Real temp_floor = 10.0;
-	amrex::Real const Eint_cold = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_cold);
-	amrex::Real const Eint_floor = quokka::EOS<FCQuantities>::ComputeEintFromTgas(rho, temp_floor);
+	amrex::Real const Eint_cold = quokka::EOS<MHDFCQuantities>::ComputeEintFromTgas(rho, temp_cold);
+	amrex::Real const Eint_floor = quokka::EOS<MHDFCQuantities>::ComputeEintFromTgas(rho, temp_floor);
 	amrex::Real const Emag = 10.0 * Eint_floor;
 	amrex::Real const Bx = std::sqrt(2.0 * Emag); // By, Bz are zero
 
-	state_cc.setVal(rho, HydroSystem<FCQuantities>::density_index, 1, 0);
-	state_cc.setVal(Eint_cold + Emag, HydroSystem<FCQuantities>::energy_index, 1, 0);
-	state_cc.setVal(Eint_cold, HydroSystem<FCQuantities>::internalEnergy_index, 1, 0);
-	state_fc[0].setVal(Bx, Physics_Indices<FCQuantities>::mhdFirstIndex, 1, 0);
+	state_cc.setVal(rho, HydroSystem<MHDFCQuantities>::density_index, 1, 0);
+	state_cc.setVal(Eint_cold + Emag, HydroSystem<MHDFCQuantities>::energy_index, 1, 0);
+	state_cc.setVal(Eint_cold, HydroSystem<MHDFCQuantities>::internalEnergy_index, 1, 0);
+	state_fc[0].setVal(Bx, Physics_Indices<MHDFCQuantities>::mhdFirstIndex, 1, 0);
 
 	// Enforce temperature floor:
 	// this should raise the temperature from temp_cold to temp_floor,
 	// while leaving the magnetic energy unchanged
-	HydroSystem<FCQuantities>::EnforceLimits(0.0, 0.0, temp_floor, state_cc, state_fc, geom,
-						 [] AMREX_GPU_DEVICE(amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
-								     amrex::Real base_density_floor) noexcept -> amrex::Real { return base_density_floor; });
+	HydroSystem<MHDFCQuantities>::EnforceLimits(0.0, 0.0, temp_floor, state_cc, state_fc, geom,
+						    [] AMREX_GPU_DEVICE(amrex::Real /*x*/, amrex::Real /*y*/, amrex::Real /*z*/,
+									amrex::Real base_density_floor) noexcept -> amrex::Real { return base_density_floor; });
 	amrex::Gpu::streamSynchronizeAll();
 
 	amrex::Real const expected_Etot = Eint_floor + Emag;
-	amrex::Real const actual_Etot = state_cc.min(HydroSystem<FCQuantities>::energy_index);
+	amrex::Real const actual_Etot = state_cc.min(HydroSystem<MHDFCQuantities>::energy_index);
 	amrex::Real const Etot_rel_error = std::abs(actual_Etot - expected_Etot) / std::max(std::abs(expected_Etot), 1.0);
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Etot_rel_error <= 1000.0 * std::numeric_limits<amrex::Real>::epsilon(),
 					 std::format("MHD temperature floor total energy mismatch: got {}, expected {}", actual_Etot, expected_Etot));
 
-	amrex::Real const actual_aux_eint = state_cc.min(HydroSystem<FCQuantities>::internalEnergy_index);
+	amrex::Real const actual_aux_eint = state_cc.min(HydroSystem<MHDFCQuantities>::internalEnergy_index);
 	amrex::Real const aux_rel_error = std::abs(actual_aux_eint - Eint_floor) / std::max(std::abs(Eint_floor), 1.0);
 	AMREX_ALWAYS_ASSERT_WITH_MESSAGE(aux_rel_error <= 1000.0 * std::numeric_limits<amrex::Real>::epsilon(),
 					 std::format("MHD auxiliary internal energy floor mismatch: got {}, expected {}", actual_aux_eint, Eint_floor));
 }
 
-void checkDivFreeRestart(QuokkaSimulation<FCQuantities> const &sim)
+void checkDivFreeRestart(QuokkaSimulation<MHDFCQuantities> const &sim)
 {
 	auto const &state_fc = sim.getNewMF_fc();
 	auto const &state_cc = sim.getNewMF_cc();
@@ -221,7 +221,7 @@ void checkDivFreeRestart(QuokkaSimulation<FCQuantities> const &sim)
 
 		amrex::Real max_b = 0.0;
 		for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
-			max_b = std::max(max_b, state_fc[lev][dir].norm0(MHDSystem<FCQuantities>::bfield_index, 0, false));
+			max_b = std::max(max_b, state_fc[lev][dir].norm0(MHDSystem<MHDFCQuantities>::bfield_index, 0, false));
 		}
 
 		auto const &dx = sim.geom[lev].CellSizeArray();
@@ -243,14 +243,14 @@ auto problem_main() -> int
 
 	setAmrNCell(coarse_ncells);
 	setPlotfileParams("fcq_pre");
-	QuokkaSimulation<FCQuantities> sim_write;
+	QuokkaSimulation<MHDFCQuantities> sim_write;
 	checkEnforceLimitsPreservesMagneticEnergy();
 	sim_write.setInitialConditions();
 	amrex::Print() << "\n";
 
 	setAmrNCell(fine_ncells);
 	setPlotfileParams("fcq_post");
-	QuokkaSimulation<FCQuantities> sim_restart;
+	QuokkaSimulation<MHDFCQuantities> sim_restart;
 	sim_restart.setChkFile("chk0000000");
 	sim_restart.setInitialConditions();
 	amrex::Print() << "\n";

--- a/src/problems/MHDFastWaveConvergence/testMHDFastWaveConvergence.cpp
+++ b/src/problems/MHDFastWaveConvergence/testMHDFastWaveConvergence.cpp
@@ -25,21 +25,21 @@
 #include "util/BC.hpp"
 #include "util/richardson.hpp"
 
-struct FastWaveConvergence {};
+struct MHDFastWaveConvergence {};
 
-template <> struct quokka::EOS_Traits<FastWaveConvergence> {
+template <> struct quokka::EOS_Traits<MHDFastWaveConvergence> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<FastWaveConvergence> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDFastWaveConvergence> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };
 
 constexpr double sound_speed = 1.0;
-constexpr double gamma_gas = quokka::EOS_Traits<FastWaveConvergence>::gamma;
+constexpr double gamma_gas = quokka::EOS_Traits<MHDFastWaveConvergence>::gamma;
 constexpr double bg_density = 1.0;
 constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
 constexpr double b0_magn = 1.0;
@@ -304,12 +304,12 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double Etot = Ekin + Emag + Eint;
 
 		// write state
-		state(i, j, k, HydroSystem<FastWaveConvergence>::density_index) = density;
-		state(i, j, k, HydroSystem<FastWaveConvergence>::x1Momentum_index) = v_prf[0] * density;
-		state(i, j, k, HydroSystem<FastWaveConvergence>::x2Momentum_index) = v_prf[1] * density;
-		state(i, j, k, HydroSystem<FastWaveConvergence>::x3Momentum_index) = v_prf[2] * density;
-		state(i, j, k, HydroSystem<FastWaveConvergence>::energy_index) = Etot;
-		state(i, j, k, HydroSystem<FastWaveConvergence>::internalEnergy_index) = Eint;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::density_index) = density;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::x1Momentum_index) = v_prf[0] * density;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::x2Momentum_index) = v_prf[1] * density;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::x3Momentum_index) = v_prf[2] * density;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<MHDFastWaveConvergence>::internalEnergy_index) = Eint;
 
 	} else if (cen == quokka::centering::fc) {
 		// compute b-field using the magnetic vector potential to preserve div(b) = 0 topology
@@ -319,26 +319,26 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 				dx[1] -
 			    (Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L + dx[2], time) - Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L, time)) /
 				dx[2];
-			state(i, j, k, MHDSystem<FastWaveConvergence>::bfield_index) = b_x1;
+			state(i, j, k, MHDSystem<MHDFastWaveConvergence>::bfield_index) = b_x1;
 		} else if (dir == quokka::direction::y) {
 			const double b_x2 =
 			    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L + dx[2], time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) /
 				dx[2] -
 			    (Az_prf(x1_prf_L + dx[0], x2_prf_L, x3_prf_L + dx[2] / 2.0, time) - Az_prf(x1_prf_L, x2_prf_L, x3_prf_L + dx[2] / 2.0, time)) /
 				dx[0];
-			state(i, j, k, MHDSystem<FastWaveConvergence>::bfield_index) = b_x2;
+			state(i, j, k, MHDSystem<MHDFastWaveConvergence>::bfield_index) = b_x2;
 		} else if (dir == quokka::direction::z) {
 			const double b_x3 =
 			    (Ay_prf(x1_prf_L + dx[0], x2_prf_L + dx[1] / 2.0, x3_prf_L, time) - Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L, time)) /
 				dx[0] -
 			    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L + dx[1], x3_prf_L, time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) /
 				dx[1];
-			state(i, j, k, MHDSystem<FastWaveConvergence>::bfield_index) = b_x3;
+			state(i, j, k, MHDSystem<MHDFastWaveConvergence>::bfield_index) = b_x3;
 		}
 	}
 }
 
-template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDFastWaveConvergence>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -347,7 +347,7 @@ template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGr
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_cc = Physics_Indices<FastWaveConvergence>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDFastWaveConvergence>::nvarTotal_cc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0;
@@ -356,7 +356,7 @@ template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGr
 	});
 }
 
-template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDFastWaveConvergence>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -365,7 +365,7 @@ template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGr
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_fc = Physics_Indices<FastWaveConvergence>::nvarPerDim_fc;
+	const int ncomp_fc = Physics_Indices<MHDFastWaveConvergence>::nvarPerDim_fc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_fc; ++n) {
 			state_fc(i, j, k, n) = 0;
@@ -375,8 +375,8 @@ template <> void QuokkaSimulation<FastWaveConvergence>::setInitialConditionsOnGr
 }
 
 template <>
-void QuokkaSimulation<FastWaveConvergence>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+void QuokkaSimulation<MHDFastWaveConvergence>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -393,9 +393,9 @@ void QuokkaSimulation<FastWaveConvergence>::computeReferenceSolution(amrex::Mult
 }
 
 template <>
-void QuokkaSimulation<FastWaveConvergence>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-									amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-									quokka::direction const dir)
+void QuokkaSimulation<MHDFastWaveConvergence>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+									   quokka::direction const dir)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -500,9 +500,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	pp_geom.addarr("is_periodic", is_periodic);
 
 	// Setup boundary conditions
-	auto BCs_cc = quokka::BC<FastWaveConvergence>(quokka::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MHDFastWaveConvergence>(quokka::BCType::int_dir);
 
-	const int nvars_fc = Physics_Indices<FastWaveConvergence>::nvarTotal_fc;
+	const int nvars_fc = Physics_Indices<MHDFastWaveConvergence>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -512,7 +512,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	}
 
 	// Run simulation
-	QuokkaSimulation<FastWaveConvergence> sim(BCs_cc, BCs_fc);
+	QuokkaSimulation<MHDFastWaveConvergence> sim(BCs_cc, BCs_fc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
@@ -594,8 +594,8 @@ auto problem_main() -> int
 			normalizeVector(outofplane_dir_prf);
 		}
 
-		auto BCs_cc = quokka::BC<FastWaveConvergence>(quokka::BCType::int_dir);
-		const int nvars_fc = Physics_Indices<FastWaveConvergence>::nvarTotal_fc;
+		auto BCs_cc = quokka::BC<MHDFastWaveConvergence>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<MHDFastWaveConvergence>::nvarTotal_fc;
 		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -604,7 +604,7 @@ auto problem_main() -> int
 			}
 		}
 
-		QuokkaSimulation<FastWaveConvergence> sim(BCs_cc, BCs_fc);
+		QuokkaSimulation<MHDFastWaveConvergence> sim(BCs_cc, BCs_fc);
 
 		double num_periods = 1.0;
 		{

--- a/src/problems/MHDRyuJones2aShockTube/testMHDRyuJones2aShockTube.cpp
+++ b/src/problems/MHDRyuJones2aShockTube/testMHDRyuJones2aShockTube.cpp
@@ -28,14 +28,14 @@
 #include "util/BC.hpp"
 #include "util/fextract.hpp"
 
-struct RyuJones2aShockTubeProblem {};
+struct MHDRyuJones2aShockTube {};
 
-template <> struct quokka::EOS_Traits<RyuJones2aShockTubeProblem> {
+template <> struct quokka::EOS_Traits<MHDRyuJones2aShockTube> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<RyuJones2aShockTubeProblem> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDRyuJones2aShockTube> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
@@ -60,18 +60,18 @@ constexpr amrex::Real By_L = 1.0155412503859613;     // 3.6 / sqrt(4 pi)
 constexpr amrex::Real By_R = 1.1283791670955125;     // 4 / sqrt(4 pi)
 constexpr amrex::Real Bz = std::numbers::inv_sqrtpi; // 2 / sqrt(4 pi); constant
 
-template <> void QuokkaSimulation<RyuJones2aShockTubeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDRyuJones2aShockTube>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
 	const amrex::Array4<double> &state_cc = grid_elem.array_;
 	const amrex::Box &indexRange = grid_elem.indexRange_;
 
-	const int ncomp_cc = Physics_Indices<RyuJones2aShockTubeProblem>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDRyuJones2aShockTube>::nvarTotal_cc;
 
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 		const double x = prob_lo[0] + ((i + 0.5) * dx[0]);
-		const auto gamma = quokka::EOS_Traits<RyuJones2aShockTubeProblem>::gamma;
+		const auto gamma = quokka::EOS_Traits<MHDRyuJones2aShockTube>::gamma;
 		double rho = NAN;
 		double P = NAN;
 		double vx = NAN;
@@ -105,16 +105,16 @@ template <> void QuokkaSimulation<RyuJones2aShockTubeProblem>::setInitialConditi
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0.;
 		}
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::density_index) = rho;
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::x1Momentum_index) = vx * rho;
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::x2Momentum_index) = vy * rho;
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::x3Momentum_index) = vz * rho;
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::energy_index) = P / (gamma - 1.) + Ekin + Emag;
-		state_cc(i, j, k, HydroSystem<RyuJones2aShockTubeProblem>::internalEnergy_index) = P / (gamma - 1.);
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::density_index) = rho;
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::x1Momentum_index) = vx * rho;
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::x2Momentum_index) = vy * rho;
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::x3Momentum_index) = vz * rho;
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::energy_index) = P / (gamma - 1.) + Ekin + Emag;
+		state_cc(i, j, k, HydroSystem<MHDRyuJones2aShockTube>::internalEnergy_index) = P / (gamma - 1.);
 	});
 }
 
-template <> void QuokkaSimulation<RyuJones2aShockTubeProblem>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDRyuJones2aShockTube>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -135,24 +135,24 @@ template <> void QuokkaSimulation<RyuJones2aShockTubeProblem>::setInitialConditi
 		}
 
 		if (dir == quokka::direction::x) {
-			state_fc(i, j, k, Physics_Indices<RyuJones2aShockTubeProblem>::mhdFirstIndex) = x1mag;
+			state_fc(i, j, k, Physics_Indices<MHDRyuJones2aShockTube>::mhdFirstIndex) = x1mag;
 		} else if (dir == quokka::direction::y) {
-			state_fc(i, j, k, Physics_Indices<RyuJones2aShockTubeProblem>::mhdFirstIndex) = x2mag;
+			state_fc(i, j, k, Physics_Indices<MHDRyuJones2aShockTube>::mhdFirstIndex) = x2mag;
 		} else if (dir == quokka::direction::z) {
-			state_fc(i, j, k, Physics_Indices<RyuJones2aShockTubeProblem>::mhdFirstIndex) = x3mag;
+			state_fc(i, j, k, Physics_Indices<MHDRyuJones2aShockTube>::mhdFirstIndex) = x3mag;
 		}
 	});
 }
 
 template <>
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
-AMRSimulation<RyuJones2aShockTubeProblem>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/,
-								       int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
-								       const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
+AMRSimulation<MHDRyuJones2aShockTube>::setCustomBoundaryConditions(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar, int /*dcomp*/,
+								   int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
+								   const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
 {
 	// Number of variables (use Physics_Indices which correctly accounts for enabled physics)
-	constexpr int nvar = Physics_Indices<RyuJones2aShockTubeProblem>::nvarTotal_cc;
-	const auto gamma = quokka::EOS_Traits<RyuJones2aShockTubeProblem>::gamma;
+	constexpr int nvar = Physics_Indices<MHDRyuJones2aShockTube>::nvarTotal_cc;
+	const auto gamma = quokka::EOS_Traits<MHDRyuJones2aShockTube>::gamma;
 
 	const double Emag_L = 0.5 * (Bx * Bx + By_L * By_L + Bz * Bz);
 	const double Emag_R = 0.5 * (Bx * Bx + By_R * By_R + Bz * Bz);
@@ -161,24 +161,24 @@ AMRSimulation<RyuJones2aShockTubeProblem>::setCustomBoundaryConditions(const amr
 
 	// Prepare left boundary values (left state)
 	amrex::GpuArray<amrex::Real, nvar> low_bdr_cells{};
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasEnergy_index] = P_L / (gamma - 1.) + Ekin_L + Emag_L;
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasInternalEnergy_index] = P_L / (gamma - 1.);
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasDensity_index] = rho_L;
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x1GasMomentum_index] = vx_L * rho_L;
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x2GasMomentum_index] = vy_L * rho_L;
-	low_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x3GasMomentum_index] = vz_L * rho_L;
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasEnergy_index] = P_L / (gamma - 1.) + Ekin_L + Emag_L;
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasInternalEnergy_index] = P_L / (gamma - 1.);
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasDensity_index] = rho_L;
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x1GasMomentum_index] = vx_L * rho_L;
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x2GasMomentum_index] = vy_L * rho_L;
+	low_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x3GasMomentum_index] = vz_L * rho_L;
 
 	// Prepare right boundary values (right state)
 	amrex::GpuArray<amrex::Real, nvar> high_bdr_cells{};
 	for (int n = 0; n < nvar; ++n) {
 		high_bdr_cells[n] = 0;
 	}
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasEnergy_index] = P_R / (gamma - 1.) + Ekin_R + Emag_R;
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasInternalEnergy_index] = P_R / (gamma - 1.);
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::gasDensity_index] = rho_R;
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x1GasMomentum_index] = vx_R * rho_R;
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x2GasMomentum_index] = vy_R * rho_R;
-	high_bdr_cells[RadSystem<RyuJones2aShockTubeProblem>::x3GasMomentum_index] = vz_R * rho_R;
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasEnergy_index] = P_R / (gamma - 1.) + Ekin_R + Emag_R;
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasInternalEnergy_index] = P_R / (gamma - 1.);
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::gasDensity_index] = rho_R;
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x1GasMomentum_index] = vx_R * rho_R;
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x2GasMomentum_index] = vy_R * rho_R;
+	high_bdr_cells[RadSystem<MHDRyuJones2aShockTube>::x3GasMomentum_index] = vz_R * rho_R;
 
 	// Apply boundary conditions using helper functions (direction 0 = x-axis)
 	setConstantDirichletBCLo<0>(iv, consVar, geom, low_bdr_cells);
@@ -187,9 +187,10 @@ AMRSimulation<RyuJones2aShockTubeProblem>::setCustomBoundaryConditions(const amr
 
 template <>
 template <quokka::direction dir>
-AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<RyuJones2aShockTubeProblem>::setCustomBoundaryConditionsFaceVar(
-    const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar_fc, int /*dcomp*/, int /*numcomp*/, amrex::GeometryData const &geom,
-    const amrex::Real /*time*/, const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE void
+AMRSimulation<MHDRyuJones2aShockTube>::setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &consVar_fc, int /*dcomp*/,
+									  int /*numcomp*/, amrex::GeometryData const &geom, const amrex::Real /*time*/,
+									  const amrex::BCRec * /*bcr*/, int /*bcomp*/, int /*orig_comp*/)
 {
 	// Prepare boundary values for each face direction: {x-face, y-face, z-face}
 	const amrex::GpuArray<amrex::Real, 3> low_bdr_values = {Bx, By_L, Bz};
@@ -201,7 +202,7 @@ AMREX_GPU_DEVICE AMREX_FORCE_INLINE void AMRSimulation<RyuJones2aShockTubeProble
 
 auto problem_main() -> int
 {
-	QuokkaSimulation<RyuJones2aShockTubeProblem> sim;
+	QuokkaSimulation<MHDRyuJones2aShockTube> sim;
 
 	// Main time loop
 	sim.setInitialConditions();

--- a/src/problems/MHDSlowWaveConvergence/testMHDSlowWaveConvergence.cpp
+++ b/src/problems/MHDSlowWaveConvergence/testMHDSlowWaveConvergence.cpp
@@ -25,21 +25,21 @@
 #include "util/BC.hpp"
 #include "util/richardson.hpp"
 
-struct SlowWaveConvergence {};
+struct MHDSlowWaveConvergence {};
 
-template <> struct quokka::EOS_Traits<SlowWaveConvergence> {
+template <> struct quokka::EOS_Traits<MHDSlowWaveConvergence> {
 	static constexpr double gamma = 5. / 3.;
 	static constexpr double mean_molecular_weight = C::m_u;
 };
 
-template <> struct Physics_Traits<SlowWaveConvergence> : DefaultPhysicsTraits {
+template <> struct Physics_Traits<MHDSlowWaveConvergence> : DefaultPhysicsTraits {
 	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
 	static constexpr bool is_hydro_enabled = true;
 	static constexpr bool is_mhd_enabled = true;
 };
 
 constexpr double sound_speed = 1.0;
-constexpr double gamma_gas = quokka::EOS_Traits<SlowWaveConvergence>::gamma;
+constexpr double gamma_gas = quokka::EOS_Traits<MHDSlowWaveConvergence>::gamma;
 constexpr double bg_density = 1.0;
 constexpr double bg_pressure = sound_speed * sound_speed * bg_density / gamma_gas;
 constexpr double b0_magn = 1.0;
@@ -313,12 +313,12 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 		const double Etot = Ekin + Emag + Eint;
 
 		// write state
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::density_index) = density;
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::x1Momentum_index) = v_prf[0] * density;
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::x2Momentum_index) = v_prf[1] * density;
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::x3Momentum_index) = v_prf[2] * density;
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::energy_index) = Etot;
-		state(i, j, k, HydroSystem<SlowWaveConvergence>::internalEnergy_index) = Eint;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::density_index) = density;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::x1Momentum_index) = v_prf[0] * density;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::x2Momentum_index) = v_prf[1] * density;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::x3Momentum_index) = v_prf[2] * density;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::energy_index) = Etot;
+		state(i, j, k, HydroSystem<MHDSlowWaveConvergence>::internalEnergy_index) = Eint;
 
 	} else if (cen == quokka::centering::fc) {
 		// compute b-field using the magnetic vector potential to preserve div(b) = 0 topology
@@ -328,26 +328,26 @@ void computeWaveSolution(int i, int j, int k, amrex::Array4<amrex::Real> const &
 				dx[1] -
 			    (Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L + dx[2], time) - Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L, time)) /
 				dx[2];
-			state(i, j, k, MHDSystem<SlowWaveConvergence>::bfield_index) = b_x1;
+			state(i, j, k, MHDSystem<MHDSlowWaveConvergence>::bfield_index) = b_x1;
 		} else if (dir == quokka::direction::y) {
 			const double b_x2 =
 			    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L + dx[2], time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) /
 				dx[2] -
 			    (Az_prf(x1_prf_L + dx[0], x2_prf_L, x3_prf_L + dx[2] / 2.0, time) - Az_prf(x1_prf_L, x2_prf_L, x3_prf_L + dx[2] / 2.0, time)) /
 				dx[0];
-			state(i, j, k, MHDSystem<SlowWaveConvergence>::bfield_index) = b_x2;
+			state(i, j, k, MHDSystem<MHDSlowWaveConvergence>::bfield_index) = b_x2;
 		} else if (dir == quokka::direction::z) {
 			const double b_x3 =
 			    (Ay_prf(x1_prf_L + dx[0], x2_prf_L + dx[1] / 2.0, x3_prf_L, time) - Ay_prf(x1_prf_L, x2_prf_L + dx[1] / 2.0, x3_prf_L, time)) /
 				dx[0] -
 			    (Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L + dx[1], x3_prf_L, time) - Ax_prf(x1_prf_L + dx[0] / 2.0, x2_prf_L, x3_prf_L, time)) /
 				dx[1];
-			state(i, j, k, MHDSystem<SlowWaveConvergence>::bfield_index) = b_x3;
+			state(i, j, k, MHDSystem<MHDSlowWaveConvergence>::bfield_index) = b_x3;
 		}
 	}
 }
 
-template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDSlowWaveConvergence>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -356,7 +356,7 @@ template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGr
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_cc = Physics_Indices<SlowWaveConvergence>::nvarTotal_cc;
+	const int ncomp_cc = Physics_Indices<MHDSlowWaveConvergence>::nvarTotal_cc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_cc; ++n) {
 			state_cc(i, j, k, n) = 0;
@@ -365,7 +365,7 @@ template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGr
 	});
 }
 
-template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+template <> void QuokkaSimulation<MHDSlowWaveConvergence>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
 {
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> dx = grid_elem.dx_;
 	const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> prob_lo = grid_elem.prob_lo_;
@@ -374,7 +374,7 @@ template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGr
 	const quokka::centering cen = grid_elem.cen_;
 	const quokka::direction dir = grid_elem.dir_;
 
-	const int ncomp_fc = Physics_Indices<SlowWaveConvergence>::nvarPerDim_fc;
+	const int ncomp_fc = Physics_Indices<MHDSlowWaveConvergence>::nvarPerDim_fc;
 	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 		for (int n = 0; n < ncomp_fc; ++n) {
 			state_fc(i, j, k, n) = 0;
@@ -384,8 +384,8 @@ template <> void QuokkaSimulation<SlowWaveConvergence>::setInitialConditionsOnGr
 }
 
 template <>
-void QuokkaSimulation<SlowWaveConvergence>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-								     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
+void QuokkaSimulation<MHDSlowWaveConvergence>::computeReferenceSolution(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -402,9 +402,9 @@ void QuokkaSimulation<SlowWaveConvergence>::computeReferenceSolution(amrex::Mult
 }
 
 template <>
-void QuokkaSimulation<SlowWaveConvergence>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
-									amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
-									quokka::direction const dir)
+void QuokkaSimulation<MHDSlowWaveConvergence>::computeReferenceSolution_fc(amrex::MultiFab &ref, amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &dx,
+									   amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const &prob_lo,
+									   quokka::direction const dir)
 {
 	for (amrex::MFIter iter(ref); iter.isValid(); ++iter) {
 		const amrex::Box &indexRange = iter.validbox();
@@ -509,9 +509,9 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	pp_geom.addarr("is_periodic", is_periodic);
 
 	// Setup boundary conditions
-	auto BCs_cc = quokka::BC<SlowWaveConvergence>(quokka::BCType::int_dir);
+	auto BCs_cc = quokka::BC<MHDSlowWaveConvergence>(quokka::BCType::int_dir);
 
-	const int nvars_fc = Physics_Indices<SlowWaveConvergence>::nvarTotal_fc;
+	const int nvars_fc = Physics_Indices<MHDSlowWaveConvergence>::nvarTotal_fc;
 	amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 	for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -521,7 +521,7 @@ auto runWaveTest(int nx, int ny, int nz) -> double
 	}
 
 	// Run simulation
-	QuokkaSimulation<SlowWaveConvergence> sim(BCs_cc, BCs_fc);
+	QuokkaSimulation<MHDSlowWaveConvergence> sim(BCs_cc, BCs_fc);
 
 	sim.stopTime_ = max_time;
 	sim.maxTimesteps_ = max_timesteps;
@@ -603,8 +603,8 @@ auto problem_main() -> int
 			normalizeVector(outofplane_dir_prf);
 		}
 
-		auto BCs_cc = quokka::BC<SlowWaveConvergence>(quokka::BCType::int_dir);
-		const int nvars_fc = Physics_Indices<SlowWaveConvergence>::nvarTotal_fc;
+		auto BCs_cc = quokka::BC<MHDSlowWaveConvergence>(quokka::BCType::int_dir);
+		const int nvars_fc = Physics_Indices<MHDSlowWaveConvergence>::nvarTotal_fc;
 		amrex::Vector<amrex::BCRec> BCs_fc(nvars_fc);
 		for (int icomp = 0; icomp < nvars_fc; ++icomp) {
 			for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
@@ -613,7 +613,7 @@ auto problem_main() -> int
 			}
 		}
 
-		QuokkaSimulation<SlowWaveConvergence> sim(BCs_cc, BCs_fc);
+		QuokkaSimulation<MHDSlowWaveConvergence> sim(BCs_cc, BCs_fc);
 
 		double num_periods = 1.0;
 		{


### PR DESCRIPTION
### Description

This PR is stacked on #2184, and renames each problem's C++ struct, and every template reference to it, to match the file names introduced there. `BrioWuShockTube`'s struct was `MHDShocktubeProblem`, unrelated to its own directory name; it's now `MHDBrioWuShockTube`. `RyuJones2aShockTube` drops its `Problem` suffix to match every other MHD-prefixed problem, none of which carry one.

This is purely renaming, and makes no change to the behaviour of simulations.

### Related issues

- #2184: this PR is stacked on it and needs it merged first.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; existing behaviour is preserved exactly.
- [x] I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized names across the MHD wave, shock-tube, entropy-wave, face-centered quantity, and fast/slow-wave test scenarios.
  * Preserved existing numerical setups, initial conditions, boundary conditions, and convergence behavior.
  * Added validation to reject nonzero resistivity settings in the circular Alfvén-wave convergence test, ensuring unsupported configurations fail clearly.
* **Maintenance**
  * Improved consistency when identifying and running MHD simulation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->