### PR TITLE
Restrict hydro flattening output to active dimensions

### DIFF
--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2963,9 +2963,9 @@ auto QuokkaSimulation<problem_t>::computeHydroFluxes(amrex::MultiFab const &cons
 
 		// write flattening coefficients
 		amrex::Vector<std::string> flatCompNames{"chi"};
-		WriteSingleLevelPlotfileSimplified("debug_flattening_x", flatCoefs[0], flatCompNames, lev, 1);
-		WriteSingleLevelPlotfileSimplified("debug_flattening_y", flatCoefs[1], flatCompNames, lev, 1);
-		WriteSingleLevelPlotfileSimplified("debug_flattening_z", flatCoefs[2], flatCompNames, lev, 1);
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			WriteSingleLevelPlotfileSimplified("debug_flattening_" + quokka::face_dir_str[idim], flatCoefs[idim], flatCompNames, lev, 1);
+		}
 
 		// write L interface states
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {

--- a/src/problems/HydroContact/CMakeLists.txt
+++ b/src/problems/HydroContact/CMakeLists.txt
@@ -1,1 +1,6 @@
 quokka_add_problem(JOB_NAME HydroContact)
+
+find_package(Python COMPONENTS Interpreter REQUIRED)
+add_test(NAME HydroDebugOutputTest
+    COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_hydro_debug.py
+            $<TARGET_FILE:HydroContact> ${PROJECT_SOURCE_DIR}/inputs/HydroContact.toml ${AMReX_SPACEDIM})

--- a/src/problems/HydroContact/test_hydro_debug.py
+++ b/src/problems/HydroContact/test_hydro_debug.py
@@ -1,0 +1,48 @@
+"""Run hydro with debug output and inspect every active-axis flattening plotfile."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    executable = str(Path(sys.argv[1]).resolve())
+    inputs = str(Path(sys.argv[2]).resolve())
+    dimensions = int(sys.argv[3])
+    with tempfile.TemporaryDirectory(prefix="quokka-hydro-debug-") as directory:
+        result = subprocess.run(
+            sys.argv[4:]
+            + [
+                executable,
+                inputs,
+                "max_timesteps=1",
+                "amr.n_cell=8 8 8",
+                "hydro.low_level_debugging_output=1",
+                "plotfile_interval=-1",
+                "checkpoint_interval=-1",
+                "suppress_output=1",
+            ],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        for axis_index, axis in enumerate("xyz"):
+            outputs = list(Path(directory).glob(f"debug_flattening_{axis}*"))
+            if axis_index >= dimensions:
+                assert not outputs, f"Unexpected inactive-axis output: {outputs}"
+                continue
+            assert outputs, f"Missing {axis}-axis flattening output"
+            for output in outputs:
+                header = (output / "Header").read_text().splitlines()
+                assert header[1:4] == ["1", "chi", str(dimensions)], header[:4]
+                assert (output / "Level_0" / "Cell_H").is_file(), output
+                assert any((output / "Level_0").glob("Cell_D_*")), output
+        print(f"Validated {dimensions}D hydro debug flattening plotfiles")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
With `hydro.low_level_debugging_output=1`, 1D and 2D runs pass undefined flattening MultiFabs to the plotfile writer. Limit these writes to active dimensions, using the existing axis names. The native 1D release reproduction produced spurious y-axis plotfiles; it did not crash.

Add `HydroDebugOutputTest`, which runs HydroContact for one step with debugging enabled and checks that each active axis produces a one-component `chi` plotfile with the correct dimension and data files, while inactive axes produce no output.

Validation:
- The regression failed on the original 1D implementation because it produced inactive-axis output.
- Native CTest runs passed in 1D, 2D, and 3D, using real HydroContact sources and AMReX in temporary harness builds.
- The same regression passed with `mpirun --oversubscribe -np 2` in 3D.
- `git diff --check` and the required post-commit `quokka-pre-commit.sh` hooks passed.

GPU execution was not tested. The test checks output structure, not numerical flattening accuracy.

Closes #2223.
