### PR TITLE
Normalize spherical-section clipping to the cell scale

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,4 +165,6 @@ endif()
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
+add_subdirectory(math/geometry_tests)
+
 add_subdirectory(problems)

--- a/src/math/geometry_tests/CMakeLists.txt
+++ b/src/math/geometry_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(SphericalAreaTest testSphericalArea.cpp)
+target_link_libraries(SphericalAreaTest PRIVATE AMReX::amrex)
+target_include_directories(SphericalAreaTest PRIVATE ..)
+target_compile_features(SphericalAreaTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(SphericalAreaTest)
+endif()
+add_test(NAME SphericalAreaTest COMMAND SphericalAreaTest)

--- a/src/math/geometry_tests/testSphericalArea.cpp
+++ b/src/math/geometry_tests/testSphericalArea.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <cmath>
 #include <iostream>
+#include <numbers>
 
 auto main(int argc, char **argv) -> int
 {
@@ -19,11 +20,11 @@ auto main(int argc, char **argv) -> int
 				const auto s = scale;
 				areas[0] = quokka::math::sphericalSectionAreaInCell(s, .5 * s, 1.5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s);
 				areas[1] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., .5 * s);
-				const auto n = 1. / std::sqrt(2.);
+				const auto n = 1. / std::numbers::sqrt2;
 				areas[2] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, n, n, 0., n * s);
 				areas[3] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 2. * s);
 				areas[4] = planeBoxSectionArea(7.5 * s, 8.5 * s, -4.5 * s, -3.5 * s, 1.5 * s, 2.5 * s, 1., 0., 0., 8. * s);
-				const auto diagonal = 1. / std::sqrt(3.);
+				const auto diagonal = std::numbers::inv_sqrt3;
 				areas[5] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, diagonal, diagonal, diagonal, 0.);
 				areas[6] = planeBoxSectionArea(0., 0., -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 0.);
 				areas[7] = planeBoxSectionArea(.5 * s, -.5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 0.);
@@ -33,7 +34,8 @@ auto main(int argc, char **argv) -> int
 			});
 			std::array<amrex::Real, 10> actual{};
 			amrex::Gpu::copy(amrex::Gpu::deviceToHost, results.begin(), results.end(), actual.begin());
