### PR TITLE
Update Frontier profile to ROCm 10.0

### DIFF
--- a/scripts/hpc_profiles/frontier.profile
+++ b/scripts/hpc_profiles/frontier.profile
@@ -2,50 +2,80 @@
 # please set your project account
 export proj="ast236"  # change me!
 
+## modules
 source /opt/cray/pe/cpe/26.03/restore_lmod_system_defaults.sh
-
+module load Core/26.05
 module load PrgEnv-cray
 module load craype-x86-trento
 module load craype-accel-amd-gfx90a
-
 module load cce/21.0.0
-module load rocm/7.2.0 # MUST use rocm/6.3.1 or newer
 module load cray-mpich/9.1.0
-
 module load cray-hdf5/1.14.3.9
 module load cray-python/3.12.12
-module load cmake/4.1.0
-
+module load cmake/4.1.5
 # adios2 (optional)
 module load adios2/2.11.0-mpi
-
 # emacs (optional)
 module load emacs
 
-# alias to request an interactive batch node for one hour
+## aliases
 alias getNode="salloc -A $proj -J quokka -t 01:00:00 -p batch -N 1"
-# alias to run a command on a batch node for up to 30min
 #   usage: runNode <command>
 alias runNode="srun -A $proj -J quokka -t 00:30:00 -p batch -N 1"
-
 alias snodes="sinfo -O PartitionName:12,StateComplete:50,Nodes:10,Reason:90 -S +P,+E,+t"
 alias savail="sinfo -O PartitionName:12,Nodes:10,StateComplete:50 -S +P,+E,+t -t alloc,idle"
 
+## ROCm 7.14.0
+# ROCm 7.14 user-space SDK for the MI250X (gfx90a). The host amdgpu driver is supplied by Frontier
+ROCM_VENV="${HOME}/venvs/rocm-7.14"
+
+# Keep pip's large downloads and temporary build files out of $HOME, where
+# Setonix applies a comparatively small quota. Pawsey defines $MYSCRATCH
+# for each user/project, so no account-specific paths are needed.
+export PIP_CACHE_DIR="/tmp/${USER}/pip-cache"
+export TMPDIR="/tmp/${USER}/pip-tmp"
+mkdir -p "${PIP_CACHE_DIR}" "${TMPDIR}" "$(dirname "${ROCM_VENV}")"
+
+# Checking only bin/python is insufficient: a failed pip invocation leaves a
+# valid but incomplete virtual environment. Retry until the target SDK exists.
+if [[ ! -x "${ROCM_VENV}/bin/python" ]] ||
+   ! "${ROCM_VENV}/bin/python" -m pip show rocm-sdk-device-gfx90a \
+     >/dev/null 2>&1; then
+  python -m venv "${ROCM_VENV}"
+  "${ROCM_VENV}/bin/python" -m pip install --upgrade pip
+  "${ROCM_VENV}/bin/python" -m pip install \
+    --index-url https://repo.amd.com/rocm/whl-multi-arch/ \
+    "rocm[libraries,devel,device-gfx90a]==7.14.0"
+  fi
+source "${ROCM_VENV}/bin/activate"
+
+echo "Initializing ROCm SDK... (may take several minutes on a parallel file system, please be patient)"
+rocm-sdk init
+
+# Expose the wheel-provided ROCm installation to CMake and AMReX. The SDK
+# activation places hipcc on PATH but does not currently publish its CMake
+# package prefix or HIP installation path.
+ROCM_SDK_ROOT="${ROCM_VENV}/lib/python3.12/site-packages/_rocm_sdk_devel"
+export ROCM_PATH="${ROCM_SDK_ROOT}"
+export HIP_PATH="${ROCM_SDK_ROOT}"
+export CMAKE_PREFIX_PATH="${ROCM_SDK_ROOT}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+export LD_LIBRARY_PATH="${ROCM_SDK_ROOT}/lib:${CRAY_LD_LIBRARY_PATH}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+## environment variables
+
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1
-
 # optimize ROCm/HIP compilation for MI250X
 export AMREX_AMD_ARCH=gfx90a
-
-# compiler environment hints
+# compilers
 export CC=$(which hipcc)
 export CXX=$(which hipcc)
-export FC=$(which ftn)
 
-# these flags are REQUIRED
+# These flags are required when using hipcc directly instead of the Cray
+# compiler wrappers. In particular, link the GPU Transport Layer (GTL) needed
+# by GPU-aware MPICH on gfx90a.
 export CFLAGS="-I${MPICH_DIR}/include"
 export CXXFLAGS="-I${MPICH_DIR}/include"
 export LDFLAGS="-L${MPICH_DIR}/lib -lmpi \
   ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
   ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}"
-export LD_LIBRARY_PATH=$CRAY_LD_LIBRARY_PATH:$LD_LIBRARY_PATH


### PR DESCRIPTION
### Description
Updates the Frontier profile to use the latest (compatible) version of ROCm.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Frontier environment setup with Core 26.05, CCE 21.0.2, ROCm 10.0.0, and CMake 4.1.5.
  * Removed the optional ADIOS2 module from the default environment.
  * Simplified the environment configuration by removing the explicit Fortran compiler setting.
  * Improved library path handling for more consistent environment initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->