### PR TITLE
Restore metadata floating-point state on exceptions

### DIFF
--- a/src/problems/MetadataFEnv/CMakeLists.txt
+++ b/src/problems/MetadataFEnv/CMakeLists.txt
@@ -1,0 +1,4 @@
+quokka_add_problem(JOB_NAME MetadataFEnv ADD_TEST OFF)
+find_package(Python COMPONENTS Interpreter REQUIRED)
+add_test(NAME MetadataFEnvTest COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_metadata_fenv.py
+  $<TARGET_FILE:MetadataFEnv> ${PROJECT_SOURCE_DIR}/inputs/HydroContact.toml)

--- a/src/problems/MetadataFEnv/testMetadataFEnv.cpp
+++ b/src/problems/MetadataFEnv/testMetadataFEnv.cpp
@@ -1,0 +1,45 @@
+#include "QuokkaSimulation.hpp"
+#include <cfenv>
+
+struct MetadataProblem {};
+template <> struct Physics_Traits<MetadataProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+};
+
+auto problem_main() -> int
+{
+	QuokkaSimulation<MetadataProblem> sim;
+	amrex::ParmParse pp("metadata_test");
+	std::string directory;
+	bool expect_exception = false;
+	pp.get("directory", directory);
+	pp.get("expect_exception", expect_exception);
+
+	// Hold the caller's traps before raising a sticky exception for the restoration check.
+	std::fenv_t original{};
+	AMREX_ALWAYS_ASSERT(std::feholdexcept(&original) == 0);
+	AMREX_ALWAYS_ASSERT(std::fesetround(FE_DOWNWARD) == 0);
+	AMREX_ALWAYS_ASSERT(std::feraiseexcept(FE_DIVBYZERO) == 0);
+	amrex::setFPExcept(amrex::FPExcept::invalid);
+	const auto traps_before = amrex::getFPExcept();
+	const int flags_before = std::fetestexcept(FE_ALL_EXCEPT);
+	const int rounding_before = std::fegetround();
+	bool caught = false;
+	try {
+		sim.ReadMetadataFile(directory);
+	} catch (const YAML::Exception &) {
+		caught = true;
+	}
+	const auto traps_after = amrex::getFPExcept();
+	const int flags_after = std::fetestexcept(FE_ALL_EXCEPT);
+	const int rounding_after = std::fegetround();
+	AMREX_ALWAYS_ASSERT(std::fesetenv(&original) == 0);
+
+	const bool restored = traps_before == traps_after && flags_before == flags_after && rounding_before == rounding_after;
+	amrex::Print() << "Metadata exception expected/caught: " << expect_exception << '/' << caught << "; floating-point environment restored: " << restored
+		       << '\n';
+#if !(defined(__linux__) && defined(__GLIBC__))
+	amrex::Print() << "Trap-mask controls unavailable on this platform; checked exception flags and rounding mode.\n";
+#endif
+	return caught == expect_exception && restored ? 0 : 1;
+}

--- a/src/problems/MetadataFEnv/test_metadata_fenv.py
+++ b/src/problems/MetadataFEnv/test_metadata_fenv.py
@@ -1,0 +1,38 @@
+"""Check real metadata reads on normal and YAML exception paths."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    executable = str(Path(sys.argv[1]).resolve())
+    inputs = str(Path(sys.argv[2]).resolve())
+    cases = {
+        "valid": "number: 1.25\nstring: hello\nsequence: [1, 2]\nmap: {a: 1}\n",
+        "missing": None,
+        "malformed": "value: [\n",
+        "conversion": "? [a, b]\n: value\n",
+    }
+    failures = []
+    with tempfile.TemporaryDirectory(prefix="quokka-metadata-fenv-") as root:
+        for name, contents in cases.items():
+            directory = Path(root) / name
+            directory.mkdir()
+            if contents is not None:
+                (directory / "metadata.yaml").write_text(contents)
+            result = subprocess.run(
+                sys.argv[3:]
+                + [executable, inputs, f"metadata_test.directory={directory}",
+                   f"metadata_test.expect_exception={int(name != 'valid')}", "suppress_output=1"],
+                cwd=directory, capture_output=True, text=True, timeout=60, check=False,
+            )
+            print(f"{name}: {'PASS' if result.returncode == 0 else 'FAIL'}", flush=True)
+            if result.returncode != 0:
+                failures.append(result.stdout + result.stderr)
+    assert not failures, "\n".join(failures)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -4510,8 +4510,20 @@ template <typename problem_t> void AMRSimulation<problem_t>::WriteMetadataFile(s
 
 template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(std::string const &chkfilename)
 {
-	fenv_t orig_feenv;
-	feholdexcept(&orig_feenv); // disable FPE for YAML reading
+	struct ScopedFEnvHold {
+		std::fenv_t environment{};
+		ScopedFEnvHold()
+		{
+			AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::feholdexcept(&environment) == 0,
+							 "Could not hold floating-point environment for metadata reading");
+		}
+		~ScopedFEnvHold() { std::fesetenv(&environment); }
+		ScopedFEnvHold(const ScopedFEnvHold &) = delete;
+		auto operator=(const ScopedFEnvHold &) -> ScopedFEnvHold & = delete;
+		ScopedFEnvHold(ScopedFEnvHold &&) = delete;
+		auto operator=(ScopedFEnvHold &&) -> ScopedFEnvHold & = delete;
+	};
+	const ScopedFEnvHold environment_hold{}; // Disable FPE for YAML reading; restore on normal and exceptional exits.
 
 	// read metadata file in on all ranks (needed when restarting from checkpoint)
 	const std::string MetadataFileName(chkfilename + "/metadata.yaml");
@@ -4537,8 +4549,6 @@ template <typename problem_t> void AMRSimulation<problem_t>::ReadMetadataFile(st
 			amrex::Print() << std::format("\t{} = (complex type)\n", key);
 		}
 	}
-
-	fesetenv(&orig_feenv); // restore FPE
 }
 
 template <typename problem_t> void AMRSimulation<problem_t>::WriteStatisticsFile()


### PR DESCRIPTION
`ReadMetadataFile` temporarily holds floating-point exceptions while parsing YAML, but exceptions from file loading or conversion bypass its explicit restoration. Use a noncopyable scope guard to restore the saved environment on both normal return and stack unwinding. Fail explicitly if holding the environment is unsupported instead of later restoring an invalid snapshot.

Add `MetadataFEnvTest`, which calls the actual simulation method for a valid mapping, missing file, malformed YAML, and an unconvertible mapping key. The test seeds an exception flag and nondefault rounding mode, verifies the expected YAML exception, and checks that the saved environment survives. It also checks the trap mask through AMReX on Linux/glibc.

Validation:
- Original code passed the valid mapping and failed environment restoration on all three exception paths.
- Fixed code passed all four cases with `ctest --test-dir /private/tmp/quokka-metadata-fenv-harness/build --output-on-failure`, using a native 1D build of the actual simulation and yaml-cpp code.
- `git diff --check` and required post-commit `quokka-pre-commit.sh` hooks passed.

The macOS run validates exception flags and rounding mode; AMReX does not provide trap-mask controls on this platform, so Linux/glibc trap-mask validation remains unrun locally. No GPU execution or full checkpoint-restart simulation was run.

Closes #1684.
