### PR TITLE
Initialize the spare cell state after level remakes

### DIFF
--- a/inputs/RemakeCellState.toml
+++ b/inputs/RemakeCellState.toml
@@ -1,0 +1,13 @@
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+quokka.bc = ["periodic", "periodic", "periodic"]
+amr.n_cell = [16, 16, 16]
+amr.max_level = 1
+amr.blocking_factor = 8
+do_subcycle = 0
+do_reflux = 0
+plotfile_interval = -1
+checkpoint_interval = -1
+max_timesteps = 1
+fab.do_initval = 1
+fab.initval = -9876.0

--- a/src/problems/RemakeCellState/CMakeLists.txt
+++ b/src/problems/RemakeCellState/CMakeLists.txt
@@ -1,0 +1,1 @@
+quokka_add_problem(JOB_NAME RemakeCellState)

--- a/src/problems/RemakeCellState/testRemakeCellState.cpp
+++ b/src/problems/RemakeCellState/testRemakeCellState.cpp
@@ -1,0 +1,98 @@
+#include "QuokkaSimulation.hpp"
+
+struct RemakeProblem {};
+template <> struct quokka::EOS_Traits<RemakeProblem> {
+	static constexpr double gamma = 1.4;
+	static constexpr double mean_molecular_weight = C::m_u;
+};
+template <> struct Physics_Traits<RemakeProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
+};
+
+template <> void QuokkaSimulation<RemakeProblem>::setInitialConditionsOnGrid(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		for (int n = 0; n < Physics_Indices<RemakeProblem>::nvarTotal_cc; ++n) {
+			a(i, j, k, n) = 0.0;
+		}
+		a(i, j, k, HydroSystem<RemakeProblem>::density_index) = 2.0;
+		a(i, j, k, HydroSystem<RemakeProblem>::energy_index) = 4.0;
+		a(i, j, k, HydroSystem<RemakeProblem>::internalEnergy_index) = 4.0;
+	});
+}
+
+class RemakeSimulation : public QuokkaSimulation<RemakeProblem>
+{
+      public:
+	auto checkRemakes() -> int
+	{
+		// Create a real fine level before testing both root and fine-level remakes.
+		amrex::BoxArray fine(Geom(1).Domain());
+		const amrex::DistributionMapping fine_dm(fine);
+		MakeNewLevelFromCoarse(1, 0.0, fine, fine_dm);
+		SetBoxArray(1, fine);
+		SetDistributionMap(1, fine_dm);
+		SetFinestLevel(1);
+		int errors = 0;
+		for (int lev = 0; lev <= 1; ++lev) {
+			amrex::BoxArray ba(Geom(lev).Domain());
+			ba.maxSize(8);
+			const amrex::DistributionMapping dm(ba);
+			RemakeLevel(lev, 0.0, ba, dm);
+			SetBoxArray(lev, ba);
+			SetDistributionMap(lev, dm);
+			const auto &current = state_new_cc_[lev];
+			const auto &previous = state_old_cc_[lev];
+			const int ncomp = current.nComp();
+			const int ngrow = current.nGrow();
+			amrex::MultiFab difference(ba, dm, ncomp, ngrow);
+			amrex::MultiFab::Copy(difference, previous, 0, 0, ncomp, ngrow);
+			amrex::MultiFab::Subtract(difference, current, 0, 0, ncomp, ngrow);
+			bool equal = !difference.contains_nan(0, ncomp, ngrow);
+			for (int n = 0; n < ncomp; ++n) {
+				equal = equal && difference.norm0(n, ngrow) == 0.0;
+			}
+			if (!equal) {
+				++errors;
+				amrex::Print() << "Old cell buffer differs after remake at level " << lev << '\n';
+			}
+			AMREX_ALWAYS_ASSERT(tNew_[lev] == 0.0 && tOld_[lev] < -1.e100);
+		}
+		return errors;
+	}
+	auto checkConstantState() -> int
+	{
+		int errors = 0;
+		for (int lev = 0; lev <= finestLevel(); ++lev) {
+			const auto &state = state_new_cc_[lev];
+			if (state.contains_nan()) {
+				++errors;
+			}
+			for (int n = 0; n < state.nComp(); ++n) {
+				const double expected =
+				    n == HydroSystem<RemakeProblem>::density_index
+					? 2.0
+					: (n == HydroSystem<RemakeProblem>::energy_index || n == HydroSystem<RemakeProblem>::internalEnergy_index ? 4.0 : 0.0);
+				if (std::abs(state.min(n) - expected) > 1.e-12 || std::abs(state.max(n) - expected) > 1.e-12) {
+					++errors;
+				}
+			}
+		}
+		return errors;
+	}
+};
+
+auto problem_main() -> int
+{
+	RemakeSimulation sim;
+	sim.stopTime_ = 0.01;
+	sim.setInitialConditions();
+	const int errors = sim.checkRemakes();
+	if (errors != 0) {
+		return 1;
+	}
+	sim.evolve();
+	return sim.checkConstantState() == 0 ? 0 : 1;
+}

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -2518,6 +2518,8 @@ void AMRSimulation<problem_t>::RemakeLevel(int level, amrex::Real time, const am
 	amrex::MultiFab int_state_new_cc(ba, dm, ncomp_cc, nghost_cc);
 	amrex::MultiFab int_state_old_cc(ba, dm, ncomp_cc, nghost_cc);
 	FillPatch(level, time, int_state_new_cc, 0, ncomp_cc, quokka::centering::cc, quokka::direction::na, FillPatchType::fillpatch_function);
+	// Keep the spare buffer initialized, as in MakeNewLevelFromCoarse. Its timestamp remains invalid until the next advance.
+	amrex::MultiFab::Copy(int_state_old_cc, int_state_new_cc, 0, 0, ncomp_cc, nghost_cc);
 	std::swap(int_state_new_cc, state_new_cc_[level]);
 	std::swap(int_state_old_cc, state_old_cc_[level]);
 


### PR DESCRIPTION
`RemakeLevel` swaps an unfilled allocation into `state_old_cc_`. Initialize that spare buffer by copying the remapped current state, including ghost cells, matching the initialized-buffer behavior of `MakeNewLevelFromCoarse` without a second interpolation.

The issue's temporal consequence needs qualification: remaking a level invalidates `tOld_`, and the next normal advance swaps the current buffer into the old slot. This change establishes deterministic buffer contents; it does not make the old timestamp valid or reconstruct historical data. A normal time-interpolation failure was not reproduced.

Add `RemakeCellState`: seed allocations with a known sentinel, create a fine level, repartition and remake both root and fine levels, then compare every old/current component including ghosts. Verify that the old timestamp remains invalid and that the following hydro step preserves the constant state.

Validation:
- Original implementation failed the old-buffer checks at both levels.
- Fixed native 1D regression passes: `ctest --test-dir /private/tmp/quokka-remake-cell-harness/build --output-on-failure`.
- Two MPI ranks pass: `mpirun --oversubscribe -np 2 /private/tmp/quokka-remake-cell-harness/build/RemakeCellState /private/tmp/quokka-audit-remake-old-state/inputs/RemakeCellState.toml suppress_output=1`.
- `git diff --check` and required post-commit `quokka-pre-commit.sh` hooks pass.

GPU and higher-dimensional execution were not tested. This adds one local buffer copy per level remake.

Closes #1679.
