### PR TITLE
Av/issue 2207

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -730,8 +730,9 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		hpp.query("enabled", enableElectronConduction_);
 		hpp.query("conductivity_prefactor", electronConductionKappa0_);
 		if (enableElectronConduction_ == 1) {
-			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(electronConductionKappa0_ > 0.0, "conduction.conductivity_prefactor must be positive when "
-											    "conduction is enabled; set conduction.enabled = 0 to disable conduction ");
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(electronConductionKappa0_ > 0.0,
+							 "conduction.conductivity_prefactor must be positive when "
+							 "conduction is enabled; set conduction.enabled = 0 to disable conduction ");
 		}
 		hpp.query("conduction_cfl", conductionCFL);
 		hpp.query("flux_limiter_phi", electronConductionFluxLimiterPhi_);

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -729,6 +729,10 @@ template <typename problem_t> void QuokkaSimulation<problem_t>::readParmParse()
 		amrex::ParmParse const hpp("conduction");
 		hpp.query("enabled", enableElectronConduction_);
 		hpp.query("conductivity_prefactor", electronConductionKappa0_);
+		if (enableElectronConduction_ == 1) {
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(electronConductionKappa0_ > 0.0, "conduction.conductivity_prefactor must be positive when "
+											    "conduction is enabled; set conduction.enabled = 0 to disable conduction ");
+		}
 		hpp.query("conduction_cfl", conductionCFL);
 		hpp.query("flux_limiter_phi", electronConductionFluxLimiterPhi_);
 		hpp.query("saturation_factor", electronConductionSaturationFactor_);

--- a/src/conduction/ElectronConduction.hpp
+++ b/src/conduction/ElectronConduction.hpp
@@ -42,7 +42,7 @@ template <typename problem_t> class ElectronConduction
 				    amrex::Real dt, ElectronConductionParams const &params, std::array<amrex::MultiFab, AMREX_SPACEDIM> &heat_flux)
 	{
 		static_assert(Physics_Traits<problem_t>::is_hydro_enabled, "Electron conduction requires hydro to be enabled.");
-		
+
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::BoxArray const ba_face = amrex::convert(state.boxArray(), amrex::IntVect::TheDimensionVector(idim));
 			heat_flux[idim].define(ba_face, state.DistributionMap(), 1, 0);

--- a/src/conduction/ElectronConduction.hpp
+++ b/src/conduction/ElectronConduction.hpp
@@ -42,7 +42,12 @@ template <typename problem_t> class ElectronConduction
 				    amrex::Real dt, ElectronConductionParams const &params, std::array<amrex::MultiFab, AMREX_SPACEDIM> &heat_flux)
 	{
 		static_assert(Physics_Traits<problem_t>::is_hydro_enabled, "Electron conduction requires hydro to be enabled.");
-
+		
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			amrex::BoxArray const ba_face = amrex::convert(state.boxArray(), amrex::IntVect::TheDimensionVector(idim));
+			heat_flux[idim].define(ba_face, state.DistributionMap(), 1, 0);
+			heat_flux[idim].setVal(0.0);
+		}
 		if ((dt <= 0.0) || (params.conductivity_prefactor <= 0.0)) {
 			return;
 		}
@@ -115,12 +120,6 @@ template <typename problem_t> class ElectronConduction
 			conductivity_arr[bx](i, j, k) = kappa;
 			saturated_flux_arr[bx](i, j, k) = qsat;
 		});
-
-		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-			amrex::BoxArray const ba_face = amrex::convert(state.boxArray(), amrex::IntVect::TheDimensionVector(idim));
-			heat_flux[idim].define(ba_face, state.DistributionMap(), 1, 0);
-			heat_flux[idim].setVal(0.0);
-		}
 
 		auto const &temp = temperature.const_arrays();
 		auto const &kappa = conductivity.const_arrays();

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1275,7 +1275,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	// compute timestep based on conduction parameters
 	amrex::ValLocPair<amrex::Real, amrex::IntVect> conduction_dt{.value = std::numeric_limits<amrex::Real>::max(),
 								     .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
-	if (enableElectronConduction_ == 1 && electronConductionKappa0_ > 0.0) {
+	if (enableElectronConduction_ == 1) {
 		double c_v = C::k_B / (::quokka::EOS_Traits<problem_t>::mean_molecular_weight * (::quokka::EOS_Traits<problem_t>::gamma - 1.0));
 		double diffusion_coefficient = electronConductionKappa0_ / (state_new_cc_[lev].min(0) * c_v);
 		conduction_dt.value = 0.5 * conductionCFL * dx_min * dx_min / diffusion_coefficient / AMREX_SPACEDIM;

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1275,7 +1275,7 @@ template <typename problem_t> auto AMRSimulation<problem_t>::computeTimestepAtLe
 	// compute timestep based on conduction parameters
 	amrex::ValLocPair<amrex::Real, amrex::IntVect> conduction_dt{.value = std::numeric_limits<amrex::Real>::max(),
 								     .index = amrex::IntVect{AMREX_D_DECL(-1, -1, -1)}};
-	if (enableElectronConduction_ == 1) {
+	if (enableElectronConduction_ == 1 && electronConductionKappa0_ > 0.0) {
 		double c_v = C::k_B / (::quokka::EOS_Traits<problem_t>::mean_molecular_weight * (::quokka::EOS_Traits<problem_t>::gamma - 1.0));
 		double diffusion_coefficient = electronConductionKappa0_ / (state_new_cc_[lev].min(0) * c_v);
 		conduction_dt.value = 0.5 * conductionCFL * dx_min * dx_min / diffusion_coefficient / AMREX_SPACEDIM;


### PR DESCRIPTION
### Description
Fixing issue 2207.

Fixing zero divide in `simulation.hpp` and returning `heat_flux` array properly.
### Related issues
[Are there any GitHub issues that are fixed by this pull request? Add a link to them here.](https://github.com/quokka-astro/quokka/issues/2207#event-30618137847)

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x ] I have added a description (see above).
- [ x] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Heat-flux data is now initialized consistently, including when conduction exits early.
  - Electron-conduction timestep calculations are skipped when conduction is disabled or has a non-positive conductivity value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->