### PR TITLE
Fix RemakeLevel: preserve fine mhd face field on regrid

### DIFF
--- a/inputs/MHDRemakeFaceField.toml
+++ b/inputs/MHDRemakeFaceField.toml
@@ -1,9 +1,3 @@
-# Regression test for issue #2210: RemakeLevel discards the existing fine mhd face
-# field on regrid instead of preserving it. Level 1 covers the full domain (refineGrid
-# tags everything) so that a decomposition-only remake (see testMHDRemakeFaceField.cpp,
-# triggered via SetMaxGridSize + regrid()) gives 100% overlap between the old and new
-# level-1 BoxArray: any change to the fine field can only come from RemakeLevel.
-
 geometry.prob_lo = [0.0, 0.0, 0.0]
 geometry.prob_hi = [1.0, 1.0, 1.0]
 quokka.bc = ["periodic", "periodic", "periodic"]

--- a/inputs/MHDRemakeFaceField.toml
+++ b/inputs/MHDRemakeFaceField.toml
@@ -1,0 +1,24 @@
+# Regression test for issue #2210: RemakeLevel discards the existing fine mhd face
+# field on regrid instead of preserving it. Level 1 covers the full domain (refineGrid
+# tags everything) so that a decomposition-only remake (see testMHDRemakeFaceField.cpp,
+# triggered via SetMaxGridSize + regrid()) gives 100% overlap between the old and new
+# level-1 BoxArray: any change to the fine field can only come from RemakeLevel.
+
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+quokka.bc = ["periodic", "periodic", "periodic"]
+
+amr.n_cell = [16, 16, 16]
+amr.max_level = 1
+amr.max_grid_size = 32
+amr.blocking_factor = 8
+amr.n_error_buf = 0
+amr.grid_eff = 0.9
+
+do_reflux = 1
+do_subcycle = 1
+do_tracers = 0
+
+stop_time = 1.0
+max_timesteps = 0
+tiny_profiler.enabled = 0

--- a/src/problems/MHDRemakeFaceField/CMakeLists.txt
+++ b/src/problems/MHDRemakeFaceField/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(AMReX_SPACEDIM EQUAL 3)
+  quokka_add_problem(JOB_NAME MHDRemakeFaceField)
+endif()

