### PR TITLE
Use level periodicity for histogram fine masks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -165,4 +165,6 @@ endif()
 
 set (QuokkaObjSources "${QuokkaSourcesNoEOS}" "${gamma_law_sources}")
 
+add_subdirectory(io/periodic_pdf_tests)
+
 add_subdirectory(problems)

--- a/src/io/DiagPDF.H
+++ b/src/io/DiagPDF.H
@@ -115,8 +115,7 @@ template <typename problem_t> void DiagPDF::processDiag(int a_nstep, const amrex
 			mask.define(a_state[lev]->boxArray(), a_state[lev]->DistributionMap(), 1, amrex::IntVect(0));
 			mask.setVal(1);
 		} else {
-			mask =
-			    amrex::makeFineMask(*a_state[lev], *a_state[lev + 1], amrex::IntVect(0), m_refRatio[lev], amrex::Periodicity::NonPeriodic(), 1, 0);
+			mask = amrex::makeFineMask(*a_state[lev], *a_state[lev + 1], amrex::IntVect(0), m_refRatio[lev], m_geoms[lev].periodicity(), 1, 0);
 		}
 		auto const &sarrs = a_state[lev]->const_arrays();
 		auto const &marrs = mask.arrays();

--- a/src/io/periodic_pdf_tests/CMakeLists.txt
+++ b/src/io/periodic_pdf_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(PDFPeriodicTest testPDFPeriodic.cpp ../DiagPDF.cpp ../DiagBase.cpp ../DiagFilter.cpp)
+target_link_libraries(PDFPeriodicTest PRIVATE AMReX::amrex yaml-cpp::yaml-cpp)
+target_include_directories(PDFPeriodicTest PRIVATE .. ../..)
+target_compile_features(PDFPeriodicTest PRIVATE cxx_std_20)
+if(AMReX_GPU_BACKEND MATCHES "CUDA")
+  setup_target_for_cuda_compilation(PDFPeriodicTest)
+endif()
+add_test(NAME PDFPeriodicTest COMMAND PDFPeriodicTest)

--- a/src/io/periodic_pdf_tests/testPDFPeriodic.cpp
+++ b/src/io/periodic_pdf_tests/testPDFPeriodic.cpp
@@ -1,0 +1,88 @@
+#include "AMReX_ParmParse.H"
+#include "DiagPDF.H"
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+struct PeriodicPDF {};
+
+auto main(int argc, char **argv) -> int
+{
+	amrex::Initialize(argc, argv);
+	int failures = 0;
+	{
+		int id = 0;
+		for (const bool periodic : {false, true}) {
+			for (const bool shifted : {false, true}) {
+				if (shifted && !periodic) {
+					continue;
+				}
+				const amrex::Box domain(amrex::IntVect(0), amrex::IntVect(3));
+				const amrex::RealBox physical(amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(0., 0., 0.)},
+							      amrex::Array<amrex::Real, AMREX_SPACEDIM>{AMREX_D_DECL(2., 2., 2.)});
+				amrex::Array<int, AMREX_SPACEDIM> periodicity{};
+				periodicity[0] = periodic ? 1 : 0;
+				const amrex::Geometry coarseGeom(domain, physical, 0, periodicity);
+				const amrex::Geometry fineGeom(amrex::refine(domain, 2), physical, 0, periodicity);
+				auto fineBox = amrex::refine(domain, 2);
+				fineBox.setBig(0, 3);
+				if (shifted) {
+					fineBox.shift(0, 8);
+				} // Represent the fine patch by its periodic image.
+				amrex::BoxArray coarseBoxes(domain), fineBoxes(fineBox);
+				coarseBoxes.maxSize(2);
+				fineBoxes.maxSize(4);
+				const amrex::DistributionMapping coarseMap(coarseBoxes), fineMap(fineBoxes);
+				amrex::MultiFab coarse(coarseBoxes, coarseMap, 1, 0), fine(fineBoxes, fineMap, 1, 0);
+				coarse.setVal(1.);
+				fine.setVal(1.);
+				const amrex::Vector<const amrex::MultiFab *> states{&coarse, &fine};
+				const amrex::Vector<std::string> names{"gasDensity"};
+				const amrex::Vector<amrex::Geometry> geoms{coarseGeom, fineGeom};
+				const amrex::Vector<amrex::IntVect> ratios{amrex::IntVect(2)};
+				for (const std::string weight : {"cell_counts", "volume", "mass"}) {
+					const auto prefix = "periodic_pdf_" + std::to_string(id++);
+					amrex::ParmParse pp(prefix);
+					pp.add("int", 1);
+					pp.add("weight_by", weight);
+					pp.addarr("var_names", names);
+					amrex::ParmParse vp(prefix + ".gasDensity");
+					vp.add("nBins", 2);
+					vp.addarr("range", amrex::Vector<amrex::Real>{.5, 1.5});
+					DiagPDF diagnostic;
+					diagnostic.init(prefix, prefix);
+					diagnostic.prepare(2, geoms, {coarseBoxes, fineBoxes}, {coarseMap, fineMap}, names);
+					diagnostic.setDiagData<PeriodicPDF>(nullptr, &states, &names, &geoms, &ratios, nullptr);
+					diagnostic.processDiag<PeriodicPDF>(1, 0.);
+					if (amrex::ParallelDescriptor::IOProcessor()) {
+						std::ifstream file(prefix + "0000001.dat");
+						std::string line;
+						amrex::Real total = 0.;
+						int rows = 0;
+						while (std::getline(file, line)) {
+							std::stringstream row(line);
+							int bin;
+							amrex::Real lo, hi, value;
+							if (row >> bin >> lo >> hi >> value) {
+								total += value;
+								++rows;
+							}
+						}
+						const amrex::Real expected = weight == "cell_counts"
+										 ? .5 * std::pow(4., AMREX_SPACEDIM) + .5 * std::pow(8., AMREX_SPACEDIM)
+										 : std::pow(2., AMREX_SPACEDIM);
+						if (rows != 2 || std::abs(total - expected) > 1.e-12) {
+							std::cerr << "periodic=" << periodic << " shifted=" << shifted << " weight=" << weight << " got "
+								  << total << " expected " << expected << '\n';
+							++failures;
+						}
+					}
+				}
+			}
+		}
+	}
+	amrex::ParallelDescriptor::ReduceIntSum(failures);
+	amrex::Finalize();
+	return failures == 0 ? 0 : 1;
+}

