### PR TITLE
Fix wiring of MHDBalsaraVortex params

### DIFF
--- a/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
+++ b/src/problems/MHDBalsaraVortex/testMHDBalsaraVortex.cpp
@@ -220,6 +220,7 @@ auto problem_main() -> int
 
 	int advection_int = 0;
 	double num_periods = 1.0;
+	hpp.query("vortex_radius", vortex_radius);
 	hpp.query("vortex_Mach", vortex_Mach);
 	hpp.query("vortex_b_magn", vortex_b_magn);
 	hpp.query("advection", advection_int);


### PR DESCRIPTION
### Description

This PR correctly wires up `vortex_radius` for `MHDBalsaraVortex` to its problem input toml; this was being silently ignored, and permanently defaulted to `1.0` regardless of any toml key.

`inputs/MHDBalsaraVortex.toml` doesn't set `vortex_radius`, so default behaviour is unchanged.

### Related issues

N/A.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above): n/a, see Related issues.
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code: n/a, no new physics; existing behaviour is preserved exactly.
- [x] I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`.
