### PR TITLE
Scope 2D writer byte counts to each output stream

### DIFF
--- a/src/io/DiagFramePlane.cpp
+++ b/src/io/DiagFramePlane.cpp
@@ -353,8 +353,6 @@ void DiagFramePlane::VisMF2D(const amrex::MultiFab &a_mf, const std::string &a_m
 	auto whichRD = amrex::FArrayBox::getDataDescriptor();
 	bool const doConvert(*whichRD != amrex::FPC::NativeRealDescriptor());
 
-	amrex::Long bytesWritten(0);
-
 	std::string const filePrefix(a_mf_name + "_D_");
 
 	bool const calcMinMax = false;
@@ -389,6 +387,7 @@ void DiagFramePlane::VisMF2D(const amrex::MultiFab &a_mf, const std::string &a_m
 		nfi.SetDynamic();
 	}
 	for (; nfi.ReadyToWrite(); ++nfi) {
+		amrex::Long bytesWritten(0);
 		int const whichRDBytes(whichRD->numBytes());
 		int nFABs(0);
 		amrex::Long writeDataItems(0);

--- a/src/io/projection.cpp
+++ b/src/io/projection.cpp
@@ -187,8 +187,6 @@ void VisMF2D(const amrex::MultiFab &a_mf, const std::string &a_mf_name)
 	auto whichRD = amrex::FArrayBox::getDataDescriptor();
 	bool const doConvert(*whichRD != amrex::FPC::NativeRealDescriptor());
 
-	amrex::Long bytesWritten(0);
-
 	std::string const filePrefix(a_mf_name + "_D_");
 
 	bool const calcMinMax = false;
@@ -223,6 +221,7 @@ void VisMF2D(const amrex::MultiFab &a_mf, const std::string &a_mf_name)
 		nfi.SetDynamic();
 	}
 	for (; nfi.ReadyToWrite(); ++nfi) {
+		amrex::Long bytesWritten(0);
 		int const whichRDBytes(whichRD->numBytes());
 		int nFABs(0);
 		amrex::Long writeDataItems(0);


### PR DESCRIPTION
Move `bytesWritten` into the `NFilesIter` write loop in both custom 2D VisMF writers, so each output stream owns its counter.

The runtime premise of #1862 needs qualification: the vendored AMReX iterator sets `finishedWriting` when a rank advances after writing, including static, sparse, dynamic, and non-MPI paths. I did not establish a reachable repeated-write iteration per rank, so this is a scope cleanup rather than a reproduced output-corruption fix.

Validation: a temporary native 3D harness called both actual `VisMF2D` implementations with four boxes and two components on two MPI ranks, using both balanced ownership and a sparse layout with all boxes on rank zero. Before/after runs produced 10 byte-identical output files (7,822 bytes total). Command: `mpirun --oversubscribe -np 2 /private/tmp/quokka-vismf-harness/build/VisMFSmoke` in separate output directories. GPU execution and more than two ranks were not tested.

`git diff --check` and the required post-commit `quokka-pre-commit.sh` hooks passed.

Closes #1862.