--- a/src/io/periodic_pdf_tests/testPDFPeriodic.cpp
+++ b/src/io/periodic_pdf_tests/testPDFPeriodic.cpp
@@ -30,11 +30,14 @@ auto main(int argc, char **argv) -> int
 				if (shifted) {
 					fineBox.shift(0, 8);
 				} // Represent the fine patch by its periodic image.
-				amrex::BoxArray coarseBoxes(domain), fineBoxes(fineBox);
+				amrex::BoxArray coarseBoxes(domain);
+				amrex::BoxArray fineBoxes(fineBox);
 				coarseBoxes.maxSize(2);
 				fineBoxes.maxSize(4);
-				const amrex::DistributionMapping coarseMap(coarseBoxes), fineMap(fineBoxes);
-				amrex::MultiFab coarse(coarseBoxes, coarseMap, 1, 0), fine(fineBoxes, fineMap, 1, 0);
+				const amrex::DistributionMapping coarseMap(coarseBoxes);
+				const amrex::DistributionMapping fineMap(fineBoxes);
+				amrex::MultiFab coarse(coarseBoxes, coarseMap, 1, 0);
+				amrex::MultiFab fine(fineBoxes, fineMap, 1, 0);
 				coarse.setVal(1.);
 				fine.setVal(1.);
 				const amrex::Vector<const amrex::MultiFab *> states{&coarse, &fine};
@@ -62,8 +65,10 @@ auto main(int argc, char **argv) -> int
 						int rows = 0;
 						while (std::getline(file, line)) {
 							std::stringstream row(line);
-							int bin;
-							amrex::Real lo, hi, value;
+							int bin = 0;
+							amrex::Real lo = 0.;
+							amrex::Real hi = 0.;
+							amrex::Real value = 0.;
 							if (row >> bin >> lo >> hi >> value) {
 								total += value;
 								++rows;


### PR DESCRIPTION
DiagPDF now passes the coarse level's geometry periodicity to makeFineMask. A fine patch represented by a periodic image therefore masks the same covered coarse cells as its in-domain representation, avoiding duplicate histogram weight.

Closes #1845.

Adds CTest-registered PDFPeriodicTest that invokes actual histogram accumulation on two-level MultiFabs. Nine cases compare nonperiodic in-domain patches, periodic in-domain patches, and periodic-image patches under cell-count, volume, and mass weighting. Explicit nondegenerate bin bounds keep the separate histogram upper-edge issue out of this test.

Validation:
- Before the fix, periodic-image volume/mass totaled 12 instead of 8, and cell counts totaled 320 instead of 288. In-domain controls passed.
- `cmake --build /private/tmp/quokka-periodic-pdf-harness/build`
- `ctest --test-dir /private/tmp/quokka-periodic-pdf-harness/build --output-on-failure` — all nine cases passed through a standalone harness using native 3D AMReX/yaml-cpp.
- `mpirun --oversubscribe -np 2 /private/tmp/quokka-periodic-pdf-harness/build/tests/PDFPeriodicTest` — passed outside the macOS sandbox.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

The regression deliberately supplies a periodic-image fine patch directly to the diagnostic. It does not demonstrate that an ordinary simulation's canonical in-domain BoxArrays encounter this case. GPU and full simulation runs were not performed.
