### PR TITLE
Fix bilinear interpolation origins and upper edges

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,3 +166,4 @@ endif()
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
 add_subdirectory(problems)
+add_subdirectory(math/tests)

--- a/src/math/Interpolate2D.hpp
+++ b/src/math/Interpolate2D.hpp
@@ -31,8 +31,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto interpolate2d(double x, double y, 
 	y = amrex::Clamp(y, yi, yf);
 
 	// compute indices
-	int ix = amrex::Clamp(static_cast<int>(std::floor((x - xi) / dx)), xv.begin, xv.end - 1);
-	int iy = amrex::Clamp(static_cast<int>(std::floor((y - yi) / dy)), yv.begin, yv.end - 1);
+	int ix = amrex::Clamp(xv.begin + static_cast<int>(std::floor((x - xi) / dx)), xv.begin, xv.end - 1);
+	int iy = amrex::Clamp(yv.begin + static_cast<int>(std::floor((y - yi) / dy)), yv.begin, yv.end - 1);
 	int iix = (ix == xv.end - 1) ? ix : ix + 1;
 	int iiy = (iy == yv.end - 1) ? iy : iy + 1;
 
@@ -55,17 +55,17 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto interpolate2d(double x, double y, 
 		w12 = (x2 - x) * (y - y1) / vol;
 		w21 = (x - x1) * (y2 - y) / vol;
 		w22 = (x - x1) * (y - y1) / vol;
-	} else if (ix == iix && yi != iiy) {
+	} else if (ix == iix && iy != iiy) {
 		const double vol = (y2 - y1);
 		AMREX_ASSERT(vol > 0.);
 		w11 = (y2 - y) / vol;
 		w12 = (y - y1) / vol;
-	} else if (ix != iix && yi == iiy) {
+	} else if (ix != iix && iy == iiy) {
 		const double vol = (x2 - x1);
 		AMREX_ASSERT(vol > 0.);
 		w11 = (x2 - x) / vol;
 		w21 = (x - x1) / vol;
-	} else { // ix == iix && yi == iiy
+	} else { // ix == iix && iy == iiy
 		w11 = 1.0;
 	}
 

--- a/src/math/Interpolate2D.hpp
+++ b/src/math/Interpolate2D.hpp
@@ -31,8 +31,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto interpolate2d(double x, double y, 
 	y = amrex::Clamp(y, yi, yf);
 
 	// compute indices
-	int ix = amrex::Clamp(xv.begin + static_cast<int>(std::floor((x - xi) / dx)), xv.begin, xv.end - 1);
-	int iy = amrex::Clamp(yv.begin + static_cast<int>(std::floor((y - yi) / dy)), yv.begin, yv.end - 1);
+	const int ix = amrex::Clamp(xv.begin + static_cast<int>(std::floor((x - xi) / dx)), xv.begin, xv.end - 1);
+	const int iy = amrex::Clamp(yv.begin + static_cast<int>(std::floor((y - yi) / dy)), yv.begin, yv.end - 1);
 	int iix = (ix == xv.end - 1) ? ix : ix + 1;
 	int iiy = (iy == yv.end - 1) ? iy : iy + 1;
 

--- a/src/math/tests/CMakeLists.txt
+++ b/src/math/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(Interpolate2DTest testInterpolate2D.cpp)
+target_link_libraries(Interpolate2DTest PRIVATE AMReX::amrex)
+target_include_directories(Interpolate2DTest PRIVATE ..)
+target_compile_features(Interpolate2DTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(Interpolate2DTest)
+endif()
+add_test(NAME Interpolate2DTest COMMAND Interpolate2DTest)

--- a/src/math/tests/testInterpolate2D.cpp
+++ b/src/math/tests/testInterpolate2D.cpp
@@ -1,0 +1,45 @@
+#include <array>
+#include <cmath>
+#include <iostream>
+
+#include "Interpolate2D.hpp"
+
+auto main() -> int
+{
+	// Nonlinear samples expose selection of the wrong interpolation interval.
+	const std::array<double, 4> x{0., 1., 2., 3.};
+	const std::array<double, 4> y{10., 11., 12., 13.};
+	std::array<double, 16> values{};
+	for (int j = 0; j < 4; ++j) {
+		for (int i = 0; i < 4; ++i) {
+			values[i + 4 * j] = x[i] * x[i] + y[j] * y[j];
+		}
+	}
+	int failures = 0;
+	for (const int xb : {0, 5, -5}) {
+		for (const int yb : {0, 7, -7}) {
+			const amrex::Table1D<const double> xv(x.data(), xb, xb + 4);
+			const amrex::Table1D<const double> yv(y.data(), yb, yb + 4);
+			const amrex::Table2D<const double> table(values.data(), {xb, yb}, {xb + 4, yb + 4});
+			// Interior, both upper edges, corners, and clamping outside every edge.
+			for (const auto &point : std::array<std::array<double, 3>, 10>{{{1.5, 10.5, 113.},
+											{1.5, 13., 171.5},
+											{3., 11.5, 141.5},
+											{3., 13., 178.},
+											{0., 10., 100.},
+											{-1., 11.5, 132.5},
+											{4., 11.5, 141.5},
+											{1.5, 9., 102.5},
+											{1.5, 14., 171.5},
+											{4., 14., 178.}}}) {
+				const double actual = interpolate2d(point[0], point[1], xv, yv, table);
+				if (!std::isfinite(actual) || std::abs(actual - point[2]) > 1.e-12) {
+					std::cerr << "origins " << xb << ',' << yb << " at " << point[0] << ',' << point[1] << ": got " << actual
+						  << ", expected " << point[2] << '\n';
+					++failures;
+				}
+			}
+		}
+	}
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fix bilinear interpolation for tables with nonzero index origins and for upper boundaries. Coordinate offsets now include the corresponding table origin, and degenerate-edge branches compare y indices consistently. Previously, shifted tables selected incorrect intervals; upper edges could return corner values or NaNs.

Closes #1698.
Closes #2224.

Adds the CTest-registered Interpolate2DTest with 90 cases using real AMReX Table1D/Table2D views, nonlinear samples, zero/positive/negative origins, upper edges, corners, and out-of-range clamping.

Validation:
- Built the regression target against the existing native 1D AMReX build through a standalone CMake harness; it failed before the fix and passed afterward.
- `cmake --build /private/tmp/quokka-interpolation-harness/build`
- `ctest --test-dir /private/tmp/quokka-interpolation-harness/build --output-on-failure` — passed.
- `./scripts/bash/quokka-pre-commit.sh` — passed all applicable hooks after installing pre-commit in a temporary environment.
- `git diff --check` — passed.

Validation covers the host helper; a full simulation build and GPU execution were not run.