-			const std::array<amrex::Real, 10> expected{1., 1., 0., 0., 1., 3. * std::sqrt(3.) / 4., 0., 0., 3. * std::sqrt(3.) / 4., 6.};
+			const std::array<amrex::Real, 10> expected{1., 1., 0., 0., 1., 3. * std::numbers::sqrt3 / 4., 0., 0., 3. * std::numbers::sqrt3 / 4.,
+								   6.};
 			for (int i = 0; i < 10; ++i) {
 				const auto normalized = actual[i] / (scale * scale);
 				if (!std::isfinite(normalized) || std::abs(normalized - expected[i]) > 1.e-12) {

--- a/src/math/geometry_tests/testSphericalArea.cpp
+++ b/src/math/geometry_tests/testSphericalArea.cpp
@@ -1,0 +1,48 @@
+#include "AMReX.H"
+#include "AMReX_GpuContainers.H"
+#include "AMReX_GpuLaunch.H"
+#include "spherical_geometry.hpp"
+#include <array>
+#include <cmath>
+#include <iostream>
+
+auto main(int argc, char **argv) -> int
+{
+	amrex::Initialize(argc, argv);
+	int failures = 0;
+	{
+		for (const amrex::Real scale : {1., 1.e-14, 1.e14}) {
+			amrex::Gpu::DeviceVector<amrex::Real> results(10);
+			auto *areas = results.data();
+			amrex::ParallelFor(1, [=] AMREX_GPU_DEVICE(int) {
+				using quokka::math::detail::planeBoxSectionArea;
+				const auto s = scale;
+				areas[0] = quokka::math::sphericalSectionAreaInCell(s, .5 * s, 1.5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s);
+				areas[1] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., .5 * s);
+				const auto n = 1. / std::sqrt(2.);
+				areas[2] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, n, n, 0., n * s);
+				areas[3] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 2. * s);
+				areas[4] = planeBoxSectionArea(7.5 * s, 8.5 * s, -4.5 * s, -3.5 * s, 1.5 * s, 2.5 * s, 1., 0., 0., 8. * s);
+				const auto diagonal = 1. / std::sqrt(3.);
+				areas[5] = planeBoxSectionArea(-.5 * s, .5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, diagonal, diagonal, diagonal, 0.);
+				areas[6] = planeBoxSectionArea(0., 0., -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 0.);
+				areas[7] = planeBoxSectionArea(.5 * s, -.5 * s, -.5 * s, .5 * s, -.5 * s, .5 * s, 1., 0., 0., 0.);
+				areas[8] = planeBoxSectionArea(7.5 * s, 8.5 * s, -4.5 * s, -3.5 * s, 1.5 * s, 2.5 * s, diagonal, diagonal, diagonal,
+							       6. * s * diagonal);
+				areas[9] = planeBoxSectionArea(-.5 * s, .5 * s, -s, s, -1.5 * s, 1.5 * s, 1., 0., 0., 0.);
+			});
+			std::array<amrex::Real, 10> actual{};
+			amrex::Gpu::copy(amrex::Gpu::deviceToHost, results.begin(), results.end(), actual.begin());
+			const std::array<amrex::Real, 10> expected{1., 1., 0., 0., 1., 3. * std::sqrt(3.) / 4., 0., 0., 3. * std::sqrt(3.) / 4., 6.};
+			for (int i = 0; i < 10; ++i) {
+				const auto normalized = actual[i] / (scale * scale);
+				if (!std::isfinite(normalized) || std::abs(normalized - expected[i]) > 1.e-12) {
+					std::cerr << "scale " << scale << " case " << i << ": got " << normalized << ", expected " << expected[i] << '\n';
+					++failures;
+				}
+			}
+		}
+	}
+	amrex::Finalize();
+	return failures == 0 ? 0 : 1;
+}

--- a/src/math/spherical_geometry.hpp
+++ b/src/math/spherical_geometry.hpp
@@ -200,7 +200,7 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto planeBoxSectionArea(amrex::Real co
 	if (dx <= 0.0 || dy <= 0.0 || dz <= 0.0) {
 		return 0.0;
 	}
-	const amrex::Real scale = std::max(dx, std::max(dy, dz));
+	const amrex::Real scale = std::max({dx, dy, dz});
 	const amrex::Real xc = x0 + 0.5 * dx;
 	const amrex::Real yc = y0 + 0.5 * dy;
 	const amrex::Real zc = z0 + 0.5 * dz;

--- a/src/math/spherical_geometry.hpp
+++ b/src/math/spherical_geometry.hpp
@@ -1,7 +1,9 @@
 #ifndef SPHERICAL_GEOMETRY_HPP_
 #define SPHERICAL_GEOMETRY_HPP_
 
+#include <algorithm>
 #include <cmath>
+#include <limits>
 
 #include "AMReX_Array.H"
 #include "AMReX_GpuQualifiers.H"
@@ -54,13 +56,14 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto addPointUnique(amrex::GpuArray<Poi
 	}
 }
 
-AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto planeBoxSectionArea(amrex::Real const x0, amrex::Real const x1, amrex::Real const y0, amrex::Real const y1,
-								  amrex::Real const z0, amrex::Real const z1, amrex::Real const nx, amrex::Real const ny,
-								  amrex::Real const nz, amrex::Real const d) -> amrex::Real
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto normalizedPlaneBoxSectionArea(amrex::Real const x0, amrex::Real const x1, amrex::Real const y0,
+									    amrex::Real const y1, amrex::Real const z0, amrex::Real const z1,
+									    amrex::Real const nx, amrex::Real const ny, amrex::Real const nz,
+									    amrex::Real const d) -> amrex::Real
 {
-	// Plane: n·x = d. Compute exact area of intersection polygon with an axis-aligned box.
-	const amrex::Real scale = (std::abs(x0) + std::abs(x1) + std::abs(y0) + std::abs(y1) + std::abs(z0) + std::abs(z1) + std::abs(d) + 1.0);
-	const amrex::Real tol = 1.0e-12 * scale;
+	// Plane: n·x = d, with unit normal n and cell-centered coordinates
+	// normalized by the largest box side. Tolerances are dimensionless.
+	const amrex::Real tol = 64.0 * std::numeric_limits<amrex::Real>::epsilon();
 
 	const amrex::GpuArray<Point, 8> verts{Point{x0, y0, z0}, Point{x1, y0, z0}, Point{x0, y1, z0}, Point{x1, y1, z0},
 					      Point{x0, y0, z1}, Point{x1, y0, z1}, Point{x0, y1, z1}, Point{x1, y1, z1}};
@@ -185,6 +188,29 @@ AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto planeBoxSectionArea(amrex::Real co
 		area2 += u[i] * v[j] - v[i] * u[j];
 	}
 	return 0.5 * std::abs(area2);
+}
+
+AMREX_FORCE_INLINE AMREX_GPU_HOST_DEVICE auto planeBoxSectionArea(amrex::Real const x0, amrex::Real const x1, amrex::Real const y0, amrex::Real const y1,
+								  amrex::Real const z0, amrex::Real const z1, amrex::Real const nx, amrex::Real const ny,
+								  amrex::Real const nz, amrex::Real const d) -> amrex::Real
+{
+	const amrex::Real dx = x1 - x0;
+	const amrex::Real dy = y1 - y0;
+	const amrex::Real dz = z1 - z0;
+	if (dx <= 0.0 || dy <= 0.0 || dz <= 0.0) {
+		return 0.0;
+	}
+	const amrex::Real scale = std::max(dx, std::max(dy, dz));
+	const amrex::Real xc = x0 + 0.5 * dx;
+	const amrex::Real yc = y0 + 0.5 * dy;
+	const amrex::Real zc = z0 + 0.5 * dz;
+	// Translate the plane along with the box; fused operations limit cancellation.
+	const amrex::Real local_d = std::fma(-nx, xc, std::fma(-ny, yc, std::fma(-nz, zc, d))) / scale;
+	const amrex::Real hx = 0.5 * (dx / scale);
+	const amrex::Real hy = 0.5 * (dy / scale);
+	const amrex::Real hz = 0.5 * (dz / scale);
+	const amrex::Real area = normalizedPlaneBoxSectionArea(-hx, hx, -hy, hy, -hz, hz, nx, ny, nz, local_d);
+	return (area * scale) * scale;
 }
 
 } // namespace detail


### PR DESCRIPTION
Spherical-section area calculations now clip the tangent plane in cell-centered coordinates normalized by the largest cell side, then rescale the polygon area. The previous absolute tolerance floor merged distinct vertices when coordinates were small: the reported square section returned zero at length scale 1e-14 instead of area 1e-28.

Closes #2237.

Uses a dimensionless tolerance based on floating-point precision, translates the plane offset consistently, and rejects degenerate or reversed cells before normalization. The spherical tangent-plane approximation is unchanged.

Adds CTest-registered SphericalAreaTest with 30 cases at scales 1, 1e-14, and 1e14: the reported spherical cell, tangent faces/edges, misses, translated axis-aligned and diagonal sections, rectangular cells, and invalid cells. Test calculations use AMReX ParallelFor and device storage so GPU builds can exercise the same path.

Validation:
- The native regression reproduced disappearing sections before the fix; all 30 cases pass afterward with normalized area error below 1e-12.
- `cmake --build /private/tmp/quokka-spherical-harness/build`
- `ctest --test-dir /private/tmp/quokka-spherical-harness/build --output-on-failure` — passed through a standalone harness using the existing native 3D AMReX build.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

Actual GPU execution and full DiskGalaxy flux-diagnostic runs were not performed.