--- a/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
+++ b/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
@@ -1,0 +1,140 @@
+/// \file testMHDRemakeFaceField.cpp
+/// \brief Regression test for issue #2210: RemakeLevel discards a level's existing
+///        fine mhd face field, replacing it with coarse-interpolated data even when
+///        the remake is a pure re-decomposition (same physical coverage).
+///
+/// Setup: level 1 covers the entire domain (refineGrid tags everything), and Bx
+/// alternates sign by fine y-face index so it is exactly divergence-free (Bx depends
+/// only on j) but its coarse restriction discards the alternation entirely. After
+/// setInitialConditions(), SetMaxGridSize() + regrid() forces AMReX to re-chop level 1's
+/// BoxArray with unchanged tags, so the new BoxArray retains 100% overlap with the old
+/// one: FillPatchTwoLevels' coarse-interpolation branch never even triggers, so any
+/// change to the retained Bx values can only come from RemakeLevel discarding the
+/// level's own prior fine data instead of copying it forward.
+///
+/// Development (no fix): RemakeLevel's face-centred path calls FillCoarsePatchFaceArray,
+///   which only ever reads GetDataFaceArray(lev - 1, ...) and interpolates from coarse,
+///   so the alternating fine structure is replaced by the coarse-restricted mean.
+/// Fix: RemakeLevel now calls FillPatchFaceArray for the new-time state, which merges in
+///   the level's own existing fine data on overlapping coverage.
+
+#include "AMReX_MultiFab.H"
+#include "AMReX_ParmParse.H"
+#include "AMReX_Print.H"
+
+#include "QuokkaSimulation.hpp"
+#include "hydro/hydro_system.hpp"
+
+struct MHDRemakeFaceField {};
+
+namespace
+{
+constexpr double B0 = 1.0;
+constexpr double delta = 0.3;
+} // namespace
+
+template <> struct quokka::EOS_Traits<MHDRemakeFaceField> {
+	static constexpr double gamma = 5. / 3.;
+	static constexpr double mean_molecular_weight = C::m_u;
+};
+
+template <> struct HydroSystem_Traits<MHDRemakeFaceField> {
+	static constexpr bool reconstruct_eint = false;
+};
+
+template <> struct Physics_Traits<MHDRemakeFaceField> : DefaultPhysicsTraits {
+	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_mhd_enabled = true;
+};
+
+template <> void QuokkaSimulation<MHDRemakeFaceField>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const amrex::Array4<double> &state_cc = grid_elem.array_;
+	constexpr double rho = 1.0;
+	constexpr double P = 1.0;
+	constexpr double Emag = 0.5 * B0 * B0;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::density_index) = rho;
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::x1Momentum_index) = 0.0;
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::x2Momentum_index) = 0.0;
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::x3Momentum_index) = 0.0;
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::energy_index) = P / (quokka::EOS_Traits<MHDRemakeFaceField>::gamma - 1.) + Emag;
+		state_cc(i, j, k, HydroSystem<MHDRemakeFaceField>::internalEnergy_index) = P / (quokka::EOS_Traits<MHDRemakeFaceField>::gamma - 1.);
+	});
+}
+
+// Bx alternates by fine y-face index j: divergence-free (Bx depends only on j, By=Bz=0),
+// but averages to B0 on any coarse restriction, discarding delta.
+template <> void QuokkaSimulation<MHDRemakeFaceField>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid_elem)
+{
+	const amrex::Array4<double> &state_fc = grid_elem.array_;
+	const amrex::Box &indexRange = grid_elem.indexRange_;
+	const quokka::direction dir = grid_elem.dir_;
+
+	amrex::ParallelFor(indexRange, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		if (dir == quokka::direction::x) {
+			const double sign = (j % 2 == 0) ? 1.0 : -1.0;
+			state_fc(i, j, k, Physics_Indices<MHDRemakeFaceField>::mhdFirstIndex) = B0 + delta * sign;
+		} else {
+			state_fc(i, j, k, Physics_Indices<MHDRemakeFaceField>::mhdFirstIndex) = 0.0;
+		}
+	});
+}
+
+// tag the entire level-0 domain unconditionally, so level 1 always covers the full
+// domain regardless of how SetMaxGridSize() re-chops it into boxes
+template <> void QuokkaSimulation<MHDRemakeFaceField>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+{
+	if (lev > 0) {
+		return;
+	}
+	auto tag = tags.arrays();
+	amrex::ParallelFor(tags, [=] AMREX_GPU_DEVICE(int bx, int i, int j, int k) noexcept { tag[bx](i, j, k) = amrex::TagBox::SET; });
+}
+
+auto problem_main() -> int
+{
+	QuokkaSimulation<MHDRemakeFaceField> sim;
+	sim.setInitialConditions();
+	AMREX_ALWAYS_ASSERT(sim.finestLevel() == 1);
+
+	const auto &Bx_new_before = sim.getNewMF_fc()[1][0];
+	const int ncomp = Bx_new_before.nComp();
+	amrex::MultiFab Bx_before(Bx_new_before.boxArray(), Bx_new_before.DistributionMap(), ncomp, 0);
+	amrex::MultiFab::Copy(Bx_before, Bx_new_before, 0, 0, ncomp, 0);
+	const amrex::Real energy_before = amrex::MultiFab::Dot(Bx_before, 0, ncomp, 0);
+	const auto old_num_boxes = static_cast<long>(Bx_before.boxArray().size());
+
+	// force a decomposition-only remake of level 1: identical tags, different box chopping
+	sim.SetMaxGridSize(8);
+	sim.regrid(0, 0.0, false);
+	AMREX_ALWAYS_ASSERT(sim.finestLevel() == 1);
+
+	const auto &Bx_new_after = sim.getNewMF_fc()[1][0];
+	const auto new_num_boxes = static_cast<long>(Bx_new_after.boxArray().size());
+	amrex::Print() << "level-1 box count: " << old_num_boxes << " -> " << new_num_boxes << "\n";
+	AMREX_ALWAYS_ASSERT(new_num_boxes != old_num_boxes); // sanity check: the remake actually re-chopped the level
+
+	amrex::MultiFab Bx_after_remapped(Bx_before.boxArray(), Bx_before.DistributionMap(), ncomp, 0);
+	Bx_after_remapped.ParallelCopy(Bx_new_after, 0, 0, ncomp, 0, 0);
+	const amrex::Real energy_after = amrex::MultiFab::Dot(Bx_after_remapped, 0, ncomp, 0);
+
+	amrex::MultiFab::Subtract(Bx_after_remapped, Bx_before, 0, 0, ncomp, 0);
+	const amrex::Real max_diff = Bx_after_remapped.norminf(0, 0);
+	const amrex::Real energy_rel_diff = std::abs(energy_after - energy_before) / energy_before;
+
+	amrex::Print() << "max |Bx_after - Bx_before| on retained overlap = " << max_diff << "\n";
+	amrex::Print() << "magnetic energy: before=" << energy_before << " after=" << energy_after << " rel_diff=" << energy_rel_diff << "\n";
+
+	constexpr amrex::Real tol = 1.0e-12;
+	if (max_diff > tol * delta || energy_rel_diff > tol) {
+		amrex::Print() << "ISSUE #2210 REPRODUCED: RemakeLevel discarded the level's existing fine mhd "
+				  "face field instead of preserving it across the remake.\n";
+		return 1;
+	}
+	amrex::Print() << "Test passed: fine mhd face field preserved across RemakeLevel.\n";
+	return 0;
+}

