### PR TITLE
Use face callbacks for single-face coarse fills

### DIFF
--- a/inputs/SingleFaceFill.toml
+++ b/inputs/SingleFaceFill.toml
@@ -1,0 +1,10 @@
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+geometry.is_periodic = [0, 0, 0]
+amr.n_cell = [8, 8, 8]
+amr.max_level = 1
+amr.blocking_factor = 8
+do_subcycle = 0
+do_reflux = 0
+plotfile_interval = -1
+checkpoint_interval = -1

--- a/src/problems/SingleFaceFill/CMakeLists.txt
+++ b/src/problems/SingleFaceFill/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(AMReX_SPACEDIM EQUAL 3)
+  quokka_add_problem(JOB_NAME SingleFaceFill)
+endif()

--- a/src/problems/SingleFaceFill/testSingleFaceFill.cpp
+++ b/src/problems/SingleFaceFill/testSingleFaceFill.cpp
@@ -1,0 +1,107 @@
+#include "QuokkaSimulation.hpp"
+
+struct SingleFaceProblem {};
+template <> struct Physics_Traits<SingleFaceProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr bool is_mhd_enabled = true;
+	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
+};
+
+template <> void QuokkaSimulation<SingleFaceProblem>::setInitialConditionsOnGrid(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < Physics_Indices<SingleFaceProblem>::nvarTotal_cc; ++n) {
+			a(i, j, k, n) = 0.0;
+		}
+		a(i, j, k, HydroSystem<SingleFaceProblem>::density_index) = 1.0;
+		a(i, j, k, HydroSystem<SingleFaceProblem>::energy_index) = 100.0;
+		a(i, j, k, HydroSystem<SingleFaceProblem>::internalEnergy_index) = 100.0;
+	});
+}
+
+template <> void QuokkaSimulation<SingleFaceProblem>::setInitialConditionsOnGridFaceVars(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	const int axis = static_cast<int>(grid.dir_);
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) { a(i, j, k, 0) = axis + 1.0; });
+}
+
+template <>
+template <quokka::direction dir>
+AMREX_GPU_DEVICE void AMRSimulation<SingleFaceProblem>::setCustomBoundaryConditionsFaceVar(const amrex::IntVect &iv, amrex::Array4<amrex::Real> const &dest,
+											   int dcomp, int numcomp, amrex::GeometryData const &geom,
+											   amrex::Real /*time*/, const amrex::BCRec * /*bcr*/, int /*bcomp*/,
+											   int /*orig_comp*/)
+{
+	constexpr int axis = static_cast<int>(dir);
+	const auto domain = amrex::convert(geom.Domain(), amrex::IntVect::TheDimensionVector(axis));
+	if (!domain.contains(iv)) {
+		for (int n = 0; n < numcomp; ++n) {
+			dest(iv, dcomp + n) = 100.0 + axis;
+		}
+	}
+}
+
+class SingleFaceSimulation : public QuokkaSimulation<SingleFaceProblem>
+{
+      public:
+	using QuokkaSimulation<SingleFaceProblem>::QuokkaSimulation;
+	auto check() -> int
+	{
+		int errors = 0;
+		for (int axis = 0; axis < 3; ++axis) {
+			const auto box = amrex::convert(Geom(1).Domain(), amrex::IntVect::TheDimensionVector(axis));
+			amrex::BoxArray ba(box);
+			const amrex::DistributionMapping dm(ba);
+			amrex::MultiFab mf(ba, dm, 3, 2);
+			mf.setVal(-999.0);
+			amrex::Vector<amrex::BCRec> bcs(1);
+			for (int d = 0; d < 3; ++d) {
+				bcs[0].setLo(d, amrex::BCType::ext_dir);
+				bcs[0].setHi(d, amrex::BCType::ext_dir);
+			}
+			FillCoarsePatch(1, 0.0, mf, 1, 1, bcs, quokka::centering::fc, static_cast<quokka::direction>(axis));
+			amrex::Gpu::DeviceScalar<int> failure(0);
+			auto *failed = failure.dataPtr();
+			for (amrex::MFIter it(mf); it.isValid(); ++it) {
+				const auto a = mf.const_array(it);
+				amrex::ParallelFor(3, [=] AMREX_GPU_DEVICE(int point) {
+					amrex::IntVect iv(4);
+					iv[axis] = point == 0 ? -1 : (point == 1 ? 17 : 4);
+					const double expected = point == 2 ? axis + 1.0 : 100.0 + axis;
+					if (a(iv, 0) != -999.0 || a(iv, 2) != -999.0 || !std::isfinite(a(iv, 1)) || std::abs(a(iv, 1) - expected) > 1.e-12) {
+						amrex::Gpu::Atomic::Add(failed, 1);
+					}
+				});
+			}
+			const int count = failure.dataValue();
+			errors += count;
+			if (count) {
+				amrex::Print() << "Single-face fill failed for axis " << axis << '\n';
+			}
+		}
+		amrex::ParallelDescriptor::ReduceIntSum(errors);
+		return errors;
+	}
+};
+
+auto problem_main() -> int
+{
+	amrex::Vector<amrex::BCRec> cc(Physics_Indices<SingleFaceProblem>::nvarTotal_cc), fc(3);
+	for (auto &bc : cc) {
+		for (int d = 0; d < 3; ++d) {
+			bc.setLo(d, amrex::BCType::foextrap);
+			bc.setHi(d, amrex::BCType::foextrap);
+		}
+	}
+	for (auto &bc : fc) {
+		for (int d = 0; d < 3; ++d) {
+			bc.setLo(d, amrex::BCType::ext_dir);
+			bc.setHi(d, amrex::BCType::ext_dir);
+		}
+	}
+	SingleFaceSimulation sim(cc, fc);
+	sim.setInitialConditions();
+	return sim.check() == 0 ? 0 : 1;
+}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -3381,6 +3381,10 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex:
 	BL_PROFILE("AMRSimulation::FillCoarsePatch()"); // NOLINT(misc-const-correctness)
 
 	AMREX_ASSERT(lev > 0);
