### PR TITLE
Compute multigroup blackbody emission over the covered spectrum only

### DIFF
--- a/src/problems/RadhydroBB/testRadhydroBB.cpp
+++ b/src/problems/RadhydroBB/testRadhydroBB.cpp
@@ -207,7 +207,7 @@ auto checkBlackbodyEmission() -> bool
 		const double frac_err = std::abs(fractions[g] - frac_exact[g]) / frac_exact[g];
 		const double deriv_err = std::abs(deriv[g] - a_T3 * deriv_exact[g]) / (a_T3 * deriv_exact[g]);
 		amrex::Print() << "group " << g << ": Planck fraction = " << fractions[g] << " (rel. error " << frac_err << "), d(4 pi B / c)/dT = " << deriv[g]
-				       << " (rel. error " << deriv_err << ")\n";
+			       << " (rel. error " << deriv_err << ")\n";
 		if (frac_err > tol || deriv_err > tol) {
 			amrex::Print() << "FAILED: group " << g << " does not emit the Planck function integrated over its own band only.\n";
 			success = false;
@@ -227,7 +227,7 @@ auto checkBlackbodyEmission() -> bool
 	const double full_deriv_sum = sum(RadSystem<PulseProblem>::ComputeThermalRadiationTempDerivativeMultiGroup(T_test, full_bounds));
 	if (std::abs(full_frac_sum - 1.0) > 1.0e-10 || std::abs(full_deriv_sum - 4.0 * a_T3) > 1.0e-10 * a_T3) {
 		amrex::Print() << "FAILED: groups spanning the whole spectrum give total fraction " << full_frac_sum << " (expected 1) and total derivative "
-				       << full_deriv_sum << " (expected " << 4.0 * a_T3 << ").\n";
+			       << full_deriv_sum << " (expected " << 4.0 * a_T3 << ").\n";
 		success = false;
 	}
 

--- a/src/problems/RadhydroBB/testRadhydroBB.cpp
+++ b/src/problems/RadhydroBB/testRadhydroBB.cpp
@@ -10,6 +10,7 @@
 #include "math/interpolate.hpp"
 #include "radiation/radiation_system.hpp"
 #include "util/BC.hpp"
+#include <array>
 #include <cmath>
 #include <format>
 #include <fstream>
@@ -179,6 +180,58 @@ template <> void QuokkaSimulation<PulseProblem>::setInitialConditionsOnGrid(quok
 		state_cc(i, j, k, RadSystem<PulseProblem>::x2GasMomentum_index) = 0.;
 		state_cc(i, j, k, RadSystem<PulseProblem>::x3GasMomentum_index) = 0.;
 	});
