### PR TITLE
Pack face boundary records by direction during regrids

### DIFF
--- a/inputs/FaceBCPacking.toml
+++ b/inputs/FaceBCPacking.toml
@@ -1,0 +1,10 @@
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+geometry.is_periodic = [0, 0, 0]
+amr.n_cell = [8, 8, 8]
+amr.max_level = 1
+amr.blocking_factor = 8
+do_subcycle = 0
+do_reflux = 0
+plotfile_interval = -1
+checkpoint_interval = -1

--- a/src/problems/FaceBCPacking/CMakeLists.txt
+++ b/src/problems/FaceBCPacking/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(AMReX_SPACEDIM EQUAL 3)
+  quokka_add_problem(JOB_NAME FaceBCPacking)
+endif()

--- a/src/problems/FaceBCPacking/testFaceBCPacking.cpp
+++ b/src/problems/FaceBCPacking/testFaceBCPacking.cpp
@@ -1,0 +1,108 @@
+#include "QuokkaSimulation.hpp"
+
+struct FaceProblem {};
+template <> struct Physics_Traits<FaceProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
+};
+
+template <> void QuokkaSimulation<FaceProblem>::setInitialConditionsOnGrid(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < Physics_Indices<FaceProblem>::nvarTotal_cc; ++n) {
+			a(i, j, k, n) = 0.0;
+		}
+		a(i, j, k, HydroSystem<FaceProblem>::density_index) = 1.0;
+		a(i, j, k, HydroSystem<FaceProblem>::energy_index) = 100.0;
+		a(i, j, k, HydroSystem<FaceProblem>::internalEnergy_index) = 100.0;
+	});
+}
+
+template <> void QuokkaSimulation<FaceProblem>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	const int axis = static_cast<int>(grid.dir_);
+	const auto dx = grid.dx_;
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) { a(i, j, k, 0) = axis == 2 ? 3.0 + (i + 0.5) * dx[0] : axis + 1.0; });
+}
+
+class FaceSimulation : public QuokkaSimulation<FaceProblem>
+{
+      public:
+	using QuokkaSimulation<FaceProblem>::QuokkaSimulation;
+	auto check(bool remake) -> int
+	{
+		amrex::BoxArray ba(Geom(1).Domain());
+		if (remake) {
+			ba.maxSize(8);
+		}
+		const amrex::DistributionMapping dm(ba);
+		if (remake) {
+			RemakeLevel(1, 0.0, ba, dm);
+		} else {
+			MakeNewLevelFromCoarse(1, 0.0, ba, dm);
+		}
+		SetBoxArray(1, ba);
+		SetDistributionMap(1, dm);
+		SetFinestLevel(1);
+		int errors = 0;
+		for (int axis = 0; axis < 3; ++axis) {
+			for (int old = 0; old < 2; ++old) {
+				auto &mf = old ? state_old_fc_[1][axis] : state_new_fc_[1][axis];
+				amrex::Gpu::DeviceScalar<int> failed(0);
+				auto *error = failed.dataPtr();
+				for (amrex::MFIter it(mf); it.isValid(); ++it) {
+					const auto a = mf.const_array(it);
+					// Interior transverse indices avoid edge/corner boundary conventions.
+					amrex::ParallelFor(2, [=] AMREX_GPU_DEVICE(int side) {
+						const int i = side == 0 ? -2 : 17;
+						if (a.contains(i, 3, 3)) {
+							const int interior = axis == 0 ? (side == 0 ? 0 : 16) : (side == 0 ? 1 : 14);
+							const double expected = (axis == 1 ? -1.0 : 1.0) * a(interior, 3, 3, 0);
+							if (!std::isfinite(expected) || !std::isfinite(a(i, 3, 3, 0)) ||
+							    std::abs(a(i, 3, 3, 0) - expected) > 1.e-12) {
+								amrex::Gpu::Atomic::Add(error, 1);
+							}
+						}
+					});
+				}
+				const int count = failed.dataValue();
+				errors += count;
+				if (count) {
+					amrex::Print() << "Face BC mismatch: remake=" << remake << " axis=" << axis << " old=" << old << '\n';
+				}
+			}
+		}
+		amrex::ParallelDescriptor::ReduceIntSum(errors);
+		return errors;
+	}
+};
+
+auto problem_main() -> int
+{
+	constexpr int nc = Physics_Indices<FaceProblem>::nvarTotal_cc;
+	amrex::Vector<amrex::BCRec> cc(nc), fc(3);
+	for (auto &bc : cc) {
+		for (int d = 0; d < 3; ++d) {
+			bc.setLo(d, amrex::BCType::foextrap);
+			bc.setHi(d, amrex::BCType::foextrap);
+		}
+	}
+	for (auto &bc : fc) {
+		for (int d = 0; d < 3; ++d) {
+			bc.setLo(d, amrex::BCType::foextrap);
+			bc.setHi(d, amrex::BCType::foextrap);
+		}
+	}
+	fc[1].setLo(0, amrex::BCType::reflect_odd);
+	fc[1].setHi(0, amrex::BCType::reflect_odd);
+	fc[2].setLo(0, amrex::BCType::reflect_even);
+	fc[2].setHi(0, amrex::BCType::reflect_even);
+	FaceSimulation sim(cc, fc);
+	sim.setInitialConditions();
+	int errors = sim.check(false);
+	errors += sim.check(true);
+	return errors == 0 ? 0 : 1;
+}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2497,7 +2497,7 @@ void AMRSimulation<problem_t>::MakeNewLevelFromCoarse(int level, amrex::Real tim
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			new_mf_array[idim] = &state_new_fc_[level][idim];
 			old_mf_array[idim] = &state_old_fc_[level][idim];
-			BCs_array[idim] = BCs_fc_;
+			BCs_array[idim].assign(BCs_fc_.begin() + idim * ncomp_per_dim_fc, BCs_fc_.begin() + (idim + 1) * ncomp_per_dim_fc);
 		}
 		FillCoarsePatchFaceArray(level, time, new_mf_array, 0, ncomp_per_dim_fc, BCs_array);
 		FillCoarsePatchFaceArray(level, time, old_mf_array, 0, ncomp_per_dim_fc, BCs_array);