+	if (cen == quokka::centering::fc) {
+		AMREX_ALWAYS_ASSERT_WITH_MESSAGE(static_cast<int>(dir) >= 0 && static_cast<int>(dir) < AMREX_SPACEDIM,
+						 "FillCoarsePatch requires a valid face direction");
+	}
 
 	amrex::Vector<amrex::MultiFab *> cmf;
 	amrex::Vector<amrex::Real> ctime;
@@ -3390,15 +3394,19 @@ void AMRSimulation<problem_t>::FillCoarsePatch(int lev, amrex::Real time, amrex:
 		amrex::Abort("FillCoarsePatch: how did this happen?");
 	}
 
-	amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>> boundaryFunctor(setBoundaryFunctor<problem_t>{});
-	amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>>> finePhysicalBoundaryFunctor(geom[lev], BCs, boundaryFunctor);
-	amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>>> coarsePhysicalBoundaryFunctor(geom[lev - 1], BCs, boundaryFunctor);
-
 	if (cen == quokka::centering::cc) {
+		amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>> boundaryFunctor(setBoundaryFunctor<problem_t>{});
+		amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>>> finePhysicalBoundaryFunctor(geom[lev], BCs, boundaryFunctor);
+		amrex::PhysBCFunct<amrex::GpuBndryFuncFab<setBoundaryFunctor<problem_t>>> coarsePhysicalBoundaryFunctor(geom[lev - 1], BCs, boundaryFunctor);
 		amrex::InterpFromCoarseLevel(mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev], coarsePhysicalBoundaryFunctor, 0,
 					     finePhysicalBoundaryFunctor, 0, refRatio(lev - 1), getAmrInterpolaterCellCentered(), BCs, 0);
 	} else if (cen == quokka::centering::fc) {
-		amrex::Interpolater *face_mapper = &amrex::face_divfree_interp;
+		using FaceBoundary = amrex::GpuBndryFuncFab<setBoundaryFunctorFaceVar<problem_t>>;
+		FaceBoundary boundaryFunctor(setBoundaryFunctorFaceVar<problem_t>{dir});
+		amrex::PhysBCFunct<FaceBoundary> finePhysicalBoundaryFunctor(geom[lev], BCs, boundaryFunctor);
+		amrex::PhysBCFunct<FaceBoundary> coarsePhysicalBoundaryFunctor(geom[lev - 1], BCs, boundaryFunctor);
+		// A single face field needs the generic face interpolator; divergence-free interpolation requires all directions.
+		amrex::Interpolater *face_mapper = getAmrInterpolaterFaceCentered();
 		amrex::InterpFromCoarseLevel(mf, time, *cmf[0], 0, icomp, ncomp, geom[lev - 1], geom[lev], coarsePhysicalBoundaryFunctor, 0,
 					     finePhysicalBoundaryFunctor, 0, refRatio(lev - 1), face_mapper, BCs, 0);
 	} else {


### PR DESCRIPTION
The single-face branch of `FillCoarsePatch` constructs cell-centred boundary functors and selects `face_divfree_interp`, whose single-FArrayBox overload aborts. Use the directional face-variable callback for coarse and fine physical boundaries and the existing generic face-centred interpolator. Validate the direction before indexing the face-state array.

Add `SingleFaceFill`, a native 3D regression that calls the actual simulation helper for each face direction. It checks direction-dependent custom boundary values on both sides, a constant interior field, and a nonzero destination-component offset while preserving sentinel values in neighboring components.

Validation:
- Original implementation aborts with `FaceDivFree does not work on a single FArrayBox. Call 'interp_arr' instead.`
- Changing only the interpolator removes that abort but the boundary checks fail on all three axes.
- Complete fix passes `ctest --test-dir /private/tmp/quokka-single-face-harness/build --output-on-failure` using native Quokka/AMReX sources.
- `git diff --check` and required post-commit `quokka-pre-commit.sh` hooks pass.

This repairs the generic single-face helper. Coupled magnetic-field refinement still uses the separate divergence-preserving face-array helper. GPU execution and time-evolved MHD simulations were not tested.

Closes #1683.
