### PR TITLE
Fix macOS CI dependencies

### DIFF
--- a/.github/workflows/cmake-macos.yml
+++ b/.github/workflows/cmake-macos.yml
@@ -52,8 +52,7 @@ jobs:
 
     - name: Install Homebrew dependencies
       run: |
-        brew install ccache openmpi hdf5@1.10 || true
-        brew link --force hdf5@1.10
+        brew install ccache openmpi hdf5 || true
 
     - name: Output HDF5 configuration (verbose)
       run: h5cc -showconfig


### PR DESCRIPTION
### Description
Fixes the dependency installation for macOS CI on Github Actions.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS build environment to use the default Homebrew HDF5 package.
  * Removed the legacy forced-linking step for the pinned HDF5 version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->