+}
+
+// Check the multigroup blackbody emission and its temperature derivative for group boundaries that do NOT span the whole spectrum. The energy fractions must
+// then integrate the Planck function over [boundaries[0], boundaries[n_groups_]] only -- neither renormalized to 1, nor with the emission outside the bands
+// folded into the first and last groups -- and likewise for the temperature derivative. This problem uses k_B = a_rad = nu_unit = 1, so x = h nu / (k T) is
+// just nu / T. The reference values below are high-precision quadratures of the Planck integral and of its temperature-derivative kernel,
+//     P(x) = (15/pi^4) \int_0^x s^3 / (e^s - 1) ds ,   D(x) = (15/pi^4) \int_0^x s^4 e^s / (e^s - 1)^2 ds ,
+// over the bands [0.5, 1], [1, 2], [2, 4], [4, 6], which straddle the peak of the Planck function.
+auto checkBlackbodyEmission() -> bool
+{
+	bool success = true;
+	const double T_test = 1.0;
+	const double a_T3 = a_rad * T_test * T_test * T_test;
+	// the tolerance is set by the accuracy of the tabulated Planck integral, which is far tighter than the errors of order 10 to 100 per cent that folding
+	// the out-of-band emission into the first and last groups would produce
+	const double tol = 1.0e-3;
+
+	const amrex::GpuArray<double, n_groups_ + 1> narrow_bounds{0.5, 1.0, 2.0, 4.0, 6.0};
+	const std::array<double, n_groups_> frac_exact{0.029324531565, 0.146526992267, 0.415881855008, 0.263137844912};
+	const std::array<double, n_groups_> deriv_exact{0.0425155795, 0.2900926449, 1.3136624416, 1.2921345740};
+
+	const auto fractions = RadSystem<PulseProblem>::ComputePlanckEnergyFractions(narrow_bounds, T_test);
+	const auto deriv = RadSystem<PulseProblem>::ComputeThermalRadiationTempDerivativeMultiGroup(T_test, narrow_bounds);
+	for (int g = 0; g < n_groups_; ++g) {
+		const double frac_err = std::abs(fractions[g] - frac_exact[g]) / frac_exact[g];
+		const double deriv_err = std::abs(deriv[g] - a_T3 * deriv_exact[g]) / (a_T3 * deriv_exact[g]);
+		amrex::Print() << "group " << g << ": Planck fraction = " << fractions[g] << " (rel. error " << frac_err << "), d(4 pi B / c)/dT = " << deriv[g]
+				       << " (rel. error " << deriv_err << ")\n";
+		if (frac_err > tol || deriv_err > tol) {
+			amrex::Print() << "FAILED: group " << g << " does not emit the Planck function integrated over its own band only.\n";
+			success = false;
+		}
+	}
+	// the bands cover only part of the spectrum, so they must emit strictly less than a_rad T^4
+	const double frac_sum = sum(fractions);
+	amrex::Print() << "Planck energy fraction inside x = [0.5, 6]: " << frac_sum << " (expected 0.85487)\n";
+	if (frac_sum > 0.99) {
+		amrex::Print() << "FAILED: a set of groups covering only part of the spectrum emits the full a_rad T^4.\n";
+		success = false;
+	}
+
+	// groups that DO span the whole spectrum must still emit exactly a_rad T^4 in total, with total derivative 4 a_rad T^3
+	const amrex::GpuArray<double, n_groups_ + 1> full_bounds{0.0, 1.0, 3.0, 10.0, inf};
+	const double full_frac_sum = sum(RadSystem<PulseProblem>::ComputePlanckEnergyFractions(full_bounds, T_test));
+	const double full_deriv_sum = sum(RadSystem<PulseProblem>::ComputeThermalRadiationTempDerivativeMultiGroup(T_test, full_bounds));
+	if (std::abs(full_frac_sum - 1.0) > 1.0e-10 || std::abs(full_deriv_sum - 4.0 * a_T3) > 1.0e-10 * a_T3) {
+		amrex::Print() << "FAILED: groups spanning the whole spectrum give total fraction " << full_frac_sum << " (expected 1) and total derivative "
+				       << full_deriv_sum << " (expected " << 4.0 * a_T3 << ").\n";
+		success = false;
+	}
+
+	return success;
 }
 
 auto problem_main() -> int
@@ -458,6 +511,9 @@ auto problem_main() -> int
 	// Cleanup and exit
 	int status = 0;
 	if ((rel_error > error_tol) || std::isnan(rel_error) || (rel_error_T > error_tol) || std::isnan(rel_error_T)) {
+		status = 1;
+	}
+	if (!checkBlackbodyEmission()) {
 		status = 1;
 	}
 	return status;

--- a/src/radiation/planck_integral.hpp
+++ b/src/radiation/planck_integral.hpp
@@ -262,4 +262,33 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto integrate_planck_from_0_to_x(const
 	return y;
 }
 