@@ -2546,7 +2546,7 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			int_state_new_fc[idim] = amrex::MultiFab(amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim)), dm, ncomp_per_dim_fc, nghost_fc);
 			int_state_old_fc[idim] = amrex::MultiFab(amrex::convert(ba, amrex::IntVect::TheDimensionVector(idim)), dm, ncomp_per_dim_fc, nghost_fc);
-			BCs_array[idim] = BCs_fc_;
+			BCs_array[idim].assign(BCs_fc_.begin() + idim * ncomp_per_dim_fc, BCs_fc_.begin() + (idim + 1) * ncomp_per_dim_fc);
 		}
 		amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> int_state_new_fc_ptr;
 		amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM> int_state_old_fc_ptr;


### PR DESCRIPTION
`MakeNewLevelFromCoarse` and `RemakeLevel` copy the full flattened face-boundary vector into every directional slot. As a result, all face fields receive the first direction's boundary records. Slice out exactly `ncomp_per_dim_fc` records for each direction before passing them to the face-array interpolation helper.

Add the native 3D `FaceBCPacking` regression. It gives Bx extrapolation, By odd reflection, and Bz even reflection at both x boundaries. After level creation and a decomposition-changing level remake, it checks both old and new face states against the discrete extrapolation/reflection contract, using the actual interior values produced by coarse interpolation.

Validation:
- The finalized regression fails on the original implementation for By and Bz in both old/new states after both creation and remake (eight failing groups); Bx controls pass.
- `ctest --test-dir /private/tmp/quokka-face-bc-harness/build --output-on-failure` passes with the fix in a native build using actual Quokka/AMReX sources.
- `mpirun --oversubscribe -np 2 /private/tmp/quokka-face-bc-harness/build/FaceBCPacking /private/tmp/quokka-audit-face-bc-packing/inputs/FaceBCPacking.toml suppress_output=1` passes.
- `git diff --check` and required post-commit `quokka-pre-commit.sh` hooks pass.

GPU execution and time-evolved MHD simulations were not tested. This touches the same remake block as #2241, which separately preserves overlapping fine face data; both changes should be retained when reconciling that code.

Closes #1678.
Closes #1680.
