### PR TITLE
Av/issue 2218

### DIFF
--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1062,7 +1062,7 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 
 				if (nscalars_ > 0) {
 					for (int n = 0; n < nscalars_; ++n) {
-						if (rho == 0.0) {
+						if (rho <= 0.0) {
 							state[bx](i, j, k, scalar0_index + n) = 0.0;
 						} else {
 							state[bx](i, j, k, scalar0_index + n) *= rho_new / rho;

--- a/src/hydro/hydro_system.hpp
+++ b/src/hydro/hydro_system.hpp
@@ -1062,10 +1062,10 @@ void HydroSystem<problem_t>::EnforceLimits(amrex::Real const densityFloor, amrex
 
 				if (nscalars_ > 0) {
 					for (int n = 0; n < nscalars_; ++n) {
-						if (rho_new == 0.0) {
+						if (rho == 0.0) {
 							state[bx](i, j, k, scalar0_index + n) = 0.0;
 						} else {
-							state[bx](i, j, k, scalar0_index + n) *= rho / rho_new;
+							state[bx](i, j, k, scalar0_index + n) *= rho_new / rho;
 						}
 					}
 				}


### PR DESCRIPTION
### Description
Fix for issue 2218.

### Related issues
closes #2218 

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [ x] I have added a description (see above).
- [ x] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [ ] I have added tests for any new physics that this PR adds to the code.
- [ ] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected passive-scalar handling when a density floor is applied.
  - Scalars are now rescaled consistently for valid densities and safely set to zero when the original density is non-positive, improving simulation stability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->