+// Compute x * d/dx of integrate_planck_from_0_to_x(x), i.e. (15 / pi^4) * x^4 / (exp(x) - 1). This is the boundary term that appears when the normalized
+// Planck integral is differentiated with respect to temperature at fixed group edges, since x = h nu / (k T) is proportional to 1 / T.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto planck_integral_edge_term(const Real x) -> Real
+{
+	AMREX_ASSERT(!std::isnan(x));
+	AMREX_ASSERT(x >= 0.);
+
+	if (x <= 0.) {
+		return 0.;
+	}
+	if (x > 100.) {
+		// exp(-100) < 1e-43, so this term is negligible. This branch also covers x = infinity.
+		return 0.;
+	}
+	if (x < 1.0e-10) {
+		// Taylor series: x^4 / (exp(x) - 1) = x^3 - x^4 / 2 + ...
+		return x * x * x / gInf;
+	}
+	return x * x * x * x / (std::exp(x) - 1.0) / gInf;
+}
+
+// Cumulative form of the temperature derivative of the Planck spectrum, D(x) = (15 / pi^4) \int_0^x s^4 e^s / (e^s - 1)^2 ds, obtained by integrating the
+// exact kernel by parts. The emission of a group [nu_L, nu_R] then has d/dT (a T^4 f_g) = a T^3 [D(x_R) - D(x_L)], and D(infinity) = 4 recovers
+// d(a T^4)/dT for a set of groups that spans the whole spectrum.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE auto integrate_planck_derivative_from_0_to_x(const Real x) -> Real
+{
+	return 4. * integrate_planck_from_0_to_x(x) - planck_integral_edge_term(x);
+}
+
 #endif // PLANCKINTEGRAL_HPP_

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -579,35 +579,25 @@ template <typename problem_t> class RadSystem : public HyperbolicSystem<problem_
 	AMREX_GPU_DEVICE static auto ComputeEddingtonTensor(double fx_L, double fy_L, double fz_L) -> std::array<std::array<double, 3>, 3>;
 };
 
-// Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature
-// This function enforces that the total fraction is 1.0, no matter what are the group boundaries
+// Compute radiation energy fractions for each photon group from a Planck function, given nGroups, radBoundaries, and temperature.
+// The fraction of group g is P(x_{g+1}) - P(x_g), where P is the Planck integral from 0 to x normalized to unity and x = energy_unit * nu / (k T).
+// The group boundaries need not span the whole spectrum: blackbody emission below boundaries[0], above boundaries[nGroupsThermal_], or inside a chemical
+// band is simply dropped rather than folded into the nearest group, so the fractions sum to <= 1.
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputePlanckEnergyFractions(amrex::GpuArray<double, nGroups_ + 1> const &boundaries, amrex::Real temperature)
     -> quokka::valarray<amrex::Real, nGroups_>
 {
 	quokka::valarray<amrex::Real, nGroups_> radEnergyFractions{};
 	if constexpr (nGroups_ == 1) {
+		// a single group always spans the whole spectrum; see radBoundaries_
 		radEnergyFractions[0] = 1.0;
 		return radEnergyFractions;
 	} else {
 		amrex::Real const energy_unit_over_kT = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * temperature);
-		amrex::Real y = NAN;
-		amrex::Real previous = 0.0;
-		// Only the thermal groups (the leading nGroupsThermal_ groups) receive blackbody emission. When
-		// chemical bands are present the thermal fractions are NOT renormalized: the blackbody radiation
-		// above the first chemical-band boundary is simply dropped, so the fractions sum to < 1.
+		// Only the thermal groups (the leading nGroupsThermal_ groups) receive blackbody emission, and their fractions are NOT renormalized.
+		amrex::Real previous = integrate_planck_from_0_to_x(boundaries[0] * energy_unit_over_kT);
 		for (int g = 0; g < nGroupsThermal_; ++g) {
-			if (g == nGroups_ - 1) {
-				// no chemical bands: the last group carries all remaining blackbody, total fraction = 1.0
-				y = 1.0;
-			} else {
-				const amrex::Real x = boundaries[g + 1] * energy_unit_over_kT;
-				if (x >= 100.) { // 100. is the upper limit of x in the table
-					y = 1.0;
-				} else {
-					y = integrate_planck_from_0_to_x(x);
-				}
-			}
+			const amrex::Real y = integrate_planck_from_0_to_x(boundaries[g + 1] * energy_unit_over_kT);
 			radEnergyFractions[g] = y - previous;
 			previous = y;
 		}
@@ -661,7 +651,7 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeMultiGroup(amrex::Real temperature,
-												 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+																							 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
     -> quokka::valarray<amrex::Real, nGroups_>
 {
 	quokka::valarray<amrex::Real, nGroups_> d_fourpiboverc_d_t{};
@@ -679,21 +669,11 @@ AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDeri
 		// where P is the same normalized Planck integral used for the energy fractions, so the exact
 		// derivative costs one extra term per group boundary. D(inf) = 4 recovers d(a T^4)/dT.
 		amrex::Real const energy_unit_over_kT = RadSystem_Traits<problem_t>::energy_unit / (boltzmann_constant_ * temperature);
-		amrex::Real y = NAN;
-		amrex::Real previous = 0.0;
-		// Only the thermal groups emit; the chemical bands are left at 0, as in ComputePlanckEnergyFractions.
+		// As in ComputePlanckEnergyFractions, only the thermal groups emit, the group boundaries need not span the
+		// whole spectrum, and no renormalization is applied; the chemical bands are left at 0.
+		amrex::Real previous = integrate_planck_derivative_from_0_to_x(boundaries[0] * energy_unit_over_kT);
 		for (int g = 0; g < nGroupsThermal_; ++g) {
-			if (g == nGroups_ - 1) {
-				// no chemical bands: the last group carries all remaining blackbody, so D = D(inf) = 4
-				y = 4.0;
-			} else {
-				const amrex::Real x = boundaries[g + 1] * energy_unit_over_kT;
-				if (x >= 100.) { // 100. is the upper limit of x in the table
-					y = 4.0;
-				} else {
-					y = 4. * integrate_planck_from_0_to_x(x) - (x * x * x * x / (std::exp(x) - 1.0)) / gInf;
-				}
-			}
+			const amrex::Real y = integrate_planck_derivative_from_0_to_x(boundaries[g + 1] * energy_unit_over_kT);
 			d_fourpiboverc_d_t[g] = a_T3 * (y - previous);
 			previous = y;
 		}

--- a/src/radiation/radiation_system.hpp
+++ b/src/radiation/radiation_system.hpp
@@ -651,7 +651,7 @@ template <typename problem_t> AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::C
 
 template <typename problem_t>
 AMREX_GPU_HOST_DEVICE auto RadSystem<problem_t>::ComputeThermalRadiationTempDerivativeMultiGroup(amrex::Real temperature,
-																							 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
+												 amrex::GpuArray<double, nGroups_ + 1> const &boundaries)
     -> quokka::valarray<amrex::Real, nGroups_>
 {
 	quokka::valarray<amrex::Real, nGroups_> d_fourpiboverc_d_t{};


### PR DESCRIPTION
### Description

#### Problem

Multigroup blackbody emission assumed the group boundaries span the whole spectrum, so it could not be used with bands covering only part of it.

`ComputePlanckEnergyFractions` started the cumulative Planck integral at $0$ instead of at `boundaries[0]`, and, when no chemical bands were declared, forced the last group to $P = 1$. Group 0 therefore absorbed all blackbody emission below the first group edge and the last group everything above the last edge, so a set of bands covering only part of the spectrum still emitted the full $a_r T^4$. `ComputeThermalRadiationTempDerivativeMultiGroup` had the same two problems, starting at $D = 0$ and forcing $D = 4$ in the last group.

Truncation at the top was already handled when chemical bands are declared (`nGroupsThermal_ < nGroups_`), and the derivative already carried the correct edge term at interior boundaries. What was missing was the lower edge in both functions, and the upper edge for a plain thermal multigroup setup.

#### Solution

Both functions now evaluate the cumulative integral at every group edge, including the first and the last. The energy fraction of group $g$ is $P(x_{g+1}) - P(x_g)$, with $P$ the Planck integral from 0 to $x$ normalized to unity and $x = \mathrm{energy\_unit}\,\nu / (k T)$. Emission falling outside the covered range is dropped rather than folded into the edge groups, so the fractions sum to $\leq 1$.

For the temperature derivative, $x \propto 1/T$ at fixed group edges, so $f_g$ is itself temperature dependent and $\mathrm{d}/\mathrm{d}T\,(a_r T^4 f_g) = 4 a_r T^3 f_g + a_r T^4 \, \mathrm{d}f_g/\mathrm{d}T$. Integrating the exact kernel by parts gives the cumulative form

$$D(x) = \frac{15}{\pi^4} \int_0^x \frac{s^4 e^s}{(e^s - 1)^2} \mathrm{d}s = 4 P(x) - \frac{15}{\pi^4} \frac{x^4}{e^x - 1} ,$$

so that $\mathrm{d}/\mathrm{d}T\,(a_r T^4 f_g) = a_r T^3 [D(x_{g+1}) - D(x_g)]$, which telescopes and uses the same boundary loop as the fractions. This is added as `integrate_planck_derivative_from_0_to_x` in `planck_integral.hpp`, together with the guarded edge term $x P'(x)$ that it needs at $x = 0$ and $x = \infty$.

The change is backward compatible: because $D(0) = 0$ and $D(\infty) = 4$, groups that do span the whole spectrum still give a total emission of exactly $a_r T^4$ and a total derivative of exactly $4 a_r T^3$, so nothing changes for existing problems beyond the residual Planck integral outside their outermost edges.

#### Testing

`RadhydroBB` gains `checkBlackbodyEmission()`, which compares the group fractions and their temperature derivatives against high-precision quadratures of $P$ and $D$ over the bands $x \in [0.5, 1], [1, 2], [2, 4], [4, 6]$, covering only $85.5\%$ of the spectrum. It also checks that a set of groups spanning the whole spectrum still gives a total fraction of $1$ and a total derivative of $4 a_r T^3$.

The check fails on `development` and passes with this PR:

| quantity | `development` | this PR | exact |
|---|---|---|---|
| group 0 fraction | 0.0346212 (+18.1%) | 0.0293275 (+1.0e-4) | 0.0293245 |
| group 0 derivative | 0.0488662 (+14.9%) | 0.0425274 (+2.8e-4) | 0.0425156 |
| group 3 fraction | 0.4029742 (+53.1%) | 0.2631313 (+2.5e-5) | 0.2631378 |
| group 3 derivative | 2.3473955 (+81.7%) | 1.2921084 (+2.0e-5) | 1.2921346 |
| total fraction | 1.0 | 0.8548635 | 0.8548712 |

Groups 1 and 2 are interior to the band and are unchanged, as expected. The residual errors of order $10^{-4}$ are the accuracy of the tabulated Planck integral, not of the formula; a finite difference of the tabulated fractions differs from the analytic derivative by about $0.3\%$, which is the differentiated interpolation error of that table, so the test compares against exact quadratures rather than a finite difference.

No regressions: the physics part of `RadhydroBB` moves from a relative L1 error norm of $0.0025374$ to $0.0025373$ against a tolerance of $0.1$, and all 26 `Rad*` problems that build in 1D were built and run, all passing. GPU CI is green on both `quick` (CUDA) and `rocm-quick` (HIP), which build `RadhydroBB` and run its ctest, now including the new check.

### Related issues
N/A

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [x] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have manually triggered the GPU tests with the magic comment `/azp run`. `quick` (CUDA) and `rocm-quick` (HIP) both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved multigroup blackbody radiation calculations to integrate emission and temperature derivatives over each explicitly defined spectral band.
  - Partial-spectrum groups now represent only their selected bands rather than being automatically renormalized to the full spectrum.
  - Full-spectrum configurations continue to produce the expected total blackbody energy and temperature derivative.

- **Tests**
  - Added validation against high-precision reference calculations for spectral energy fractions and temperature derivatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->