### PR TITLE
Correct example boundary records and geometry access

### DIFF
--- a/src/problems/HydroShuOsher/testHydroShuOsher.cpp
+++ b/src/problems/HydroShuOsher/testHydroShuOsher.cpp
@@ -274,8 +274,8 @@ auto problem_main() -> int
 	const int ncomp_cc = Physics_Indices<ShocktubeProblem>::nvarTotal_cc;
 	amrex::Vector<amrex::BCRec> BCs_cc(ncomp_cc);
 	for (int n = 0; n < ncomp_cc; ++n) {
-		BCs_cc[0].setLo(0, amrex::BCType::foextrap); // Dirichlet
-		BCs_cc[0].setHi(0, amrex::BCType::ext_dir);
+		BCs_cc[n].setLo(0, amrex::BCType::foextrap); // outflow
+		BCs_cc[n].setHi(0, amrex::BCType::ext_dir);
 		for (int i = 1; i < AMREX_SPACEDIM; ++i) {
 			BCs_cc[n].setLo(i, amrex::BCType::int_dir); // periodic
 			BCs_cc[n].setHi(i, amrex::BCType::int_dir);

--- a/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
+++ b/src/problems/HydrostaticAtmosphere/testHydrostaticAtmosphere.cpp
@@ -46,10 +46,10 @@ AMRSimulation<HydrostaticAtmosphereProblem>::setCustomBoundaryConditions(const a
 {
 	auto [i, j, k] = iv.dim3();
 
-	amrex::Real const *dx = geom.CellSize();
-	amrex::Real const *prob_lo = geom.ProbLo();
+	amrex::Real const dx = geom.CellSize(0);
+	amrex::Real const prob_lo = geom.ProbLo(0);
 
-	amrex::Real const x = prob_lo[0] + (static_cast<amrex::Real>(i) + 0.5) * dx[0]; // NOLINT(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+	amrex::Real const x = prob_lo + (static_cast<amrex::Real>(i) + 0.5) * dx;
 	amrex::Real const rho_atm = g_base_density_floor * std::exp(-x / g_scale_height);
 	amrex::Real const rho_init = kRhoInitFactor * rho_atm;
 	amrex::Real const Eint_init = quokka::EOS<HydrostaticAtmosphereProblem>::ComputeEintFromTgas(rho_init, kTgasInit);


### PR DESCRIPTION
Shu–Osher initializes x-boundary records on component zero repeatedly, leaving the remaining conserved components without the intended records. Set `BCs_cc[n]` inside the component loop and correct the outflow comment.

In the hydrostatic atmosphere boundary callback, use scalar `GeometryData::CellSize(0)` and `ProbLo(0)` accessors instead of obtaining raw pointers and indexing them.

The premise of #1851 needs qualification: the vendored AMReX `GeometryData` owns its arrays and is explicitly GPU-safe. Its pointer accessors run inside the device callback; this is not a demonstrated capture of host geometry pointers. The issue's proposed `CellSizeArray()`/`ProbLoArray()` methods are unavailable on this type. Scalar accessors remove the raw-pointer pattern without changing the required callback interface or numerical expression.

Validation: the existing `HydroShuOsher` and `HydrostaticAtmosphere` CTests passed before and after the patch in native 1D temporary harness builds using actual Quokka/AMReX sources. Shu–Osher ran its full reference-solution comparison. These tests did not reproduce a numerical failure before the change. GPU execution was not tested.

Commands:
- `ctest --test-dir /private/tmp/quokka-bc-harness-HydroShuOsher/build --output-on-failure`
- `ctest --test-dir /private/tmp/quokka-bc-harness-HydrostaticAtmosphere/build --output-on-failure`
- `git diff --check`
- Required post-commit `quokka-pre-commit.sh` hooks: passed.

Closes #1850.
Closes #1851.
