### PR TITLE
Fix convergence tolerance for weak nonzero gas-dust coupling

### DIFF
--- a/src/problems/RadDust/testRadDust.cpp
+++ b/src/problems/RadDust/testRadDust.cpp
@@ -5,6 +5,7 @@
 #ifdef HAVE_PYTHON
 #include "util/matplotlibcpp.h"
 #endif
+#include "AMReX_GpuAsyncArray.H"
 #include "AMReX_Print.H"
 #include "QuokkaSimulation.hpp"
 #include "fundamental_constants.H"
@@ -96,6 +97,30 @@ template <> AMREX_GPU_HOST_DEVICE auto RadSystem<DustProblem>::ComputeThermalRad
 	return radiation_constant_;
 }
 
+auto testWeakNonzeroResidualScale() -> bool
+{
+	constexpr double x0 = 1.0;
+	constexpr double expected_root = 1.0e-2;
+	constexpr double physical_scale = 1.0e-16;
+	constexpr double relative_tolerance = 1.0e-8;
+
+	auto const rhs = [] AMREX_GPU_HOST_DEVICE(double x) noexcept -> double { return x * x * x * x - 1.0e-8; };
+	auto const jac = [] AMREX_GPU_HOST_DEVICE(double x) noexcept -> double { return 4.0 * x * x * x; };
+
+	double solution = NAN;
+	amrex::AsyncArray solution_async(&solution, 1);
+	double *solution_device = solution_async.data();
+	amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE(int /*i*/) noexcept {
+		solution_device[0] = RadSystem<DustProblem>::BackwardEulerOneVariable(rhs, jac, x0, physical_scale);
+	});
+	solution_async.copyToHost(&solution, 1);
+
+	const double residual = std::abs(rhs(solution));
+	const bool converged = (solution > 0.0) && (std::abs(solution - expected_root) < 1.0e-12) && (residual < 10.0 * relative_tolerance * physical_scale);
+	amrex::Print() << "Weak non-zero residual-scale test: solution = " << solution << ", residual = " << residual << '\n';
+	return converged;
+}
+
 template <> void QuokkaSimulation<DustProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
 {
 	// extract variables required from the geom object
@@ -162,8 +187,14 @@ auto problem_main() -> int
 	// evolve
 	sim.evolve();
 
+	const bool weak_nonzero_scale_test_passed = testWeakNonzeroResidualScale();
+
 	int status = 0;
 	if (amrex::ParallelDescriptor::IOProcessor()) {
+		if (!weak_nonzero_scale_test_passed) {
+			status = 1;
+		}
+
 		// read in exact solution
 		std::vector<double> ts_exact{};
 		std::vector<double> Trad_exact{};

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1637,18 +1637,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 	// The caller supplies the physical scale against which its residual must be measured. Preserve every
 	// positive scale, however small: weak but non-zero gas-dust coupling relies on a correspondingly tight
 	// inner tolerance because the outer solve reconstructs T_d with a factor inversely proportional to that
-	// coupling. Scaling instead by a larger initial residual can therefore amplify the accepted inner error
-	// enough to drive the outer temperature negative.
-	//
-	// Exactly decoupled dust has a zero physical scale. Only in that case, fall back to the initial residual
-	// so the criterion requests a relative residual reduction rather than an impossible strict zero.
+	// coupling. Clamp a non-positive scale to zero, which accepts only an exact-zero initial residual.
 	const double f0 = rhs(x0);
-	AMREX_ASSERT(compare >= 0.0);
-	if (f0 == 0.0) {
-		return x0;
-	}
-	const double scale = (compare > 0.0) ? compare : std::abs(f0);
-	if (std::abs(f0) < rel_tol * scale) {
+	const double scale = std::max(0.0, compare);
+	if (std::abs(f0) <= rel_tol * scale) {
 		return x0;
 	}
 

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1634,13 +1634,20 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 	const double rel_change_tol = 1.0e-6;
 	const int max_iter_td = 100;
 
-	// Tolerance scale. The caller passes the physical scale its residual should be measured against, but for
-	// the dust temperature that scale is the gas-dust collisional term, which vanishes identically when the
-	// coupling coefficient is set to zero. The tolerance would then be zero and could never be met. Fall
-	// back to the size of the initial residual so the criterion degrades to a relative reduction instead of
-	// something unsatisfiable.
+	// The caller supplies the physical scale against which its residual must be measured. Preserve every
+	// positive scale, however small: weak but non-zero gas-dust coupling relies on a correspondingly tight
+	// inner tolerance because the outer solve reconstructs T_d with a factor inversely proportional to that
+	// coupling. Scaling instead by a larger initial residual can therefore amplify the accepted inner error
+	// enough to drive the outer temperature negative.
+	//
+	// Exactly decoupled dust has a zero physical scale. Only in that case, fall back to the initial residual
+	// so the criterion requests a relative residual reduction rather than an impossible strict zero.
 	const double f0 = rhs(x0);
-	const double scale = std::max(compare, std::abs(f0));
+	AMREX_ASSERT(compare >= 0.0);
+	if (f0 == 0.0) {
+		return x0;
+	}
+	const double scale = (compare > 0.0) ? compare : std::abs(f0);
 	if (std::abs(f0) < rel_tol * scale) {
 		return x0;
 	}

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -1637,9 +1637,10 @@ AMREX_GPU_DEVICE auto RadSystem<problem_t>::BackwardEulerOneVariable(RHSFunction
 	// The caller supplies the physical scale against which its residual must be measured. Preserve every
 	// positive scale, however small: weak but non-zero gas-dust coupling relies on a correspondingly tight
 	// inner tolerance because the outer solve reconstructs T_d with a factor inversely proportional to that
-	// coupling. Clamp a non-positive scale to zero, which accepts only an exact-zero initial residual.
+	// coupling. When no positive physical scale exists, fall back to the initial residual so the solver
+	// requests a relative residual reduction instead of an impossible strict zero.
 	const double f0 = rhs(x0);
-	const double scale = std::max(0.0, compare);
+	const double scale = (compare > 0.0) ? compare : std::abs(f0);
 	if (std::abs(f0) <= rel_tol * scale) {
 		return x0;
 	}


### PR DESCRIPTION
### Description

This PR fixes the weak but non-zero gas-dust coupling convergence regression in `BackwardEulerOneVariable`. It preserves the caller-provided physical residual scale whenever `compare > 0`, uses `abs(f0)` only for the exactly decoupled case, and adds a regression test to `RadDust` that distinguishes the corrected behavior from the overly relaxed tolerance introduced by PR #2126.

### Related issues

Fixes #2188

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems. Not applicable because I am not a quokka-astro organization member.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved radiation solver convergence for cases with weak but non-zero physical scales.
  * Ensured convergence checks consistently use the configured residual scale.
  * Improved reliability when solving decoupled or near-zero-scale conditions.

* **Tests**
  * Added GPU coverage validating solver convergence and residual accuracy under weak-scale conditions.
  * Test failures now correctly report a failing process status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->