### PR TITLE
Include histogram upper endpoints without admitting outliers

### DIFF
--- a/docs/markdown/insitu_analysis.md
+++ b/docs/markdown/insitu_analysis.md
@@ -84,7 +84,7 @@ quokka.slice_z.field_names = gasDensity gasInternalEnergy temperature
 
 This adds histogram outputs (as fixed-width text files) at fixed timestep intervals as the simulation evolves. The quantity accumulated in each bin is the total mass, volume, or cell count summed over all cells not covered by refined grids over all AMR levels. If unspecified in the input parameters, the default is to accumulate the volume in each bin.
 
-By default, the bins extend over the full range of the data at a given timestep. The *range* parameter can instead specify the minimum and maximum extent for the bins. Bins can be optionally log-spaced by setting *log_spaced_bins = 1*.
+By default, the bins extend over the full range of the data at a given timestep. The *range* parameter can instead specify the minimum and maximum extent for the bins. The last bin includes the upper endpoint, for both automatic and explicit ranges. Values strictly outside an explicit range are excluded. Interior bin edges belong to the bin on their right. Bins can be optionally log-spaced by setting *log_spaced_bins = 1*.
 
 Normalization of the output is left up to the user.
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,4 +165,6 @@ endif()
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
+add_subdirectory(io/pdf_tests)
+
 add_subdirectory(problems)

--- a/src/io/DiagPDF.H
+++ b/src/io/DiagPDF.H
@@ -44,19 +44,28 @@ class DiagPDF : public DiagBase::Register<DiagPDF>
 	// helper functions
 	static auto getIdxVec(int linidx, std::vector<int> const &nBins) -> std::vector<int>;
 
-	AMREX_GPU_HOST_DEVICE AMREX_INLINE static auto getBinIndex1D(const amrex::Real &realInputVal, const amrex::Real &transformedLowBnd,
-								     const amrex::Real &transformedBinWidth, bool doLog) -> int;
+	AMREX_GPU_HOST_DEVICE AMREX_INLINE static auto getBinIndex1D(amrex::Real value, amrex::Real low, amrex::Real high, amrex::Real transformedLow,
+								     amrex::Real width, int nBins, bool doLog) -> int;
 
 	AMREX_GPU_HOST_DEVICE AMREX_INLINE auto getTotalBinCount() -> amrex::Long;
 };
 
 // Inline member function implementations
