### PR TITLE
Fill time-averaged velocity ghosts for tracer advection

### DIFF
--- a/inputs/TracerUniformFlow.toml
+++ b/inputs/TracerUniformFlow.toml
@@ -1,0 +1,15 @@
+geometry.prob_lo = [0.0, 0.0, 0.0]
+geometry.prob_hi = [1.0, 1.0, 1.0]
+quokka.bc = ["periodic", "periodic", "periodic"]
+amr.n_cell = [32, 32, 32]
+amr.max_level = 0
+amr.max_grid_size = 32
+amr.blocking_factor = 8
+regrid_interval = -1
+do_subcycle = 1
+do_reflux = 1
+do_tracers = 1
+max_timesteps = 1
+constant_dt = 0.001953125
+plotfile_interval = -1
+checkpoint_interval = -1

--- a/src/QuokkaSimulation.hpp
+++ b/src/QuokkaSimulation.hpp
@@ -2418,6 +2418,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> flux_rk2;
 	std::array<amrex::MultiFab, AMREX_SPACEDIM> avgFaceVel;
 	const int nghost_vel = 2; // 2 ghost faces are needed for tracer particles
+	const int nghost_vel_average = (do_tracers != 0) ? nghost_vel : 0;
 
 	for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 		auto ba_fc = amrex::convert(ba_cc, amrex::IntVect::TheDimensionVector(idim));
@@ -2585,7 +2586,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::MultiFab::Saxpy(flux_rk2[idim], stage1Weight, fluxArrays[idim], 0, 0, nvars_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, 0);
+			amrex::MultiFab::Saxpy(avgFaceVel[idim], stage1Weight, faceVel[idim], 0, 0, 1, nghost_vel_average);
 		}
 
 		ApplyHydroStateFixup(stateNew_cc, stateNew_fc, lev);
@@ -2633,7 +2634,7 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 
 		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 			amrex::MultiFab::Saxpy(flux_rk2[idim], 0.5, fluxArrays[idim], 0, 0, nvars_, 0);
-			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, 0);
+			amrex::MultiFab::Saxpy(avgFaceVel[idim], 0.5, faceVel[idim], 0, 0, 1, nghost_vel_average);
 			if constexpr (Physics_Traits<problem_t>::is_mhd_enabled) {
 				amrex::MultiFab::Saxpy(ec_emf_components_rk_ave[idim], 0.5, ec_emf_components_rk_stage2[idim], 0, 0, 1, 0);
 			}
@@ -2735,6 +2736,12 @@ auto QuokkaSimulation<problem_t>::advanceHydroAtLevel(amrex::MultiFab &state_old
 	}
 
 	if (do_tracers != 0 && final_success) {
+		// Riemann solves on stage-filled state ghosts supply physical and coarse-fine boundary velocities.
+		// Refresh patch/periodic overlaps from the accepted valid faces, including any FOFC replacements.
+		for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+			avgFaceVel[idim].OverrideSync(geom[lev].periodicity());
+			avgFaceVel[idim].FillBoundary(geom[lev].periodicity());
+		}
 		TracerPC->AdvectWithUmac(avgFaceVel.data(), lev, dt_lev);
 	}
 

