### PR TITLE
Consume checkpoint requests satisfied by scheduled output

### DIFF
--- a/src/problems/HydroContact/CMakeLists.txt
+++ b/src/problems/HydroContact/CMakeLists.txt
@@ -1,1 +1,5 @@
 quokka_add_problem(JOB_NAME HydroContact)
+find_package(Python COMPONENTS Interpreter REQUIRED)
+add_test(NAME CheckpointSentinelTest
+  COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_checkpoint_sentinel.py
+    $<TARGET_FILE:HydroContact> ${CMAKE_SOURCE_DIR}/inputs/HydroContact.toml)

--- a/src/problems/HydroContact/test_checkpoint_sentinel.py
+++ b/src/problems/HydroContact/test_checkpoint_sentinel.py
@@ -1,0 +1,42 @@
+"""Run real checkpoint output with scheduled and unscheduled sentinel requests."""
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    executable = str(pathlib.Path(sys.argv[1]).resolve())
+    inputs = str(pathlib.Path(sys.argv[2]).resolve())
+    failures = 0
+    cases = [
+        ('step-scheduled', ['checkpoint_interval=1'], True),
+        ('time-scheduled', ['checkpoint_interval=-1', 'checkpointtime_interval=1e-10'], True),
+        ('unscheduled', ['checkpoint_interval=10'], True),
+        ('no-request', ['checkpoint_interval=10'], False),
+    ]
+    for name, parameters, request in cases:
+        with tempfile.TemporaryDirectory(prefix='checkpoint-sentinel-') as directory:
+            root = pathlib.Path(directory)
+            sentinel = root / 'checkpointNow'
+            if request:
+                sentinel.touch()
+            result = subprocess.run(
+                sys.argv[3:] + [executable, inputs, 'max_timesteps=2', 'amr.n_cell=8 8 8',
+                 'plotfile_interval=-1', 'suppress_output=1'] + parameters,
+                cwd=root, capture_output=True, text=True, timeout=60)
+            output = result.stdout + result.stderr
+            writes = [line.strip() for line in output.splitlines() if line.startswith('Writing checkpoint ')]
+            step_one = writes.count('Writing checkpoint chk0000001')
+            passed = result.returncode == 0 and not sentinel.exists() and step_one == int(request)
+            if request:
+                passed = passed and (root / 'chk0000001' / 'Header').is_file()
+            if not passed:
+                failures += 1
+                print(f'{name}: exit={result.returncode}, sentinel={sentinel.exists()}, writes={writes}\n{output}')
+    print(f'{len(cases)} cases, {failures} failures')
+    return bool(failures)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -1671,9 +1671,11 @@ template <typename problem_t> void AMRSimulation<problem_t>::evolve()
 		amrex::ParallelDescriptor::Bcast(&force_checkpoint_flag, 1, amrex::ParallelDescriptor::IOProcessorNumber());
 		force_checkpoint_now = (force_checkpoint_flag == 1);
 
-		if (force_checkpoint_now && last_chk_file_step != step + 1) {
-			last_chk_file_step = step + 1;
-			WriteCheckpointFile();
+		if (force_checkpoint_now) {
+			if (last_chk_file_step != step + 1) {
+				last_chk_file_step = step + 1;
+				WriteCheckpointFile();
+			}
 			if (amrex::ParallelDescriptor::IOProcessor()) {
 				std::error_code remove_ec;
 				if (!std::filesystem::remove(checkpoint_sentinel, remove_ec) && remove_ec) {


### PR DESCRIPTION
A checkpointNow request is now removed when a scheduled checkpoint has already satisfied it on the same timestep. Previously removal was inside the duplicate-write guard, so coincident requests remained on disk and could trigger later writes or survive the run. The change follows the neighboring outputNow handling: guard only the write, then consume the request on the I/O rank.

Closes #2212.

Adds CheckpointSentinelTest to HydroContact's CTest registration. Four real simulation scenarios cover step-scheduled output, time-scheduled output, an unscheduled request, and no request. Checks sentinel removal, exactly one step-1 write when requested, and the checkpoint Header file.

Validation:
- Before the fix, both scheduled-request scenarios left the sentinel behind; the other controls passed.
- Built native 1D HydroContact from this branch using a standalone harness with the existing checkout's matching AMReX, Microphysics, HDF5, and yaml-cpp dependencies; Python plotting support was disabled.
- `ctest --test-dir /private/tmp/quokka-checkpoint-harness/build --output-on-failure` — all four scenarios passed.
- `python3 src/problems/HydroContact/test_checkpoint_sentinel.py /private/tmp/quokka-checkpoint-harness/build/HydroContact inputs/HydroContact.toml mpirun --oversubscribe -np 2` — all four passed outside the macOS sandbox.
- `./scripts/bash/quokka-pre-commit.sh` and `git diff --check` — passed.

GPU execution and checkpoint restart/readback were not tested; the regression exercises actual simulation evolution and checkpoint writes.