--- a/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
+++ b/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
@@ -91,7 +91,7 @@ auto problem_main() -> int
 	amrex::MultiFab Bx_before(Bx_new_before.boxArray(), Bx_new_before.DistributionMap(), ncomp, 0);
 	amrex::MultiFab::Copy(Bx_before, Bx_new_before, 0, 0, ncomp, 0);
 	const amrex::Real energy_before = amrex::MultiFab::Dot(Bx_before, 0, ncomp, 0);
-	const auto old_num_boxes = static_cast<long>(Bx_before.boxArray().size());
+	const amrex::Long old_num_boxes = Bx_before.boxArray().size();
 
 	// force a decomposition-only remake of level 1: identical tags, different box chopping
 	sim.SetMaxGridSize(8);
@@ -99,7 +99,7 @@ auto problem_main() -> int
 	AMREX_ALWAYS_ASSERT(sim.finestLevel() == 1);
 
 	const auto &Bx_new_after = sim.getNewMF_fc()[1][0];
-	const auto new_num_boxes = static_cast<long>(Bx_new_after.boxArray().size());
+	const amrex::Long new_num_boxes = Bx_new_after.boxArray().size();
 	amrex::Print() << "level-1 box count: " << old_num_boxes << " -> " << new_num_boxes << "\n";
 	AMREX_ALWAYS_ASSERT(new_num_boxes != old_num_boxes); // sanity check: the remake actually re-chopped the level
 

--- a/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
+++ b/src/problems/MHDRemakeFaceField/testMHDRemakeFaceField.cpp
@@ -1,22 +1,7 @@
 /// \file testMHDRemakeFaceField.cpp
-/// \brief Regression test for issue #2210: RemakeLevel discards a level's existing
-///        fine mhd face field, replacing it with coarse-interpolated data even when
-///        the remake is a pure re-decomposition (same physical coverage).
+/// \brief Regression test verifying RemakeLevel preserves a level's fine mhd face
+///        field on regrid instead of discarding it.
 ///
