### PR TITLE
Fix adaptive ODE initialization and signed error scaling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,3 +166,4 @@ endif()
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
 add_subdirectory(problems)
+add_subdirectory(math/ode_tests)

--- a/src/math/ODEIntegrate.hpp
+++ b/src/math/ODEIntegrate.hpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "AMReX_Algorithm.H"
 #include "AMReX_BLassert.H"
@@ -115,7 +116,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto error_norm(quokka::valarray<Real, 
 
 	Real err_sq = 0;
 	for (int i = 0; i < N; ++i) {
-		Real w_i = 1. / (reltol * y0[i] + abstol[i]);
+		Real w_i = 1. / (reltol * std::abs(y0[i]) + abstol[i]);
 		err_sq += (yerr[i] * yerr[i]) * (w_i * w_i);
 	}
 	const Real err = std::sqrt(err_sq / N);
@@ -132,11 +133,35 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F const &rhs
 	// with local truncation error bounded by relative tolerance 'reltol'
 	// and absolute tolerances 'abstol'.
 
-	// initial timestep
+	steps_taken = maxStepsODEIntegrate; // failure unless the entire interval is integrated
+	if (t1 == t0) {
+		steps_taken = 0;
+		return;
+	}
+	if (!(t1 > t0)) {
+		return;
+	}
+
+	// Evaluate a copy, as RHS callbacks may modify their input state.
 	quokka::valarray<Real, N> ydot0{};
-	rhs(t0, y0, ydot0);
-	const Real dt_guess = 0.1 * min(abs(y0 / ydot0));
-	AMREX_ASSERT(dt_guess > 0.0);
+	quokka::valarray<Real, N> y_arg = y0;
+	if (rhs(t0, y_arg, ydot0) != 0) {
+		return;
+	}
+	// Bound the initial step by the interval and include the absolute tolerance
+	// so a component starting at zero does not force a zero timestep.
+	Real dt_guess = t1 - t0;
+	for (int i = 0; i < N; ++i) {
+		if (ydot0[i] != 0.) {
+			const Real timescale = std::max(std::abs(y0[i]), abstol[i]) / std::abs(ydot0[i]);
+			const Real candidate = 0.1 * timescale;
+			if (std::isfinite(candidate) && candidate > 0.) {
+				dt_guess = std::min(dt_guess, candidate);
+			}
+		}
+	}
+	const Real min_step = std::nextafter(t0, std::numeric_limits<Real>::infinity()) - t0;
+	dt_guess = std::max(dt_guess, min_step);
 
 	// adaptive timestep controller
 	const int maxRetries = 7;
@@ -149,7 +174,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F const &rhs
 
 	// integration loop
 	Real time = t0;
-	Real dt = std::isnan(dt_guess) ? (t1 - t0) : dt_guess;
+	Real dt = dt_guess;
 	quokka::valarray<Real, N> &y = y0;
 	quokka::valarray<Real, N> yerr{};
 	quokka::valarray<Real, N> ynew{};
@@ -163,6 +188,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void rk_adaptive_integrate(F const &rhs
 
 		bool step_success = false;
 		for (int k = 0; k < maxRetries; ++k) {
+			if (!(dt > 0.) || !(time + dt > time)) {
+				break; // the requested accuracy cannot be reached at this time resolution
+			}
 			// compute single step of chosen RK method
 			int ierr = rk12_single_step(rhs, time, y, dt, ynew, yerr);
 

--- a/src/math/ode_tests/CMakeLists.txt
+++ b/src/math/ode_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(ODERegressionTest testODERegression.cpp)
+target_link_libraries(ODERegressionTest PRIVATE AMReX::amrex)
+target_include_directories(ODERegressionTest PRIVATE ../..)
+target_compile_features(ODERegressionTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(ODERegressionTest)
+endif()
+add_test(NAME ODERegressionTest COMMAND ODERegressionTest)

--- a/src/math/ode_tests/testODERegression.cpp
+++ b/src/math/ode_tests/testODERegression.cpp
@@ -1,0 +1,110 @@
+#include <cmath>
+#include <iostream>
+#include <limits>
+
+#include "math/ODEIntegrate.hpp"
+
+auto main() -> int
+{
+	int failures = 0;
+	const auto check = [&failures](bool passed, const char *message) {
+		if (!passed) {
+			std::cerr << message << '\n';
+			++failures;
+		}
+	};
+	const quokka::valarray<Real, 1> positive{1.};
+	const quokka::valarray<Real, 1> negative{-1.};
+	const quokka::valarray<Real, 1> error{0.1};
+	const quokka::valarray<Real, 1> tolerance{0.1};
+	check(std::abs(error_norm(positive, error, 0.1, tolerance) - error_norm(negative, error, 0.1, tolerance)) < 1.e-14,
+	      "Error norm must be invariant under state sign changes");
+	{
+		quokka::valarray<Real, 1> y{1.};
+		int calls = 0;
+		const auto rhs = [&calls](Real, auto &state, auto &derivative) {
+			++calls;
+			if (calls == 1) {
+				state[0] = 99.;
+				return 1;
+			}
+			derivative[0] = 1.;
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, tolerance, steps);
+		check(calls == 1 && steps == maxStepsODEIntegrate && y[0] == 1., "Initial RHS failure must return failure without changing state or retrying");
+	}
+	for (const Real initial : {0., -1., 1.}) {
+		quokka::valarray<Real, 1> y{initial};
+		const quokka::valarray<Real, 1> atol{1.e-10};
+		const auto rhs = [](Real, auto &, auto &derivative) {
+			derivative[0] = 1.;
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, atol, steps);
+		check(steps > 0 && steps < maxStepsODEIntegrate && std::abs(y[0] - initial - 1.) < 1.e-12,
+		      "Constant source must advance from zero and signed states");
+	}
+	{
+		quokka::valarray<Real, 3> y{0., 2., 0.};
+		const quokka::valarray<Real, 3> atol{1.e-10, 1.e-10, 1.e-10};
+		const auto rhs = [](Real, auto &, auto &derivative) {
+			derivative = {1., -1., 0.};
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, atol, steps);
+		check(steps < maxStepsODEIntegrate && std::abs(y[0] - 1.) < 1.e-12 && std::abs(y[1] - 1.) < 1.e-12 && y[2] == 0.,
+		      "Mixed zero states and stationary components must integrate");
+	}
+	{
+		quokka::valarray<Real, 1> y{0.};
+		const auto rhs = [](Real, auto &, auto &derivative) {
+			derivative[0] = 0.;
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, tolerance, steps);
+		check(steps > 0 && steps < maxStepsODEIntegrate && y[0] == 0., "Stationary zero solution must succeed");
+	}
+	{
+		quokka::valarray<Real, 1> y{0.};
+		const quokka::valarray<Real, 1> atol{1.e-30};
+		const auto rhs = [](Real, auto &, auto &derivative) {
+			derivative[0] = 1.;
+			return 0;
+		};
+		const Real start = 1.e16;
+		const Real end = std::nextafter(start, std::numeric_limits<Real>::infinity());
+		int steps = 0;
+		rk_adaptive_integrate(rhs, start, y, end, 1.e-4, atol, steps);
+		check(steps < maxStepsODEIntegrate && y[0] == end - start, "Initial step must advance representable time");
+	}
+	for (const Real sign : {-1., 1.}) {
+		quokka::valarray<Real, 1> y{sign};
+		const quokka::valarray<Real, 1> atol{1.e-8};
+		const auto rhs = [](Real, auto &state, auto &derivative) {
+			derivative[0] = -state[0];
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, atol, steps);
+		check(steps > 0 && steps < maxStepsODEIntegrate && std::abs(y[0] - sign * std::exp(-1.)) < 1.e-4,
+		      "Signed exponential decay must meet the accuracy target");
+	}
+	{
+		quokka::valarray<Real, 1> y{0.};
+		const quokka::valarray<Real, 1> atol{1.e-8};
+		const auto rhs = [](Real, auto &state, auto &derivative) {
+			derivative[0] = 1. + state[0];
+			return 0;
+		};
+		int steps = 0;
+		rk_adaptive_integrate(rhs, 0., y, 1., 1.e-4, atol, steps);
+		check(steps > 0 && steps < maxStepsODEIntegrate && std::abs(y[0] - std::expm1(1.)) < 2.e-4,
+		      "Nonlinear growth from zero must meet the accuracy target");
+	}
+	return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Adaptive ODE integration now advances components that start at zero, weights negative states by their magnitude, and stops immediately when the initial RHS evaluation fails.

The initial timestep includes each component's absolute tolerance, is bounded by the integration interval, and is at least one representable time increment. Stationary components do not constrain it. Subsequent retries report failure if the timestep cannot advance time. Initial RHS evaluation uses a state copy, preserving the caller's state on failure. The existing `steps_taken == maxStepsODEIntegrate` failure contract is retained.

Closes #1699.
Closes #1700.
Closes #2065.

Adds CTest-registered ODERegressionTest covering sign-invariant norms, an initial callback failure that mutates its input, constant sources from zero and signed states, mixed zero/stationary components, representable-time advancement, signed exponential decay, and growth from zero against analytic solutions.

Validation:
- The native AMReX regression failed before the fix on all three reported defects and passed afterward.
- `cmake --build /private/tmp/quokka-ode-harness/build`
- `ctest --test-dir /private/tmp/quokka-ode-harness/build --output-on-failure` — passed. The standalone harness builds the registered target against the existing 1D AMReX build.
- `./scripts/bash/quokka-pre-commit.sh` — all applicable hooks passed.
- `git diff --check` — passed.

GPU execution and the full cooling simulation suite have not been run.
