### PR TITLE
Validate particle splits and conserve CICRad luminosity

### DIFF
--- a/docs/markdown/particles.md
+++ b/docs/markdown/particles.md
@@ -7,6 +7,12 @@
 
 All particle features can only be activated when compiled with `-DAMReX_SPACEDIM=3`.
 
+## Refined-restart particle splitting
+
+When a restart increases the root-grid resolution, CIC and CICRad particles split by default into `refinement_factor^3` children per parent. Set `particles.split_particles_on_restart_refine = 0` to retain the original particles. Other particle types do not opt into this restart policy.
+
+Splitting conserves total mass and momentum. CICRad luminosity is also extensive: each radiation group's luminosity is divided equally among the children. Positions and birth/death times are copied unchanged. Children receive random velocity kicks with the mean kick removed to conserve momentum; the current kick calculation requires CGS units. The splitting routine rejects nonpositive factors.
+
 ## Sink Particle Type
 
 Sink particles carry the following real-valued attributes:

--- a/inputs/ParticleSplit.toml
+++ b/inputs/ParticleSplit.toml
@@ -1,0 +1,11 @@
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+quokka.bc = ["periodic", "periodic", "periodic"]
+amr.n_cell = [8, 8, 8]
+amr.max_level = 0
+amr.blocking_factor = 8
+max_timesteps = 0
+plotfile_interval = -1
+checkpoint_interval = -1
+suppress_output = 1
+do_subcycle = 0