-AMREX_GPU_HOST_DEVICE AMREX_INLINE auto DiagPDF::getBinIndex1D(const amrex::Real &realInputVal, const amrex::Real &transformedLowBnd,
-							       const amrex::Real &transformedBinWidth, const bool doLog) -> int
+AMREX_GPU_HOST_DEVICE AMREX_INLINE auto DiagPDF::getBinIndex1D(amrex::Real value, amrex::Real low, amrex::Real high, amrex::Real transformedLow,
+							       amrex::Real width, int nBins, bool doLog) -> int
 {
-	amrex::Real const val = doLog ? std::log10(realInputVal) : realInputVal;
-	int const cbin = static_cast<int>(std::floor((val - transformedLowBnd) / transformedBinWidth));
-	return cbin;
+	// Check physical bounds before transforming or converting to an integer.
+	if (!std::isfinite(value) || value < low || value > high) {
+		return -1;
+	}
+	// The last bin includes its upper endpoint for both automatic and explicit ranges.
+	if (value == high) {
+		return nBins - 1;
+	}
+	const amrex::Real transformed = doLog ? std::log10(value) : value;
+	const amrex::Real index = std::floor((transformed - transformedLow) / width);
+	// Roundoff in the transform can put an in-range value just beyond an edge.
+	return static_cast<int>(amrex::Clamp(index, amrex::Real(0), static_cast<amrex::Real>(nBins - 1)));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_INLINE auto DiagPDF::getTotalBinCount() -> amrex::Long
@@ -158,8 +167,12 @@ template <typename problem_t> void DiagPDF::processDiag(int a_nstep, const amrex
 		amrex::Gpu::AsyncVector<int> doLog_d(nvars);
 		amrex::Gpu::AsyncVector<amrex::Real> lowBnd_d(nvars);
 		amrex::Gpu::AsyncVector<amrex::Real> binWidth_d(nvars);
+		amrex::Gpu::AsyncVector<amrex::Real> realLow_d(nvars);
+		amrex::Gpu::AsyncVector<amrex::Real> realHigh_d(nvars);
 
 		// copy arrays to device
+		amrex::Gpu::copy(amrex::Gpu::hostToDevice, m_lowBnd.begin(), m_lowBnd.end(), realLow_d.begin());
+		amrex::Gpu::copy(amrex::Gpu::hostToDevice, m_highBnd.begin(), m_highBnd.end(), realHigh_d.begin());
 		amrex::Gpu::copy(amrex::Gpu::hostToDevice, fieldIdx.begin(), fieldIdx.end(), idx_d.begin());
 		amrex::Gpu::copy(amrex::Gpu::hostToDevice, m_nBins.begin(), m_nBins.end(), nbins_d.begin());
 		amrex::Gpu::copy(amrex::Gpu::hostToDevice, m_useLogSpacedBins.begin(), m_useLogSpacedBins.end(), doLog_d.begin());
@@ -174,6 +187,8 @@ template <typename problem_t> void DiagPDF::processDiag(int a_nstep, const amrex
 		auto const *lowBnd_p = lowBnd_d.data();
 		auto const *binWidth_p = binWidth_d.data();
 		auto const *doLog_p = doLog_d.data();
+		auto const *realLow_p = realLow_d.data();
+		auto const *realHigh_p = realHigh_d.data();
 
 		// compute histogram
 		amrex::ParallelFor(*a_state[lev], amrex::IntVect(0), [=] AMREX_GPU_DEVICE(int box_no, int i, int j, int k) noexcept {
@@ -184,8 +199,9 @@ template <typename problem_t> void DiagPDF::processDiag(int a_nstep, const amrex
 
 				for (int n = 0; n < nvars; ++n) {
 					// compute 1D index
-					const int bin = getBinIndex1D(sarrs[box_no](i, j, k, idx_p[n]), lowBnd_p[n], binWidth_p[n], doLog_p[n]); // NOLINT
-					if (bin < 0 || bin >= nbins_p[n]) {									 // NOLINT
+					const int bin = getBinIndex1D(sarrs[box_no](i, j, k, idx_p[n]), realLow_p[n], realHigh_p[n], lowBnd_p[n], binWidth_p[n],
+								      nbins_p[n], doLog_p[n]); // NOLINT
+					if (bin < 0 || bin >= nbins_p[n]) {		       // NOLINT
 						within_range = false;
 					}
 					// compute linear index in N-D histogram

--- a/src/io/pdf_tests/CMakeLists.txt
+++ b/src/io/pdf_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(PDFBoundsTest testPDFBounds.cpp ../DiagPDF.cpp ../DiagBase.cpp ../DiagFilter.cpp)
+target_link_libraries(PDFBoundsTest PRIVATE AMReX::amrex yaml-cpp::yaml-cpp)
+target_include_directories(PDFBoundsTest PRIVATE .. ../..)
+target_compile_features(PDFBoundsTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(PDFBoundsTest)
+endif()
+add_test(NAME PDFBoundsTest COMMAND PDFBoundsTest)

--- a/src/io/pdf_tests/testPDFBounds.cpp
+++ b/src/io/pdf_tests/testPDFBounds.cpp
@@ -1,0 +1,107 @@
+#include "AMReX_ParmParse.H"
+#include "DiagPDF.H"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+struct PDFTest {};
+
+auto main(int argc, char **argv) -> int
+{
+	amrex::Initialize(argc, argv);
+	int failures = 0;
+	{
+		const amrex::Box domain(amrex::IntVect(0), amrex::IntVect(3));
+		const amrex::RealBox physical(amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(0., 0., 0.)},
+					      amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(2., 2., 2.)});
+		const amrex::Array<int, AMREX_SPACEDIM> periodic{};
+		const amrex::Geometry geometry(domain, physical, 0, periodic);
+		amrex::BoxArray boxes(domain);
+		boxes.maxSize(2);
+		const amrex::DistributionMapping mapping(boxes);
+		amrex::MultiFab state(boxes, mapping, 3, 0);
+		for (amrex::MFIter mfi(state); mfi.isValid(); ++mfi) {
+			const auto a = state.array(mfi);
+			amrex::ParallelFor(mfi.validbox(), [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+				a(i, j, k, 0) = 2.;
+				a(i, j, k, 1) = 1. + i % 3;
+				a(i, j, k, 2) = 4. - a(i, j, k, 1);
+			});
+		}
+		amrex::Gpu::streamSynchronize();
+		const amrex::Vector<const amrex::MultiFab *> states{&state};
+		const amrex::Vector<std::string> names{"gasDensity", "q", "r"};
+		const amrex::Vector<amrex::Geometry> geoms{geometry};
+		const amrex::Vector<amrex::IntVect> ratios;
+		int id = 0;
+		for (const int rangeMode : {0, 1, 2}) {
+			for (const int logarithmic : {0, 1}) {
+				for (const int axes : {1, 2}) {
+					for (const std::string weight : {"cell_counts", "volume", "mass"}) {
+						const auto prefix = "pdf_test_" + std::to_string(id++);
+						amrex::ParmParse pp(prefix);
+						pp.add("int", 1);
+						pp.add("weight_by", weight);
+						pp.addarr("var_names", axes == 1 ? amrex::Vector<std::string>{"q"} : amrex::Vector<std::string>{"q", "r"});
+						for (const auto &var : {"q", "r"}) {
+							amrex::ParmParse vp(prefix + "." + var);
+							vp.add("nBins", 2);
+							vp.add("log_spaced_bins", logarithmic);
+							if (rangeMode != 0 && std::string(var) == "q") {
+								vp.addarr("range", rangeMode == 1 ? amrex::Vector<amrex::Real>{1., 2.}
+												  : amrex::Vector<amrex::Real>{2., 3.});
+							}
+						}
+						DiagPDF diagnostic;
+						diagnostic.init(prefix, prefix);
+						diagnostic.prepare(1, geoms, {boxes}, {mapping}, names);
+						diagnostic.setDiagData<PDFTest>(nullptr, &states, &names, &geoms, &ratios, nullptr);
+						diagnostic.processDiag<PDFTest>(1, 0.);
+						if (amrex::ParallelDescriptor::IOProcessor()) {
+							std::ifstream file(prefix + "0000001.dat");
+							std::string line;
+							amrex::Real total = 0.;
+							int rows = 0;
+							while (std::getline(file, line)) {
+								if (line.empty() || line.front() == '#') {
+									continue;
+								}
+								std::stringstream row(line);
+								amrex::Real value = 0., last = 0.;
+								int columns = 0;
+								while (row >> value) {
+									last = value;
+									++columns;
+								}
+								if (columns == 0) {
+									continue;
+								}
+								if (columns != 3 * axes + 1) {
+									++failures;
+								}
+								total += last;
+								++rows;
+							}
+							amrex::Real expected =
+							    weight == "cell_counts" ? std::pow(4., AMREX_SPACEDIM) : std::pow(2., AMREX_SPACEDIM);
+							if (weight == "mass") {
+								expected *= 2.;
+							}
+							if (rangeMode != 0) {
+								expected *= rangeMode == 1 ? .75 : .5;
+							}
+							if (rows != (1 << axes) || std::abs(total - expected) > 1.e-12) {
+								std::cerr << prefix << " total=" << total << " expected=" << expected << '\n';
+								++failures;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	amrex::ParallelDescriptor::ReduceIntSum(failures);
+	amrex::Finalize();
+	return failures == 0 ? 0 : 1;
+}

--- a/src/io/pdf_tests/testPDFBounds.cpp
+++ b/src/io/pdf_tests/testPDFBounds.cpp
@@ -68,7 +68,8 @@ auto main(int argc, char **argv) -> int
 									continue;
 								}
 								std::stringstream row(line);
-								amrex::Real value = 0., last = 0.;
+								amrex::Real value = 0.;
+								amrex::Real last = 0.;
 								int columns = 0;
 								while (row >> value) {
 									last = value;
@@ -91,7 +92,7 @@ auto main(int argc, char **argv) -> int
 							if (rangeMode != 0) {
 								expected *= rangeMode == 1 ? .75 : .5;
 							}
-							if (rows != (1 << axes) || std::abs(total - expected) > 1.e-12) {
+							if (rows != static_cast<int>(1U << axes) || std::abs(total - expected) > 1.e-12) {
 								std::cerr << prefix << " total=" << total << " expected=" << expected << '\n';
 								++failures;
 							}


### PR DESCRIPTION
DiagPDF now includes the upper endpoint in the final histogram bin for automatic and explicit ranges. Previously, maximum-valued cells mapped to index nBins and were discarded, losing cell counts, volume, or mass. A 64-cell test previously counted only 48 cells with one axis and 16 with two axes.

Closes #2231.

Checks membership against physical bounds before logarithmic transforms or integer conversion, so out-of-range values remain excluded even if transformations round them onto an edge. In-range indices are bounded against floating-point roundoff. The endpoint convention is documented in the in-situ analysis guide.

Adds CTest-registered PDFBoundsTest that runs actual DiagPDF accumulation and reads the output histograms. Its 36 cases cover automatic ranges, explicit ranges excluding data below or above the bounds, linear/logarithmic bins, one/two histogram axes, and cell-count/volume/mass weights.

Validation:
- The finalized regression reproduced lost weight on the original header and passes with the fix.
- `cmake --build /private/tmp/quokka-pdf-harness/build`
- `ctest --test-dir /private/tmp/quokka-pdf-harness/build --output-on-failure` — passed using a standalone harness for the registered target against native 3D AMReX/yaml-cpp.
- `mpirun --oversubscribe -np 2 /private/tmp/quokka-pdf-harness/build/tests/PDFBoundsTest` — passed outside the macOS sandbox.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

GPU execution and full simulation runs were not performed. Periodic fine-mask handling (#1845) remains separate.