--- a/src/problems/TracerUniformFlow/CMakeLists.txt
+++ b/src/problems/TracerUniformFlow/CMakeLists.txt
@@ -1,0 +1,23 @@
+if(AMReX_SPACEDIM EQUAL 3)
+  quokka_add_problem(JOB_NAME TracerUniformFlow ADD_TEST OFF)
+  foreach(order IN ITEMS 1 2)
+    foreach(layout IN ITEMS single split amr)
+      set(level 0)
+      set(grid_size 32)
+      if(NOT layout STREQUAL "single")
+        set(grid_size 16)
+      endif()
+      if(layout STREQUAL "amr")
+        set(level 1)
+      endif()
+      add_test(NAME TracerUniformFlow_${order}_${layout}
+        COMMAND TracerUniformFlow ${PROJECT_SOURCE_DIR}/inputs/TracerUniformFlow.toml
+        hydro.rk_integrator_order=${order} amr.max_grid_size=${grid_size} amr.max_level=${level} ${QuokkaTestParams}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+    endforeach()
+    add_test(NAME TracerUniformFlow_${order}_physical
+      COMMAND TracerUniformFlow ${PROJECT_SOURCE_DIR}/inputs/TracerUniformFlow.toml
+      hydro.rk_integrator_order=${order} "quokka.bc=foextrap foextrap foextrap" tracer_test.offset=0.0 ${QuokkaTestParams}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+  endforeach()
+endif()

--- a/src/problems/TracerUniformFlow/testTracerUniformFlow.cpp
+++ b/src/problems/TracerUniformFlow/testTracerUniformFlow.cpp
@@ -1,0 +1,105 @@
+#include "QuokkaSimulation.hpp"
+#include "particles/particle_IO.hpp"
+#include <algorithm>
+#include <array>
+#include <vector>
+
+struct TracerProblem {};
+template <> struct Physics_Traits<TracerProblem> : DefaultPhysicsTraits {
+	static constexpr bool is_hydro_enabled = true;
+	static constexpr UnitSystem unit_system = UnitSystem::CONSTANTS;
+};
+template <> struct quokka::EOS_Traits<TracerProblem> {
+	static constexpr double gamma = 1.4;
+	static constexpr double mean_molecular_weight = C::m_u;
+};
+
+template <> void QuokkaSimulation<TracerProblem>::setInitialConditionsOnGrid(quokka::grid const &grid)
+{
+	const auto a = grid.array_;
+	amrex::ParallelFor(grid.indexRange_, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+		a(i, j, k, 0) = 1.0;
+		a(i, j, k, 1) = 1.0;
+		a(i, j, k, 2) = 1.0;
+		a(i, j, k, 3) = 1.0;
+		a(i, j, k, 4) = 4.0;
+		a(i, j, k, 5) = 2.5;
+	});
+}
+
+template <> void QuokkaSimulation<TracerProblem>::refineGrid(int lev, amrex::TagBoxArray &tags, amrex::Real /*time*/, int /*ngrow*/)
+{
+	const auto dx = geom[lev].CellSizeArray();
+	const auto arrays = tags.arrays();
+	amrex::ParallelFor(tags, [=] AMREX_GPU_DEVICE(int box, int i, int j, int k) {
+		if ((i + 0.5) * dx[0] < 0.25) {
+			arrays[box](i, j, k) = amrex::TagBox::SET;
+		}
+	});
+}
+
+class TracerSimulation : public QuokkaSimulation<TracerProblem>
+{
+      public:
+	using Position = std::array<long long, 3>;
+	void moveNearFaces()
+	{
+		double offset = 0.49;
+		amrex::ParmParse("tracer_test").query("offset", offset);
+		if (max_level > 0) {
+			AMREX_ALWAYS_ASSERT(finestLevel() == 1);
+			AMREX_ALWAYS_ASSERT(boxArray(1).numPts() < Geom(1).Domain().numPts());
+		}
+		for (int lev = 0; lev <= finestLevel(); ++lev) {
+			const auto dx = Geom(lev).CellSizeArray();
+			for (amrex::AmrTracerParticleContainer::ParIterType it(*TracerPC, lev); it.isValid(); ++it) {
+				auto *p = it.GetArrayOfStructs()().data();
+				amrex::ParallelFor(it.numParticles(), [=] AMREX_GPU_DEVICE(int i) {
+					for (int d = 0; d < 3; ++d) {
+						p[i].pos(d) += offset * dx[d];
+					}
+				});
+			}
+		}
+		TracerPC->Redistribute();
+	}
+	auto positions(double displacement) -> std::vector<Position>
+	{
+		const auto [ids, reals, ints] = quokka::particle_io::getParticleDataAtAllLevels(static_cast<amrex::TracerParticleContainer *>(TracerPC.get()));
+		std::vector<Position> result;
+		for (const auto &p : reals) {
+			Position position{};
+			bool keep = true;
+			for (int d = 0; d < 3; ++d) {
+				const double x = p[d] + displacement;
+				if (!Geom(0).isPeriodic(d) && (x < 0.0 || x >= 1.0)) {
+					keep = false;
+					break;
+				}
+				position[d] = std::llround((x - std::floor(x)) * 1.e10) % 10000000000LL;
+			}
+			if (keep) {
+				result.push_back(position);
+			}
+		}
+		std::sort(result.begin(), result.end());
+		return result;
+	}
+};
+
+auto problem_main() -> int
+{
+	TracerSimulation sim;
+	sim.setInitialConditions();
+	sim.moveNearFaces();
+	const auto expected = sim.positions(0.001953125);
+	sim.evolve();
+	const auto actual = sim.positions(0.0);
+	int failed = 0;
+	if (amrex::ParallelDescriptor::IOProcessor()) {
+		failed = expected.empty() || actual != expected;
+		amrex::Print() << "Analytic tracer displacement: " << (failed ? "FAIL" : "PASS") << " (" << actual.size() << " particles)\n";
+	}
+	amrex::ParallelDescriptor::ReduceIntMax(failed);
+	return failed;
+}


### PR DESCRIPTION
## Problem and solution

Tracer advection interpolates two ghost layers of the time-averaged face velocity, but the stage accumulation only populated valid faces. Even uniform flow therefore displaced tracers incorrectly near grid boundaries.

Accumulate both ghost layers when tracers are enabled, then synchronize shared faces and exchange patch/periodic ghosts after the accepted hydro update and any flux corrections. Stage Riemann solves already supply velocities at physical and coarse-fine boundaries.

Closes #2240.

## Validation

- Added eight CTest cases checking all 32,768 tracer positions against uniform-flow analytic displacement: Euler and RK2, single patch, split patches, partial AMR with subcycling, and physical outflow boundaries.
- The six periodic cases failed against the original code. All eight final cases passed in the native 3D harness: `ctest --test-dir /private/tmp/quokka-tracer-harness/build --output-on-failure`.
- Two-rank AMR/RK2 case passed: `mpirun --oversubscribe -np 2 /private/tmp/quokka-tracer-harness/build/TracerUniformFlow /private/tmp/quokka-audit-tracer-velocity-ghosts/inputs/TracerUniformFlow.toml amr.max_grid_size=16 amr.max_level=1 suppress_output=1`.
- Required post-commit hooks passed.

The native harness compiles this branch's sources against locally built AMReX and Microphysics dependencies. GPU execution is untested; these smooth-flow regressions do not force a first-order flux correction event.