--- a/src/particles/PhysicsParticles.hpp
+++ b/src/particles/PhysicsParticles.hpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -514,6 +515,7 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 
 	void splitParticles(int const lev, int const splitFactor) override
 	{
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(splitFactor > 0, "splitParticles requires splitFactor > 0");
 		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(Physics_Traits<problem_t>::unit_system == UnitSystem::CGS,
 						 "The current implementation of velocity kick in particle splitting assumes cgs units."
 						 "Please implement the appropriate scaling for other unit systems.");
@@ -522,8 +524,14 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 			for (typename ContainerType::ParIterType pIter(*container_, lev); pIter.isValid(); ++pIter) {
 				// Update NextID to include particles that will be created
 				const amrex::Long npart_old = pIter.numParticles();
-				const unsigned int max_new_particles = splitFactor * npart_old;
+				// Check the total tile size before multiplying, then retain the full particle-count width.
+				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(npart_old <=
+								     std::numeric_limits<amrex::Long>::max() / (static_cast<amrex::Long>(splitFactor) + 1),
+								 "splitParticles particle count overflow");
+				const amrex::Long max_new_particles = static_cast<amrex::Long>(splitFactor) * npart_old;
 				const amrex::Long pid = ContainerType::ParticleType::NextID();
+				AMREX_ALWAYS_ASSERT_WITH_MESSAGE(max_new_particles <= amrex::LongParticleIds::LastParticleID - pid,
+								 "splitParticles particle ID overflow");
 				ContainerType::ParticleType::NextID(pid + max_new_particles);
 
 				// Resize particle tile
@@ -569,6 +577,13 @@ template <typename ContainerType, typename problem_t, ParticleType particleType>
 						p_new.cpu() = cpu_id;
 						p_new.id() = pid + idx * splitFactor + idx_new;
 						p_new.rdata(mass_idx) = old_mass / static_cast<amrex::Real>(splitFactor);
+						if constexpr (particleType_ == ParticleType::CICRad) {
+							// CICRad stores extensive luminosities after its mass, velocity, and activation times.
+							// Divide every group among children; positions and activation times remain intensive.
+							for (int comp = CICRadParticleLumIdx; comp < ContainerType::ParticleType::NReal; ++comp) {
+								p_new.rdata(comp) /= static_cast<amrex::Real>(splitFactor);
+							}
+						}
 
 						if (has_velocity_components) {
 							// Sample a velocity kick uniformly in the volume of a sphere in velocity space.

--- a/src/problems/ParticleSplit/CMakeLists.txt
+++ b/src/problems/ParticleSplit/CMakeLists.txt
@@ -1,0 +1,6 @@
+if(AMReX_SPACEDIM EQUAL 3)
+  quokka_add_problem(JOB_NAME ParticleSplit ADD_TEST OFF)
+  find_package(Python COMPONENTS Interpreter REQUIRED)
+  add_test(NAME ParticleSplitTest COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_particle_split.py
+    $<TARGET_FILE:ParticleSplit> ${PROJECT_SOURCE_DIR}/inputs/ParticleSplit.toml)
+endif()

--- a/src/problems/ParticleSplit/testParticleSplit.cpp
+++ b/src/problems/ParticleSplit/testParticleSplit.cpp
@@ -1,0 +1,106 @@
+#include "QuokkaSimulation.hpp"
+
+struct SplitProblem {};
+
+template <> struct Physics_Traits<SplitProblem> : DefaultPhysicsTraits {
+	static constexpr UnitSystem unit_system = UnitSystem::CGS;
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr int nGroups = 3;
+};
+
+template <> struct RadSystem_Traits<SplitProblem> {
+	static constexpr double c_hat_over_c = 1.0;
+	static constexpr double Erad_floor = 0.0;
+	static constexpr double energy_unit = C::ev2erg;
+	static constexpr amrex::GpuArray<double, 4> radBoundaries{1.0, 2.0, 3.0, 4.0};
+	static constexpr double beta_order = 1;
+	static constexpr OpacityModel opacity_model = OpacityModel::piecewise_constant_opacity;
+};
+
+template <> struct Particle_Traits<SplitProblem> : DefaultParticleTraits {
+	static constexpr ParticleSwitch particle_switch = ParticleSwitch::CIC | ParticleSwitch::CICRad;
+};
+
+template <> void QuokkaSimulation<SplitProblem>::setInitialConditionsOnGrid(quokka::grid const &grid_elem)
+{
+	const auto state = grid_elem.array_;
+	amrex::ParallelFor(grid_elem.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < Physics_Indices<SplitProblem>::nvarTotal_cc; ++n) {
+			state(i, j, k, n) = 0.0;
+		}
+		state(i, j, k, HydroSystem<SplitProblem>::density_index) = 1.0;
+		state(i, j, k, HydroSystem<SplitProblem>::energy_index) = 1.0;
+		state(i, j, k, HydroSystem<SplitProblem>::internalEnergy_index) = 1.0;
+	});
+}
+
+template <> void QuokkaSimulation<SplitProblem>::createInitialCICParticles()
+{
+	CICParticles->InitFromAsciiFile("cic.txt", quokka::CICParticleRealComps, nullptr);
+}
+
+template <> void QuokkaSimulation<SplitProblem>::createInitialCICRadParticles()
+{
+	CICRadParticles->InitFromAsciiFile("cicrad.txt", quokka::CICRadParticleRealComps<SplitProblem>, nullptr);
+}
+
+auto problem_main() -> int
+{
+	QuokkaSimulation<SplitProblem> sim;
+	sim.setInitialConditions();
+	amrex::ParmParse pp("split_test");
+	int split_factor = 1;
+	if (pp.query("factor", split_factor)) {
+		sim.GetParticleRegister().getParticleDescriptor(quokka::ParticleType::CICRad)->splitParticles(0, split_factor);
+	}
+	int expected_count = 1;
+	pp.query("expected_count", expected_count);
+	for (const auto type : {quokka::ParticleType::CIC, quokka::ParticleType::CICRad}) {
+		auto *descriptor = sim.GetParticleRegister().getParticleDescriptor(type);
+		const int count = type == quokka::ParticleType::CIC && pp.contains("factor") ? 1 : expected_count;
+		AMREX_ALWAYS_ASSERT(descriptor->getNumParticles() == count);
+		AMREX_ALWAYS_ASSERT(std::abs(descriptor->computeStellarMass() - 8.0) < 1.e-12);
+		const auto [reals, ints] = descriptor->getParticleDataAtLevel(0);
+		if (amrex::ParallelDescriptor::IOProcessor()) {
+			amrex::GpuArray<double, 3> momentum{};
+			for (const auto &particle : reals) {
+				AMREX_ALWAYS_ASSERT(std::abs(particle[3] * count - 8.0) < 1.e-12);
+				for (int d = 0; d < 3; ++d) {
+					momentum[d] += particle[3] * particle[4 + d];
+				}
+				for (int d = 0; d < 3; ++d) {
+					AMREX_ALWAYS_ASSERT(particle[d] == 0.5);
+				}
+				if (type == quokka::ParticleType::CICRad) {
+					AMREX_ALWAYS_ASSERT(particle[3 + quokka::CICRadParticleBirthTimeIdx] == 2.0);
+					AMREX_ALWAYS_ASSERT(particle[3 + quokka::CICRadParticleDeathTimeIdx] == 10.0);
+					for (int group = 0; group < 3; ++group) {
+						const auto luminosity = particle[3 + quokka::CICRadParticleLumIdx + group];
+						AMREX_ALWAYS_ASSERT(std::abs(luminosity * count - 8.0 * (group + 1)) < 1.e-12);
+					}
+				}
+			}
+			for (const auto value : momentum) {
+				AMREX_ALWAYS_ASSERT(std::abs(value) < 1.e-12);
+			}
+		}
+		if (type == quokka::ParticleType::CICRad) {
+			// Cover the full deposition stencil when particles lie on MPI box boundaries.
+			constexpr int deposition_ghosts = amrex::ParticleInterpolator::WendlandC2<>::stencil_width / 2;
+			amrex::MultiFab radiation(sim.boxArray(0), sim.DistributionMap(0), 3, deposition_ghosts);
+			for (const double time : {1.0, 3.0, 10.0}) {
+				radiation.setVal(0.0);
+				descriptor->depositRadiation(radiation, 0, time, 3);
+				const auto dx = sim.Geom(0).CellSizeArray();
+				for (int group = 0; group < 3; ++group) {
+					const double luminosity = radiation.sum(group) * dx[0] * dx[1] * dx[2];
+					const double expected = (time < 2.0 || time >= 10.0) ? 0.0 : 8.0 * (group + 1);
+					AMREX_ALWAYS_ASSERT(std::abs(luminosity - expected) < 1.e-12);
+				}
+			}
+		}
+	}
+	sim.WriteCheckpointFile();
+	amrex::Print() << "Particle split checks passed\n";
+	return 0;
+}

--- a/src/problems/ParticleSplit/test_particle_split.py
+++ b/src/problems/ParticleSplit/test_particle_split.py
@@ -1,0 +1,62 @@
+"""Check splitting through real checkpoints, plus direct factor validation."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    executable = str(Path(sys.argv[1]).resolve())
+    inputs = str(Path(sys.argv[2]).resolve())
+    failures = []
+    with tempfile.TemporaryDirectory(prefix="quokka-particle-split-") as temporary:
+        root = Path(temporary)
+
+        def run(name, arguments, rejected=False):
+            directory = root / name
+            directory.mkdir()
+            (directory / "cic.txt").write_text("1\n0.5 0.5 0.5 8 0 0 0\n")
+            (directory / "cicrad.txt").write_text(
+                "1\n0.5 0.5 0.5 8 0 0 0 2 10 8 16 24\n"
+            )
+            result = subprocess.run(
+                sys.argv[3:] + [executable, inputs] + arguments,
+                cwd=directory,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+            output = result.stdout + result.stderr
+            if rejected:
+                passed = result.returncode != 0 and "splitParticles requires splitFactor > 0" in output
+            else:
+                passed = result.returncode == 0 and "Particle split checks passed" in output
+                if name.startswith("restart_"):
+                    passed = passed and "Restart from checkpoint" in output
+                if name == "restart_refined":
+                    passed = passed and "Splitting CICRad_particles using split_factor = 8" in output
+            if not passed:
+                failures.append(f"{name}:\n{output}")
+            print(f"{name}: {'PASS' if passed else 'FAIL'}", flush=True)
+            return directory
+
+        seed = run("seed", [])
+        checkpoint = seed / "chk0000000"
+        assert (checkpoint / "Header").is_file(), "Missing seed checkpoint"
+        restart = [f"restartfile={checkpoint}"]
+        run("restart_unchanged", restart)
+        run("restart_refined", restart + ["amr.n_cell=16 16 16", "split_test.expected_count=8"])
+        run("restart_refined_no_split", restart + ["amr.n_cell=16 16 16", "particles.split_particles_on_restart_refine=0"])
+        run("factor_one", ["split_test.factor=1"])
+        run("factor_three", ["split_test.factor=3", "split_test.expected_count=3"])
+        run("factor_zero", ["split_test.factor=0"], rejected=True)
+        # Test negatives only once zero is rejected, avoiding an invalid huge allocation on the old implementation.
+        if not any(failure.startswith("factor_zero:") for failure in failures):
+            run("factor_negative", ["split_test.factor=-1"], rejected=True)
+        assert not failures, "\n".join(failures)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refining a checkpoint by a factor of two creates eight CICRad children per parent but previously copied the parent's full luminosity to every child. Divide all CICRad luminosity groups among the children, preserving total mass and luminosity. Positions, activation times, and the existing momentum-conserving velocity treatment are retained.

Reject nonpositive split factors before touching particles. Use full-width particle counts and check tile-size and ID arithmetic before allocation instead of narrowing the child count to `unsigned int`. Document the refined-restart splitting policy.

Add `ParticleSplitTest`, a native 3D problem plus subprocess driver. It creates CIC and three-group CICRad particles, writes an actual checkpoint, and exercises ordinary restart, factor-two refined restart, and splitting-disabled restart. It checks counts, mass, momentum, positions, activation times, per-child luminosities, and integrated mesh deposition before activation, while active, and at death. Direct factors 1 and 3 and rejected factors 0 and -1 complete eight scenarios.

Validation:
- On the original implementation, the corrected regression reached actual eight-way restart splitting and failed the luminosity check; direct factor 3 also failed luminosity conservation, and factor 0 deleted the particle.
- `ctest --test-dir /private/tmp/quokka-particle-split-harness/build --output-on-failure` passed all scenarios using actual Quokka/AMReX sources in a temporary native build.
- `python3 src/problems/ParticleSplit/test_particle_split.py /private/tmp/quokka-particle-split-harness/build/ParticleSplit inputs/ParticleSplit.toml mpirun --oversubscribe -np 2` passed all scenarios.
- `git diff --check` and the required post-commit `quokka-pre-commit.sh` hooks passed.

GPU execution and radiation transport evolution were not tested; the test directly verifies radiation deposition following the real simulation restart path. Extreme allocation sizes were not exercised.

Closes #1689.
Closes #2213.