-/// Setup: level 1 covers the entire domain (refineGrid tags everything), and Bx
-/// alternates sign by fine y-face index so it is exactly divergence-free (Bx depends
-/// only on j) but its coarse restriction discards the alternation entirely. After
-/// setInitialConditions(), SetMaxGridSize() + regrid() forces AMReX to re-chop level 1's
-/// BoxArray with unchanged tags, so the new BoxArray retains 100% overlap with the old
-/// one: FillPatchTwoLevels' coarse-interpolation branch never even triggers, so any
-/// change to the retained Bx values can only come from RemakeLevel discarding the
-/// level's own prior fine data instead of copying it forward.
-///
-/// Development (no fix): RemakeLevel's face-centred path calls FillCoarsePatchFaceArray,
-///   which only ever reads GetDataFaceArray(lev - 1, ...) and interpolates from coarse,
-///   so the alternating fine structure is replaced by the coarse-restricted mean.
-/// Fix: RemakeLevel now calls FillPatchFaceArray for the new-time state, which merges in
-///   the level's own existing fine data on overlapping coverage.
 
 #include "AMReX_MultiFab.H"
 #include "AMReX_ParmParse.H"

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -389,6 +389,8 @@ template <typename problem_t> class AMRSimulation : public amrex::AmrCore
 			     quokka::direction dir);
 	void FillCoarsePatchFaceArray(int lev, amrex::Real time, amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> &mf_array, int icomp, int ncomp,
 				      amrex::Array<amrex::Vector<amrex::BCRec>, AMREX_SPACEDIM> &BCs_array);
+	void FillPatchFaceArray(int lev, amrex::Real time, amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> &mf_array, int icomp, int ncomp,
+				amrex::Array<amrex::Vector<amrex::BCRec>, AMREX_SPACEDIM> &BCs_array);
 	void GetData(int lev, amrex::Real time, amrex::Vector<amrex::MultiFab *> &data, amrex::Vector<amrex::Real> &datatime, quokka::centering cen,
 		     quokka::direction dir);
 	void GetDataFaceArray(int lev, amrex::Real time, amrex::Array<amrex::Vector<amrex::MultiFab *>, AMREX_SPACEDIM> &data_array,
@@ -2554,7 +2556,9 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 			int_state_new_fc_ptr[idim] = &int_state_new_fc[idim];
 			int_state_old_fc_ptr[idim] = &int_state_old_fc[idim];
 		}
-		FillCoarsePatchFaceArray(level, time, int_state_new_fc_ptr, 0, ncomp_per_dim_fc, BCs_array);
+		// preserves the existing fine field on overlapping coverage; see FillPatchFaceArray
+		FillPatchFaceArray(level, time, int_state_new_fc_ptr, 0, ncomp_per_dim_fc, BCs_array);
+		// old-time data is invalidated by the tOld_ sentinel set above, so a coarse-only fill suffices
 		FillCoarsePatchFaceArray(level, time, int_state_old_fc_ptr, 0, ncomp_per_dim_fc, BCs_array);
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			std::swap(int_state_new_fc[idim], state_new_fc_[level][idim]);
@@ -3444,6 +3448,55 @@ void AMRSimulation<problem_t>::FillCoarsePatchFaceArray(int lev, amrex::Real tim
 
 	amrex::InterpFromCoarseLevel(mf_array, time, cmf_ptrs, 0, icomp, ncomp, geom[lev - 1], geom[lev], coarsePhysicalBoundaryFunctor, 0,
 				     finePhysicalBoundaryFunctor, 0, refRatio(lev - 1), &amrex::face_divfree_interp, BCs_array, 0);
+}
+
+// Fill face-centred data for all directions simultaneously, preserving existing fine data on
+// overlapping coverage and divergence-preservingly interpolating from coarse elsewhere.
+template <typename problem_t>
+void AMRSimulation<problem_t>::FillPatchFaceArray(int lev, amrex::Real time, amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> &mf_array, int icomp, int ncomp,
+						  amrex::Array<amrex::Vector<amrex::BCRec>, AMREX_SPACEDIM> &BCs_array)
+{
+	BL_PROFILE("AMRSimulation::FillPatchFaceArray()"); // NOLINT(misc-const-correctness)
+
+	AMREX_ASSERT(lev > 0);
+
+	amrex::Array<amrex::Vector<amrex::MultiFab *>, AMREX_SPACEDIM> cmf_array;
+	amrex::Array<amrex::Vector<amrex::MultiFab *>, AMREX_SPACEDIM> fmf_array;
+	amrex::Vector<amrex::Real> ctime;
+	amrex::Vector<amrex::Real> ftime;
+	GetDataFaceArray(lev - 1, time, cmf_array, ctime);
+	GetDataFaceArray(lev, time, fmf_array, ftime);
+
+	amrex::Vector<amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM>> cmf;
+	for (int itime = 0; itime < static_cast<int>(ctime.size()); ++itime) {
+		amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> level_mfs;
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			level_mfs[idim] = cmf_array[idim][itime];
+		}
+		cmf.push_back(level_mfs);
+	}
+	amrex::Vector<amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM>> fmf;
+	for (int itime = 0; itime < static_cast<int>(ftime.size()); ++itime) {
+		amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> level_mfs;
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			level_mfs[idim] = fmf_array[idim][itime];
+		}
+		fmf.push_back(level_mfs);
+	}
+
+	using BndryFunc = amrex::GpuBndryFuncFab<setBoundaryFunctorFaceVar<problem_t>>;
+	amrex::Array<amrex::PhysBCFunct<BndryFunc>, AMREX_SPACEDIM> finePhysicalBoundaryFunctor;
+	amrex::Array<amrex::PhysBCFunct<BndryFunc>, AMREX_SPACEDIM> coarsePhysicalBoundaryFunctor;
+
+	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+		const auto dir = static_cast<quokka::direction>(idim);
+		BndryFunc boundaryFunctor(setBoundaryFunctorFaceVar<problem_t>{dir});
+		finePhysicalBoundaryFunctor[idim] = amrex::PhysBCFunct<BndryFunc>(geom[lev], BCs_array[idim], boundaryFunctor);
+		coarsePhysicalBoundaryFunctor[idim] = amrex::PhysBCFunct<BndryFunc>(geom[lev - 1], BCs_array[idim], boundaryFunctor);
+	}
+
+	amrex::FillPatchTwoLevels(mf_array, time, cmf, ctime, fmf, ftime, 0, icomp, ncomp, geom[lev - 1], geom[lev], coarsePhysicalBoundaryFunctor, 0,
+				  finePhysicalBoundaryFunctor, 0, refRatio(lev - 1), &amrex::face_divfree_interp, BCs_array, 0);
 }
 
 // utility to copy in data from state_old_cc_[lev] and/or state_new_cc_[lev]


