### PR TITLE
Fix wiring of MHDQuirk params

### DIFF
--- a/inputs/MHDQuirk.toml
+++ b/inputs/MHDQuirk.toml
@@ -24,3 +24,7 @@ do_subcycle = 0
 plotfile_interval = -1
 
 hydro.reconstruction_order = 2
+
+cfl = 0.4
+stop_time = 0.4
+max_timesteps = 2000

--- a/src/problems/MHDQuirk/testMHDQuirk.cpp
+++ b/src/problems/MHDQuirk/testMHDQuirk.cpp
@@ -282,10 +282,6 @@ auto problem_main() -> int
 	// Problem initialization
 	QuokkaSimulation<MHDQuirk> sim(BCs_cc, BCs_fc);
 
-	sim.stopTime_ = 0.4;
-	sim.cflNumber_ = 0.4;
-	sim.maxTimesteps_ = 2000;
-
 	// initialize
 	sim.setInitialConditions();
 


### PR DESCRIPTION
### Description

This PR correctly wires up `cfl`, `stop_time`, and `max_timesteps` for `MHDQuirk` to its problem input toml; these were being silently ignored, and hardcoded in `problem_main()`.

`inputs/MHDQuirk.toml` now sets these explicitly to the previously-hardcoded values, so default behaviour is unchanged.

### Related issues

N/A.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above): n/a, see Related issues.
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; existing behaviour is preserved exactly.
- [x] I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable simulation controls for CFL, stop time, and maximum timesteps.

* **Tests**
  * Updated the MHD Quirk test to use the simulation’s default runtime settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->