### PR TITLE
Reject nonpositive vector strides

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,4 +165,6 @@ endif()
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
+add_subdirectory(util/array_tests)
+
 add_subdirectory(problems)

--- a/src/util/ArrayUtil.hpp
+++ b/src/util/ArrayUtil.hpp
@@ -8,12 +8,17 @@
 /// \file ArrayUtil.hpp
 /// \brief Implements functions to manipulate arrays (CPU only).
 
+#include <stdexcept>
 #include <vector>
 
-template <typename T> auto strided_vector_from(std::vector<T> &v, int stride) -> std::vector<T>
+// The stride must be positive, including for an empty input vector.
+template <typename T> auto strided_vector_from(const std::vector<T> &v, int stride) -> std::vector<T>
 {
+	if (stride <= 0) {
+		throw std::invalid_argument("strided_vector_from: stride must be positive");
+	}
 	std::vector<T> strided_v;
-	for (std::size_t i = 0; i < v.size(); i += stride) {
+	for (std::size_t i = 0; i < v.size(); i += static_cast<std::size_t>(stride)) {
 		strided_v.push_back(v[i]);
 	}
 	return strided_v; // move semantics implied

--- a/src/util/array_tests/CMakeLists.txt
+++ b/src/util/array_tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_executable(ArrayUtilTest testArrayUtil.cpp)
+target_include_directories(ArrayUtilTest PRIVATE ..)
+target_compile_features(ArrayUtilTest PRIVATE cxx_std_20)
+add_test(NAME ArrayUtilTest COMMAND ArrayUtilTest)

--- a/src/util/array_tests/testArrayUtil.cpp
+++ b/src/util/array_tests/testArrayUtil.cpp
@@ -1,0 +1,56 @@
+#include "ArrayUtil.hpp"
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+// Bound the zero-stride reproducer even before input validation exists.
+struct CopyLimited {
+	static inline int copies = 0;
+	CopyLimited() = default;
+	CopyLimited(const CopyLimited &)
+	{
+		if (++copies > 20) {
+			throw std::runtime_error("Zero stride repeatedly copies the first element");
+		}
+	}
+};
+
+auto main() -> int
+{
+	int failures = 0;
+	const auto check = [&failures](bool passed, const char *message) {
+		if (!passed) {
+			std::cerr << message << '\n';
+			++failures;
+		}
+	};
+	const std::vector<int> values{0, 1, 2, 3, 4};
+	check(strided_vector_from(values, 1) == values, "Stride one must preserve all values");
+	check(strided_vector_from(values, 2) == std::vector<int>({0, 2, 4}), "Stride two must preserve selected values and order");
+	check(strided_vector_from(values, 10) == std::vector<int>({0}), "Large stride must select first value");
+	check(strided_vector_from(values, std::numeric_limits<int>::max()) == std::vector<int>({0}), "Maximum stride must select first value");
+	std::vector<int> empty;
+	check(strided_vector_from(empty, 1).empty(), "Empty input must return empty output");
+	for (const int stride : {0, -1, std::numeric_limits<int>::min()}) {
+		std::vector<CopyLimited> bounded(1);
+		CopyLimited::copies = 0;
+		bool rejected = false;
+		try {
+			(void)strided_vector_from(bounded, stride);
+		} catch (const std::invalid_argument &) {
+			rejected = true;
+		} catch (const std::runtime_error &error) {
+			std::cerr << error.what() << '\n';
+		}
+		check(rejected, "Nonpositive stride must throw invalid_argument before copying");
+		check(CopyLimited::copies == 0, "Invalid stride must not copy input values");
+		rejected = false;
+		try {
+			(void)strided_vector_from(empty, stride);
+		} catch (const std::invalid_argument &) {
+			rejected = true;
+		}
+		check(rejected, "Invalid stride must also be rejected for empty input");
+	}
+	return failures == 0 ? 0 : 1;
+}

--- a/src/util/array_tests/testArrayUtil.cpp
+++ b/src/util/array_tests/testArrayUtil.cpp
@@ -7,7 +7,11 @@
 struct CopyLimited {
 	static inline int copies = 0;
 	CopyLimited() = default;
-	CopyLimited(const CopyLimited &)
+	~CopyLimited() = default;
+	CopyLimited(CopyLimited &&) = default;
+	auto operator=(const CopyLimited &) -> CopyLimited & = default;
+	auto operator=(CopyLimited &&) -> CopyLimited & = default;
+	CopyLimited(const CopyLimited & /*other*/)
 	{
 		if (++copies > 20) {
 			throw std::runtime_error("Zero stride repeatedly copies the first element");
@@ -29,10 +33,10 @@ auto main() -> int
 	check(strided_vector_from(values, 2) == std::vector<int>({0, 2, 4}), "Stride two must preserve selected values and order");
 	check(strided_vector_from(values, 10) == std::vector<int>({0}), "Large stride must select first value");
 	check(strided_vector_from(values, std::numeric_limits<int>::max()) == std::vector<int>({0}), "Maximum stride must select first value");
-	std::vector<int> empty;
+	const std::vector<int> empty;
 	check(strided_vector_from(empty, 1).empty(), "Empty input must return empty output");
 	for (const int stride : {0, -1, std::numeric_limits<int>::min()}) {
-		std::vector<CopyLimited> bounded(1);
+		const std::vector<CopyLimited> bounded(1);
 		CopyLimited::copies = 0;
 		bool rejected = false;
 		try {


### PR DESCRIPTION
`strided_vector_from` now throws `std::invalid_argument` for zero or negative strides before copying elements, including for empty input. Zero previously caused an unbounded loop; negative strides converted to unsigned indices unexpectedly. Positive strides retain their existing behavior, and input vectors can now be const.

Closes #2053.

Adds CTest-registered ArrayUtilTest for stride one, stride two, oversized and maximum strides, empty and const inputs, and zero/negative/minimum integer strides. A copy-limited element reproduces the original zero-stride loop deterministically without exhausting memory.

Validation:
- The native regression failed before the fix and passed afterward.
- `cmake --build /private/tmp/quokka-array-harness/build`
- `ctest --test-dir /private/tmp/quokka-array-harness/build --output-on-failure` — passed. A standalone CMake harness builds the registered target.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

This helper is CPU-only. Full simulation/plotting tests were not run.