### PR DESCRIPTION
### Description

This PR fixes a bug: RemakeLevel discards existing fine face-centred data on a level whenever it is rebuilt. It rebuilt face-centred quantities using `FillCoarsePatchFaceArray`, which only pulls from the coarse level. This is not consistent with how cell-centred quantities are rebuilt: they merge existing fine data with coarse via `FillPatch`. `FillPatchFaceArray` now adopts the same merge strategy, using `amrex::FillPatchTwoLevels` with `face_divfree_interp`, so fine faces already present are preserved on overlapping coverage, falling back to coarse interpolation only where coverage is genuinely new.

The old-time state keeps its existing coarse-only fill, matching how the cell-centred strategy leaves `int_state_old_cc` unfilled after a remake, because it is not used again.

### Validation

`MHDRemakeFaceField` (new problem) sets a divergence-free `Bx(y)` face field on level 1, forces a decomposition-only remake (`SetMaxGridSize` + `regrid()`, unchanged tags so the new BoxArray fully overlaps the old one), and checks the retained field and magnetic energy are unchanged to round-off. Reverting the fix reproduces the issue exactly: the fine structure collapses to the coarse mean and magnetic energy drops ~8%. Confirmed on both CPU and an A100 GPU (Gadi `gpursaa`).

### Related issues

- #2210: this PR implements the fix.

### Checklist

- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the Contributing Guide.
- [x] I have added tests for any new physics that this PR adds to the code: `MHDRemakeFaceField` regression test added.
- [x] I have triggered GPU tests: needs `/azp run` (full suite), not just `/azp run quick` — this touches `simulation.hpp`, shared base code outside `src/problems`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a three-dimensional MHD face-field simulation configuration with adaptive mesh refinement, periodic boundaries, and standard runtime settings.
  - Added a regression test for preserving magnetic face fields during grid reconfiguration.

- **Bug Fixes**
  - Improved adaptive-mesh regridding to preserve existing fine-resolution magnetic face fields while applying divergence-preserving interpolation to newly covered regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->