### PR TITLE
stabilize reduced dust operator algebra

### DIFF
--- a/src/dust/DustSources.hpp
+++ b/src/dust/DustSources.hpp
@@ -58,54 +58,54 @@ template <typename problem_t> class DustSources
 	using Vec3 = amrex::SmallVector<amrex::Real, 3>;
 
 	struct ReducedOperator {
-		amrex::Real coeffIdentity;
+		amrex::Real coeffPerpendicular;
 		amrex::Real coeffCross;
 		amrex::Real coeffParallel;
 
 		AMREX_GPU_HOST_DEVICE auto operator+(ReducedOperator const &rhs) const -> ReducedOperator
 		{
-			return {coeffIdentity + rhs.coeffIdentity, coeffCross + rhs.coeffCross, coeffParallel + rhs.coeffParallel};
+			return {coeffPerpendicular + rhs.coeffPerpendicular, coeffCross + rhs.coeffCross, coeffParallel + rhs.coeffParallel};
 		}
 
 		AMREX_GPU_HOST_DEVICE auto operator-(ReducedOperator const &rhs) const -> ReducedOperator
 		{
-			return {coeffIdentity - rhs.coeffIdentity, coeffCross - rhs.coeffCross, coeffParallel - rhs.coeffParallel};
+			return {coeffPerpendicular - rhs.coeffPerpendicular, coeffCross - rhs.coeffCross, coeffParallel - rhs.coeffParallel};
 		}
 
 		AMREX_GPU_HOST_DEVICE auto operator*(ReducedOperator const &rhs) const -> ReducedOperator
 		{
 			ReducedOperator result{};
-			result.coeffIdentity = coeffIdentity * rhs.coeffIdentity - coeffCross * rhs.coeffCross;
-			result.coeffCross = coeffIdentity * rhs.coeffCross + coeffCross * rhs.coeffIdentity;
-			result.coeffParallel = coeffIdentity * rhs.coeffParallel + coeffParallel * rhs.coeffIdentity + coeffParallel * rhs.coeffParallel +
-					       coeffCross * rhs.coeffCross;
+			result.coeffPerpendicular = coeffPerpendicular * rhs.coeffPerpendicular - coeffCross * rhs.coeffCross;
+			result.coeffCross = coeffPerpendicular * rhs.coeffCross + coeffCross * rhs.coeffPerpendicular;
+			result.coeffParallel = coeffParallel * rhs.coeffParallel;
 			return result;
 		}
 
 		AMREX_GPU_HOST_DEVICE auto operator*(amrex::Real scale) const -> ReducedOperator
 		{
-			return {scale * coeffIdentity, scale * coeffCross, scale * coeffParallel};
+			return {scale * coeffPerpendicular, scale * coeffCross, scale * coeffParallel};
 		}
 
 		friend AMREX_GPU_HOST_DEVICE auto operator*(amrex::Real scale, ReducedOperator const &op) -> ReducedOperator { return op * scale; }
 
 		[[nodiscard]] AMREX_GPU_HOST_DEVICE auto inverse() const -> ReducedOperator
 		{
-			amrex::Real const denom_perp = coeffIdentity * coeffIdentity + coeffCross * coeffCross;
-			amrex::Real const parallel_denom = coeffIdentity + coeffParallel;
+			amrex::Real const denom_perp = coeffPerpendicular * coeffPerpendicular + coeffCross * coeffCross;
 			AMREX_ASSERT(denom_perp > 0.0);
-			AMREX_ASSERT(std::abs(parallel_denom) > 0.0);
-			amrex::Real const inv_parallel = 1.0 / parallel_denom;
-			return {coeffIdentity / denom_perp, -coeffCross / denom_perp, inv_parallel - coeffIdentity / denom_perp};
+			AMREX_ASSERT(std::abs(coeffParallel) > 0.0);
+			return {coeffPerpendicular / denom_perp, -coeffCross / denom_perp, 1.0 / coeffParallel};
 		}
 
 		[[nodiscard]] AMREX_GPU_HOST_DEVICE auto apply(Vec3 const &x, Vec3 const &b_hat) const -> Vec3
 		{
 			amrex::Real const x_parallel = b_hat.dot(x);
 			Vec3 result = Vec3::Zero();
-			result[0] = coeffIdentity * x[0] + coeffCross * (x[1] * b_hat[2] - x[2] * b_hat[1]) + coeffParallel * x_parallel * b_hat[0];
-			result[1] = coeffIdentity * x[1] + coeffCross * (x[2] * b_hat[0] - x[0] * b_hat[2]) + coeffParallel * x_parallel * b_hat[1];
-			result[2] = coeffIdentity * x[2] + coeffCross * (x[0] * b_hat[1] - x[1] * b_hat[0]) + coeffParallel * x_parallel * b_hat[2];
+			result[0] = coeffPerpendicular * (x[0] - x_parallel * b_hat[0]) + coeffCross * (x[1] * b_hat[2] - x[2] * b_hat[1]) +
+				    coeffParallel * x_parallel * b_hat[0];
+			result[1] = coeffPerpendicular * (x[1] - x_parallel * b_hat[1]) + coeffCross * (x[2] * b_hat[0] - x[0] * b_hat[2]) +
+				    coeffParallel * x_parallel * b_hat[1];
+			result[2] = coeffPerpendicular * (x[2] - x_parallel * b_hat[2]) + coeffCross * (x[0] * b_hat[1] - x[1] * b_hat[0]) +
+				    coeffParallel * x_parallel * b_hat[2];
 			return result;
 		}
 	};
