### PR TITLE
Honor transverse coordinates in line extraction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,4 +165,6 @@ endif()
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
+add_subdirectory(util/extract_tests)
+
 add_subdirectory(problems)

--- a/src/util/extract_tests/CMakeLists.txt
+++ b/src/util/extract_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(FextractTest testFextract.cpp ../fextract.cpp)
+target_link_libraries(FextractTest PRIVATE AMReX::amrex)
+target_include_directories(FextractTest PRIVATE ..)
+target_compile_features(FextractTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(FextractTest)
+endif()
+add_test(NAME FextractTest COMMAND FextractTest)

--- a/src/util/extract_tests/testFextract.cpp
+++ b/src/util/extract_tests/testFextract.cpp
@@ -1,0 +1,93 @@
+#include "fextract.hpp"
+#include <cmath>
+#include <iostream>
+
+auto main(int argc, char **argv) -> int
+{
+	amrex::Initialize(argc, argv);
+	int failures = 0;
+	{
+		for (const int origin : {0, 5}) {
+			const amrex::Box domain(amrex::IntVect(origin), amrex::IntVect(origin + 3));
+			const amrex::RealBox physical(amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(2., 2., 2.)},
+						      amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(6., 6., 6.)});
+			const amrex::Array<int, AMREX_SPACEDIM> periodic{};
+			amrex::Geometry geometry(domain, physical, 0, periodic);
+			for (const int boxSize : {4, 2}) {
+				amrex::BoxArray boxes(domain);
+				boxes.maxSize(boxSize);
+				amrex::DistributionMapping mapping(boxes);
+				amrex::MultiFab data(boxes, mapping, 2, 0);
+				for (amrex::MFIter mfi(data); mfi.isValid(); ++mfi) {
+					const auto field = data.array(mfi);
+					amrex::ParallelFor(mfi.validbox(), [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+						const auto value = AMREX_D_TERM((2.5 + i - origin), +10. * (2.5 + j - origin), +100. * (2.5 + k - origin));
+						field(i, j, k, 0) = value;
+						field(i, j, k, 1) = -value;
+					});
+				}
+				amrex::Gpu::streamSynchronize();
+				for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+					amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> coordinates{AMREX_D_DECL(2.25, 3.25, 4.25)};
+					coordinates[dir] = -1.e100; // The longitudinal coordinate must be ignored.
+					const auto [positions, values] = fextract(data, geometry, dir, coordinates);
+					if (amrex::ParallelDescriptor::IOProcessor()) {
+						if (positions.size() != 4) {
+							++failures;
+							continue;
+						}
+						for (int cell = 0; cell < 4; ++cell) {
+							amrex::Real expected = 0.;
+							amrex::Real weight = 1.;
+							for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+								expected += weight * (d == dir ? 2.5 + cell : 2.5 + d);
+								weight *= 10.;
+							}
+							if (positions[cell] != 2.5 + cell || values[0][cell] != expected || values[1][cell] != -expected) {
+								std::cerr << "Distinct transverse coordinates selected the wrong profile\n";
+								++failures;
+							}
+						}
+					}
+				}
+
+				for (int dir = 0; dir < AMREX_SPACEDIM; ++dir) {
+					for (const amrex::Real coordinate : {2.25, 4.25, -1., 10.}) {
+						for (const bool center : {false, true}) {
+							const auto [positions, values] = fextract(data, geometry, dir, coordinate, center);
+							if (!amrex::ParallelDescriptor::IOProcessor()) {
+								continue;
+							}
+							if (positions.size() != 4 || values.size() != 2 || values[0].size() != 4 || values[1].size() != 4) {
+								std::cerr << "Incorrect profile size at origin " << origin << '\n';
+								++failures;
+								continue;
+							}
+							const auto transverse =
+							    center ? 4.5 : (coordinate < 2. ? 2.5 : (coordinate >= 6. ? 5.5 : std::floor(coordinate) + .5));
+							for (int cell = 0; cell < 4; ++cell) {
+								amrex::Real expected = 0.;
+								amrex::Real weight = 1.;
+								for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+									expected += weight * (d == dir ? 2.5 + cell : transverse);
+									weight *= 10.;
+								}
+								if (std::abs(positions[cell] - (2.5 + cell)) > 1.e-12 ||
+								    std::abs(values[0][cell] - expected) > 1.e-12 ||
+								    std::abs(values[1][cell] + expected) > 1.e-12) {
+									std::cerr << "Wrong slice or position: origin=" << origin << " direction=" << dir
+										  << " coordinate=" << coordinate << " center=" << center << '\n';
+									++failures;
+									break;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	amrex::ParallelDescriptor::ReduceIntSum(failures);
+	amrex::Finalize();
+	return failures == 0 ? 0 : 1;
+}

--- a/src/util/fextract.cpp
+++ b/src/util/fextract.cpp
@@ -1,3 +1,4 @@
+#include "fextract.hpp"
 #include <algorithm>
 #include <limits>
 #include <numeric>
@@ -14,71 +15,33 @@
 
 using namespace amrex; // NOLINT
 
-auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coord, const bool center = false)
+auto fextract(MultiFab &mf, Geometry &geom, const int idir, const GpuArray<Real, AMREX_SPACEDIM> &slice_coords, const bool center)
     -> std::tuple<Vector<Real>, Vector<Gpu::HostVector<Real>>>
 {
-	AMREX_D_TERM(Real xcoord = slice_coord;, Real ycoord = slice_coord;, Real zcoord = slice_coord;)
-
-	GpuArray<Real, AMREX_SPACEDIM> problo = geom.ProbLoArray();
-	GpuArray<Real, AMREX_SPACEDIM> dx0 = geom.CellSizeArray();
-	Box probdom0 = geom.Domain();
-	const auto lo0 = amrex::lbound(probdom0);
-	const auto hi0 = amrex::ubound(probdom0);
-
-	// compute the index of the center or lower left of the domain on the
-	// coarse grid.  These are used to set the position of the slice in
-	// the transverse direction.
-
-	AMREX_D_TERM(int iloc = 0;, int jloc = 0;, int kloc = 0;)
-	if (center) {
-		AMREX_D_TERM(iloc = (hi0.x - lo0.x + 1) / 2 + lo0.x;, jloc = (hi0.y - lo0.y + 1) / 2 + lo0.y;, kloc = (hi0.z - lo0.z + 1) / 2 + lo0.z;)
-	}
-
-	if (idir == 0) {
-		// we specified the x value to pass through
-		iloc = hi0.x;
-		for (int i = lo0.x; i <= hi0.x; ++i) {
-			amrex::Real xc = problo[0] + (i + 0.5) * dx0[0];
-			if (xc > xcoord) {
-				iloc = i;
-				break;
-			}
-		}
-	}
-
-#if AMREX_SPACEDIM >= 2
-	if (idir == 1) {
-		// we specified the y value to pass through
-		jloc = hi0.y;
-		for (int j = lo0.y; j <= hi0.y; ++j) {
-			amrex::Real yc = problo[1] + (j + 0.5) * dx0[1];
-			if (yc > ycoord) {
-				jloc = j;
-				break;
-			}
-		}
-	}
-#endif
-
-#if AMREX_SPACEDIM == 3
-	if (idir == 2) {
-		// we specified the z value to pass through
-		kloc = hi0.z;
-		for (int k = lo0.z; k <= hi0.z; ++k) {
-			amrex::Real zc = problo[2] + (k + 0.5) * dx0[2];
-			if (zc > zcoord) {
-				kloc = k;
-				break;
-			}
-		}
-	}
-#endif
-
 	if (idir < 0 || idir >= AMREX_SPACEDIM) {
-		amrex::Abort("invalid direction!");
+		amrex::Abort("fextract: invalid direction");
 	}
-
-	const IntVect ivloc{AMREX_D_DECL(iloc, jloc, kloc)};
+	const auto problo = geom.ProbLoArray();
+	const auto dx0 = geom.CellSizeArray();
+	const auto probdom0 = geom.Domain();
+	const auto lo0 = amrex::lbound(probdom0);
+	IntVect ivloc = probdom0.smallEnd();
+	for (int dim = 0; dim < AMREX_SPACEDIM; ++dim) {
+		if (dim == idir) {
+			continue;
+		}
+		const int lower = probdom0.smallEnd(dim);
+		const int upper = probdom0.bigEnd(dim);
+		if (center) {
+			ivloc[dim] = lower + probdom0.length(dim) / 2;
+		} else {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::isfinite(slice_coords[dim]), "fextract: transverse coordinates must be finite");
+			// Select the cell containing the coordinate. Clamp before conversion
+			// to avoid overflow for coordinates far outside the physical domain.
+			const Real offset = std::floor((slice_coords[dim] - problo[dim]) / dx0[dim]);
+			ivloc[dim] = lower + static_cast<int>(amrex::Clamp(offset, Real(0), static_cast<Real>(upper - lower)));
+		}
+	}
 
 	Vector<Real> pos;
 	Vector<Gpu::HostVector<Real>> data(mf.nComp());
@@ -114,10 +77,10 @@ auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coo
 			const int offset = offsets[box_idx];
 			const int start_dir = bx.smallEnd(idir);
 			const int local_len = bx.length(idir);
-			amrex::LoopOnCpu(bx, [problo, dx, idir, offset, start_dir, local_len, &pos](int i, int j, int k) {
-				Array<Real, AMREX_SPACEDIM> p = {AMREX_D_DECL(problo[0] + static_cast<Real>(i + 0.5) * dx[0],
-									      problo[1] + static_cast<Real>(j + 0.5) * dx[1],
-									      problo[2] + static_cast<Real>(k + 0.5) * dx[2])};
+			amrex::LoopOnCpu(bx, [problo, dx, lo0, idir, offset, start_dir, local_len, &pos](int i, int j, int k) {
+				Array<Real, AMREX_SPACEDIM> p = {AMREX_D_DECL(problo[0] + static_cast<Real>(i - lo0.x + 0.5) * dx[0],
+									      problo[1] + static_cast<Real>(j - lo0.y + 0.5) * dx[1],
+									      problo[2] + static_cast<Real>(k - lo0.z + 0.5) * dx[2])};
 				int idx = offset;
 				if (idir == 0) {
 					idx += i - start_dir;
@@ -249,4 +212,12 @@ auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coo
 		}
 	}
 	return std::make_tuple(pos, data);
+}
+
+auto fextract(MultiFab &mf, Geometry &geom, const int idir, const Real slice_coord, const bool center)
+    -> std::tuple<Vector<Real>, Vector<Gpu::HostVector<Real>>>
+{
+	GpuArray<Real, AMREX_SPACEDIM> coordinates{};
+	coordinates.fill(slice_coord);
+	return fextract(mf, geom, idir, coordinates, center);
 }

--- a/src/util/fextract.hpp
+++ b/src/util/fextract.hpp
@@ -9,6 +9,15 @@
 #include <AMReX_PlotFileUtil.H>
 #include <AMReX_Print.H>
 
+// Extract the line along idir through the cells containing the transverse
+// coordinates. The coordinate along idir is ignored. Out-of-domain coordinates
+// are clamped to the nearest cell. center selects the upper midpoint cell in
+// each transverse direction and ignores coordinates. Full sorted profiles are
+// gathered on the I/O rank; other ranks retain their local data.
+auto fextract(amrex::MultiFab &mf, amrex::Geometry &geom, int idir, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> &slice_coords, bool center = false)
+    -> std::tuple<amrex::Vector<amrex::Real>, amrex::Vector<amrex::Gpu::HostVector<amrex::Real>>>;
+
+// Convenience overload: use the same physical coordinate on every transverse axis.
 auto fextract(amrex::MultiFab &mf, amrex::Geometry &geom, int idir, amrex::Real slice_coord, bool center = false)
     -> std::tuple<amrex::Vector<amrex::Real>, amrex::Vector<amrex::Gpu::HostVector<amrex::Real>>>;
 


### PR DESCRIPTION
`fextract` now selects the requested transverse cells instead of changing the longitudinal index that is immediately discarded. Calls such as the DustAdvection3D profiles at coordinate 0.5 now sample the intended interior line.

Closes #2220.

The scalar coordinate applies to every transverse axis. A new GpuArray overload accepts separate coordinates per axis, ignoring the longitudinal entry. Both select the cell containing each coordinate and clamp outside-domain positions to the nearest cell. `center=true` keeps explicit midpoint selection. Index conversion and returned physical positions now account for nonzero domain index origins. These semantics are documented in the header.

Adds CTest-registered FextractTest using real multicomponent MultiFabs, every active direction, scalar/vector coordinates, center mode, clamping, zero/shifted index origins, and single/multiple-box decompositions. Checks sorted positions and both data components.

Validation:
- Native 3D regression reproduced incorrect slice selection and shifted-origin positions before the fix.
- `cmake --build /private/tmp/quokka-fextract-harness/build`
- `ctest --test-dir /private/tmp/quokka-fextract-harness/build --output-on-failure` — passed (108 profiles).
- `cmake --build /private/tmp/quokka-fextract-harness/build-1d`
- `ctest --test-dir /private/tmp/quokka-fextract-harness/build-1d --output-on-failure` — passed (36 profiles).
- `mpirun --oversubscribe -np 2 /private/tmp/quokka-fextract-harness/build/tests/FextractTest` — passed outside the macOS sandbox.
- Standalone harnesses build the registered target against existing native AMReX builds.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

GPU execution and the full DustAdvection3D simulation were not run.