@@ -300,9 +300,9 @@ AMREX_GPU_HOST_DEVICE auto DustSources<problem_t>::ComputeDustStageAffineOperato
     -> DustStageAffineOperators
 {
 	DustStageAffineOperators ops{};
-	ReducedOperator const identity{1.0, 0.0, 0.0};
-	ReducedOperator const T1 = {-alpha1, omega_L1, 0.0};
-	ReducedOperator const T2 = {-alpha2, omega_L2, 0.0};
+	ReducedOperator const identity{1.0, 0.0, 1.0};
+	ReducedOperator const T1 = {-alpha1, omega_L1, -alpha1};
+	ReducedOperator const T2 = {-alpha2, omega_L2, -alpha2};
 	ReducedOperator const L1 = dt * T1;
 	ReducedOperator const L2 = dt * T2;
 
@@ -331,10 +331,10 @@ AMREX_GPU_HOST_DEVICE auto DustSources<problem_t>::SolveGasStageRates(amrex::Gpu
 								      amrex::GpuArray<Vec3, nDustGroups_> const &q_n, Vec3 const &b_hat) -> GasStageRates
 {
 	GasStageRates rates{Vec3::Zero(), Vec3::Zero()};
-	ReducedOperator lambda11{1.0, 0.0, 0.0};
+	ReducedOperator lambda11{1.0, 0.0, 1.0};
 	ReducedOperator lambda12{0.0, 0.0, 0.0};
 	ReducedOperator lambda21{0.0, 0.0, 0.0};
-	ReducedOperator lambda22{1.0, 0.0, 0.0};
+	ReducedOperator lambda22{1.0, 0.0, 1.0};
 	Vec3 r1 = Vec3::Zero();
 	Vec3 r2 = Vec3::Zero();
 

--- a/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
+++ b/src/problems/DustDampedGyromotion/testDustDampedGyromotion.cpp
@@ -711,6 +711,32 @@ void writeDynamicEpsteinConvergenceCsv(const std::vector<CoefficientTreatmentCon
 	}
 }
 
+auto stronglyUnresolvedGyromotionOperatorPasses() -> bool
+{
+	using DustSystem = DustSources<DustGyroNoDrag>;
+	constexpr double omega_dt = 1.0e8;
+	auto const ops = DustSystem::ComputeDustStageAffineOperators(0.0, omega_dt, 0.0, omega_dt, epsilon, 1.0, 1.0, 1.0, 1.0, -1.0);
+	amrex::GpuArray<DustSystem::DustStageAffineOperators, 1> const group_ops{ops};
+	amrex::GpuArray<DustSystem::Vec3, 1> q_n{};
+	q_n[0][0] = 1.0;
+	q_n[0][1] = -2.0;
+	q_n[0][2] = 3.0;
+	DustSystem::Vec3 const b_hat{0.0, 0.0, 1.0};
+	auto const gas_stage = DustSystem::SolveGasStageRates(group_ops, q_n, b_hat);
+	auto const dust_stage1 = ops.P1.apply(q_n[0], b_hat) + ops.X1.apply(gas_stage.k1, b_hat) + ops.Y1.apply(gas_stage.k2, b_hat);
+	auto const dust_stage2 = ops.P2.apply(q_n[0], b_hat) + ops.X2.apply(gas_stage.k1, b_hat) + ops.Y2.apply(gas_stage.k2, b_hat);
+
+	auto const finite_operator = [](DustSystem::ReducedOperator const &op) {
+		return std::isfinite(op.coeffPerpendicular) && std::isfinite(op.coeffCross) && std::isfinite(op.coeffParallel);
+	};
+	auto const finite_vector = [](DustSystem::Vec3 const &vec) { return std::isfinite(vec[0]) && std::isfinite(vec[1]) && std::isfinite(vec[2]); };
+	bool const finite = finite_operator(ops.P1) && finite_operator(ops.P2) && finite_operator(ops.X1) && finite_operator(ops.X2) &&
+			    finite_operator(ops.Y1) && finite_operator(ops.Y2) && finite_vector(gas_stage.k1) && finite_vector(gas_stage.k2) &&
+			    finite_vector(dust_stage1) && finite_vector(dust_stage2);
+	double const parallel_rate = std::max({std::abs(gas_stage.k1[2]), std::abs(gas_stage.k2[2]), std::abs(dust_stage1[2]), std::abs(dust_stage2[2])});
+	return finite && (parallel_rate < 1.0e-14);
+}
+
 auto problem_main() -> int
 {
 	bool write_csv = true;
@@ -821,7 +847,7 @@ auto problem_main() -> int
 		const double dynamic_charge_minimum_change = 1.0e-2;
 		const double dynamic_charge_minimum_order = 3.8;
 
-		bool passed = true;
+		bool passed = stronglyUnresolvedGyromotionOperatorPasses();
 		for (auto const &run : epstein_no_b_runs) {
 			amrex::Print() << "[Pure Damping][" << quokka::dust::resolvedRkSchemeName(run.scheme)
 				       << "] Relative L2 drift error = " << run.drift_l2_error << "\n";


### PR DESCRIPTION
This PR is stacked on #2202  and should be merged only after #2202 has been merged.

### Description
This PR fixes numerical cancellation in the reduced dust drag and Lorentz operators during strongly unresolved gyromotion. Previously, the response parallel to the magnetic field was recovered by adding two stored coefficients. During strongly unresolved gyromotion, these coefficients can become large and nearly equal in magnitude with opposite signs, causing their much smaller sum to be lost to roundoff. `ReducedOperator` now stores the coefficients perpendicular and parallel to the magnetic field independently, so operator products and inverses preserve the correct parallel response. A regression check in `DustDampedGyromotion` exercises pure gyromotion with $\Delta t |\Omega_{\rm L}| = 10^8$, verifies that the stage operators and rates remain finite, and confirms that the Lorentz force does not change momentum parallel to the magnetic field.

### Related issues
Fixes https://github.com/quokka-astro/quokka/issues/2219

### Checklist
_Before this pull request can be reviewed, all of these tasks should be completed. Denote completed tasks with an `x` inside the square brackets `[ ]` in the Markdown source below:_
- [x] I have added a description (see above).
- [x] I have added a link to any related issues (if applicable; see above).
- [ ] I have read the [Contributing Guide](https://github.com/quokka-astro/quokka/blob/development/CONTRIBUTING.md).
- [x] I have added tests for any new physics that this PR adds to the code.
- [x] *(For quokka-astro org members)* I have triggered GPU tests for changed problems with `/azp run quick` and `/azp run rocm-quick`, or `/azp run` if this PR changes base modules affecting multiple problems.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of perpendicular and parallel components in dust and gas-stage operator calculations.
  - Increased numerical stability for strongly unresolved gyromotion scenarios, including prevention of non-finite results and unwanted parallel motion.

- **Tests**
  - Added validation for extreme gyromotion conditions to ensure operator coefficients and calculated stage vectors remain finite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->